### PR TITLE
feat(fem): surface effective modal mass (global axes) for Calculix + Code_Aster

### DIFF
--- a/src/ada/fem/formats/calculix/results/read_eigen_data.py
+++ b/src/ada/fem/formats/calculix/results/read_eigen_data.py
@@ -42,8 +42,8 @@ def get_eigen_data(dat_file: str | os.PathLike) -> EigenDataSummary:
             f_hz=float(freq_cycl),
             f_imag_rad=float(freq_imag_rad),
         )
-        participation_data = {pn: p for pn, p in zip(part_factor_names, part[1:])}
-        eff_mass_data = {pn: p for pn, p in zip(eff_mass_names, part[1:])}
-        eigen_modes.append(EigenMode(no=mode, **eig_output, **participation_data, **eff_mass_data))
+        participation_data = {pn: float(p) for pn, p in zip(part_factor_names, part[1:])}
+        eff_mass_data = {pn: float(p) for pn, p in zip(eff_mass_names, modal[1:])}
+        eigen_modes.append(EigenMode(no=int(float(mode)), **eig_output, **participation_data, **eff_mass_data))
 
-    return EigenDataSummary(eigen_modes, tot_eff_mass)
+    return EigenDataSummary(eigen_modes, [float(x) for x in tot_eff_mass])

--- a/src/ada/fem/formats/calculix/results/read_frd_file.py
+++ b/src/ada/fem/formats/calculix/results/read_frd_file.py
@@ -309,6 +309,12 @@ def to_fea_result_obj(ccx_results: CcxResultModel, frd_file) -> FEAResult:
     mesh = Mesh(elements=[elem_block], nodes=nodes)
 
     software_version = extract_calculix_version(frd_file)
+
+    # Eigen analyses: the participation factors + effective modal mass
+    # (global axes, 6 DOF) live in the sibling .dat, not the .frd field
+    # stream. Parse them when present so they surface via get_eig_summary.
+    eigen_mode_data = _read_eigen_mode_data(ccx_results, frd_file)
+
     return FEAResult(
         frd_file.name,
         FEATypes.CALCULIX,
@@ -317,7 +323,31 @@ def to_fea_result_obj(ccx_results: CcxResultModel, frd_file) -> FEAResult:
         results_file_path=frd_file,
         description=description,
         software_version=software_version,
+        eigen_mode_data=eigen_mode_data,
     )
+
+
+def _read_eigen_mode_data(ccx_results: CcxResultModel, frd_file: pathlib.Path):
+    """Return the EigenDataSummary from the sibling ``.dat`` for an eigen
+    run, or ``None``. Calculix writes the modal parameters to the ``.dat``;
+    a frequency step is signalled by per-mode ``eigen_freq`` on the field
+    results."""
+    is_eigen = any(getattr(r, "eigen_freq", None) is not None for r in ccx_results.results)
+    if not is_eigen:
+        return None
+    dat_file = frd_file.with_suffix(".dat")
+    if not dat_file.exists():
+        return None
+    from ada.fem.formats.calculix.results.read_eigen_data import get_eigen_data
+
+    try:
+        summary = get_eigen_data(dat_file)
+    except Exception as exc:  # noqa: BLE001 — modal mass is supplementary
+        from ada.config import logger
+
+        logger.warning(f"Could not read eigen modal data from {dat_file.name}: {exc}")
+        return None
+    return summary if summary.modes else None
 
 
 def to_mesh_data(ccx_results: CcxResultModel) -> MeshData:

--- a/src/ada/fem/formats/code_aster/execute.py
+++ b/src/ada/fem/formats/code_aster/execute.py
@@ -44,8 +44,13 @@ def run_code_aster(
         metadata=metadata,
         auto_execute=execute,
     )
+    # Declare the modal-mass table output only when the .comm emits it
+    # (eigen steps write IMPR_TABLE(... UNITE=81 ...)); avoids declaring a
+    # result file the run never produces for non-eigen analyses.
+    comm_path = pathlib.Path(inp_path).with_suffix(".comm")
+    emits_modal_mass = comm_path.exists() and "UNITE=81" in comm_path.read_text(encoding="utf-8", errors="ignore")
     with open(inp_path, "w") as f:
