### PR TITLE
feat: cross-section + curved-plate + sphere round-trip; valid IFC

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -7546,7 +7546,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.4.1-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.5.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8175,7 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.4.1-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.5.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -8573,7 +8573,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.4.1-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.5.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10602,25 +10602,25 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.4.1-py312h29cc896_0.conda
-  sha256: 031e6cafbe744a466639f4def3e1537cffe848da34ad67aade6dfde4ba5d0896
-  md5: effc2db6874da5a0c82e586c7073490e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.5.0-py312h29cc896_0.conda
+  sha256: a5db40b7b8afe466994ffb9d869418efb547d0b3452d817c44bdfda49a2b7728
+  md5: 1f51078f27c02d0c7e3a99ff57a1b792
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=hash-mapping
-  size: 11558341
-  timestamp: 1780468547706
+  size: 11562194
+  timestamp: 1780671756132
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -19812,24 +19812,24 @@ packages:
   purls: []
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.4.1-py312h9b4feea_0.conda
-  sha256: 991f29c76f7fd666a9be57946c70ee85e770b33cc0cf2363e111d7d91abf2907
-  md5: 94c392e04051c474bb38f206afbf1fb3
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.5.0-py312h9b4feea_0.conda
+  sha256: 7f085cd40082fdc30782a592a6067db3142eee204c0f72e4c88b99c9849e8f12
+  md5: 527473c6004392948d5300102cb82616
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
-  - python_abi 3.12.* *_cp312
-  - libzlib >=1.3.2,<2.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=compressed-mapping
-  size: 9764290
-  timestamp: 1780468653571
+  - pkg:pypi/ada-cpp?source=hash-mapping
+  size: 9772208
+  timestamp: 1780671814927
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -23561,25 +23561,25 @@ packages:
   purls: []
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.4.1-py312h710a262_0.conda
-  sha256: 55b74db3295cb7a7d738abc645e41dd5fd3e43d605dd1aafcfb725c85f9f223c
-  md5: 8f9eb274c4c674628a1bd4e4738f9e15
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.5.0-py312h710a262_0.conda
+  sha256: 423f624e151eb928b0a895be0794eb747d134f3bffb201c24cd3fb658a84a952
+  md5: 66ec1022111a5dff114f1f52d469b59e
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   - libzlib >=1.3.2,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=compressed-mapping
-  size: 4954579
-  timestamp: 1780468576046
+  - pkg:pypi/ada-cpp?source=hash-mapping
+  size: 4959083
+  timestamp: 1780671830853
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.toml
+++ b/pixi.toml
@@ -131,7 +131,7 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # `adacpp` and without `pyocc` exercises adacpp as the sole CAD backend
 # (no pythonocc fallback by design).
 [feature.adacpp.dependencies]
-ada-cpp = "0.4.1.*"
+ada-cpp = "0.5.0.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/scripts/viewer_upload.py
+++ b/scripts/viewer_upload.py
@@ -5,7 +5,8 @@ CLI so debug artifacts (intermediate GLBs, diagnostic STEP files, etc)
 can be dropped into a scope without going through the browser.
 
 Auth: ``ADAPY_API_TOKEN`` (a CLI token minted from the admin panel).
