### PR TITLE
chore: publish docs to Pages on docs/verification changes to main

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -3,8 +3,25 @@ name: ci-docs
 on:
   workflow_dispatch:
   push:
+    # Republish to Pages when the docs/report sources land on main —
+    # previously this only happened on a version tag, so verification/
+    # changes (e.g. new report tables) didn't show up until the next
+    # release. Tags still publish (release footer / git-describe string).
+    # NOTE: GitHub applies this `paths` filter to the tag pushes in this
+    # same block too; release commits normally touch src/ada or
+    # pyproject, but if one doesn't, republish via workflow_dispatch.
+    branches:
+      - main
     tags:
       - 'v*.*.*'
+    paths:
+      - 'docs/**'
+      - 'verification/**'
+      - 'src/ada/**'
+      - 'pixi.toml'
+      - 'pixi.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/ci-pages.yml'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The GitHub Pages docs (`ci-docs`) previously only **published** on a version tag, so `verification/` changes (e.g. the new FEA report tables) didn't reach the published site until the next release.

This adds a **path-gated push-to-main trigger** so a merge that touches the docs/report sources republishes Pages:

```yaml
push:
  branches: [main]
  tags: ['v*.*.*']
  paths: [docs/**, verification/**, src/ada/**, pixi.toml, pixi.lock, pyproject.toml, .github/workflows/ci-pages.yml]
```

The publish step (`if: github.event_name != 'pull_request'`) already fires on push events, so no other change is needed.

### Caveat
GitHub applies the `paths` filter to the **tag** pushes in this same block too (it can't path-filter per-ref within one `push:`). Release commits normally touch `src/ada/**` or `pyproject.toml` (both listed), so tag publishing keeps working; if a release ever lands without touching these paths, republish via **workflow_dispatch**. If you'd rather not risk that, the alternative is to drop the `paths` filter (republish on every main push) — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)