-        f.write(write_export_file(name, cpus))
+        f.write(write_export_file(name, cpus, emits_modal_mass=emits_modal_mass))
 
     return ca.run(exit_on_complete=exit_on_complete)
 
@@ -63,7 +68,7 @@ class CodeAsterExecute(LocalExecute):
         return out
 
 
-def write_export_file(name: str, cpus: int):
+def write_export_file(name: str, cpus: int, emits_modal_mass: bool = False):
     export_str = f"""P actions make_etude
 P memory_limit 1274
 P time_limit 900
@@ -75,6 +80,12 @@ F comm {name}.comm D 1
 F mmed {name}.med D 20
 F mess {name}.mess R 6
 F rmed {name}.rmed R 80"""
+
+    if emits_modal_mass:
+        # Eigen runs dump effective modal mass + participation factors to a
+        # CSV on unit 81 (see write/steps/eigen.py); the reader picks it up
+        # next to the .rmed.
+        export_str += f"\nF libr {name}.modalmass.csv R 81"
 
     return export_str
 

--- a/src/ada/fem/formats/code_aster/results/read_rmed_results.py
+++ b/src/ada/fem/formats/code_aster/results/read_rmed_results.py
@@ -38,6 +38,15 @@ def read_rmed_file(rmed_file: str | pathlib.Path) -> FEAResult:
     if mess_file.exists():
         software_version = get_code_aster_version_from_mess(mess_file)
 
+    # Eigen runs: pull mode frequencies + the effective modal mass /
+    # participation factors (global axes) the writer dumped next to the
+    # .rmed, so they surface through FEAResult.get_eig_summary.
+    eigen_mode_data = None
+    if mr.is_eigen_analysis:
+        from ada.fem.formats.code_aster.results.results import get_eigen_data
+
+        eigen_mode_data = get_eigen_data(rmed_file)
+
     return FEAResult(
         rmed_file.stem,
         software=FEATypes.CODE_ASTER,
@@ -45,6 +54,7 @@ def read_rmed_file(rmed_file: str | pathlib.Path) -> FEAResult:
         mesh=mr.mesh,
         results_file_path=rmed_file,
         software_version=software_version,
+        eigen_mode_data=eigen_mode_data,
     )
 
 

--- a/src/ada/fem/formats/code_aster/results/results.py
+++ b/src/ada/fem/formats/code_aster/results/results.py
@@ -28,9 +28,57 @@ def get_eigen_data(rmed_file) -> EigenDataSummary:
         for mname, m in modes.items():
             mode = m.attrs["NDT"]
             freq = m.attrs["PDT"]
-            eigen_modes.append(EigenMode(mode, f_hz=freq))
+            eigen_modes.append(EigenMode(int(mode), f_hz=float(freq)))
+
+    # Effective modal mass + participation factors aren't in the MED field
+    # output — the writer dumps them (global translational axes) to a CSV
+    # next to the .rmed via NORM_MODE/IMPR_TABLE. Merge them in when present.
+    modal_mass = _read_modal_mass_csv(pathlib.Path(rmed_file).with_suffix(".modalmass.csv"))
+    if modal_mass:
+        for em in eigen_modes:
+            row = modal_mass.get(em.no)
+            if row is None:
+                continue
+            em.efx, em.efy, em.efz = row.get("MASS_EFFE_DX"), row.get("MASS_EFFE_DY"), row.get("MASS_EFFE_DZ")
+            em.px, em.py, em.pz = row.get("FACT_PARTICI_DX"), row.get("FACT_PARTICI_DY"), row.get("FACT_PARTICI_DZ")
 
     return EigenDataSummary(eigen_modes)