-Base URL: ``ADAPY_API_BASE`` (e.g. ``https://viewer.example.com``).
+Base URL: ``ADAPY_API_BASE`` *or* ``ADAPY_BASE_URL``
+(e.g. ``https://viewer.example.com``).
 
 Examples:
     pixi run viewer-upload ./debug.glb
@@ -33,6 +34,21 @@ def _env(name: str) -> str:
         )
         sys.exit(2)
     return val
+
+
+def _env_any(*names: str) -> str:
+    """First non-empty match among ``names``. Accepts either ``ADAPY_API_BASE``
+    or the more common ``ADAPY_BASE_URL`` — matching ``audit_fetch.py`` so folks
+    can reach for whichever they already have in their .env."""
+    for n in names:
+        val = os.environ.get(n, "").strip()
+        if val:
+            return val
+    sys.stderr.write(
+        f"error: none of {', '.join(names)} are set. Set the viewer base URL "
+        f"to (e.g.) https://viewer.example.com.\n"
+    )
+    sys.exit(2)
 
 
 def _normalize_base(raw: str) -> str:
@@ -69,7 +85,7 @@ def _content_type_for(path: pathlib.Path) -> str:
 
 
 def upload(local: pathlib.Path, scope: str, key: str) -> str:
-    base = _normalize_base(_env("ADAPY_API_BASE"))
+    base = _normalize_base(_env_any("ADAPY_API_BASE", "ADAPY_BASE_URL"))
     token = _env("ADAPY_API_TOKEN")
 
     # Strip leading slashes; the {key:path} matcher accepts subdirs

--- a/src/ada/api/beams/beam_revolved.py
+++ b/src/ada/api/beams/beam_revolved.py
@@ -7,7 +7,6 @@ from ada.geom import Geometry
 from ada.geom.placement import Axis1Placement, Axis2Placement3D
 from ada.geom.solids import RevolvedAreaSolid
 
-from ...config import logger
 from .base_bm import Beam
 
 if TYPE_CHECKING:
@@ -34,33 +33,39 @@ class BeamRevolve(Beam):
         return self._curve
 
     def solid_geom(self) -> Geometry[RevolvedAreaSolid]:
-        # todo: This currently does not work as intended
-        logger.warning("BeamRevolve.solid_geom() is not yet implemented correctly")
+        """Revolve the section profile around the curve's rotation axis.
+
+        The profile is placed perpendicular to the arc at ``p1`` and revolved.
+        The placement frame is X = radial (p1 -> away from axis), Y = rotation
+        axis (the section "up"), Z = arc tangent (the profile normal).
+
+        The revolution ``axis`` is in global coordinates — the convention both CAD
+        backends build from. The IFC writer converts it to the Position-local frame
+        that ``IfcRevolvedAreaSolid.Axis`` requires.
+        """
+        import numpy as np
+
         from ada import Direction, Point
-        from ada.core.constants import O
-        from ada.core.vector_transforms import global_2_local_nodes
+        from ada.geom.booleans import BooleanOperation
         from ada.geom.solids import RevolvedAreaSolid
 
-        normal = self.curve.rot_axis.get_normalized()
-        xvec1 = self.curve.profile_normal.get_normalized()
-        yvec = self.curve.profile_perpendicular.get_normalized()
+        p1 = np.asarray(self.curve.p1, dtype=float)
+        rot_axis = np.asarray(self.curve.rot_axis, dtype=float)
+        rot_axis = rot_axis / np.linalg.norm(rot_axis)
+        rot_origin = np.asarray(self.curve.rot_origin, dtype=float)
 
-        new_csys = (normal, yvec, xvec1)
-
-        # Revolve Point
-        diff = self.curve.rot_origin - self.curve.p1
-        # diff_tra = sec_place.transform_array_from_other_place([diff],loc_place)[0]
-        # n_tra = Direction(sec_place.transform_array_from_other_place([normal],loc_place, ignore_translation=True)[0]).get_normalized()
-        diff_tra = Point(global_2_local_nodes(new_csys, O, [diff])[0])
-        n_tra = Direction(global_2_local_nodes(new_csys, O, [normal])[0]).get_normalized()
+        # Radial direction at p1 = component of (p1 - rot_origin) perpendicular to
+        # the rotation axis; the arc tangent (profile normal) is axis x radial.
+        radial = p1 - rot_origin
+        radial = radial - np.dot(radial, rot_axis) * rot_axis
+        radial = radial / np.linalg.norm(radial)
+        tangent = np.cross(rot_axis, radial)
+        tangent = tangent / np.linalg.norm(tangent)
 
         profile = geo_conv.section_to_arbitrary_profile_def_with_voids(self.section)
-
-        position = Axis2Placement3D(self.curve.p1, xvec1, normal)
-        axis = Axis1Placement(location=diff_tra, axis=n_tra)
-
-        # position = Placement(origin=Point(0, -0.1, 0.0)).to_axis2placement3d()
-        # axis = Axis1Placement(location=Point(-1.3, 0.1, 0.0), axis=Direction(0, -1, 0))
+        position = Axis2Placement3D(Point(*p1), Direction(*tangent), Direction(*radial))
+        axis = Axis1Placement(location=Point(*rot_origin), axis=Direction(*rot_axis))
 
         solid = RevolvedAreaSolid(profile, position, axis, self.curve.angle)
-        return Geometry(self.guid, solid, self.color)
+        booleans = [BooleanOperation(x.primitive.solid_geom(), x.bool_op) for x in self.booleans]
+        return Geometry(self.guid, solid, self.color, bool_operations=booleans)

--- a/src/ada/api/piping/base_piping.py
+++ b/src/ada/api/piping/base_piping.py
@@ -13,10 +13,8 @@ from ada.base.units import Units
 from ada.config import Config, logger
 from ada.core.exceptions import VectorNormalizeError
 from ada.core.utils import Counter, roundoff
-from ada.core.vector_transforms import global_2_local_nodes
 from ada.core.vector_utils import (
     angle_between,
-    calc_yvec,
     calc_zvec,
     unit_vector,
     vector_length,
@@ -316,9 +314,8 @@ class PipeSegElbow(BackendGeom):
 
         return get_solid_occ(self)
 
-    def solid_geom(self, ifc_impl=False) -> Geometry:
-        from ada import Direction, Point
-        from ada.core.constants import O
+    def solid_geom(self) -> Geometry:
+        from ada import Direction
         from ada.geom.booleans import BooleanOperation
         from ada.geom.solids import RevolvedAreaSolid
 
@@ -328,21 +325,10 @@ class PipeSegElbow(BackendGeom):
         xvec2 = Direction(self.arc_seg.e_normal).get_normalized()
         normal = Direction([x if abs(x) != 0.0 else 0.0 for x in calc_zvec(xvec2, xvec1)]).get_normalized()
 
-        # todo: update OCC handling so that this conditional no longer is needed, and always ifc_impl=True
-        if ifc_impl:
-            # Revolve Point
-            diff = self.arc_seg.center - self.arc_seg.p1
-            yvec = calc_yvec(normal, xvec1)
-            new_csys = (normal, yvec, xvec1)
-
-            diff_tra = global_2_local_nodes(new_csys, O, [diff])[0]
-            n_tra = global_2_local_nodes(new_csys, O, [normal])[0]
-
-            position = Axis2Placement3D(self.arc_seg.p1, xvec1, normal)
-            axis = Axis1Placement(location=Point(diff_tra), axis=Direction(n_tra).get_normalized())
-        else:
-            position = Axis2Placement3D(self.p1, xvec1, normal)
-            axis = Axis1Placement(location=self.arc_seg.center, axis=normal)
+        # Revolution axis is global (the convention both CAD backends build from);
+        # the IFC writer transforms it into the Position-local frame on export.
+        position = Axis2Placement3D(self.p1, xvec1, normal)
+        axis = Axis1Placement(location=self.arc_seg.center, axis=normal)
 
         revolve_angle = 180 - np.rad2deg(angle_between(xvec1, xvec2))
 

--- a/src/ada/api/piping/base_piping.py
+++ b/src/ada/api/piping/base_piping.py
@@ -13,12 +13,7 @@ from ada.base.units import Units
 from ada.config import Config, logger
 from ada.core.exceptions import VectorNormalizeError
 from ada.core.utils import Counter, roundoff
-from ada.core.vector_utils import (
-    angle_between,
-    calc_zvec,
-    unit_vector,
-    vector_length,
-)
+from ada.core.vector_utils import angle_between, calc_zvec, unit_vector, vector_length
 from ada.geom import Geometry
 from ada.geom.direction import Direction
 from ada.geom.placement import Axis1Placement, Axis2Placement3D

--- a/src/ada/api/primitives/base.py
+++ b/src/ada/api/primitives/base.py
@@ -158,7 +158,10 @@ class Shape(BackendGeom):
         import ada.geom.solids as geo_so
         import ada.geom.surfaces as geo_su
 
-        if isinstance(self.geom.geometry, (geo_su.AdvancedFace, geo_su.ClosedShell, geo_so.Box)):
+        if isinstance(
+            self.geom.geometry,
+            (geo_su.AdvancedFace, geo_su.ClosedShell, geo_so.Box, geo_so.Sphere, geo_so.Cylinder, geo_so.Cone),
+        ):
 
             self.geom.bool_operations = [BooleanOperation(x.primitive.solid_geom(), x.bool_op) for x in self.booleans]
             return self.geom

--- a/src/ada/cadit/ifc/read/geom/curves.py
+++ b/src/ada/cadit/ifc/read/geom/curves.py
@@ -9,8 +9,64 @@ def get_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.CURVE_GEOM_TYP
         return indexed_poly_curve(ifc_entity)
     elif ifc_entity.is_a("IfcPolyline"):
         return poly_line(ifc_entity)
+    elif ifc_entity.is_a("IfcRationalBSplineCurveWithKnots"):
+        return rational_b_spline_curve_with_knots(ifc_entity)
+    elif ifc_entity.is_a("IfcBSplineCurveWithKnots"):
+        return b_spline_curve_with_knots(ifc_entity)
+    elif ifc_entity.is_a("IfcSurfaceCurve"):
+        # The 3D curve is the geometric master; the attached p-curve is recovered
+        # separately by oriented_edge() onto the OrientedEdge.
+        return get_curve(ifc_entity.Curve3D)
     else:
         raise NotImplementedError(f"Geometry type {ifc_entity.is_a()} not implemented")
+
+
+def pcurve_2d_from_surface_curve(surface_curve: ifcopenshell.entity_instance) -> geo_cu.Pcurve2dBSpline | None:
+    """Recover the UV p-curve (2D B-spline) attached to an IfcSurfaceCurve."""
+    associated = getattr(surface_curve, "AssociatedGeometry", None)
+    if not associated:
+        return None
+    ref = associated[0].ReferenceCurve  # IfcPcurve.ReferenceCurve
+    if not ref.is_a("IfcBSplineCurveWithKnots"):
+        return None
+    weights = list(ref.WeightsData) if ref.is_a("IfcRationalBSplineCurveWithKnots") else None
+    return geo_cu.Pcurve2dBSpline(
+        degree=ref.Degree,
+        control_points_2d=[(float(p.Coordinates[0]), float(p.Coordinates[1])) for p in ref.ControlPointsList],
+        knots=list(ref.Knots),
+        knot_multiplicities=list(ref.KnotMultiplicities),
+        weights=weights,
+        closed=bool(ref.ClosedCurve),
+    )
+
+
+def b_spline_curve_with_knots(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.BSplineCurveWithKnots:
+    return geo_cu.BSplineCurveWithKnots(
+        degree=ifc_entity.Degree,
+        control_points_list=[Point(p.Coordinates) for p in ifc_entity.ControlPointsList],
+        curve_form=geo_cu.BSplineCurveFormEnum(ifc_entity.CurveForm),
+        closed_curve=ifc_entity.ClosedCurve,
+        self_intersect=ifc_entity.SelfIntersect,
+        knot_multiplicities=list(ifc_entity.KnotMultiplicities),
+        knots=list(ifc_entity.Knots),
+        knot_spec=geo_cu.KnotType.from_str(ifc_entity.KnotSpec),
+    )
+
+
+def rational_b_spline_curve_with_knots(
+    ifc_entity: ifcopenshell.entity_instance,
+) -> geo_cu.RationalBSplineCurveWithKnots:
+    return geo_cu.RationalBSplineCurveWithKnots(
+        degree=ifc_entity.Degree,
+        control_points_list=[Point(p.Coordinates) for p in ifc_entity.ControlPointsList],
+        curve_form=geo_cu.BSplineCurveFormEnum(ifc_entity.CurveForm),
+        closed_curve=ifc_entity.ClosedCurve,
+        self_intersect=ifc_entity.SelfIntersect,
+        knot_multiplicities=list(ifc_entity.KnotMultiplicities),
+        knots=list(ifc_entity.Knots),
+        knot_spec=geo_cu.KnotType.from_str(ifc_entity.KnotSpec),
+        weights_data=list(ifc_entity.WeightsData),
+    )
 
 
 def poly_line(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.PolyLine:
@@ -31,18 +87,38 @@ def indexed_poly_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.Index
 
 
 def edge(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.Edge:
-    return geo_cu.Edge(
-        start=Point(ifc_entity.EdgeStart.VertexGeometry.Coordinates),
-        end=Point(ifc_entity.EdgeEnd.VertexGeometry.Coordinates),
-    )
+    start = Point(ifc_entity.EdgeStart.VertexGeometry.Coordinates)
+    end = Point(ifc_entity.EdgeEnd.VertexGeometry.Coordinates)
+
+    # An IfcEdgeCurve carries the actual trimming curve (e.g. a B-spline). Dropping
+    # it (as a bare IfcEdge) leaves an OCC face with no p-curve, which tessellates to
+    # a degenerate, near-zero-area mesh — the curved plate looks "missing".
+    if ifc_entity.is_a("IfcEdgeCurve") and ifc_entity.EdgeGeometry is not None:
+        return geo_cu.EdgeCurve(
+            start=start,
+            end=end,
+            edge_geometry=get_curve(ifc_entity.EdgeGeometry),
+            same_sense=ifc_entity.SameSense,
+        )
+
+    return geo_cu.Edge(start=start, end=end)
 
 
 def oriented_edge(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.OrientedEdge:
+    ee = ifc_entity.EdgeElement
+
+    # Recover the UV p-curve when the edge geometry is an IfcSurfaceCurve — without
+    # it the trimmed B-spline face tessellates degenerate (near-zero area).
+    pcurve = None
+    if ee.is_a("IfcEdgeCurve") and ee.EdgeGeometry is not None and ee.EdgeGeometry.is_a("IfcSurfaceCurve"):
+        pcurve = pcurve_2d_from_surface_curve(ee.EdgeGeometry)
+
     return geo_cu.OrientedEdge(
         start=Point(ifc_entity.EdgeStart.VertexGeometry.Coordinates),
         end=Point(ifc_entity.EdgeEnd.VertexGeometry.Coordinates),
-        edge_element=edge(ifc_entity.EdgeElement),
+        edge_element=edge(ee),
         orientation=ifc_entity.Orientation,
+        pcurve=pcurve,
     )
 
 

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -6,7 +6,14 @@ from ada.geom import curves as geo_cu
 from ada.geom import solids as geo_so
 from ada.geom import surfaces as geo_su
 
-from .solids import extruded_solid_area, ifc_block, revolved_solid_area
+from .solids import (
+    extruded_solid_area,
+    ifc_block,
+    ifc_cone,
+    ifc_cylinder,
+    ifc_sphere,
+    revolved_solid_area,
+)
 from .surfaces import advanced_face, shell_based_surface_model, triangulated_face_set
 
 GEOM = Union[geo_so.SOLID_GEOM_TYPES | geo_cu.CURVE_GEOM_TYPES | geo_su.SURFACE_GEOM_TYPES]
@@ -32,6 +39,12 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return triangulated_face_set(geom_repr)
     elif geom_repr.is_a("IfcBlock"):
         return ifc_block(geom_repr)
+    elif geom_repr.is_a("IfcSphere"):
+        return ifc_sphere(geom_repr)
+    elif geom_repr.is_a("IfcRightCircularCylinder"):
+        return ifc_cylinder(geom_repr)
+    elif geom_repr.is_a("IfcRightCircularCone"):
+        return ifc_cone(geom_repr)
     elif geom_repr.is_a("IfcAdvancedFace"):
         return advanced_face(geom_repr)
     elif geom_repr.is_a("IfcShellBasedSurfaceModel"):

--- a/src/ada/cadit/ifc/read/geom/solids.py
+++ b/src/ada/cadit/ifc/read/geom/solids.py
@@ -2,9 +2,15 @@ import ifcopenshell
 
 from ada.geom import solids as geo_so
 from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
 
 from .placement import axis1placement, axis2placement, axis3d, ifc_direction
 from .surfaces import get_surface
+
+
+def ifc_sphere(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Sphere:
+    center = Point(*ifc_entity.Position.Location.Coordinates)
+    return geo_so.Sphere(center=center, radius=ifc_entity.Radius)
 
 
 def extruded_solid_area(ifc_entity: ifcopenshell.entity_instance) -> geo_so.ExtrudedAreaSolid:
@@ -26,6 +32,16 @@ def revolved_solid_area(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Revo
         axis=revolve_axis,
         angle=ifc_entity.Angle,
     )
+
+
+def ifc_cylinder(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Cylinder:
+    position = axis2placement(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()
+    return geo_so.Cylinder(position=position, radius=ifc_entity.Radius, height=ifc_entity.Height)
+
+
+def ifc_cone(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Cone:
+    position = axis2placement(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()
+    return geo_so.Cone(position=position, bottom_radius=ifc_entity.BottomRadius, height=ifc_entity.Height)
 
 
 def ifc_block(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Box:

--- a/src/ada/cadit/ifc/read/read_beam_section.py
+++ b/src/ada/cadit/ifc/read/read_beam_section.py
@@ -4,12 +4,31 @@ from ada.sections import Section
 
 
 def import_section_from_ifc(profile_def, units=Units.M) -> Section:
-    """Takes any subclass of ProfileDef"""
+    """Takes any subclass of ProfileDef and returns an adapy Section.
+
+    Resolution order:
+      1. adapy parameter bag (IfcProfileProperties) -> exact parametric section.
+      2. Native parametric IFC profile defs (I/T/circle-hollow).
+      3. Polyline/arbitrary geometry -> recognise parametric or keep as POLY.
+      4. Last resort: parse the profile name string.
+    """
+    from ada.cadit.ifc.sections_props import (
+        read_profile_section_params,
+        section_from_param_dict,
+    )
     from ada.sections.string_to_section import interpret_section_str
 
+    name = getattr(profile_def, "ProfileName", None)
+
+    # 1. Exact round-trip via the adapy parameter bag (works for every type).
+    params = read_profile_section_params(profile_def)
+    if params is not None:
+        return section_from_param_dict(name, params, units)
+
+    # 2. Native parametric profile defs.
     if profile_def.is_a("IfcIShapeProfileDef"):
-        sec = Section(
-            name=profile_def.ProfileName,
+        return Section(
+            name=name,
             sec_type=Section.TYPES.IPROFILE,
             h=profile_def.OverallDepth,
             w_top=profile_def.OverallWidth,
@@ -18,11 +37,11 @@ def import_section_from_ifc(profile_def, units=Units.M) -> Section:
             t_ftop=profile_def.FlangeThickness,
             t_fbtn=profile_def.FlangeThickness,
             units=units,
-            sec_str=profile_def.ProfileName,
+            sec_str=name,
         )
     elif profile_def.is_a("IfcTShapeProfileDef"):
-        sec = Section(
-            name=profile_def.ProfileName,
+        return Section(
+            name=name,
             sec_type=Section.TYPES.TPROFILE,
             h=profile_def.Depth,
             w_top=profile_def.FlangeWidth,
@@ -31,24 +50,58 @@ def import_section_from_ifc(profile_def, units=Units.M) -> Section:
             units=units,
         )
     elif profile_def.is_a("IfcCircleHollowProfileDef"):
-        sec = Section(
-            name=profile_def.ProfileName,
+        return Section(
+            name=name,
             sec_type="TUB",
             r=profile_def.Radius,
             wt=profile_def.WallThickness,
             units=units,
         )
-    elif profile_def.is_a("IfcUShapeProfileDef"):
+
+    # 3. Polyline / arbitrary geometry -> reconstruct from the curves.
+    if profile_def.is_a("IfcArbitraryClosedProfileDef") or profile_def.is_a("IfcArbitraryProfileDefWithVoids"):
+        sec = _section_from_arbitrary_profile(profile_def, name, units)
+        if sec is not None:
+            return sec
+
+    # 4. Last resort: interpret the profile name string.
+    try:
+        logger.info(f'No native/geometry support for Ifc beam "{profile_def=}", trying name parse')
+        sec, _ = interpret_section_str(profile_def.ProfileName)
+    except Exception as e:
+        logger.warning(f'Unable to process section "{name}" -> error: "{e}"')
+        sec = None
+    if sec is None:
         raise NotImplementedError(f'IFC section type "{profile_def}" is not yet implemented')
-        # sec = Section(ifc_elem.ProfileName)
-    else:
-        try:
-            logger.info(f'No Native support for Ifc beam "{profile_def=}"')
-            sec, tap = interpret_section_str(profile_def.ProfileName)
-        except ValueError as e:
-            logger.warning(f'Unable to process section "{profile_def.ProfileName}" -> error: "{e}" ')
-            sec = None
-        if sec is None:
-            raise NotImplementedError(f'IFC section type "{profile_def}" is not yet implemented')
 
     return sec
+
+
+def _section_from_arbitrary_profile(profile_def, name, units) -> Section | None:
+    """Reconstruct a Section from an arbitrary (polyline) profile def."""
+    from ada.cadit.ifc.read.geom.surfaces import arbitrary_closed_profile_def
+    from ada.sections.from_geometry import section_from_polyline
+
+    try:
+        apd = arbitrary_closed_profile_def(profile_def)
+        outer = _curve_to_points2d(apd.outer_curve)
+        inner_curves = [_curve_to_points2d(c) for c in apd.inner_curves]
+    except NotImplementedError as e:
+        logger.warning(f'Unable to read arbitrary profile geometry for "{name}" -> {e}')
+        return None
+
+    inner = inner_curves[0] if inner_curves else None
+    return section_from_polyline(outer, inner, name=name, units=units)
+
+
+def _curve_to_points2d(curve) -> list[tuple[float, float]]:
+    from ada.geom import curves as geo_cu
+
+    if isinstance(curve, geo_cu.PolyLine):
+        raw = [tuple(p) for p in curve.points]
+    elif isinstance(curve, geo_cu.IndexedPolyCurve):
+        raw = curve.get_points()
+    else:
+        raise NotImplementedError(f"Unsupported profile curve geometry {type(curve).__name__}")
+
+    return [(float(p[0]), float(p[1])) for p in raw]

--- a/src/ada/cadit/ifc/read/read_beams.py
+++ b/src/ada/cadit/ifc/read/read_beams.py
@@ -94,7 +94,7 @@ def import_revolved_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) ->
     from ada import Placement
     from ada.core.vector_transforms import transform3d
 
-    logger.warning("Reading IFC Beams swept along IfcTrimmedCurve is WIP")
+    logger.debug("Reading revolved IFC beam (swept along IfcTrimmedCurve)")
 
     r = axis.BasisCurve.Radius
     curve_place = get_placement(axis.BasisCurve.Position)

--- a/src/ada/cadit/ifc/read/read_ifc.py
+++ b/src/ada/cadit/ifc/read/read_ifc.py
@@ -75,7 +75,14 @@ class IfcReader:
 
             logger.info(f"importing {name}")
 
-            obj = import_physical_ifc_elem(product, name, self.ifc_store)
+            try:
+                obj = import_physical_ifc_elem(product, name, self.ifc_store)
+            except Exception as e:
+                # A single unsupported/broken element must not abort import of the
+                # entire model — log it and keep going.
+                logger.warning(f'Skipping product "{name}" (#{product.id()}, {product.is_a()}): {e}')
+                continue
+
             if obj is None:
                 continue
 

--- a/src/ada/cadit/ifc/read/read_physical_objects.py
+++ b/src/ada/cadit/ifc/read/read_physical_objects.py
@@ -8,7 +8,7 @@ from .exceptions import NoIfcAxesAttachedError, UnableToConvertBoolResToBeamExce
 from .read_beams import import_ifc_beam
 from .read_pipe import import_pipe_segment
 from .read_plates import import_ifc_plate
-from .read_shapes import import_ifc_shape
+from .read_shapes import import_ifc_shape, import_ifc_sphere
 
 if TYPE_CHECKING:
     from ada.cadit.ifc.store import IfcStore
@@ -39,6 +39,11 @@ def import_physical_ifc_elem(product, name, ifc_store: IfcStore):
 
     if product.is_a("IfcPipeFitting"):
         logger.info('"IfcPipeFitting" is not yet added')
+
+    # Sphere-bodied products (e.g. node/support markers) -> parametric PrimSphere.
+    sphere = import_ifc_sphere(product, name, ifc_store)
+    if sphere is not None:
+        return sphere
 
     obj = import_ifc_shape(product, name, ifc_store)
 

--- a/src/ada/cadit/ifc/read/read_plates.py
+++ b/src/ada/cadit/ifc/read/read_plates.py
@@ -17,13 +17,79 @@ if TYPE_CHECKING:
     from ada.cadit.ifc.store import IfcStore
 
 
-def import_ifc_plate(ifc_elem: ifcopenshell.entity_instance, name, ifc_store: IfcStore) -> Plate:
+# Default thickness for curved plates whose IFC carries only a surface (no
+# layer-set / thickness). Used purely for the flat-plate render fallback.
+_CURVED_PLATE_DEFAULT_T = 0.01
+
+
+def _is_extruded_arbitrary(geometry) -> bool:
+    return isinstance(geometry, geo_so.ExtrudedAreaSolid) and isinstance(
+        getattr(geometry, "swept_area", None), geo_su.ArbitraryProfileDef
+    )
+
+
+def _read_plate_material(ifc_elem, name, ifc_store: IfcStore):
+    mat = None
+    if ifc_store.assembly is not None:
+        mat = ifc_store.assembly.get_by_name(name)
+    if mat is None:
+        mat = read_material(get_associated_material(ifc_elem), ifc_store)
+    return mat
+
+
+def _edge_loop_points(advanced_face: geo_su.AdvancedFace) -> list[tuple[float, float, float]]:
+    """Perimeter (vertex) points of the face's outer bound, for the flat fallback."""
+    if not advanced_face.bounds:
+        return []
+    loop = advanced_face.bounds[0].bound
+    edge_list = getattr(loop, "edge_list", None) or []
+    return [tuple(float(c) for c in edge.start) for edge in edge_list]
+
+
+def _import_curved_plate(ifc_elem, name, advanced_face: geo_su.AdvancedFace, ifc_store: IfcStore):
+    """Import an ``IfcAdvancedFace`` plate as a :class:`PlateCurved`.
+
+    Mirrors the gxml curved-plate path: keep the B-spline surface as the
+    geometry and attach the outer-loop endpoints as ``_flat_fallback_pts`` so the
+    tessellator degrades to a flat plate if the trimmed B-spline can't be meshed.
+    """
+    from ada import PlateCurved
+    from ada.geom import Geometry
+
+    from .read_color import get_product_color
+
+    color = get_product_color(ifc_elem, ifc_store.f)
+    pc = PlateCurved(
+        name,
+        Geometry(ifc_elem.GlobalId, advanced_face, color),
+        t=_CURVED_PLATE_DEFAULT_T,
+        mat=_read_plate_material(ifc_elem, name, ifc_store),
+        guid=ifc_elem.GlobalId,
+        ifc_store=ifc_store,
+        units=ifc_store.assembly.units,
+        color=color,
+    )
+    fallback_pts = _edge_loop_points(advanced_face)
+    if fallback_pts:
+        pc._flat_fallback_pts = fallback_pts
+    return pc
+
+
+def import_ifc_plate(ifc_elem: ifcopenshell.entity_instance, name, ifc_store: IfcStore):
     logger.info(f"importing {name}")
     geometries = get_product_definitions(ifc_elem)
-    if len(geometries) != 1:
-        raise NotImplementedError("Plate geometry with multiple bodies is not currently supported")
-    if not isinstance(geometries[0].swept_area, geo_su.ArbitraryProfileDef):
-        raise NotImplementedError("Plate geometry with non-arbitrary profile is not currently supported")
+
+    # A curved (B-spline) plate surface -> PlateCurved (with flat-plate fallback).
+    if len(geometries) == 1 and isinstance(geometries[0], geo_su.AdvancedFace):
+        return _import_curved_plate(ifc_elem, name, geometries[0], ifc_store)
+
+    # Only an extruded arbitrary profile maps to a parametric Plate. Anything else
+    # (e.g. another BREP form) is imported as a generic geometry-backed Shape so it
+    # still renders and round-trips.
+    if len(geometries) != 1 or not _is_extruded_arbitrary(geometries[0]):
+        from .read_shapes import import_ifc_shape
+
+        return import_ifc_shape(ifc_elem, name, ifc_store, force_geom=True)
 
     body: geo_so.ExtrudedAreaSolid = geometries[0]
     points2d = body.swept_area.outer_curve.to_points2d()

--- a/src/ada/cadit/ifc/read/read_shapes.py
+++ b/src/ada/cadit/ifc/read/read_shapes.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     from ada.cadit.ifc.store import IfcStore
 
 
-def import_ifc_shape(product: ifcopenshell.entity_instance, name, ifc_store: IfcStore):
+def import_ifc_shape(product: ifcopenshell.entity_instance, name, ifc_store: IfcStore, force_geom: bool = False):
     logger.info(f'importing Shape "{name}"')
 
     color = get_product_color(product, ifc_store.f)
 
-    if Config().ifc_import_shape_geom:
+    if Config().ifc_import_shape_geom or force_geom:
         geometries = get_product_definitions(product)
         if len(geometries) > 1:
             logger.warning(
@@ -45,6 +45,49 @@ def import_ifc_shape(product: ifcopenshell.entity_instance, name, ifc_store: Ifc
     return Shape(
         name,
         geom=geometries,
+        guid=product.GlobalId,
+        ifc_store=ifc_store,
+        units=ifc_store.assembly.units,
+        color=color,
+        opacity=color.opacity if color is not None else 1.0,
+        **extra_opts,
+    )
+
+
+def _body_items(product: ifcopenshell.entity_instance) -> list:
+    if product.Representation is None:
+        return []
+    for rep in product.Representation.Representations:
+        if rep.RepresentationIdentifier == "Body":
+            return list(rep.Items)
+    return []
+
+
+def import_ifc_sphere(product: ifcopenshell.entity_instance, name, ifc_store: IfcStore):
+    """Import a product whose body is a single ``IfcSphere`` as a ``PrimSphere``.
+
+    Returns ``None`` if the product is not a plain sphere (so callers can fall
+    through to the generic shape importer).
+    """
+    items = _body_items(product)
+    if len(items) != 1 or not items[0].is_a("IfcSphere"):
+        return None
+
+    from ada.api.primitives import PrimSphere
+
+    sphere = items[0]
+    center = tuple(float(x) for x in sphere.Position.Location.Coordinates)
+    color = get_product_color(product, ifc_store.f)
+
+    extra_opts = {}
+    obj_placement = product.ObjectPlacement
+    if obj_placement is not None and obj_placement.PlacementRelTo:
+        extra_opts["placement"] = Placement.from_4x4_matrix(get_local_placement(obj_placement))
+
+    return PrimSphere(
+        name,
+        center,
+        float(sphere.Radius),
         guid=product.GlobalId,
         ifc_store=ifc_store,
         units=ifc_store.assembly.units,

--- a/src/ada/cadit/ifc/read/reader_utils.py
+++ b/src/ada/cadit/ifc/read/reader_utils.py
@@ -172,10 +172,11 @@ def add_to_assembly(assembly: Assembly, obj, ifc_parent, elements2part):
 
 def add_to_parent(parent: Part | Pipe, obj):
     from ada import Beam, Part, Pipe, PipeSegElbow, PipeSegStraight, Plate, Shape
+    from ada.api.plates.base_pl import PlateCurved
 
     if isinstance(obj, Beam):
         parent.add_beam(obj)
-    elif isinstance(obj, Plate):
+    elif isinstance(obj, (Plate, PlateCurved)):
         parent.add_plate(obj)
     elif issubclass(type(obj), Shape) and isinstance(parent, Part):
         parent.add_shape(obj)

--- a/src/ada/cadit/ifc/sections_props.py
+++ b/src/ada/cadit/ifc/sections_props.py
@@ -1,0 +1,192 @@
+"""Roundtrip of adapy parametric cross-section parameters through IFC.
+
+adapy writes several section types to IFC as *polyline* profiles
+(``IfcArbitraryClosedProfileDef`` / ``IfcArbitraryProfileDefWithVoids``), which on
+their own carry no parametric intent (height, web/flange thickness, ...). To make
+the adapy -> IFC -> adapy round-trip lossless we additionally attach the parametric
+parameters directly to the profile via the schema-native ``IfcProfileProperties``
+(IFC4: ``IfcProfileDef.HasProperties``). On import these are preferred over both the
+profile name string and the geometry, so the exact section is reconstructed.
+
+For foreign IFC (no adapy params) the importer falls back to reconstructing the
+section from the polyline geometry (see :mod:`ada.sections.from_geometry`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ada.base.units import Units
+from ada.sections.categories import BaseTypes
+
+if TYPE_CHECKING:
+    import ifcopenshell
+
+    from ada.sections.concept import Section
+
+# Name of the IfcProfileProperties bag holding the adapy parameters.
+ADA_SECTION_PSET = "ADA_SectionParameters"
+
+# Numeric parametric fields carried through the round-trip.
+SECTION_PARAM_KEYS = ("h", "w_top", "w_btn", "t_w", "t_ftop", "t_fbtn", "r", "wt")
+
+# GeneralProperties fields carried for GENERAL sections (e.g. GeniE general beams,
+# which have no explicit geometry — only numeric cross-section properties). Written
+# with a "gp_" prefix so they never collide with the geometric keys above.
+GENERAL_PROP_FIELDS = (
+    "Ax",
+    "Ix",
+    "Iy",
+    "Iz",
+    "Iyz",
+    "Wxmin",
+    "Wymin",
+    "Wzmin",
+    "Shary",
+    "Sharz",
+    "Shceny",
+    "Shcenz",
+    "Sy",
+    "Sz",
+    "Sfy",
+    "Sfz",
+    "Cy",
+    "Cz",
+    "Cgy",
+    "Cgz",
+)
+_GP_PREFIX = "gp_"
+
+# Only these (fully parametric) types get an ADA parameter bag. POLY and GENERAL
+# carry their definition in the geometry itself, so re-import reconstructs them
+# from the curves rather than from parameters.
+_PARAM_TYPES = (
+    BaseTypes.BOX,
+    BaseTypes.IPROFILE,
+    BaseTypes.TPROFILE,
+    BaseTypes.ANGULAR,
+    BaseTypes.CHANNEL,
+    BaseTypes.FLATBAR,
+    BaseTypes.TUBULAR,
+    BaseTypes.CIRCULAR,
+)
+
+
+def section_param_props(section: Section) -> dict | None:
+    """Parameter dict for ``section``, or ``None`` if it carries no parameters.
+
+    GENERAL sections (no explicit geometry) serialize their GeneralProperties;
+    POLY sections carry their definition in the geometry and return ``None``.
+    """
+    if section.type == BaseTypes.GENERAL:
+        props = _general_param_props(section)
+    elif section.type in _PARAM_TYPES:
+        props = {"sec_type": section.type.value}
+        for key in SECTION_PARAM_KEYS:
+            value = getattr(section, key)
+            if value is not None:
+                props[key] = float(value)
+    else:
+        return None
+
+    if props is None:
+        return None
+
+    try:
+        sec_str = section.sec_str
+    except Exception:
+        sec_str = None
+    if sec_str:
+        props["sec_str"] = sec_str
+
+    return props
+
+
+def _general_param_props(section: Section) -> dict | None:
+    gp = section.properties
+    if gp is None:
+        return None
+    props: dict[str, float | str] = {"sec_type": BaseTypes.GENERAL.value}
+    for field in GENERAL_PROP_FIELDS:
+        value = getattr(gp, field, None)
+        if value is not None:
+            props[_GP_PREFIX + field] = float(value)
+    return props
+
+
+def section_from_param_dict(name: str | None, props: dict, units: Units = Units.M) -> Section:
+    """Rebuild a :class:`Section` from an ADA parameter dict."""
+    from ada.sections.concept import GeneralProperties, Section
+
+    if props.get("sec_type") == BaseTypes.GENERAL.value:
+        gp_kwargs = {
+            field: float(props[_GP_PREFIX + field])
+            for field in GENERAL_PROP_FIELDS
+            if props.get(_GP_PREFIX + field) is not None
+        }
+        return Section(
+            name=name,
+            sec_type=BaseTypes.GENERAL,
+            genprops=GeneralProperties(**gp_kwargs),
+            sec_str=props.get("sec_str"),
+            units=units,
+        )
+
+    kwargs = {k: float(props[k]) for k in SECTION_PARAM_KEYS if props.get(k) is not None}
+    return Section(
+        name=name,
+        sec_type=props["sec_type"],
+        sec_str=props.get("sec_str"),
+        units=units,
+        **kwargs,
+    )
+
+
+def write_profile_section_props(f: ifcopenshell.file, profile, section: Section) -> None:
+    """Attach an ``IfcProfileProperties`` parameter bag to ``profile`` (if parametric)."""
+    from .utils import ifc_value_map
+
+    params = section_param_props(section)
+    if not params:
+        return
+
+    properties = [
+        f.create_entity("IfcPropertySingleValue", Name=key, NominalValue=ifc_value_map(f, value))
+        for key, value in params.items()
+    ]
+    f.create_entity(
+        "IfcProfileProperties",
+        Name=ADA_SECTION_PSET,
+        Properties=properties,
+        ProfileDefinition=profile,
+    )
+
+
+def read_profile_section_params(profile_def) -> dict | None:
+    """Read the ADA parameter dict attached to ``profile_def``, or ``None``.
+
+    Uses the IFC4 ``HasProperties`` inverse when available. (IFC2x3 has no such
+    inverse on ``IfcProfileDef``; those files fall back to geometry on import.)
+    """
+    has_properties = getattr(profile_def, "HasProperties", None)
+    if not has_properties:
+        return None
+
+    for prop_set in has_properties:
+        if not prop_set.is_a("IfcProfileProperties"):
+            continue
+        if prop_set.Name != ADA_SECTION_PSET:
+            continue
+        return _single_values_to_dict(prop_set.Properties)
+
+    return None
+
+
+def _single_values_to_dict(properties) -> dict:
+    out = {}
+    for prop in properties or []:
+        if not prop.is_a("IfcPropertySingleValue"):
+            continue
+        nominal = prop.NominalValue
+        out[prop.Name] = nominal.wrappedValue if nominal is not None else None
+    return out

--- a/src/ada/cadit/ifc/store.py
+++ b/src/ada/cadit/ifc/store.py
@@ -199,6 +199,10 @@ class IfcStore:
         # Write all deferred IfcRelDefinesByType memberships in one pass.
         self.flush_rel_defines_by_type()
 
+        # Drop relationships that ended up with no members (empty RelatedObjects
+        # violates the schema's [1:?] cardinality) so the output validates clean.
+        self.writer.prune_empty_relationships()
+
         add_str = f"Added {num_new_objects} objects and {num_new_spatial_objects} spatial elements"
         mod_str = f"Modified {num_mod} objects"
         del_str = f"Deleted {num_del} objects"

--- a/src/ada/cadit/ifc/write/geom/curves.py
+++ b/src/ada/cadit/ifc/write/geom/curves.py
@@ -92,20 +92,75 @@ def b_spline_curve_with_knots(bs: geo_cu.BSplineCurveWithKnots, f: ifcopenshell.
     )
 
 
-def create_edge_curve(ec: geo_cu.EdgeCurve, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
-    """Converts an EdgeCurve to an IFC representation"""
-    if isinstance(ec.edge_geometry, geo_cu.RationalBSplineCurveWithKnots):
-        edge_geometry = rational_b_spline_curve_with_knots(ec.edge_geometry, f)
-    elif isinstance(ec.edge_geometry, geo_cu.BSplineCurveWithKnots):
-        edge_geometry = b_spline_curve_with_knots(ec.edge_geometry, f)
-    elif isinstance(ec.edge_geometry, geo_cu.Ellipse):
-        edge_geometry = create_ellipse(ec.edge_geometry, f)
-    elif isinstance(ec.edge_geometry, geo_cu.Circle):
-        edge_geometry = circle_curve(ec.edge_geometry, f)
-    elif isinstance(ec.edge_geometry, geo_cu.Line):
-        edge_geometry = create_line(ec.edge_geometry, f)
+def _edge_geometry_3d(edge_geometry, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    if isinstance(edge_geometry, geo_cu.RationalBSplineCurveWithKnots):
+        return rational_b_spline_curve_with_knots(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.BSplineCurveWithKnots):
+        return b_spline_curve_with_knots(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.Ellipse):
+        return create_ellipse(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.Circle):
+        return circle_curve(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.Line):
+        return create_line(edge_geometry, f)
     else:
-        raise NotImplementedError(f"Unsupported edge geometry type: {type(ec.edge_geometry)}")
+        raise NotImplementedError(f"Unsupported edge geometry type: {type(edge_geometry)}")
+
+
+def b_spline_curve_2d(pc: geo_cu.Pcurve2dBSpline, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Write a 2D (UV) B-spline curve — the parameter-space p-curve on a surface."""
+    pts = [f.create_entity("IfcCartesianPoint", (float(u), float(v))) for u, v in pc.control_points_2d]
+    common = dict(
+        Degree=pc.degree,
+        ControlPointsList=pts,
+        CurveForm="UNSPECIFIED",
+        ClosedCurve=bool(pc.closed),
+        SelfIntersect=False,
+        Knots=[float(x) for x in pc.knots],
+        KnotMultiplicities=[int(x) for x in pc.knot_multiplicities],
+        KnotSpec="UNSPECIFIED",
+    )
+    if pc.weights:
+        return f.create_entity("IfcRationalBSplineCurveWithKnots", WeightsData=[float(x) for x in pc.weights], **common)
+    return f.create_entity("IfcBSplineCurveWithKnots", **common)
+
+
+def create_surface_curve(
+    ec: geo_cu.EdgeCurve,
+    pcurve: geo_cu.Pcurve2dBSpline,
+    basis_surface: ifcopenshell.entity_instance,
+    f: ifcopenshell.file,
+) -> ifcopenshell.entity_instance:
+    """Build an IfcSurfaceCurve carrying both the 3D curve and its UV p-curve.
+
+    Preserving the p-curve is what lets a re-imported B-spline face tessellate
+    (OCC needs the 2D parametric curve to trim the surface; the bare 3D curve
+    alone yields a degenerate, near-zero-area mesh)."""
+    curve_3d = _edge_geometry_3d(ec.edge_geometry, f)
+    ifc_pcurve = f.create_entity("IfcPcurve", BasisSurface=basis_surface, ReferenceCurve=b_spline_curve_2d(pcurve, f))
+    return f.create_entity(
+        "IfcSurfaceCurve",
+        Curve3D=curve_3d,
+        AssociatedGeometry=[ifc_pcurve],
+        MasterRepresentation="CURVE3D",
+    )
+
+
+def create_edge_curve(
+    ec: geo_cu.EdgeCurve,
+    f: ifcopenshell.file,
+    pcurve: geo_cu.Pcurve2dBSpline | None = None,
+    basis_surface: ifcopenshell.entity_instance | None = None,
+) -> ifcopenshell.entity_instance:
+    """Converts an EdgeCurve to an IFC representation.
+
+    When a UV ``pcurve`` and its ``basis_surface`` are supplied, the edge
+    geometry is written as an IfcSurfaceCurve so the p-curve survives the
+    round-trip; otherwise just the bare 3D curve is written."""
+    if pcurve is not None and basis_surface is not None:
+        edge_geometry = create_surface_curve(ec, pcurve, basis_surface, f)
+    else:
+        edge_geometry = _edge_geometry_3d(ec.edge_geometry, f)
 
     return f.create_entity(
         "IfcEdgeCurve",
@@ -127,10 +182,18 @@ def create_line(line: geo_cu.Line, f: ifcopenshell.file) -> ifcopenshell.entity_
     return f.create_entity("IfcLine", Pnt=cpt(f, line.pnt), Dir=vector(line.dir, f))
 
 
-def oriented_edge(oe: geo_cu.OrientedEdge, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
-    """Converts an OrientedEdge to an IFC representation"""
+def oriented_edge(
+    oe: geo_cu.OrientedEdge,
+    f: ifcopenshell.file,
+    basis_surface: ifcopenshell.entity_instance | None = None,
+) -> ifcopenshell.entity_instance:
+    """Converts an OrientedEdge to an IFC representation.
+
+    ``basis_surface`` (the parent face's surface entity) enables writing the
+    edge's UV p-curve when present."""
     if isinstance(oe.edge_element, geo_cu.EdgeCurve):
-        edge_element = create_edge_curve(oe.edge_element, f)
+        pcurve = getattr(oe, "pcurve", None)
+        edge_element = create_edge_curve(oe.edge_element, f, pcurve=pcurve, basis_surface=basis_surface)
     elif isinstance(oe.edge_element, geo_cu.Edge):
         edge_element = create_edge(oe.edge_element, f)
     else:
@@ -145,7 +208,11 @@ def oriented_edge(oe: geo_cu.OrientedEdge, f: ifcopenshell.file) -> ifcopenshell
     )
 
 
-def edge_loop(el: geo_cu.EdgeLoop, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+def edge_loop(
+    el: geo_cu.EdgeLoop,
+    f: ifcopenshell.file,
+    basis_surface: ifcopenshell.entity_instance | None = None,
+) -> ifcopenshell.entity_instance:
     """Converts an EdgeLoop to an IFC representation"""
-    edges = [oriented_edge(e, f) for e in el.edge_list]
+    edges = [oriented_edge(e, f, basis_surface=basis_surface) for e in el.edge_list]
     return f.create_entity("IfcEdgeLoop", EdgeList=edges)

--- a/src/ada/cadit/ifc/write/geom/curves.py
+++ b/src/ada/cadit/ifc/write/geom/curves.py
@@ -92,6 +92,11 @@ def b_spline_curve_with_knots(bs: geo_cu.BSplineCurveWithKnots, f: ifcopenshell.
     )
 
 
+def poly_line(pl: geo_cu.PolyLine, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a PolyLine to an IFC representation"""
+    return f.create_entity("IfcPolyline", Points=[cpt(f, p) for p in pl.points])
+
+
 def _edge_geometry_3d(edge_geometry, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     if isinstance(edge_geometry, geo_cu.RationalBSplineCurveWithKnots):
         return rational_b_spline_curve_with_knots(edge_geometry, f)
@@ -103,6 +108,10 @@ def _edge_geometry_3d(edge_geometry, f: ifcopenshell.file) -> ifcopenshell.entit
         return circle_curve(edge_geometry, f)
     elif isinstance(edge_geometry, geo_cu.Line):
         return create_line(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.PolyLine):
+        return poly_line(edge_geometry, f)
+    elif isinstance(edge_geometry, geo_cu.IndexedPolyCurve):
+        return indexed_poly_curve(edge_geometry, f)
     else:
         raise NotImplementedError(f"Unsupported edge geometry type: {type(edge_geometry)}")
 

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -51,7 +51,13 @@ def extruded_area_solid_tapered(
 
 
 def revolved_area_solid(ras: geo_so.RevolvedAreaSolid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
-    """Converts a RevolvedAreaSolid to an IFC representation"""
+    """Converts a RevolvedAreaSolid to an IFC representation.
+
+    The geom carries the revolution axis in global coordinates (the convention
+    both CAD backends build from). ``IfcRevolvedAreaSolid.Axis`` is defined in the
+    ``Position`` coordinate system, so we transform global -> local here — keeping
+    the geom backend-native while emitting spec-correct IFC.
+    """
     import math
 
     axis3d = ifc_placement_from_axis3d(ras.position, f)
@@ -61,9 +67,29 @@ def revolved_area_solid(ras: geo_so.RevolvedAreaSolid, f: ifcopenshell.file) -> 
     else:
         raise NotImplementedError(f"Unsupported swept area type: {type(ras.swept_area)}")
 
-    revolve_point = point(ras.axis.location, f)
-    rev_axis_dir = direction(ras.axis.axis, f)
-    revolve_axis1 = f.create_entity("IfcAxis1Placement", revolve_point, rev_axis_dir)
+    loc_pt, loc_dir = _axis_global_to_position_local(ras)
+    revolve_axis1 = f.create_entity("IfcAxis1Placement", point(loc_pt, f), direction(loc_dir, f))
     angle = math.radians(ras.angle)
 
     return f.create_entity("IfcRevolvedAreaSolid", SweptArea=profile, Position=axis3d, Axis=revolve_axis1, Angle=angle)
+
+
+def _axis_global_to_position_local(ras: geo_so.RevolvedAreaSolid):
+    """Express the (global) revolution axis in ``ras.position``'s local frame."""
+    import numpy as np
+
+    pos = ras.position
+    xdir = np.asarray(pos.ref_direction, dtype=float)
+    zdir = np.asarray(pos.axis, dtype=float)
+    xdir = xdir / np.linalg.norm(xdir)
+    zdir = zdir / np.linalg.norm(zdir)
+    ydir = np.cross(zdir, xdir)
+    rot = np.column_stack([xdir, ydir, zdir])  # local -> global
+
+    origin = np.asarray(pos.location, dtype=float)
+    ax_loc = np.asarray(ras.axis.location, dtype=float)
+    ax_dir = np.asarray(ras.axis.axis, dtype=float)
+
+    local_loc = rot.T @ (ax_loc - origin)
+    local_dir = rot.T @ ax_dir
+    return tuple(float(x) for x in local_loc), tuple(float(x) for x in local_dir)

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -85,10 +85,10 @@ def bspline_surface_with_knots(
         )
 
 
-def face_bound(fb: geo_su.FaceBound, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+def face_bound(fb: geo_su.FaceBound, f: ifcopenshell.file, basis_surface=None) -> ifcopenshell.entity_instance:
     """Converts a FaceBound to an IFC representation"""
     if isinstance(fb.bound, geo_cu.EdgeLoop):
-        bound = edge_loop(fb.bound, f)
+        bound = edge_loop(fb.bound, f, basis_surface=basis_surface)
     else:
         raise NotImplementedError(f"Unsupported bound type: {type(fb.bound)}")
 
@@ -189,7 +189,8 @@ def advanced_face(af: geo_su.AdvancedFace, f: ifcopenshell.file) -> ifcopenshell
     bounds = []
     for bound in af.bounds:
         if isinstance(bound, geo_su.FaceBound):
-            bounds.append(face_bound(bound, f))
+            # Pass the face's surface so each edge's UV p-curve can be written.
+            bounds.append(face_bound(bound, f, basis_surface=face_surface))
         else:
             raise NotImplementedError(f"Unsupported bound type: {type(bound)}")
 

--- a/src/ada/cadit/ifc/write/pipes/elbow_segment.py
+++ b/src/ada/cadit/ifc/write/pipes/elbow_segment.py
@@ -107,7 +107,7 @@ def alt_elbow_revolved_solid(elbow: PipeSegElbow, f, tol=1e-1):
 
 
 def elbow_revolved_solid(elbow: PipeSegElbow, f, tol=1e-1):
-    core_geom = elbow.solid_geom(ifc_impl=True)
+    core_geom = elbow.solid_geom()
     geom: geo_so.RevolvedAreaSolid = core_geom.geometry
 
     rev_area_solid = igeo_so.revolved_area_solid(geom, f)

--- a/src/ada/cadit/ifc/write/write_ifc.py
+++ b/src/ada/cadit/ifc/write/write_ifc.py
@@ -251,6 +251,26 @@ class IfcWriter:
 
                 group.change_type = ChangeAction.NOCHANGE
 
+    def prune_empty_relationships(self) -> int:
+        """Drop relationships whose required member set ended up empty.
+
+        ``IfcRelAssociatesMaterial`` is created eagerly per material (populated as
+        elements are written), and ``IfcRelAssignsToGroup`` per group — an unused
+        material or member-less group leaves an empty ``RelatedObjects`` set, which
+        violates the schema's ``[1:?]`` cardinality and fails ifcopenshell
+        validation. Removing the empty relationship is safe: the IfcMaterial /
+        IfcGroup it points at simply stays unassigned."""
+        f = self.ifc_store.f
+        removed = 0
+        for rel_type in ("IfcRelAssociatesMaterial", "IfcRelAssignsToGroup"):
+            for rel in list(f.by_type(rel_type)):
+                if not rel.RelatedObjects:
+                    f.remove(rel)
+                    removed += 1
+        if removed:
+            logger.debug("Pruned %d IFC relationship(s) with empty member sets", removed)
+        return removed
+
     def sync_presentation_layers(self) -> int:
         from ada import Boolean, Part, Pipe
 

--- a/src/ada/cadit/ifc/write/write_sections.py
+++ b/src/ada/cadit/ifc/write/write_sections.py
@@ -10,6 +10,7 @@ from ada.core.utils import to_real
 from ada.sections.categories import SectionCat
 from ada.sections.concept import Section
 
+from ..sections_props import write_profile_section_props
 from ..utils import create_ifcindexpolyline, create_ifcpolyline
 
 
@@ -55,6 +56,11 @@ def export_beam_section_profile_def(f: ifcopenshell.file, section: Section):
 
     ifc_sec_type = section_profile_instance.get_ifc_type()
     profile = f.create_entity(ifc_sec_type, **sec_props)
+
+    # Attach the parametric parameters to the profile so the section survives a
+    # round-trip even when it is written as a (non-parametric) polyline profile.
+    write_profile_section_props(f, profile, section)
+
     return profile
 
 

--- a/src/ada/sections/from_geometry.py
+++ b/src/ada/sections/from_geometry.py
@@ -1,0 +1,242 @@
+"""Reconstruct a :class:`Section` from an explicit cross-section polyline.
+
+This is the fallback used when importing a profile that carries no adapy
+parameters (foreign IFC), e.g. an ``IfcArbitraryClosedProfileDef`` /
+``IfcArbitraryProfileDefWithVoids``. We try to recognise a parametric section
+(box, flatbar, I, T) from the geometry; if nothing matches confidently we keep
+the faithful geometry as a POLY section.
+
+The recognisers are deliberately **order- and winding-independent**: they group
+vertices by axis-aligned levels and reason about the bounding box, never about the
+sequence the points happen to appear in.
+"""
+
+from __future__ import annotations
+
+from ada.base.units import Units
+from ada.config import Config
+from ada.sections.categories import BaseTypes
+
+Point2D = tuple[float, float]
+
+
+def section_from_polyline(
+    outer_pts: list[Point2D],
+    inner_pts: list[Point2D] | None = None,
+    name: str | None = None,
+    units: Units = Units.M,
+    tol: float | None = None,
+):
+    """Return a :class:`Section` reconstructed from 2D cross-section curves.
+
+    Tries parametric recognition first and falls back to a POLY section that
+    preserves the exact geometry. Never returns ``None``.
+    """
+    from ada.sections.concept import Section
+
+    if tol is None:
+        tol = Config().general_point_tol
+
+    outer = _dedup_closing(outer_pts, tol)
+    inner = _dedup_closing(inner_pts, tol) if inner_pts else None
+
+    sec = _recognize_parametric(name, outer, inner, units, tol)
+    if sec is not None:
+        return sec
+
+    # Fallback: keep the geometry as-is.
+    return Section(
+        name=name or "PolyCurve",
+        sec_type=BaseTypes.POLY,
+        outer_poly=_as_curve_poly(outer),
+        inner_poly=_as_curve_poly(inner) if inner else None,
+        units=units,
+    )
+
+
+def _recognize_parametric(name, outer, inner, units, tol):
+    from ada.sections.concept import Section
+
+    rect = _axis_rectangle(outer, tol)
+
+    # Hollow rectangle with one rectangular void -> BOX.
+    if rect is not None and inner is not None:
+        irect = _axis_rectangle(inner, tol)
+        if irect is not None and _rect_inside(rect, irect, tol):
+            oxmin, oxmax, oymin, oymax = rect
+            ixmin, ixmax, iymin, iymax = irect
+            t_w = ((ixmin - oxmin) + (oxmax - ixmax)) / 2.0
+            return Section(
+                name=name,
+                sec_type=BaseTypes.BOX,
+                h=oymax - oymin,
+                w_top=oxmax - oxmin,
+                w_btn=oxmax - oxmin,
+                t_w=t_w,
+                t_ftop=oymax - iymax,
+                t_fbtn=iymin - oymin,
+                units=units,
+            )
+
+    # Solid rectangle, no void -> FLATBAR.
+    if rect is not None and inner is None:
+        oxmin, oxmax, oymin, oymax = rect
+        return Section(
+            name=name,
+            sec_type=BaseTypes.FLATBAR,
+            h=oymax - oymin,
+            w_top=oxmax - oxmin,
+            w_btn=oxmax - oxmin,
+            units=units,
+        )
+
+    # Open profiles (I/T) are described by a single outer curve with no void.
+    if inner is None:
+        sec = _recognize_i_or_t(name, outer, units, tol)
+        if sec is not None:
+            return sec
+
+    return None
+
+
+def _recognize_i_or_t(name, outer, units, tol):
+    """Recognise a symmetric I- or T-profile from its outer silhouette."""
+    from ada.sections.concept import Section
+
+    levels = _group_by_level(outer, axis=1, tol=tol)  # group by y
+    ys = sorted(levels)
+    counts = [len(levels[y]) for y in ys]
+
+    # I-profile: 4 y-levels, vertex counts (top->bottom) 2,4,4,2.
+    if len(ys) == 4 and counts == [2, 4, 4, 2]:
+        ybtn, y_lo, y_hi, ytop = ys
+        h = ytop - ybtn
+        w_top = _x_span(levels[ytop])
+        w_btn = _x_span(levels[ybtn])
+        t_ftop = ytop - y_hi
+        t_fbtn = y_lo - ybtn
+        t_w = _inner_x_span(levels[y_hi])
+        if not _is_symmetric(outer, tol):
+            return None
+        return Section(
+            name=name,
+            sec_type=BaseTypes.IPROFILE,
+            h=h,
+            w_top=w_top,
+            w_btn=w_btn,
+            t_w=t_w,
+            t_ftop=t_ftop,
+            t_fbtn=t_fbtn,
+            units=units,
+        )
+
+    # T-profile: 3 y-levels, vertex counts (top->bottom) 2,4,2.
+    if len(ys) == 3 and counts == [2, 4, 2]:
+        ybtn, y_mid, ytop = ys
+        if not _is_symmetric(outer, tol):
+            return None
+        return Section(
+            name=name,
+            sec_type=BaseTypes.TPROFILE,
+            h=ytop - ybtn,
+            w_top=_x_span(levels[ytop]),
+            t_w=_x_span(levels[ybtn]),
+            t_ftop=ytop - y_mid,
+            units=units,
+        )
+
+    return None
+
+
+# --- geometry helpers (all order/winding independent) -----------------------
+
+
+def _dedup_closing(pts, tol):
+    """Drop a trailing point that merely repeats the first (closing vertex)."""
+    out = [tuple(float(c) for c in (p[0], p[1])) for p in pts]
+    if len(out) > 1 and _close(out[0], out[-1], tol):
+        out = out[:-1]
+    return out
+
+
+def _close(a, b, tol):
+    return abs(a[0] - b[0]) <= tol and abs(a[1] - b[1]) <= tol
+
+
+def _bbox(pts):
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def _axis_rectangle(pts, tol):
+    """If ``pts`` is an axis-aligned rectangle, return (xmin, xmax, ymin, ymax)."""
+    uniq = _unique(pts, tol)
+    if len(uniq) != 4:
+        return None
+    xmin, xmax, ymin, ymax = _bbox(uniq)
+    if xmax - xmin <= tol or ymax - ymin <= tol:
+        return None
+    corners = [(xmin, ymin), (xmin, ymax), (xmax, ymin), (xmax, ymax)]
+    for corner in corners:
+        if not any(_close(corner, p, tol) for p in uniq):
+            return None
+    return xmin, xmax, ymin, ymax
+
+
+def _rect_inside(outer, inner, tol):
+    oxmin, oxmax, oymin, oymax = outer
+    ixmin, ixmax, iymin, iymax = inner
+    return ixmin > oxmin - tol and ixmax < oxmax + tol and iymin > oymin - tol and iymax < oymax + tol
+
+
+def _unique(pts, tol):
+    uniq = []
+    for p in pts:
+        if not any(_close(p, q, tol) for q in uniq):
+            uniq.append(p)
+    return uniq
+
+
+def _group_by_level(pts, axis, tol):
+    """Group points into buckets sharing the same coordinate on ``axis``."""
+    levels: dict[float, list] = {}
+    for p in _unique(pts, tol):
+        key = next((k for k in levels if abs(k - p[axis]) <= tol), None)
+        if key is None:
+            levels[p[axis]] = [p]
+        else:
+            levels[key].append(p)
+    return levels
+
+
+def _x_span(level_pts):
+    xs = [p[0] for p in level_pts]
+    return max(xs) - min(xs)
+
+
+def _inner_x_span(level_pts):
+    """Span between the two innermost (closest to centre) x-values in a level."""
+    xs = sorted(p[0] for p in level_pts)
+    mid = (xs[0] + xs[-1]) / 2.0
+    left = max((x for x in xs if x <= mid), default=mid)
+    right = min((x for x in xs if x >= mid), default=mid)
+    return right - left
+
+
+def _is_symmetric(pts, tol):
+    """True if the point cloud is mirror-symmetric about its mid x."""
+    xmin, xmax, _, _ = _bbox(pts)
+    midx = (xmin + xmax) / 2.0
+    uniq = _unique(pts, tol)
+    for p in uniq:
+        mirror = (2 * midx - p[0], p[1])
+        if not any(_close(mirror, q, tol) for q in uniq):
+            return False
+    return True
+
+
+def _as_curve_poly(pts):
+    from ada.api.curves import CurvePoly2d
+
+    return CurvePoly2d(pts, origin=(0, 0, 0), xdir=(1, 0, 0), normal=(0, 0, 1))

--- a/tests/core/cadit/ifc/roundtripping/test_foreign_box_polyline.py
+++ b/tests/core/cadit/ifc/roundtripping/test_foreign_box_polyline.py
@@ -1,0 +1,71 @@
+"""Foreign IFC (no adapy parameters) must be reconstructed from geometry.
+
+This reproduces the viewer audit failure where an XML->IFC converted box section
+arrived as an ``IfcArbitraryProfileDefWithVoids`` named ``mdo_B4650x2000x25x25x25``
+with no parametric metadata, which used to raise ``UnableToConvertSectionError``.
+"""
+
+import ifcopenshell
+import pytest
+
+from ada.cadit.ifc.read.read_beam_section import import_section_from_ifc
+from ada.sections.categories import BaseTypes
+
+
+def _polyline(f, pts):
+    cps = [f.create_entity("IfcCartesianPoint", Coordinates=(float(x), float(y))) for x, y in pts]
+    cps.append(cps[0])  # closed
+    return f.create_entity("IfcPolyLine", Points=cps)
+
+
+@pytest.fixture
+def ifc4_file():
+    return ifcopenshell.file(schema="IFC4")
+
+
+def test_foreign_box_polyline_recognised(ifc4_file):
+    f = ifc4_file
+    h, w, tw, tf = 4.650, 2.000, 0.025, 0.025
+    outer = _polyline(f, [(-w / 2, h / 2), (w / 2, h / 2), (w / 2, -h / 2), (-w / 2, -h / 2)])
+    inner = _polyline(
+        f, [(-w / 2 + tw, h / 2 - tf), (w / 2 - tw, h / 2 - tf), (w / 2 - tw, -h / 2 + tf), (-w / 2 + tw, -h / 2 + tf)]
+    )
+    prof = f.create_entity(
+        "IfcArbitraryProfileDefWithVoids",
+        ProfileType="AREA",
+        ProfileName="mdo_B4650x2000x25x25x25",
+        OuterCurve=outer,
+        InnerCurves=[inner],
+    )
+
+    sec = import_section_from_ifc(prof)
+
+    assert sec.type == BaseTypes.BOX
+    assert sec.h == pytest.approx(h, abs=1e-6)
+    assert sec.w_top == pytest.approx(w, abs=1e-6)
+    assert sec.t_w == pytest.approx(tw, abs=1e-6)
+    assert sec.t_ftop == pytest.approx(tf, abs=1e-6)
+    assert sec.t_fbtn == pytest.approx(tf, abs=1e-6)
+
+
+def test_foreign_solid_rect_is_flatbar(ifc4_file):
+    f = ifc4_file
+    outer = _polyline(f, [(-0.05, 0.1), (0.05, 0.1), (0.05, -0.1), (-0.05, -0.1)])
+    prof = f.create_entity("IfcArbitraryClosedProfileDef", ProfileType="AREA", ProfileName="solid", OuterCurve=outer)
+
+    sec = import_section_from_ifc(prof)
+
+    assert sec.type == BaseTypes.FLATBAR
+    assert sec.h == pytest.approx(0.2, abs=1e-6)
+    assert sec.w_top == pytest.approx(0.1, abs=1e-6)
+
+
+def test_foreign_unrecognised_falls_back_to_poly(ifc4_file):
+    f = ifc4_file
+    outer = _polyline(f, [(0, 0), (1, 0), (0.5, 1)])  # triangle -> no parametric match
+    prof = f.create_entity("IfcArbitraryClosedProfileDef", ProfileType="AREA", ProfileName="tri", OuterCurve=outer)
+
+    sec = import_section_from_ifc(prof)
+
+    assert sec.type == BaseTypes.POLY
+    assert sec.poly_outer is not None

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_advanced_face.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_advanced_face.py
@@ -1,0 +1,94 @@
+"""Isolated round-trip of curved (IfcAdvancedFace) plates through IFC.
+
+A foreign/exported IFC may represent a curved plate as a single
+``IfcAdvancedFace`` (B-spline surface) instead of an extruded profile. adapy
+imports these as :class:`PlateCurved`, keeping the surface geometry (and a flat
+fallback for rendering). This verifies adapy -> IFC -> adapy preserves the
+curved-plate geometry instead of crashing or losing it.
+"""
+
+import ada
+import ada.geom.surfaces as geo_su
+from ada.api.plates.base_pl import PlateCurved
+from ada.cadit.sat.store import SatReaderFactory
+
+
+def _curved_plate_from_sat(sat_path) -> PlateCurved:
+    sat_reader = SatReaderFactory(sat_path)
+    _, adv_face = next(iter(sat_reader.iter_advanced_faces()))
+    return PlateCurved("curved_plate", ada.geom.Geometry(1, adv_face, None), t=0.02)
+
+
+def test_advanced_face_plate_roundtrip(example_files, tmp_path):
+    pc = _curved_plate_from_sat(example_files / "sat_files/curved_plate.sat")
+    assert isinstance(pc.geom.geometry, geo_su.AdvancedFace)
+
+    fp = (ada.Assembly() / (ada.Part("P") / pc)).to_ifc(tmp_path / "curved.ifc", file_obj_only=True)
+    b = ada.from_ifc(fp)
+
+    curved = [o for o in b.get_all_physical_objects() if isinstance(o, PlateCurved)]
+    assert len(curved) == 1
+    geom = curved[0].geom.geometry
+    assert isinstance(geom, geo_su.AdvancedFace)
+    assert isinstance(geom.face_surface, geo_su.BSplineSurfaceWithKnots)
+    assert len(geom.bounds) == 1
+
+
+def test_advanced_face_plate_renders(example_files):
+    """The curved plate tessellates to a non-empty mesh (not silently dropped)."""
+    pc = _curved_plate_from_sat(example_files / "sat_files/curved_plate.sat")
+    a = ada.Assembly() / (ada.Part("P") / pc)
+
+    scene = a.to_trimesh_scene()
+    faces = sum(g.faces.shape[0] for g in scene.geometry.values())
+    assert faces > 0
+
+
+def _mesh_area(model) -> float:
+    import trimesh
+
+    scene = model.to_trimesh_scene()
+    tris = [g for g in scene.geometry.values() if isinstance(g, trimesh.Trimesh)]
+    return float(trimesh.util.concatenate(tris).area) if tris else 0.0
+
+
+def test_advanced_face_pcurve_roundtrip_preserves_area(example_files, tmp_path):
+    """The UV p-curve must survive IFC export/import.
+
+    Without it the re-imported trimmed B-spline face tessellates to a degenerate,
+    near-zero-area mesh (the curved plate looks "missing" in the viewer). Exporting
+    the p-curve via IfcSurfaceCurve/IfcPcurve keeps the area within tolerance.
+    """
+    pc = _curved_plate_from_sat(example_files / "sat_files/curved_plate.sat")
+    a = ada.Assembly() / (ada.Part("P") / pc)
+    area_src = _mesh_area(a)
+    assert area_src > 0.1
+
+    fp = a.to_ifc(tmp_path / "curved.ifc", file_obj_only=True)
+
+    # The p-curve must be present in the exported IFC.
+    assert len(fp.by_type("IfcPcurve")) > 0
+
+    b = ada.from_ifc(fp)
+    area_re = _mesh_area(b)
+    # Must stay the same order of magnitude. Without the p-curve the face collapses
+    # to <1% of its area; tessellation granularity alone varies by only a few %.
+    assert area_re > 0.5 * area_src, f"area collapsed: {area_re} vs {area_src} (p-curve likely lost)"
+
+
+def test_advanced_face_ifc_is_valid(example_files, tmp_path):
+    """The exported curved-plate IFC (with p-curves) passes ifcopenshell validation."""
+    from ifcopenshell import validate
+
+    pc = _curved_plate_from_sat(example_files / "sat_files/curved_plate.sat")
+    fp = (ada.Assembly() / (ada.Part("P") / pc)).to_ifc(tmp_path / "curved.ifc", file_obj_only=True)
+
+    logger = validate.json_logger()
+    validate.validate(fp, logger)
+    geom_issues = [
+        s
+        for s in logger.statements
+        if s.get("instance") is not None
+        and any(k in s["instance"].is_a() for k in ("Curve", "Surface", "Face", "Pcurve", "Edge", "BSpline"))
+    ]
+    assert geom_issues == []

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_revolved_beam.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_revolved_beam.py
@@ -14,6 +14,7 @@ def _solid_volume(model) -> float:
 def test_revolved_beam_solid_geom_is_valid():
     """A from-scratch revolved beam produces a solid of the expected volume."""
     import numpy as np
+
     from ada.geom.solids import RevolvedAreaSolid
 
     bm = ada.BeamRevolve("bm", ada.CurveRevolve((0, 0, 0), (0, 1, 0), 1.3, (0, 0, 1)), "IPE200")

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_revolved_beam.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_revolved_beam.py
@@ -1,0 +1,85 @@
+"""Revolved beam: valid geometry, IFC round-trip, and buildingSMART import."""
+
+import trimesh
+
+import ada
+
+
+def _solid_volume(model) -> float:
+    scene = model.to_trimesh_scene()
+    tris = [g for g in scene.geometry.values() if isinstance(g, trimesh.Trimesh)]
+    return float(trimesh.util.concatenate(tris).volume) if tris else 0.0
+
+
+def test_revolved_beam_solid_geom_is_valid():
+    """A from-scratch revolved beam produces a solid of the expected volume."""
+    import numpy as np
+    from ada.geom.solids import RevolvedAreaSolid
+
+    bm = ada.BeamRevolve("bm", ada.CurveRevolve((0, 0, 0), (0, 1, 0), 1.3, (0, 0, 1)), "IPE200")
+    assert isinstance(bm.solid_geom().geometry, RevolvedAreaSolid)
+
+    vol = _solid_volume(ada.Assembly() / (ada.Part("P") / bm))
+    expected = bm.section.properties.Ax * (bm.curve.radius * np.deg2rad(bm.curve.angle))  # area * arc length
+    assert vol == abs(vol)  # finite, positive
+    assert abs(vol - expected) / expected < 0.05
+
+
+def test_revolved_beam_roundtrip(tmp_path):
+    bm = ada.BeamRevolve("bm", ada.CurveRevolve((0, 0, 0), (0, 1, 0), 1.3, (0, 0, 1)), "IPE200")
+    a = ada.Assembly() / (ada.Part("P") / bm)
+    vol0 = _solid_volume(a)
+
+    fp = a.to_ifc(tmp_path / "rev.ifc", file_obj_only=True)
+
+    # Valid IFC geometry.
+    from ifcopenshell import validate
+
+    logger = validate.json_logger()
+    validate.validate(fp, logger)
+    geom_issues = [
+        s
+        for s in logger.statements
+        if s.get("instance") is not None
+        and any(k in s["instance"].is_a() for k in ("Revolved", "Trimmed", "Axis", "Profile", "Curve"))
+    ]
+    assert geom_issues == []
+
+    b = ada.from_ifc(fp)
+    bm2 = next(o for o in b.get_all_physical_objects() if isinstance(o, ada.BeamRevolve))
+    assert bm2.section.type == bm.section.type
+    vol1 = _solid_volume(b)
+    assert abs(vol1 - vol0) / vol0 < 0.02
+
+
+def test_revolved_beam_occ_matches_ifc_stream():
+    """The direct (OCC) tessellation and the ifcopenshell->mesh tessellation of the
+    same revolved beam must agree — i.e. the geom and the exported IFC describe the
+    same solid."""
+    bm = ada.BeamRevolve("bm", ada.CurveRevolve((0, 0, 0), (0, 1, 0), 1.3, (0, 0, 1)), "IPE200")
+    a = ada.Assembly() / (ada.Part("P") / bm)
+
+    def _vol(**kw):
+        sc = a.to_trimesh_scene(**kw)
+        tris = [g for g in sc.geometry.values() if isinstance(g, trimesh.Trimesh)]
+        return float(trimesh.util.concatenate(tris).volume)
+
+    vol_occ = _vol()
+    vol_stream = _vol(stream_from_ifc=True)
+    assert vol_occ > 0
+    assert abs(vol_stream - vol_occ) / vol_occ < 0.02
+
+
+def test_import_buildingsmart_revolved_beam(example_files):
+    """Import the buildingSMART beam-revolved-solid.ifc example and render it."""
+    import numpy as np
+
+    a = ada.from_ifc(example_files / "ifc_files/beams/beam-revolved-solid.ifc")
+    beams = [o for o in a.get_all_physical_objects() if isinstance(o, ada.BeamRevolve)]
+    assert len(beams) == 1
+    bm = beams[0]
+    assert bm.section.name == "IPE600"
+
+    vol = _solid_volume(a)
+    expected = bm.section.properties.Ax * (bm.curve.radius * np.deg2rad(bm.curve.angle))
+    assert abs(vol - expected) / expected < 0.05

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_sections.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_sections.py
@@ -1,0 +1,87 @@
+"""adapy -> IFC -> adapy cross-section round-trip fidelity.
+
+Every parametric section type carries its parameters through IFC via an
+``IfcProfileProperties`` bag attached to the profile, so re-import reproduces the
+exact section regardless of whether it was written as a parametric or polyline
+profile.
+"""
+
+import pytest
+
+import ada
+
+PARAMETRIC_SECTIONS = [
+    "BG800x600x20x30",  # box (written as a polyline profile)
+    "IPE300",  # i-profile
+    "HEA260",  # i-profile (from db)
+    "TG650x300x25x40",  # t-profile
+    "HP200x10",  # angular (written as a polyline profile)
+    "FB100x10",  # flatbar (written as a polyline profile)
+    "TUB200x10",  # tubular
+]
+
+
+@pytest.mark.parametrize("sec_str", PARAMETRIC_SECTIONS)
+def test_section_roundtrip(sec_str, tmp_path):
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), sec=sec_str)
+    sec_o = bm.section
+
+    fp = (ada.Assembly() / (ada.Part("P") / bm)).to_ifc(tmp_path / "sec.ifc", file_obj_only=True)
+    a = ada.from_ifc(fp)
+    sec_re = a.get_by_name("bm").section
+
+    assert sec_re.type == sec_o.type
+    assert sec_re.equal_props(sec_o), f"{sec_str}: {sec_re.unique_props()} != {sec_o.unique_props()}"
+
+
+def test_general_section_roundtrip(tmp_path):
+    """GeniE-style general beams (numeric properties only) survive the round-trip.
+
+    They are exported with a visual circle profile but carry the full
+    GeneralProperties via the ADA parameter bag.
+    """
+    from ada.sections.concept import GeneralProperties
+
+    gp = GeneralProperties(
+        Ax=0.00188594277,
+        Ix=7.178e-08,
+        Iy=6.1383e-06,
+        Iz=1.2361e-07,
+        Iyz=-4.5553e-07,
+        Wxmin=4e-06,
+        Wymin=5.62e-05,
+        Wzmin=4.9e-06,
+        Shary=0.0003924,
+        Sharz=0.00103,
+        Shceny=-0.0039015,
+        Shcenz=-0.061909,
+        Sy=4.76742207e-05,
+        Sz=5.61828483e-06,
+        Sfy=1,
+        Sfz=1,
+    )
+    bm = ada.Beam("bm", (0, 0, 0), (10, 0, 0), sec=ada.Section("gp1", "GENBEAM", genprops=gp))
+    sec_o = bm.section
+
+    fp = (ada.Assembly() / (ada.Part("P") / bm)).to_ifc(tmp_path / "gen.ifc", file_obj_only=True)
+    sec_re = ada.from_ifc(fp).get_by_name("bm").section
+
+    assert sec_re.type == sec_o.type
+    assert sec_re.equal_props(sec_o)
+    assert sec_re.properties.Ax == pytest.approx(gp.Ax)
+    assert sec_re.properties.Shcenz == pytest.approx(gp.Shcenz)
+
+
+def test_box_profile_props_written(tmp_path):
+    """The box profile carries an ADA parameter bag on the IfcProfileDef."""
+    from ada.cadit.ifc.sections_props import ADA_SECTION_PSET
+
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), sec="BG800x600x20x30")
+    fp = (ada.Assembly() / (ada.Part("P") / bm)).to_ifc(tmp_path / "box.ifc", file_obj_only=True)
+
+    prof_props = fp.by_type("IfcProfileProperties")
+    assert any(pp.Name == ADA_SECTION_PSET for pp in prof_props)
+    pp = next(pp for pp in prof_props if pp.Name == ADA_SECTION_PSET)
+    assert pp.ProfileDefinition.is_a("IfcArbitraryProfileDefWithVoids")
+    keys = {p.Name for p in pp.Properties}
+    assert {"sec_type", "h", "w_top", "t_w", "t_ftop"} <= keys

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_sphere.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_sphere.py
@@ -1,0 +1,31 @@
+"""Isolated round-trip of sphere-bodied products through IFC.
+
+GeniE-style node/support markers arrive as ``IfcBuildingElementProxy`` with an
+``IfcSphere`` body. adapy imports these as :class:`PrimSphere`, which fully
+round-trips (parametric centre + radius) and renders.
+"""
+
+import pytest
+
+import ada
+
+
+def test_sphere_proxy_roundtrip(tmp_path):
+    sphere = ada.PrimSphere("node1", (1.0, 2.0, 3.0), 0.5)
+
+    fp = (ada.Assembly() / (ada.Part("P") / sphere)).to_ifc(tmp_path / "sphere.ifc", file_obj_only=True)
+    b = ada.from_ifc(fp)
+
+    spheres = [o for o in b.get_all_physical_objects() if isinstance(o, ada.PrimSphere)]
+    assert len(spheres) == 1
+    assert spheres[0].radius == pytest.approx(0.5)
+    assert tuple(float(x) for x in spheres[0].cog) == pytest.approx((1.0, 2.0, 3.0))
+
+
+def test_sphere_proxy_renders(tmp_path):
+    sphere = ada.PrimSphere("node1", (0.0, 0.0, 0.0), 0.5)
+    a = ada.Assembly() / (ada.Part("P") / sphere)
+
+    scene = a.to_trimesh_scene()
+    faces = sum(g.faces.shape[0] for g in scene.geometry.values())
+    assert faces > 0

--- a/tests/core/cadit/ifc/test_empty_relationships.py
+++ b/tests/core/cadit/ifc/test_empty_relationships.py
@@ -1,0 +1,31 @@
+"""Exported IFC must not contain member-less relationships.
+
+An unused material (or a member-less group) would otherwise leave an
+``IfcRelAssociatesMaterial`` / ``IfcRelAssignsToGroup`` with an empty
+``RelatedObjects`` set, violating the schema's ``[1:?]`` cardinality and failing
+ifcopenshell validation.
+"""
+
+import ada
+from ada.materials import Material
+
+
+def test_no_empty_relationships_and_valid(tmp_path):
+    from ifcopenshell import validate
+
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), sec="IPE300")
+    a = ada.Assembly() / (ada.Part("P") / bm)
+    # An extra material that no element uses — the eager IfcRelAssociatesMaterial
+    # for it would be empty and must be pruned on export.
+    a.add_material(Material("UnusedMat"))
+
+    fp = a.to_ifc(tmp_path / "model.ifc", file_obj_only=True)
+
+    for rel_type in ("IfcRelAssociatesMaterial", "IfcRelAssignsToGroup"):
+        empties = [r for r in fp.by_type(rel_type) if not r.RelatedObjects]
+        assert empties == [], f"{len(empties)} empty {rel_type} survived export"
+
+    logger = validate.json_logger()
+    validate.validate(fp, logger)
+    cardinality_issues = [s for s in logger.statements if "RelatedObjects" in (s.get("message") or "")]
+    assert cardinality_issues == []


### PR DESCRIPTION
## Context

A viewer conversion audit failed turning an XML-derived IFC into GLB:

```
UnableToConvertSectionError: Unable to interpret section str "mdo_B4650x2000x25x25x25"
```

Fixing that surfaced a broader pattern: geometry that does not survive the **adapy → IFC → adapy** round-trip. This PR makes that round-trip faithful and the exported IFC valid.

## Cross-sections
- Export parametric params on the profile via the schema-native **`IfcProfileProperties`** (IFC4 `HasProperties`), including GENERAL sections' `GeneralProperties` (GeniE general beams). Import prefers these for an exact, lossless reconstruction.
- Foreign IFC with no adapy params: reconstruct from polyline geometry with **order/winding-independent** shape recognition (box, flatbar, I, T), else keep a faithful POLY section. (Fixes the `mdo_B...` failure.)

## Curved plates, spheres, robustness
- IFC import is now **resilient per-element** — one unsupported product is logged and skipped instead of aborting the whole model.
- Curved **`IfcAdvancedFace`** plates → `PlateCurved`. The reader now reads `IfcEdgeCurve` and, critically, **round-trips the UV p-curve** via `IfcSurfaceCurve`/`IfcPcurve`. Without it the trimmed B-spline face tessellated to a degenerate, near-zero-area mesh — the "missing" curved transition plates (e.g. `col1mainskin_elev1plate6_1`). Verified: XML→IFC→GLB area now matches the direct-XML pipeline within ~1%.
- Added `IfcSphere` / `IfcRightCircularCylinder` / `IfcRightCircularCone` readers; sphere proxies import as `PrimSphere`.

## Valid IFC
- Prune relationships left with an empty `RelatedObjects` set (`IfcRelAssociatesMaterial` for unused materials, member-less `IfcRelAssignsToGroup`) so the export passes ifcopenshell validation (full Utror export: **0 issues**, down from 42).

## Notes
- All geometry construction goes through `ada.geom` data + `ifcopenshell`; OCC/tessellation stays in the existing backend-routed code (`active_backend().build`). No direct OCC and no `src/ada/occ/*` changes.
- `scripts/viewer_upload.py` now accepts `ADAPY_BASE_URL` (matching `audit_fetch.py`).

## Tests
New round-trip tests for sections, foreign-box polyline, AdvancedFace (p-curve area preservation + IFC validity), sphere, and empty-relationship validation. **Full suite: 759 passed, 9 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)