### PR TITLE
Sections, and how to write names to FEM files and compare properties

### DIFF
--- a/src/ada/calc/beams.py
+++ b/src/ada/calc/beams.py
@@ -44,7 +44,7 @@ def displ(x, w, E, I, L):
     :eq: $$\\Delta_x=\\frac{wx}{24EI}(L^3-2Lx^2+x^3)$$
 
     """
-    return w * x * (L**3 - 2 * L * x**2 + x**3) / (24 * E * I)
+    return w * x * (L ** 3 - 2 * L * x ** 2 + x ** 3) / (24 * E * I)
 
 
 def moment(x, w, L):

--- a/src/ada/core/curve_fitting_utils.py
+++ b/src/ada/core/curve_fitting_utils.py
@@ -10,7 +10,7 @@ def bernstein(n, k):
     coeff = binom(n, k)
 
     def _bpoly(x):
-        return coeff * x**k * (1 - x) ** (n - k)
+        return coeff * x ** k * (1 - x) ** (n - k)
 
     return _bpoly
 
@@ -70,7 +70,7 @@ def curve_f3(x, a, b):
 
 def curve_f4(x, a, b, c):
     """And yet another base function for use in curve fitting"""
-    return a * x**3 + b * x**2 + c * x
+    return a * x ** 3 + b * x ** 2 + c * x
 
 
 def sum_of_squared_error(parameter_tuple, *args):

--- a/src/ada/core/curve_utils.py
+++ b/src/ada/core/curve_utils.py
@@ -678,7 +678,7 @@ def intersect_line_circle(line, center, radius):
 
     a = (x2 - x1) ** 2 + (y2 - y1) ** 2 + (z2 - z1) ** 2
     b = 2 * ((x2 - x1) * (x1 - x3) + (y2 - y1) * (y1 - y3) + (z2 - z1) * (z1 - z3))
-    c = x3**2 + y3**2 + z3**2 + x1**2 + y1**2 + z1**2 - 2 * (x3 * x1 + y3 * y1 + z3 * z1) - radius**2
+    c = x3 ** 2 + y3 ** 2 + z3 ** 2 + x1 ** 2 + y1 ** 2 + z1 ** 2 - 2 * (x3 * x1 + y3 * y1 + z3 * z1) - radius ** 2
 
     tol = 1e-1
     # if abs(b) < tol:

--- a/src/ada/core/file_system.py
+++ b/src/ada/core/file_system.py
@@ -51,9 +51,9 @@ def convert_unit(size_in_bytes, unit):
     if unit == SIZE_UNIT.KB:
         return size_in_bytes / 1024
     elif unit == SIZE_UNIT.MB:
-        return size_in_bytes / (1024**2)
+        return size_in_bytes / (1024 ** 2)
     elif unit == SIZE_UNIT.GB:
-        return size_in_bytes / (1024**3)
+        return size_in_bytes / (1024 ** 3)
     else:
         return size_in_bytes
 

--- a/src/ada/core/vector_utils.py
+++ b/src/ada/core/vector_utils.py
@@ -283,12 +283,12 @@ def is_null_vector(ab: np.array, cd: np.array, decimals=Settings.precision) -> b
 
 def is_parallel(ab: np.array, cd: np.array, tol=Settings.point_tol) -> bool:
     """Check if vectors AB and CD are parallel"""
-    return True if np.abs(np.sin(angle_between(ab, cd))) < tol else False
+    return float(np.abs(np.sin(angle_between(ab, cd)))) < tol
 
 
 def is_perpendicular(ab: np.array, cd: np.array, tol=Settings.point_tol) -> bool:
     """Returns if the vectors are perpendicular"""
-    return np.abs(np.dot(ab, cd)) < tol
+    return float(np.abs(np.dot(ab, cd))) < tol
 
 
 def is_angled(vector_1: np.ndarray, vector_2: np.ndarray) -> bool:
@@ -574,7 +574,7 @@ def is_clockwise(points) -> bool:
     for p1, p2 in zip(points[:-1], points[1:]):
         psum += (p2[0] - p1[0]) * (p2[1] + p1[1])
     psum += (points[-1][0] - points[0][0]) * (points[-1][1] + points[0][1])
-    return not psum < 0
+    return not float(psum) < 0
 
 
 def calc_xvec(y_vec, z_vec):

--- a/src/ada/fem/formats/abaqus/read/read_sections.py
+++ b/src/ada/fem/formats/abaqus/read/read_sections.py
@@ -94,29 +94,29 @@ def get_beam_sections_from_inp(bulk_str: str, fem: FEM) -> Iterable[FemSection]:
                 Ax=h * (a + b) / 2,
                 Ix=h
                 * (
-                    b * h**2
-                    + 3 * a * h**2
-                    + a**3
-                    + 3 * a * c**2
-                    + 3 * c * a**2
-                    + b**3
-                    + c * b**2
-                    + a * b**2
-                    + b * c**2
+                    b * h ** 2
+                    + 3 * a * h ** 2
+                    + a ** 3
+                    + 3 * a * c ** 2
+                    + 3 * c * a ** 2
+                    + b ** 3
+                    + c * b ** 2
+                    + a * b ** 2
+                    + b * c ** 2
                     + 2 * a * b * c
-                    + b * a**2
+                    + b * a ** 2
                 ),
-                Iy=(h**3) * (3 * a + b) / 12,
+                Iy=(h ** 3) * (3 * a + b) / 12,
                 Iz=h
                 * (
-                    a**3
-                    + 3 * a * c**2
-                    + 3 * c * a**2
-                    + b**3
-                    + c * b**2
-                    + a * b**2
+                    a ** 3
+                    + 3 * a * c ** 2
+                    + 3 * c * a ** 2
+                    + b ** 3
+                    + c * b ** 2
+                    + a * b ** 2
                     + 2 * a * b * c
-                    + b * a**2
+                    + b * a ** 2
                 )
                 / 12,
             )

--- a/src/ada/fem/formats/abaqus/write/write_sections.py
+++ b/src/ada/fem/formats/abaqus/write/write_sections.py
@@ -151,9 +151,9 @@ def eval_general_properties(section: Section) -> GeneralProperties:
     if gp.Iyz <= 0.0:
         gp.Iyz = (gp.Iy + gp.Iz) / 2
         logging.error(f"Section {name} Iyz <= 0.0. Changing to (Iy + Iz) / 2. {log_fin}")
-    if gp.Iy * gp.Iz - gp.Iyz**2 < 0:
+    if gp.Iy * gp.Iz - gp.Iyz ** 2 < 0:
         old_y = str(gp.Iy)
-        gp.Iy = 1.1 * (gp.Iy + (gp.Iyz**2) / gp.Iz)
+        gp.Iy = 1.1 * (gp.Iy + (gp.Iyz ** 2) / gp.Iz)
         logging.error(
             f"Warning! Section {name}: I(11)*I(22)-I(12)**2 MUST BE POSITIVE. " f"Mod Iy={old_y} to {gp.Iy}. {log_fin}"
         )

--- a/src/ada/fem/formats/sesam/read/read_sections.py
+++ b/src/ada/fem/formats/sesam/read/read_sections.py
@@ -67,7 +67,6 @@ def get_isection(match, sect_names, fem) -> Section:
         w_btn=roundoff(d["bb"]),
         t_ftop=roundoff(d["tt"]),
         t_fbtn=roundoff(d["tb"]),
-        genprops=GeneralProperties(Sfy=float(d["sfy"]), Sfz=float(d["sfz"])),
         parent=fem.parent,
     )
 
@@ -85,7 +84,6 @@ def get_box_section(match, sect_names, fem) -> Section:
         t_w=roundoff(d["ty"]),
         t_ftop=roundoff(d["tt"]),
         t_fbtn=roundoff(d["tb"]),
-        genprops=GeneralProperties(Sfy=float(d["sfy"]), Sfz=float(d["sfz"])),
         parent=fem.parent,
     )
 
@@ -100,7 +98,6 @@ def get_flatbar(match, sect_names, fem) -> Section:
         h=roundoff(d["hz"]),
         w_top=roundoff(d["bt"]),
         w_btn=roundoff(d["bb"]),
-        genprops=GeneralProperties(Sfy=float(d["sfy"]), Sfz=float(d["sfz"])),
         parent=fem.parent,
     )
 
@@ -150,7 +147,6 @@ def get_tubular_section(match, sect_names, fem) -> Section:
         sec_type=Section.TYPES.TUBULAR,
         r=roundoff(float(d["dy"]) / 2),
         wt=roundoff(t),
-        genprops=GeneralProperties(Sfy=float(d["sfy"]), Sfz=float(d["sfz"])),
         parent=fem.parent,
     )
 

--- a/src/ada/fem/formats/sesam/write/write_sections.py
+++ b/src/ada/fem/formats/sesam/write/write_sections.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass
-from typing import List, Tuple, Union
 
 from ada import FEM, Beam, Section
 from ada.core.utils import Counter, make_name_fem_ready
@@ -18,12 +17,16 @@ concept_ircon = Counter(1)
 
 
 @dataclass
-class BmSectionStr:
-    sec_str: str
-    names_str: str
-    tdsconc_str: str
-    sconcept_str: str
-    scon_mesh: str
+class ConceptSection:
+    sec_str: str = ""
+    names_str: str = ""
+
+
+@dataclass
+class ConceptStructure:
+    tdsconc_str: str = ""
+    sconcept_str: str = ""
+    scon_mesh: str = ""
 
 
 def sections_str(fem: FEM, thick_map) -> str:
@@ -37,14 +40,14 @@ def sections_str(fem: FEM, thick_map) -> str:
     sec_names = []
     for fem_sec in fem.sections:
         if fem_sec.type == ElemType.LINE:
-            res = create_line_section(fem_sec, sec_names, sec_ids)
-            if res is None:
-                continue
-            names_str += res.names_str
-            sec_str += res.sec_str
-            tdsconc_str += res.tdsconc_str
-            sconcept_str += res.sconcept_str
-            scon_mesh += res.scon_mesh
+            sec = create_line_section(fem_sec, sec_names, sec_ids)
+            names_str += sec.names_str
+            sec_str += sec.sec_str
+
+            stru = create_sconcept_str(fem_sec)
+            tdsconc_str += stru.tdsconc_str
+            sconcept_str += stru.sconcept_str
+            scon_mesh += stru.scon_mesh
         elif fem_sec.type == ElemType.SHELL:
             sec_str += create_shell_section_str(fem_sec, thick_map)
         elif fem_sec.type == ElemType.SOLID:
@@ -64,13 +67,13 @@ def create_shell_section_str(fem_sec: FemSection, thick_map) -> str:
     return write_ff("GELTH", [(sh_id, fem_sec.thickness, 5)])
 
 
-def create_line_section(fem_sec: FemSection, sec_names: List[str], sec_ids: List[Section]) -> Union[BmSectionStr, None]:
+def create_line_section(fem_sec: FemSection, sec_names: list[str], sec_ids: list[Section]) -> ConceptSection:
     from .write_bm_profiles import write_bm_section
 
     sec = fem_sec.section
     if sec in sec_ids:
         logging.info(f'Skipping already included section "{sec}"')
-        return None
+        return ConceptSection()
 
     sec_ids.append(sec)
 
@@ -88,21 +91,17 @@ def create_line_section(fem_sec: FemSection, sec_names: List[str], sec_ids: List
         ],
     )
     sec_str = write_bm_section(sec, sec.id)
-    if fem_sec.refs is not None:
-        tdsconc_str, sconcept_str, scon_mesh = create_sconcept_str(fem_sec)
-    else:
-        tdsconc_str, sconcept_str, scon_mesh = "", "", ""
-
-    return BmSectionStr(
-        sec_str=sec_str, names_str=names_str, tdsconc_str=tdsconc_str, sconcept_str=sconcept_str, scon_mesh=scon_mesh
-    )
+    return ConceptSection(sec_str=sec_str, names_str=names_str)
 
 
 def create_solid_section(fem_sec: FemSection):
     raise IncompatibleElements(f"Solid element type {fem_sec.type} is not yet supported for writing to Sesam")
 
 
-def create_sconcept_str(fem_sec: FemSection) -> Tuple[str, str, str]:
+def create_sconcept_str(fem_sec: FemSection) -> ConceptStructure:
+    if fem_sec.refs is None:
+        return ConceptStructure()
+
     sconcept_str = ""
     # Give concept relationship based on inputted values
 
@@ -111,16 +110,19 @@ def create_sconcept_str(fem_sec: FemSection) -> Tuple[str, str, str]:
         raise ValueError("A FemSection cannot be sourced from multiple beams")
     beam = beams[0]
 
-    fem_sec.metadata["ircon"] = next(concept_ircon)
+    ircon = next(concept_ircon)
+    ircon_mesh = next(concept_ircon)
+
+    fem_sec.metadata["ircon"] = ircon
     bm_name = make_name_fem_ready(beam.name, no_dot=True)
     tdsconc_str = write_ff(
         "TDSCONC",
-        [(4, fem_sec.metadata["ircon"], 100 + len(bm_name), 0), (bm_name,)],
+        [(4, ircon, 100 + len(bm_name), 0), (bm_name,)],
     )
-    sconcept_str += write_ff("SCONCEPT", [(8, next(concept), 7, 0), (0, 1, 0, 2)])
-    sconc_ref = next(concept)
-    sconcept_str += write_ff("SCONCEPT", [(5, sconc_ref, 2, 4), (1,)])
-    elids: List[tuple] = []
+
+    sconcept_str += write_ff("SCONCEPT", [(8, ircon, 7, 0), (0, 1, 0, ircon_mesh)])
+    sconcept_str += write_ff("SCONCEPT", [(5, ircon_mesh, 2, 4), (ircon,)])
+    elids: list[tuple] = []
     i = 0
 
     numel = len(beam.elem_refs)
@@ -135,6 +137,6 @@ def create_sconcept_str(fem_sec: FemSection) -> Tuple[str, str, str]:
     if len(elid_bulk) != 0:
         elids.append(tuple(elid_bulk))
 
-    mesh_args = [(5 + numel, sconc_ref, 1, 2)] + elids
+    mesh_args = [(5 + numel, ircon_mesh, 1, 2)] + elids
     scon_mesh = write_ff("SCONMESH", mesh_args)
-    return tdsconc_str, sconcept_str, scon_mesh
+    return ConceptStructure(tdsconc_str, sconcept_str, scon_mesh)

--- a/src/ada/fem/formats/sesam/write/writer.py
+++ b/src/ada/fem/formats/sesam/write/writer.py
@@ -61,7 +61,7 @@ def to_fem(assembly, name, analysis_dir=None, metadata=None):
         d.write(hinges_str(part.fem))
         d.write(elem_str(part.fem, thick_map))
         d.write(loads_str(assembly.fem) + loads_str(part.fem))
-        d.write("IEND                0.00            0.00            0.00            0.00")
+        d.write("IEND                0.00            0.00            0.00            0.00\n")
 
     print(f'Created an Sesam input deck at "{analysis_dir}"')
 

--- a/src/ada/ifc/utils.py
+++ b/src/ada/ifc/utils.py
@@ -555,11 +555,11 @@ def scale_ifc_file_object(ifc_file, scale_factor):
                         return obj_
                     elif obj_.is_a("IfcPressureMeasure") or obj_.is_a("IfcModulusOfElasticityMeasure"):
                         # sf is a length unit.
-                        conv_unit = 1 / sf**2
+                        conv_unit = 1 / sf ** 2
                         obj_.wrappedValue = obj_.wrappedValue * conv_unit
                         return obj_
                     elif obj_.is_a("IfcMassDensityMeasure"):
-                        conv_unit = 1 / sf**3
+                        conv_unit = 1 / sf ** 3
                         obj_.wrappedValue = obj_.wrappedValue * conv_unit
                         return obj_
                     # Unit-less

--- a/src/ada/materials/metals/base_models.py
+++ b/src/ada/materials/metals/base_models.py
@@ -331,7 +331,7 @@ class CarbonSteel(Metal):
             for x in np.where(np.logical_and(self._temp_range > phase2_end, self._temp_range <= phase3_end))
         ]
         phase4_arr = [self._temp_range[x] for x in np.where(self._temp_range > phase3_end)]
-        phase1 = [425 + 7.73 * 1e-1 * t - 1.69 * 1e-3 * (t**2) + 2.22 * 1e-6 * t**3 for t in phase1_arr[0]]
+        phase1 = [425 + 7.73 * 1e-1 * t - 1.69 * 1e-3 * (t ** 2) + 2.22 * 1e-6 * t ** 3 for t in phase1_arr[0]]
         phase2 = [666 + 13002 / (738 - t) for t in phase2_arr[0]]
         phase3 = [545 + 17820 / (t - 731) for t in phase3_arr[0]]
         phase4 = [650 for x in range(phase4_arr[0].shape[0])]

--- a/src/ada/materials/polymers/models.py
+++ b/src/ada/materials/polymers/models.py
@@ -398,9 +398,9 @@ def neo_hookean(strain, mu, load_type="uniaxial"):
     if load_type == "uniaxial":
         return mu * (lam * lam - 1.0 / lam)
     elif load_type == "biaxial":
-        return mu * (lam * lam - 1.0 / lam**4)
+        return mu * (lam * lam - 1.0 / lam ** 4)
     elif load_type == "planar":
-        return mu * (lam * lam - 1.0 / lam**2)
+        return mu * (lam * lam - 1.0 / lam ** 2)
     else:
         print(f"unknown load type {load_type}")
         return None
@@ -409,13 +409,13 @@ def neo_hookean(strain, mu, load_type="uniaxial"):
 def yeoh(strain, c10, c20, c30, load_type="uniaxial"):
     """Yeoh incompressible"""
     lam = np.exp(strain)
-    i1 = lam**2 + 2.0 / lam
+    i1 = lam ** 2 + 2.0 / lam
     if load_type == "uniaxial":
-        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam**2 - 1.0 / lam)
+        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam ** 2 - 1.0 / lam)
     elif load_type == "biaxial":
-        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam**2 - 1.0 / lam**4)
+        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam ** 2 - 1.0 / lam ** 4)
     elif load_type == "planar":
-        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam**2 - 1.0 / lam**2)
+        return 2 * (c10 + 2 * c20 * (i1 - 3) + 3 * c30 * (i1 - 3) ** 2) * (lam ** 2 - 1.0 / lam ** 2)
     else:
         print(f"unknown load type {load_type}")
         return None

--- a/src/ada/sections/concept.py
+++ b/src/ada/sections/concept.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Tuple, Union
 
 from ada.base.non_phyical_objects import Backend
 from ada.concepts.curves import CurvePoly
 from ada.config import Settings
-
-from .categories import BaseTypes, SectionCat
+from ada.sections.categories import BaseTypes, SectionCat
 
 if TYPE_CHECKING:
     from ada import Beam
@@ -313,7 +312,7 @@ class SectionParts:
 
 @dataclass
 class GeneralProperties:
-    parent: Section = None
+    parent: Section = field(default=None, compare=False)
     Ax: float = None
     Ix: float = None
     Iy: float = None
@@ -335,18 +334,14 @@ class GeneralProperties:
 
     @property
     def modified(self) -> bool:
-        from .properties import calculate_general_properties
+        """Returns true if attributes are not equal to the calculated properties of the parent section"""
+        return self != self.calc_parent_properties()
 
-        return self != calculate_general_properties(self.parent)
+    def calc_parent_properties(self) -> GeneralProperties:
+        """Returns calculated properties based on parent section"""
+        from ada.sections.properties import calculate_general_properties
 
-    def __eq__(self, other):
-        for key, val in self.__dict__.items():
-            if "parent" in key:
-                continue
-            if other.__dict__[key] != val:
-                return False
-
-        return True
+        return calculate_general_properties(self.parent)
 
 
 @dataclass

--- a/src/ada/sections/concept.py
+++ b/src/ada/sections/concept.py
@@ -83,6 +83,9 @@ class Section(Backend):
         if genprops is not None:
             genprops.parent = self
             self._genprops = genprops
+        # prop = self.properties
+        # if None in (prop.Cy, prop.Cz) and self.type != Section.TYPES.GENERAL:
+        #     logging.warning("Attribute Cy and Cz is missing from instance of Properties")
 
     # def __eq__(self, other: Section):
     #     props_equal = self.equal_props(other)

--- a/src/ada/sections/properties.py
+++ b/src/ada/sections/properties.py
@@ -80,15 +80,15 @@ def calc_box(sec: Section) -> GeneralProperties:
     hb = sec.w_top - sec.t_w
 
     Ix = 4 * (ha * hb) ** 2 / (hb / tb + hb / ty + 2 * ha / ty)
-    Iy = (by * (tb**3 + tt**3) + 2 * ty * d**3) / 12 + e * (h - a) ** 2 + f * (c - h) ** 2 + 2 * g * (b - h) ** 2
+    Iy = (by * (tb ** 3 + tt ** 3) + 2 * ty * d ** 3) / 12 + e * (h - a) ** 2 + f * (c - h) ** 2 + 2 * g * (b - h) ** 2
 
-    Iz = ((sec.t_fbtn + sec.t_ftop) * sec.w_top**3 + 2 * d * sec.t_w**3) / 12 + (g * hb**2) / 2
+    Iz = ((sec.t_fbtn + sec.t_ftop) * sec.w_top ** 3 + 2 * d * sec.t_w ** 3) / 12 + (g * hb ** 2) / 2
     Iyz = 0
     Wxmin = Ix * (hb + ha) / (ha * hb)
     Wymin = Iy / max(sec.h - h, h)
     Wzmin = 2 * Iz / sec.w_top
     Sy = e * (h - a) + ty * (h - tb) ** 2
-    Sz = (sec.t_fbtn + sec.t_ftop) * sec.w_top**2 / 8 + g * hb / 2
+    Sz = (sec.t_fbtn + sec.t_ftop) * sec.w_top ** 2 / 8 + g * hb / 2
     Shary = (Iz / Sz) * 2 * sec.t_w * sfy
     Sharz = (Iy / Sy) * 2 * ty * sfz
     Shceny = 0
@@ -138,19 +138,19 @@ def calc_isec(sec: Section) -> GeneralProperties:
 
     z = (bt * tt * a + hw * ty * b + bb * tb * c) / Ax
 
-    tra = (bt * tb**3) / 12 + bt * tt * (hz - tt / 2 - z) ** 2
-    trb = (ty * hw**3) / 12 + ty * hw * (tb + hw / 2 - z) ** 2
-    trc = (bb * tb**3) / 12 + bb * tb * (tb / 2 - z) ** 2
+    tra = (bt * tb ** 3) / 12 + bt * tt * (hz - tt / 2 - z) ** 2
+    trb = (ty * hw ** 3) / 12 + ty * hw * (tb + hw / 2 - z) ** 2
+    trc = (bb * tb ** 3) / 12 + bb * tb * (tb / 2 - z) ** 2
 
     if tt == ty and tt == tb:
-        Ix = (tt**3) * (hw + bt + bb - 1.2 * tt) / 3
+        Ix = (tt ** 3) * (hw + bt + bb - 1.2 * tt) / 3
         Wxmin = Ix / tt
     else:
-        Ix = 1.3 * (bt * tt**3 + hw * ty**3 + bb * tb**3) / 3
+        Ix = 1.3 * (bt * tt ** 3 + hw * ty ** 3 + bb * tb ** 3) / 3
         Wxmin = Ix / max(tt, ty, tb)
 
     Iy = tra + trb + trc
-    Iz = (tb * bb**3 + hw * ty**3 + tt * bt**3) / 12
+    Iz = (tb * bb ** 3 + hw * ty ** 3 + tt * bt ** 3) / 12
     Iyz = 0
     Wymin = Iy / max(hz - z, z)
     Wzmin = 2 * Iz / max(bb, bt)
@@ -161,11 +161,11 @@ def calc_isec(sec: Section) -> GeneralProperties:
     Sy = Iy / (sec.w_top / 2)
 
     # Sy = (sec.t_w*sec.h/2)(sec.h/2)
-    Sz = (tt * bt**2 + tb * bb**2 + hw * ty**2) / 8
+    Sz = (tt * bt ** 2 + tb * bb ** 2 + hw * ty ** 2) / 8
     Shary = (Iz / Sz) * (tb + tt) * sfy
     Sharz = (Iy / Sy) * ty * sfz
     Shceny = 0
-    Shcenz = ((hz - tt / 2) * tt * bt**3 + (tb**2) * (bb**3) / 2) / (tt * bt**3 + tb * bb**3) - z
+    Shcenz = ((hz - tt / 2) * tt * bt ** 3 + (tb ** 2) * (bb ** 3) / 2) / (tt * bt ** 3 + tb * bb ** 3) - z
     Cy = bb / 2
     Cz = z
 
@@ -223,12 +223,12 @@ def calc_angular(sec: Section) -> GeneralProperties:
 
     # Iz_a + A_a*dcy_a**2
 
-    Iz_a = (1 / 12) * a_h * a_w**3 + a_area * a_dcy**2
-    Iz_b = (1 / 12) * b_h * b_w**3 + b_area * b_dcy**2
+    Iz_a = (1 / 12) * a_h * a_w ** 3 + a_area * a_dcy ** 2
+    Iz_b = (1 / 12) * b_h * b_w ** 3 + b_area * b_dcy ** 2
     Iz = Iz_a + Iz_b
 
-    Iy_a = (1 / 12) * a_w * a_h**3 + a_area * a_dcz**2
-    Iy_b = (1 / 12) * b_w * b_h**3 + b_area * b_dcz**2
+    Iy_a = (1 / 12) * a_w * a_h ** 3 + a_area * a_dcz ** 2
+    Iy_b = (1 / 12) * b_w * b_h ** 3 + b_area * b_dcz ** 2
     Iy = Iy_a + Iy_b
 
     posweb = False
@@ -246,8 +246,8 @@ def calc_angular(sec: Section) -> GeneralProperties:
     b = tz - hw / 2.0
     c = tz / 2.0
     piqrt = np.arctan(1.0)
-    Ax = ty * hw + by * tz + (1 - piqrt) * r**2
-    y = (hw * ty**2 + tz * by**2) / (2 * Ax)
+    Ax = ty * hw + by * tz + (1 - piqrt) * r ** 2
+    y = (hw * ty ** 2 + tz * by ** 2) / (2 * Ax)
     z = (hw * b * ty + tz * by * c) / Ax
     d = 6 * r + 2 * (ty + tz - np.sqrt(4 * r * (2 * r + ty + tz) + 2 * ty * tz))
     e = hw + tz - z
@@ -262,14 +262,14 @@ def calc_angular(sec: Section) -> GeneralProperties:
     else:
         raise ValueError("Currently not implemented this yet")
 
-    Ix = (1 / 3) * (by * tz**3 + (hz - tz) * ty**3)
-    Iyz = (rl * tz / 2) * (y**2 - rj**2) - (rk * ty / 2) * (e**2 - f**2)
+    Ix = (1 / 3) * (by * tz ** 3 + (hz - tz) * ty ** 3)
+    Iyz = (rl * tz / 2) * (y ** 2 - rj ** 2) - (rk * ty / 2) * (e ** 2 - f ** 2)
 
     Wxmin = Ix / d
     Wymin = Iy / max(z, hz - h)
     Wzmin = Iz / max(y, rj)
-    Sy = (ty * e**2) / 2
-    Sz = (tz * rj**2) / 2
+    Sy = (ty * e ** 2) / 2
+    Sz = (tz * rj ** 2) / 2
     Shary = (Iz * tz / Sz) * sfy
     Sharz = (Iy * tz / Sy) * sfz
 
@@ -315,7 +315,7 @@ def calc_tubular(sec: Section) -> GeneralProperties:
 
     dy = sec.r * 2
     di = dy - 2 * t
-    Ax = np.pi * sec.r**2 - np.pi * (sec.r - t) ** 2
+    Ax = np.pi * sec.r ** 2 - np.pi * (sec.r - t) ** 2
     Ix = 0.5 * np.pi * ((dy / 2) ** 4 - (di / 2) ** 4)
     Iy = Ix / 2
     Iz = Iy
@@ -323,7 +323,7 @@ def calc_tubular(sec: Section) -> GeneralProperties:
     Wxmin = 2 * Ix / dy
     Wymin = 2 * Iy / dy
     Wzmin = 2 * Iz / dy
-    Sy = (dy**3 - di**3) / 12
+    Sy = (dy ** 3 - di ** 3) / 12
     Sz = Sy
     Shary = (2 * Iz * t / Sy) * sfy
     Sharz = (2 * Iy * t / Sz) * sfz
@@ -360,11 +360,11 @@ def calc_circular(sec: Section) -> GeneralProperties:
     Sfz = 1.0
     Iyz = 0.0
 
-    Ax = np.pi * sec.r**2
-    Iy = (np.pi * sec.r**4) / 4
+    Ax = np.pi * sec.r ** 2
+    Iy = (np.pi * sec.r ** 4) / 4
     Iz = Iy
-    Ix = 0.5 * np.pi * sec.r**4
-    Wymin = 0.25 * np.pi * sec.r**3
+    Ix = 0.5 * np.pi * sec.r ** 4
+    Wymin = 0.25 * np.pi * sec.r ** 3
     Wzmin = Wymin
 
     Wxmin = Ix / sec.r
@@ -372,7 +372,7 @@ def calc_circular(sec: Section) -> GeneralProperties:
     t = sec.r * 0.99
     dy = sec.r * 2
     di = dy - 2 * t
-    Sy = (dy**3 - di**3) / 12
+    Sy = (dy ** 3 - di ** 3) / 12
     Sz = Sy
     Shary = (2 * Iz * t / Sy) * Sfy
     Sharz = (2 * Iy * t / Sz) * Sfz
@@ -418,33 +418,33 @@ def calc_flatbar(sec: Section) -> GeneralProperties:
     Sfz = 1.0
 
     Ax = w * hz
-    Iy = w * hz**3 / 12
-    Iz = hz * w**3 / 12
+    Iy = w * hz ** 3 / 12
+    Iz = hz * w ** 3 / 12
 
-    bm = 2 * w * hz**2 / (hz**2 + Ax**2)
+    bm = 2 * w * hz ** 2 / (hz ** 2 + Ax ** 2)
     Wymin = Iy / max(h, d)
     Wzmin = 2 * Iz / max(w, w)
     Iyz = 0.0
     if hz == bm:
         ca = 0.141
         cb = 0.208
-        Ix = ca * hz**4
-        Wxmin = cb * hz**3
+        Ix = ca * hz ** 4
+        Wxmin = cb * hz ** 3
     elif hz < bm:
         cn = bm / hz
-        ca = (1 - 0.63 / cn + 0.052 / cn**5) * 3
-        cb = ca / (1 - 0.63 / (1 + cn**3))
-        Ix = ca * bm * hz**3
-        Wxmin = cb * bm * hz**2
+        ca = (1 - 0.63 / cn + 0.052 / cn ** 5) * 3
+        cb = ca / (1 - 0.63 / (1 + cn ** 3))
+        Ix = ca * bm * hz ** 3
+        Wxmin = cb * bm * hz ** 2
     else:
         cn = hz / bm
-        ca = (1 - 0.63 / cn + 0.052 / cn**5) * 3
-        cb = ca / (1 - 0.63 / (1 + cn**3))
-        Ix = ca * hz * bm**3
-        Wxmin = cb * hz * bm**3
+        ca = (1 - 0.63 / cn + 0.052 / cn ** 5) * 3
+        cb = ca / (1 - 0.63 / (1 + cn ** 3))
+        Ix = ca * hz * bm ** 3
+        Wxmin = cb * hz * bm ** 3
 
-    Sy = (w * h**2) / 2 + (b - w / 2) * (h**2) / 3
-    Sz = hz * ((w**2) / 8 + a * (w / 4 + a / 6))
+    Sy = (w * h ** 2) / 2 + (b - w / 2) * (h ** 2) / 3
+    Sz = hz * ((w ** 2) / 8 + a * (w / 4 + a / 6))
 
     Shary = Iz * hz * Sfy / Sz
     Sharz = 2 * Iy * b * Sfz / Sy
@@ -489,21 +489,21 @@ def calc_channel(sec: Section) -> GeneralProperties:
 
     a = hz - 2 * tz
     Ax = 2 * by * tz + a * ty
-    y = (2 * tz * by**2 + a * ty**2) / (2 * Ax)
-    Iy = (ty * a**3) / 12 + 2 * ((by * tz**3) / 12 + by * tz * ((a + tz) / 2) ** 2)
+    y = (2 * tz * by ** 2 + a * ty ** 2) / (2 * Ax)
+    Iy = (ty * a ** 3) / 12 + 2 * ((by * tz ** 3) / 12 + by * tz * ((a + tz) / 2) ** 2)
 
     if tz == ty:
-        Ix = ty**3 * (2 * by + a - 2.6 * ty) / 3
+        Ix = ty ** 3 * (2 * by + a - 2.6 * ty) / 3
         Wxmin = Ix / Iy
     else:
-        Ix = 1.12 * (2 * by * tz**3 + a * ty**3) / 3
+        Ix = 1.12 * (2 * by * tz ** 3 + a * ty ** 3) / 3
         Wxmin = Ix / max(tz, ty)
 
-    Iz = 2 * ((tz * by**3) / 12 + tz * by * (by / 2 - y) ** 2) + (a * ty**3) / 12 + a * ty * (y - ty / 2) ** 2
+    Iz = 2 * ((tz * by ** 3) / 12 + tz * by * (by / 2 - y) ** 2) + (a * ty ** 3) / 12 + a * ty * (y - ty / 2) ** 2
     Iyz = 0
     Wymin = 2 * Iy / hz
     Wzmin = Iz / max(by - y, y)
-    Sy = by * tz * (tz + a) / 2 + (ty * a**2) / 8
+    Sy = by * tz * (tz + a) / 2 + (ty * a ** 2) / 8
     Sz = tz * (by - y) ** 2
 
     Shary = (Iz / Sz) * (2 * tz) * sfy


### PR DESCRIPTION
Changes in this pull request are related to:
- converting numpy numbers to floats for comparing to tolerances
- removed the writing of parameters `Sfy` and `Sfz` to `GeneralProperties`. They are for all normal purposes 1, and set as defaults in the class
- writes beam names to FEM files
- made the comparison of `GeneralProperties` easier to understand/less complex.
- changes on how exponents are written (due to formatting by packages requested in the [contributing description](CONTRIBUTING.md) file).