+
+
+def _read_modal_mass_csv(csv_path: pathlib.Path) -> dict[int, dict[str, float]]:
+    """Parse the Code_Aster IMPR_TABLE (FORMAT='TABLEAU', SEPARATEUR=',')
+    modal-parameter dump into ``{nume_mode: {param: value}}``.
+
+    Returns an empty dict if the file is absent (non-eigen run, or an older
+    result produced before this output existed)."""
+    if not csv_path.is_file():
+        return {}
+
+    out: dict[int, dict[str, float]] = {}
+    header: list[str] | None = None
+    for raw in csv_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        cells = [c.strip() for c in raw.split(",")]
+        if header is None:
+            if "NUME_MODE" in cells and "FREQ" in cells:
+                header = cells
+            continue
+        if len(cells) < len(header):
+            continue
+        row = dict(zip(header, cells))
+        try:
+            nume = int(float(row["NUME_MODE"]))
+        except (KeyError, ValueError):
+            continue
+        parsed: dict[str, float] = {}
+        for key, val in row.items():
+            if key in ("NUME_MODE", ""):
+                continue
+            try:
+                parsed[key] = float(val)
+            except ValueError:
+                continue
+        out[nume] = parsed
+    return out
 
 
 def get_eigen_frequency_deformed_meshes(rmed_file):

--- a/src/ada/fem/formats/code_aster/write/steps/eigen.py
+++ b/src/ada/fem/formats/code_aster/write/steps/eigen.py
@@ -75,4 +75,24 @@ IMPR_RESU(
     RESU=_F(RESULTAT=modes, TOUT_CHAM='OUI'),
     UNITE=80
 )
