### PR TITLE
chore: FEA-docs effective-mass comparison tables + publish Pages on docs changes

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -3,8 +3,25 @@ name: ci-docs
 on:
   workflow_dispatch:
   push:
+    # Republish to Pages when the docs/report sources land on main —
+    # previously this only happened on a version tag, so verification/
+    # changes (e.g. new report tables) didn't show up until the next
+    # release. Tags still publish (release footer / git-describe string).
+    # NOTE: GitHub applies this `paths` filter to the tag pushes in this
+    # same block too; release commits normally touch src/ada or
+    # pyproject, but if one doesn't, republish via workflow_dispatch.
+    branches:
+      - main
     tags:
       - 'v*.*.*'
+    paths:
+      - 'docs/**'
+      - 'verification/**'
+      - 'src/ada/**'
+      - 'pixi.toml'
+      - 'pixi.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/ci-pages.yml'
   pull_request:
     branches:
       - main

--- a/verification/tasks.py
+++ b/verification/tasks.py
@@ -356,6 +356,34 @@ def eig_tables(results: list) -> list:
 
 
 @task(parent=postprocess)
+def eff_mass_compare_tables(results: list) -> list:
+    """Cross-solver effective modal mass comparison, mirroring the
+    eigenfrequency comparison tables: one table per (geom, order, global
+    direction). Directions with no excited mass (e.g. out-of-plane for a
+    planar cantilever) are skipped, as are groups with no solver that
+    reported effective mass."""
+    out: list = []
+    for key, geo, order, _hq, _caption in _COMPARISON_SPECS:
+        for direction in ("X", "Y", "Z"):
+            df = ru.create_eff_mass_comparison_df(results, geo, order, direction)
+            if df is None or df.empty:
+                continue
+            out.append(
+                TableOutcome(
+                    key=f"{key}_meff_{direction.lower()}",
+                    df=df,
+                    caption=(
+                        f"Effective modal mass [kg], global {direction} — "
+                        f"{geo}, order {order}."
+                    ),
+                    show_index=False,
+                    default_sort=("Mode", True),
+                )
+            )
+    return out
+
+
+@task(parent=postprocess)
 def eff_mass_table(results: list) -> list:
     """Summary table of effective modal mass [kg] per case (summed over
     the captured modes, global X/Y/Z). Skipped when no solver in the run

--- a/verification/utils.py
+++ b/verification/utils.py
@@ -208,6 +208,48 @@ def _case_label(res: FeaVerificationResult) -> str:
     return f"{short_name_map[res.fem_format]}_{geo}_o{elo}{s_str}{uri_str}"
 
 
+_EFF_MASS_DIR_ATTR = {"X": "efx", "Y": "efy", "Z": "efz"}
+
+
+def create_eff_mass_comparison_df(
+    results: list[FeaVerificationResult], geom_repr: str, el_order: int, direction: str
+) -> pd.DataFrame | None:
+    """Cross-solver comparison of per-mode effective modal mass [kg] in one
+    global direction — the effective-mass analogue of
+    :func:`create_df_of_data`. Rows are modes, columns are the matching
+    cases (same ``solver[_tag][R]`` convention as the frequency tables).
+
+    Returns None when no matching case carries effective mass for this
+    direction, or when every value is ~0 (e.g. an out-of-plane direction
+    a planar cantilever never excites) — so the caller skips empty tables.
+    """
+    attr = _EFF_MASS_DIR_ATTR[direction]
+    df_main = None
+
+    for res in results:
+        geo = res.metadata["geo"]
+        elo = res.metadata["elo"]
+        if geom_repr != geo or el_order != elo:
+            continue
+        modes = res.eig_data.modes if res.eig_data is not None else []
+        if not modes or all(getattr(m, attr) is None for m in modes):
+            continue
+
+        value_col = _case_label(res).replace(f"_{geo}_o{elo}", "")  # solver[_tag][R]
+        df_current = pd.DataFrame(
+            [(m.no, getattr(m, attr)) for m in modes], columns=["Mode", value_col]
+        )
+        new_col = df_current[value_col] if df_main is not None else df_current
+        df_main = append_df(df_main, new_col)
+
+    if df_main is None or df_main.empty:
+        return None
+    value_cols = [c for c in df_main.columns if c != "Mode"]
+    if not value_cols or df_main[value_cols].abs().to_numpy().max() < 1e-6:
+        return None
+    return df_main.round(1)
+
+
 def create_eff_mass_summary_df(results: list[FeaVerificationResult]) -> pd.DataFrame | None:
     """Summary of effective modal mass [kg] per case: one row per case,
     summed over its captured modes in the global X/Y/Z directions.


### PR DESCRIPTION
FEA verification-report changes (no `src/ada` / library change → `chore:`, no version bump).

## 1. Cross-solver effective modal mass comparison tables
Mirror the eigenfrequency `_COMPARISON_SPECS` tables for effective modal mass: one table per **(geom, order, global direction X/Y/Z)**, columns per solver case, rows per mode. Directions with no excited mass (out-of-plane for the planar cantilever) and groups with no effective-mass data are skipped.
- `verification/utils.py::create_eff_mass_comparison_df` + `verification/tasks.py::eff_mass_compare_tables`.

## 2. Publish docs to Pages on docs/verification changes to main
The GitHub Pages docs (`ci-docs`) previously only **published** on a version tag, so `verification/` changes didn't show up until the next release. Add a path-gated push-to-main trigger (`docs/**`, `verification/**`, `src/ada/**`, env files). Publish step already fires on push events.

**Caveat:** GitHub applies the `paths` filter to the tag pushes in that block too; release commits normally touch `src/ada`/`pyproject`, else republish via `workflow_dispatch`. Can drop the filter if you'd rather rebuild on every main push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)