### PR TITLE
Merging and splitting beams, node point precision and vector utility functions 

### DIFF
--- a/src/ada/base/non_phyical_objects.py
+++ b/src/ada/base/non_phyical_objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Union
@@ -25,7 +27,7 @@ class Backend:
         parent=None,
         ifc_settings=None,
         ifc_elem=None,
-        ifc_ref: "IfcRef" = None,
+        ifc_ref: IfcRef = None,
     ):
         self.name = name
         self.parent = parent
@@ -40,7 +42,7 @@ class Backend:
         # TODO: Currently not able to keep and edit imported ifc_elem objects
         self._ifc_elem = None
         self._ifc_ref = ifc_ref
-        self.ifc_options: "IfcExportOptions" = IfcExportOptions()
+        self.ifc_options: IfcExportOptions = IfcExportOptions()
 
     @property
     def name(self):
@@ -70,7 +72,7 @@ class Backend:
         self._guid = value
 
     @property
-    def parent(self) -> "Part":
+    def parent(self) -> Part:
         return self._parent
 
     @parent.setter
@@ -107,10 +109,10 @@ class Backend:
         return self._ifc_elem
 
     @property
-    def ifc_ref(self) -> "IfcRef":
+    def ifc_ref(self) -> IfcRef:
         return self._ifc_ref
 
-    def get_assembly(self) -> Union["Assembly", "Part"]:
+    def get_assembly(self) -> Union[Assembly, Part]:
         from ada import Assembly
 
         for ancestor in self.get_ancestors():
@@ -119,7 +121,7 @@ class Backend:
         logging.info("No Assembly found in ancestry. Returning self")
         return self
 
-    def get_ancestors(self) -> List[Union["Part", "Assembly"]]:
+    def get_ancestors(self) -> List[Union[Part, Assembly]]:
         ancestry = [self]
         current = self
         while current.parent is not None:

--- a/src/ada/base/physical_objects.py
+++ b/src/ada/base/physical_objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from typing import TYPE_CHECKING, List
@@ -29,7 +31,7 @@ class BackendGeom(Backend):
         colour=None,
         ifc_elem=None,
         placement=Placement(),
-        ifc_ref: "IfcRef" = None,
+        ifc_ref: IfcRef = None,
         opacity=1.0,
     ):
         super().__init__(name, guid, metadata, units, parent, ifc_elem=ifc_elem, ifc_ref=ifc_ref)
@@ -62,12 +64,12 @@ class BackendGeom(Backend):
         self,
         mesh_size,
         geom_repr,
-        options: "GmshOptions" = None,
+        options: GmshOptions = None,
         silent=True,
         use_quads=False,
         use_hex=False,
         name="AdaFEM",
-    ) -> "FEM":
+    ) -> FEM:
         from ada.fem.meshing import GmshOptions, GmshSession
 
         options = GmshOptions(Mesh_Algorithm=8) if options is None else options
@@ -82,7 +84,7 @@ class BackendGeom(Backend):
         geom_repr,
         name: str,
         fem_format: str,
-        options: "GmshOptions" = None,
+        options: GmshOptions = None,
         silent=True,
         use_quads=False,
         use_hex=False,
@@ -200,11 +202,11 @@ class BackendGeom(Backend):
         return False if self.opacity == 1.0 else True
 
     @property
-    def penetrations(self) -> List["Penetration"]:
+    def penetrations(self) -> List[Penetration]:
         return self._penetrations
 
     @property
-    def elem_refs(self) -> List["Elem"]:
+    def elem_refs(self) -> List[Elem]:
         return self._elem_refs
 
     @elem_refs.setter

--- a/src/ada/concepts/containers.py
+++ b/src/ada/concepts/containers.py
@@ -924,7 +924,7 @@ class Nodes:
         else:
             return list(simplesearch)
 