+
+# Effective modal mass + participation factors (global axes). These live
+# as scalar parameters on the mode_meca concept, not in the MED field
+# output, so we normalise (which (re)computes them — see Code_Aster doc
+# U4.52.11) and dump them to a CSV the reader picks up next to the .rmed.
+# Code_Aster reports effective mass along the global translational axes
+# DX/DY/DZ only (no rotational terms). The ``UNITE=81`` token here is also
+# what the .export writer keys on to declare the output file.
+modes = NORM_MODE(reuse=modes, MODE=modes, NORME='MASS_GENE')
+
+tab_modes = RECU_TABLE(
+    CO=modes,
+    NOM_PARA=(
+        'NUME_MODE', 'FREQ',
+        'MASS_EFFE_DX', 'MASS_EFFE_DY', 'MASS_EFFE_DZ',
+        'FACT_PARTICI_DX', 'FACT_PARTICI_DY', 'FACT_PARTICI_DZ',
+    ),
+)
+
+IMPR_TABLE(TABLE=tab_modes, UNITE=81, SEPARATEUR=',', FORMAT='TABLEAU')
 """

--- a/src/ada/fem/results/common.py
+++ b/src/ada/fem/results/common.py
@@ -386,6 +386,11 @@ class FEAResult:
     step_name_map: dict[int | float, str] = None
     description: str = None
     software_version: str = None
+    # Per-mode modal parameters (participation factors + effective modal
+    # mass, in the global axes) that don't live in the field-result stream.
+    # Populated by solver readers when available (e.g. Calculix .dat,
+    # Code_Aster NORM_MODE table); surfaced through get_eig_summary.
+    eigen_mode_data: EigenDataSummary | None = None
 
     def __post_init__(self):
         if self.results is None:
@@ -628,7 +633,17 @@ class FEAResult:
         return renderer_instance
 
     def get_eig_summary(self) -> EigenDataSummary:
-        """If the results are eigenvalue results, this method will return a summary of the eigenvalues and modes"""
+        """If the results are eigenvalue results, this method will return a summary of the eigenvalues and modes.
+
+        When the solver reader captured the per-mode modal parameters
+        (participation factors + effective modal mass in the global axes)
+        into ``eigen_mode_data``, that richer summary is returned as-is.
+        Otherwise we fall back to a frequency-only summary built from the
+        displacement field results.
+        """
+        if self.eigen_mode_data is not None:
+            return self.eigen_mode_data
+
         from ada.fem.results.eigenvalue import EigenDataSummary, EigenMode
 
         modes = []

--- a/src/ada/fem/results/eigenvalue.py
+++ b/src/ada/fem/results/eigenvalue.py
@@ -12,14 +12,17 @@ class EigenDataSummary:
     tot_eff_mass: List[float] = None
 
     def calc_tot_eff_mass(self):
+        # Sum per-mode effective modal mass over the 6 global DOF. Some
+        # solvers only report translational effective mass (e.g. Code_Aster
+        # gives DX/DY/DZ, no rotational terms), so missing components are
+        # treated as 0 rather than crashing the sum.
         tem = np.zeros(6)
+        dofs = ("efx", "efy", "efz", "efrx", "efry", "efrz")
         for m in self.modes:
-            tem[0] += m.efx
-            tem[1] += m.efy
-            tem[2] += m.efz
-            tem[3] += m.efrx
-            tem[4] += m.efry
-            tem[5] += m.efrz
+            for i, dof in enumerate(dofs):
+                val = getattr(m, dof, None)
+                if val is not None:
+                    tem[i] += val
         return tem.tolist()
 
     def to_dict(self) -> dict:

--- a/tests/core/fem/results/test_modal_mass.py
+++ b/tests/core/fem/results/test_modal_mass.py
@@ -1,0 +1,96 @@
+"""Effective modal mass / participation factors (global axes).
+
+Covers:
+  * Calculix ``.dat`` parsing — effective modal mass must come from the
+    effective-mass block, not the participation block (regression for the
+    ``read_eigen_data`` row mix-up).
+  * Code_Aster IMPR_TABLE CSV parsing (translational DX/DY/DZ only).
+  * ``calc_tot_eff_mass`` is None-safe (Code_Aster reports no rotational
+    effective mass, so those components stay None).
+"""
+
+from ada.fem.formats.calculix.results.read_eigen_data import get_eigen_data
+from ada.fem.formats.code_aster.results.results import _read_modal_mass_csv
+from ada.fem.results.eigenvalue import EigenDataSummary, EigenMode
+
+# Minimal Calculix .dat with distinct participation vs effective-mass
+# values so a row mix-up is detectable. Section headers match what the
+# reader looks for once whitespace is stripped (e.g. "effectivemodalmass").
+_CCX_DAT = """
+ E I G E N V A L U E   O U T P U T
+
+ MODE NO   EIGENVALUE     OMEGA        FREQUENCY       IMAG
+      1   0.1000000E+04   0.3162278E+02   0.5032922E+01   0.0000000E+00
+      2   0.4000000E+04   0.6324555E+02   0.1006584E+02   0.0000000E+00
+
+ P A R T I C I P A T I O N   F A C T O R S
+
+ MODE NO   X            Y            Z            RX           RY           RZ
+      1   0.1000000E+01   0.2000000E+01   0.3000000E+01   0.4000000E+01   0.5000000E+01   0.6000000E+01
+      2   0.1100000E+02   0.1200000E+02   0.1300000E+02   0.1400000E+02   0.1500000E+02   0.1600000E+02
+
+ E F F E C T I V E   M O D A L   M A S S
+
+ MODE NO   X            Y            Z            RX           RY           RZ
+      1   0.7000000E+02   0.8000000E+02   0.9000000E+02   0.1000000E+03   0.1100000E+03   0.1200000E+03
+      2   0.1300000E+03   0.1400000E+03   0.1500000E+03   0.1600000E+03   0.1700000E+03   0.1800000E+03
+
+ T O T A L   E F F E C T I V E   M A S S
+
+      0.2000000E+03   0.2200000E+03   0.2400000E+03   0.2600000E+03   0.2800000E+03   0.3000000E+03
+"""
+
+
+def test_ccx_eigen_dat_effective_mass_not_participation(tmp_path):
+    dat = tmp_path / "eig.dat"
+    dat.write_text(_CCX_DAT)
+
+    summary = get_eigen_data(dat)
+    assert [m.no for m in summary.modes] == [1, 2]
+
+    m1 = summary.modes[0]
+    # participation X/Y/Z come from the participation block
+    assert (m1.px, m1.py, m1.pz) == (1.0, 2.0, 3.0)
+    # effective mass X/Y/Z come from the effective-mass block (NOT a copy
+    # of participation — the regression this guards)
+    assert (m1.efx, m1.efy, m1.efz) == (70.0, 80.0, 90.0)
+    assert m1.efx != m1.px
+
+    # values are floats, not raw Fortran strings
+    assert all(isinstance(v, float) for v in (m1.px, m1.efx, m1.efrz))
+    assert summary.tot_eff_mass == [200.0, 220.0, 240.0, 260.0, 280.0, 300.0]
+
+
+_CA_CSV = """#ASTER 14.04.00 CONCEPT tab_modes CALCULE LE
+NUME_MODE,FREQ,MASS_EFFE_DX,MASS_EFFE_DY,MASS_EFFE_DZ,FACT_PARTICI_DX,FACT_PARTICI_DY,FACT_PARTICI_DZ
+1,1.31460E+01,5.72633E-28,1.19923E+02,3.53033E-25,2.39298E-14,1.09509E+01,-5.94165E-13
+2,8.22500E+01,4.10000E+02,1.10000E-20,2.00000E-24,2.02000E+01,1.00000E-10,1.00000E-12
+"""
+
+
+def test_ca_modal_mass_csv_parse(tmp_path):
+    csv = tmp_path / "x.modalmass.csv"
+    csv.write_text(_CA_CSV)
+
+    rows = _read_modal_mass_csv(csv)
+    assert set(rows) == {1, 2}
+    assert rows[1]["MASS_EFFE_DY"] == 119.923
+    assert rows[1]["FACT_PARTICI_DY"] == 10.9509
+    assert rows[2]["MASS_EFFE_DX"] == 410.0
+    # NUME_MODE is the key, not a data column
+    assert "NUME_MODE" not in rows[1]
+
+
+def test_read_modal_mass_csv_missing_file(tmp_path):
+    assert _read_modal_mass_csv(tmp_path / "nope.csv") == {}
+
+
+def test_calc_tot_eff_mass_is_none_safe():
+    # Code_Aster gives translational effective mass only; rotational stays None.
+    summary = EigenDataSummary(
+        modes=[
+            EigenMode(1, f_hz=10.0, efx=1.0, efy=2.0, efz=3.0),
+            EigenMode(2, f_hz=20.0, efx=4.0, efy=5.0, efz=6.0),
+        ]
+    )
+    assert summary.calc_tot_eff_mass() == [5.0, 7.0, 9.0, 0.0, 0.0, 0.0]

--- a/verification/tasks.py
+++ b/verification/tasks.py
@@ -356,6 +356,29 @@ def eig_tables(results: list) -> list:
 
 
 @task(parent=postprocess)
+def eff_mass_table(results: list) -> list:
+    """Summary table of effective modal mass [kg] per case (summed over
+    the captured modes, global X/Y/Z). Skipped when no solver in the run
+    reported effective mass."""
+    df = ru.create_eff_mass_summary_df(results)
+    if df is None or df.empty:
+        logger.info("no effective-mass data in any case, skipping summary table")
+        return []
+    return [
+        TableOutcome(
+            key="eff_mass_summary",
+            df=df,
+            caption=(
+                "Effective modal mass [kg] per case, summed over the captured modes "
+                "in the global X/Y/Z directions. Code_Aster reports translational "
+                "effective mass only."
+            ),
+            show_index=False,
+        )
+    ]
+
+
+@task(parent=postprocess)
 def modal_tables(results: list) -> list:
     """Per-case modal TableOutcomes + JSON cache write side effect."""
     save_cache = os.environ.get("ADA_FEM_DO_NOT_SAVE_CACHE") is None

--- a/verification/utils.py
+++ b/verification/utils.py
@@ -189,3 +189,53 @@ def create_df_of_data(
         df_main = append_df(df_main, new_col)
 
     return df_main
+
+
+def _case_label(res: FeaVerificationResult) -> str:
+    """Compact ``solver_geom_oN[_tag][R]`` label matching the comparison
+    tables' column convention."""
+    geo = res.metadata["geo"]
+    elo = res.metadata["elo"]
+    hq = res.metadata["hexquad"]
+    uri = res.metadata.get("reduced_integration", False)
+    uri_str = "R" if uri is True else ""
+    if geo.upper() == "SOLID":
+        s_str = "_TET" if hq is False else "_HEX"
+    elif geo.upper() == "SHELL":
+        s_str = "_TRI" if hq is False else "_QUAD"
+    else:
+        s_str = ""
+    return f"{short_name_map[res.fem_format]}_{geo}_o{elo}{s_str}{uri_str}"
+
+
+def create_eff_mass_summary_df(results: list[FeaVerificationResult]) -> pd.DataFrame | None:
+    """Summary of effective modal mass [kg] per case: one row per case,
+    summed over its captured modes in the global X/Y/Z directions.
+
+    Only cases whose reader populated effective mass are included
+    (Calculix + Code_Aster today); returns None if none did, so the
+    caller skips registering an empty table. Note Code_Aster reports
+    translational effective mass only — there is no rotational column.
+    """
+    rows = []
+    for res in results:
+        modes = res.eig_data.modes if res.eig_data is not None else []
+        if not modes or all(m.efx is None for m in modes):
+            continue
+
+        def _s(dof: str) -> float:
+            return float(sum(getattr(m, dof) or 0.0 for m in modes))
+
+        rows.append(
+            {
+                "Case": _case_label(res),
+                "Modes": len(modes),
+                "ΣMeff X": round(_s("efx"), 1),
+                "ΣMeff Y": round(_s("efy"), 1),
+                "ΣMeff Z": round(_s("efz"), 1),
+            }
+        )
+
+    if not rows:
+        return None
+    return pd.DataFrame(rows).sort_values("Case").reset_index(drop=True)


