### PR TITLE
fix: improve sesam xml writer

### DIFF
--- a/src/ada/api/spatial/assembly.py
+++ b/src/ada/api/spatial/assembly.py
@@ -26,6 +26,8 @@ from ada.fem import (
 _step_types = Union[StepSteadyState, StepEigen, StepImplicitStatic, StepExplicit]
 
 if TYPE_CHECKING:
+    import xml.etree.ElementTree as ET
+
     import ifcopenshell
     import ifcopenshell.validate
 
@@ -256,10 +258,10 @@ class Assembly(Part):
         print("IFC file creation complete")
         return self.ifc_store.f
 
-    def to_genie_xml(self, destination_xml):
+    def to_genie_xml(self, destination_xml, writer_postprocessor: Callable[[ET.Element, Part], None] = None):
         from ada.cadit.gxml.write.write_xml import write_xml
 
-        write_xml(self, destination_xml)
+        write_xml(self, destination_xml, writer_postprocessor=writer_postprocessor)
 
     def push(self, comment, bimserver_url, username, password, project, merge=False, sync=False):
         """Push current assembly to BimServer with a comment tag that defines the revision name"""

--- a/src/ada/cadit/gxml/write/write_beams.py
+++ b/src/ada/cadit/gxml/write/write_beams.py
@@ -31,12 +31,13 @@ def add_segments(beam: Beam):
     straight_segment = ET.SubElement(segments, "straight_segment", props)
 
     d = ["x", "y", "z"]
+    origin = beam.parent.placement.get_absolute_placement().origin
 
     geom = ET.SubElement(straight_segment, "geometry")
     wire = ET.SubElement(geom, "wire")
     guide = ET.SubElement(wire, "guide")
     for i, pos in enumerate([beam.n1, beam.n2], start=1):
-        props = {d[i]: str(k) for i, k in enumerate(pos.p)}
+        props = {d[i]: str(k) for i, k in enumerate(origin+pos.p)}
         props.update(dict(end=str(i)))
         ET.SubElement(guide, "position", props)
 

--- a/src/ada/cadit/gxml/write/write_beams.py
+++ b/src/ada/cadit/gxml/write/write_beams.py
@@ -37,7 +37,7 @@ def add_segments(beam: Beam):
     wire = ET.SubElement(geom, "wire")
     guide = ET.SubElement(wire, "guide")
     for i, pos in enumerate([beam.n1, beam.n2], start=1):
-        props = {d[i]: str(k) for i, k in enumerate(origin+pos.p)}
+        props = {d[i]: str(k) for i, k in enumerate(origin + pos.p)}
         props.update(dict(end=str(i)))
         ET.SubElement(guide, "position", props)
 

--- a/src/ada/cadit/gxml/write/write_masses.py
+++ b/src/ada/cadit/gxml/write/write_masses.py
@@ -28,12 +28,13 @@ def add_masses(root: ET.Element, part: Part):
             bc_con = ET.SubElement(sup_point, "mass")
             ET.SubElement(bc_con, "mass_scalar", dict(mass=str(mass.mass)))
     else:
-        for mass in part.masses:
-            print(mass)
-            bc_stru = ET.SubElement(root, "structure")
-            sup_point = ET.SubElement(bc_stru, "point_mass", {"name": mass.name})
-            sup_point.append(add_local_system(X, Y, Z))
-            geom = ET.SubElement(sup_point, "geometry")
-            ET.SubElement(geom, "position", {"x": str(mass.p[0]), "y": str(mass.p[1]), "z": str(mass.p[2])})
-            bc_con = ET.SubElement(sup_point, "mass")
-            ET.SubElement(bc_con, "mass_scalar", dict(mass=str(mass.mass)))
+        for p in part.get_all_subparts(True):
+            for mass in p.masses:
+                print(mass)
+                bc_stru = ET.SubElement(root, "structure")
+                sup_point = ET.SubElement(bc_stru, "point_mass", {"name": mass.name})
+                sup_point.append(add_local_system(X, Y, Z))
+                geom = ET.SubElement(sup_point, "geometry")
+                ET.SubElement(geom, "position", {"x": str(mass.p[0]), "y": str(mass.p[1]), "z": str(mass.p[2])})
+                bc_con = ET.SubElement(sup_point, "mass")
+                ET.SubElement(bc_con, "mass_scalar", dict(mass=str(mass.mass)))

--- a/src/ada/cadit/gxml/write/write_xml.py
+++ b/src/ada/cadit/gxml/write/write_xml.py
@@ -27,8 +27,9 @@ def write_xml(part: Part, xml_file, embed_sat=False):
 
     part.consolidate_sections()
     part.consolidate_materials()
-    part.move_all_nodes_here_from_subparts()
-    part.move_all_masses_here_from_subparts()
+
+    # part.move_all_nodes_here_from_subparts()
+    # part.move_all_masses_here_from_subparts()
 
     # Find the <properties> element
     structure_domain = root.find("./model/structure_domain")

--- a/src/ada/cadit/gxml/write/write_xml.py
+++ b/src/ada/cadit/gxml/write/write_xml.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import pathlib
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from .write_bcs import add_boundary_conditions
 from .write_beams import add_beams
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _XML_TEMPLATE = pathlib.Path(__file__).parent / "resources/xml_blank.xml"
 
 
-def write_xml(part: Part, xml_file, embed_sat=False):
+def write_xml(part: Part, xml_file, embed_sat=False, writer_postprocessor: Callable[[ET.Element, Part], None] = None):
     if not isinstance(xml_file, pathlib.Path):
         xml_file = pathlib.Path(xml_file)
 
@@ -49,6 +49,8 @@ def write_xml(part: Part, xml_file, embed_sat=False):
     add_beams(structures_elem, part, sat_map)
     add_boundary_conditions(structures_elem, part)
     add_masses(structures_elem, part)
+
+    writer_postprocessor(root, part)
 
     # Write the modified XML back to the file
     os.makedirs(xml_file.parent, exist_ok=True)

--- a/src/ada/cadit/gxml/write/write_xml.py
+++ b/src/ada/cadit/gxml/write/write_xml.py
@@ -50,7 +50,8 @@ def write_xml(part: Part, xml_file, embed_sat=False, writer_postprocessor: Calla
     add_boundary_conditions(structures_elem, part)
     add_masses(structures_elem, part)
 
-    writer_postprocessor(root, part)
+    if writer_postprocessor:
+        writer_postprocessor(root, part)
 
     # Write the modified XML back to the file
     os.makedirs(xml_file.parent, exist_ok=True)


### PR DESCRIPTION
- Fixes so that it no longer modifies the part and assembly objects upon writing. 
- Have also added a feature so that you can pass a xml postprocessor function to the gxml writer.
- fixes support for multiple levels of subpart by concatenating the parts into a single part
- Fixes absolute coordinates in the export. Ie. object placement now respects the spatial parent placement