-    def add(self, node: Node, point_tol=Settings.point_tol, allow_coincident=False) -> Node:
+    def add(self, node: Node, point_tol: float = Settings.point_tol, allow_coincident: bool = False) -> Node:
         """Insert node into sorted list"""
 
         def insert_node(n, i):
@@ -969,7 +969,7 @@ class Nodes:
         """Remove nodes that are without any usage references"""
         self.remove(filter(lambda x: len(x.refs) == 0, self._nodes))
 
-    def merge_coincident(self, tol=Settings.point_tol) -> None:
+    def merge_coincident(self, tol: float = Settings.point_tol) -> None:
         """
         Merge nodes which are within the standard default of Nodes.get_by_volume. Nodes merged into the node connected
         to most elements.
@@ -990,6 +990,10 @@ class Nodes:
             replace_duplicate_nodes(duplicate_nodes, node)
 
         self._sort()
+
+    def rounding_node_points(self, precision: int = Settings.precision) -> None:
+        for node in self.nodes:
+            node.p_roundoff(precision=precision)
 
     @property
     def parent(self) -> Union[Part, FEM]:

--- a/src/ada/concepts/points.py
+++ b/src/ada/concepts/points.py
@@ -26,8 +26,6 @@ class Node:
         if len(self.p) != 3:
             raise ValueError("Node object must have exactly 3 coordinates (x, y, z).")
 
-        self.p_roundoff()
-
         self._bc = bc
         self._r = r
         self._parent = parent
@@ -66,10 +64,10 @@ class Node:
     def r(self) -> float:
         return self._r
 
-    def p_roundoff(self, scale_factor: Union[int, float] = 1) -> None:
+    def p_roundoff(self, scale_factor: Union[int, float] = 1, precision: int = Settings.precision) -> None:
         from ada.core.utils import roundoff
 
-        self.p = np.array([roundoff(scale_factor * x) for x in self.p])
+        self.p = np.array([roundoff(scale_factor * x, precision=precision) for x in self.p])
 
     def add_obj_to_refs(self, item) -> None:
         if item not in self.refs:

--- a/src/ada/concepts/points.py
+++ b/src/ada/concepts/points.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Iterable, List, Union
 
 import numpy as np
 
+from ada.config import Settings
+
 if TYPE_CHECKING:
     from ada import Beam
+    from ada.concepts.containers import Nodes
     from ada.fem import Bc, Csys, Elem
 
 numeric = Union[int, float, np.number]
@@ -21,6 +25,9 @@ class Node:
         self.p: np.ndarray = np.array([*p], dtype=np.float64) if type(p) != np.ndarray else p
         if len(self.p) != 3:
             raise ValueError("Node object must have exactly 3 coordinates (x, y, z).")
+
+        self.p_roundoff()
+
         self._bc = bc
         self._r = r
         self._parent = parent
@@ -32,7 +39,7 @@ class Node:
         return self._id
 
     @id.setter
-    def id(self, value):
+    def id(self, value: int):
         self._id = value
 
     @property
@@ -48,16 +55,33 @@ class Node:
         return self.p[2]
 
     @property
-    def bc(self) -> "Bc":
+    def bc(self) -> Bc:
         return self._bc
 
     @bc.setter
-    def bc(self, value):
+    def bc(self, value: Bc):
         self._bc = value
 
     @property
     def r(self) -> float:
         return self._r
+
+    def p_roundoff(self, scale_factor: Union[int, float] = 1) -> None:
+        from ada.core.utils import roundoff
+
+        self.p = np.array([roundoff(scale_factor * x) for x in self.p])
+
+    def add_obj_to_refs(self, item) -> None:
+        if item not in self.refs:
+            self.refs.append(item)
+        else:
+            logging.warning(f"Item {item} is already in node refs")
+
+    def remove_obj_from_refs(self, item) -> None:
+        if item in self.refs:
+            self.refs.remove(item)
+        else:
+            logging.warning(f"Item {item} is not in node refs")
 
     @property
     def units(self):
@@ -66,10 +90,10 @@ class Node:
     @units.setter
     def units(self, value):
         if value != self._units:
-            from ada.core.utils import roundoff, unit_length_conversion
+            from ada.core.utils import unit_length_conversion
 
             scale_factor = unit_length_conversion(self._units, value)
-            self.p = np.array([roundoff(scale_factor * x) for x in self.p])
+            self.p_roundoff(scale_factor)
 
             if self._r is not None:
                 self._r *= scale_factor
@@ -84,7 +108,7 @@ class Node:
         self._parent = value
 
     @property
-    def refs(self) -> List[Union["Elem", "Beam", "Csys"]]:
+    def refs(self) -> List[Union[Elem, Beam, Csys]]:
         return self._refs
 
     def __getitem__(self, index):
@@ -102,12 +126,12 @@ class Node:
     def __le__(self, other):
         return tuple(self.p) <= tuple(other.p)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Node):
         if not isinstance(other, Node):
             return NotImplemented
         return (*self.p, self.id) == (*other.p, other.id)
 
-    def __ne__(self, other):
+    def __ne__(self, other: Node):
         if not isinstance(other, Node):
             return NotImplemented
         return (*self.p, self.id) != (*other.p, other.id)
@@ -117,3 +141,15 @@ class Node:
 
     def __repr__(self):
         return f"Node([{self.x}, {self.y}, {self.z}], {self.id})"
+
+
+def get_singular_node_by_volume(nodes: Nodes, p: np.ndarray, tol=Settings.point_tol) -> Node:
+    """Returns existing node within the volume, or creates and returns a new Node at the point"""
+    nds = nodes.get_by_volume(p, tol=tol)
+    if len(nds) > 0:
+        node, *other_nodes = nds
+        if len(other_nodes) > 0:
+            logging.warning(f"More than 1 node within point {p}, other nodes: {other_nodes}. Returns node {node}")
+        return node
+    else:
+        return Node(p)

--- a/src/ada/core/clash_check.py
+++ b/src/ada/core/clash_check.py
@@ -57,6 +57,7 @@ def beam_cross_check(bm1: Beam, bm2: Beam, outofplane_tol=0.1):
 
 
 def are_beams_connected(bm1: Beam, beams: List[Beam], out_of_plane_tol, point_tol, nodes, nmap) -> None:
+    # TODO: Function should be renamed, or return boolean. Unclear what the function does at the moment
     for bm2 in beams:
         if bm1 == bm2:
             continue

--- a/src/ada/core/utils.py
+++ b/src/ada/core/utils.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import annotations
+
 import logging
 import os
 import pathlib
@@ -68,12 +70,12 @@ def random_color():
     return format_color(randint(0, 255), randint(0, 255), randint(0, 255))
 
 
-def d2npy(node: "Node") -> np.ndarray:
+def d2npy(node: Node) -> np.ndarray:
     """This method takes in a node object and returns a np.array."""
     return np.array([node.x, node.y, node.z], dtype=np.float)
 
 
-def roundoff(x: float, precision=6) -> float:
+def roundoff(x: float, precision=Settings.precision) -> float:
     """Round using a specific number precision using the Decimal package"""
     import warnings
 
@@ -300,7 +302,7 @@ def faceted_tol(units):
         return 1
 
 
-def replace_node(old_node, new_node):
+def replace_node(old_node, new_node) -> None:
     """
 
     :param old_node:

--- a/src/ada/core/vector_utils.py
+++ b/src/ada/core/vector_utils.py
@@ -2,6 +2,8 @@ from typing import List
 
 import numpy as np
 
+from ada.config import Settings
+
 
 def linear_2dtransform_rotate(origin, point, degrees) -> np.ndarray:
     """
@@ -231,14 +233,39 @@ def sort_points_by_dist(p, points):
     return sorted(points, key=lambda x: vector_length(x - p))
 
 
-def is_point_on_line(a, b, p):
+def is_between_endpoints(p: np.ndarray, start: np.ndarray, end: np.ndarray, incl_endpoints: bool = False) -> bool:
+    """Returns if point p is on the line between the points start and end"""
+    ab = end - start
+    ap = p - start
+    on_line_segment = 0.0 <= get_vec_fraction(ap, ab) <= 1.0 if incl_endpoints else 0.0 < get_vec_fraction(ap, ab) < 1.0
+    return is_parallel(ab, ap) and on_line_segment
+
+
+def get_vec_fraction(vec: np.ndarray, reference_vec: np.ndarray) -> float:
+    """Returns the fraction of the projection of vec onto reference_vec."""
+    return np.dot(vec, reference_vec) / np.dot(reference_vec, reference_vec)
+
+
+def point_on_line(a: np.ndarray, b: np.ndarray, p: np.ndarray) -> np.ndarray:
+    """
+
+    :param a: Start of line
+    :param b: End of line
+    :param p: Point
+    :return:
+    """
     ap = p - a
     ab = b - a
     result = a + np.dot(ap, ab) / np.dot(ab, ab) * ab
     return result
 
 
-def is_parallel(ab: np.array, cd: np.array, tol=0.0001) -> bool:
+def is_null_vector(ab: np.array, cd: np.array, decimals=Settings.precision) -> bool:
+    """Check if difference in vectors AB and CD null vector"""
+    return np.array_equal((cd - ab).round(decimals), np.zeros_like(ab))
+
+
+def is_parallel(ab: np.array, cd: np.array, tol=Settings.point_tol) -> bool:
     """Check if vectors AB and CD are parallel"""
     return True if np.abs(np.sin(angle_between(ab, cd))) < tol else False
 

--- a/src/ada/fem/formats/utils.py
+++ b/src/ada/fem/formats/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -395,7 +397,7 @@ def should_convert(res_path, overwrite):
         return False
 
 
-def convert_shell_elem_to_plates(elem: "Elem", parent: "Part") -> List[Plate]:
+def convert_shell_elem_to_plates(elem: Elem, parent: Part) -> List[Plate]:
     from ada.core.vector_utils import is_coplanar
 
     plates = []
@@ -431,17 +433,17 @@ def convert_shell_elem_to_plates(elem: "Elem", parent: "Part") -> List[Plate]:
     return plates
 
 
-def convert_part_shell_elements_to_plates(p: "Part") -> Plates:
+def convert_part_shell_elements_to_plates(p: Part) -> Plates:
     return Plates(
         list(chain.from_iterable([convert_shell_elem_to_plates(sh, p) for sh in p.fem.elements.shell])), parent=p
     )
 
 
-def convert_part_elem_bm_to_beams(p: "Part") -> Beams:
+def convert_part_elem_bm_to_beams(p: Part) -> Beams:
     return Beams([line_elem_to_beam(bm, p) for bm in p.fem.elements.lines], parent=p)
 
 
-def line_elem_to_beam(elem: Elem, parent: "Part") -> Beam:
+def line_elem_to_beam(elem: Elem, parent: Part) -> Beam:
     """Convert FEM line element to Beam"""
 
     a = parent.get_assembly()
@@ -475,7 +477,7 @@ def line_elem_to_beam(elem: Elem, parent: "Part") -> Beam:
     )
 
 
-def convert_part_objects(p: "Part", skip_plates, skip_beams):
+def convert_part_objects(p: Part, skip_plates, skip_beams):
     if skip_plates is False:
         p._plates = convert_part_shell_elements_to_plates(p)
     if skip_beams is False:


### PR DESCRIPTION
Changes are related to:
- typing and type hints, tying to make code consistent using `from __future__ import annotations`.


Additions are related to:
- merging beams
- splitting beam into two beams
- vector functions related to merging and splitting beams
- rounding of point precision on node
- safe adding/removing of objects to/from `Node.refs`