### PR DESCRIPTION
Effective modal mass / participation factors are computed by both solvers in the **global axes**, but weren't reaching `FEAResult.get_eig_summary()`. This wires them through for both Calculix and Code_Aster.

## Calculix
- **Bugfix** in `read_eigen_data`: effective modal mass was populated from the *participation-factor* row instead of the *effective-mass* row (`part[1:]` → `modal[1:]`), and values were left as raw Fortran strings. Now reads the correct row and coerces to `float` (6 DOF: X/Y/Z + RX/RY/RZ).
- `to_fea_result_obj` parses the sibling `.dat` for eigen runs and attaches the `EigenDataSummary` to the `FEAResult`.

## Code_Aster (translational X/Y/Z only — no rotational terms; per doc `U4.52.11`)
- eigen writer adds `NORM_MODE` + `RECU_TABLE` + `IMPR_TABLE`, dumping the modal parameters to a CSV on unit 81.
- `.export` declares the unit, gated on the `.comm` actually emitting it (so non-eigen runs are unaffected).
- reader parses the CSV next to the `.rmed` and merges `MASS_EFFE_D{X,Y,Z}` / `FACT_PARTICI_D{X,Y,Z}` into the `EigenMode`s; `read_rmed_file` attaches it.

## Shared
- `FEAResult` gains an `eigen_mode_data` field; `get_eig_summary()` returns it when present (falls back to the freq-only summary otherwise).
- `calc_tot_eff_mass` is now None-safe (CA reports no rotational effective mass).

## Verification
End-to-end on the IPE400 cantilever shell-o1:
- ccx mode-1 `efy ≈ 1079` (= participation² = 32.85²), summed effective mass over 30 modes approaches the global total (~1747 kg/axis).
- CA mode-1 `efy ≈ 119.9` (= 10.95²), `tot_eff_mass = [0, 167.6, 122.0, 0, 0, 0]` (translational only).

Adds focused regression tests (ccx `.dat` parse incl. the row-mixup guard, CA CSV parser, None-safe total). Full `tests/core/fem/results` + `code_aster` suite: 124 passed, 7 skipped.

> Note: cross-solver magnitude differs because Calculix expands shells to solid elements while Code_Aster keeps native shells — both faithfully satisfy `MASS_EFFE = participation²`. Not surfaced in the verification report this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)