### PR TITLE
feat: fast FEM-shell plate path, FEM->STEP streaming, merged-plate guard

### DIFF
--- a/scripts/audit_fetch.py
+++ b/scripts/audit_fetch.py
@@ -1,122 +1,27 @@
-"""Download the source blob for a viewer audit row to ./audit_repro/<id>/.
+"""Thin shim for ``ada audit fetch`` — download an audit conversion's source.
 
-Used to reproduce a failed conversion locally without spinning up a
-viewer-api stack: pair with ``audit_repro.py`` for the round trip.
-
-Auth: ``ADAPY_API_TOKEN`` (a CLI token minted from the admin panel).
-Base URL: ``ADAPY_API_BASE`` *or* ``ADAPY_BASE_URL``
-(e.g. ``https://viewer.example.com``).
+Kept so the ``pixi run audit-fetch`` task (and existing muscle memory) keep
+working; the implementation now lives in :mod:`ada_cli.audit`.
 """
 
 from __future__ import annotations
 
 import argparse
-import gzip
-import json
-import os
 import pathlib
-import re
 import sys
-import urllib.error
-import urllib.request
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-def _env(name: str) -> str:
-    val = os.environ.get(name, "").strip()
-    if not val:
-        sys.stderr.write(
-            f"error: {name} is unset. Mint a token from the admin panel " f"(CLI token button) and export it.\n"
-        )
-        sys.exit(2)
-    return val
-
-
-def _env_any(*names: str) -> str:
-    """First non-empty match among ``names``. Lets the script accept
-    either ``ADAPY_API_BASE`` or the more common ``ADAPY_BASE_URL`` —
-    folks reach for whichever they have in their .env first."""
-    for n in names:
-        val = os.environ.get(n, "").strip()
-        if val:
-            return val
-    sys.stderr.write(
-        f"error: none of {', '.join(names)} are set. Set the viewer base URL "
-        f"to (e.g.) https://viewer.example.com.\n"
-    )
-    sys.exit(2)
-
-
-def _api_get(url: str, token: str) -> tuple[bytes, dict[str, str]]:
-    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
-    try:
-        with urllib.request.urlopen(req) as r:
-            return r.read(), {k.lower(): v for k, v in r.headers.items()}
-    except urllib.error.HTTPError as e:
-        body = e.read().decode("utf-8", errors="replace")
-        sys.stderr.write(f"HTTP {e.code} on {url}: {body}\n")
-        sys.exit(1)
-
-
-def _filename_from_disposition(value: str | None) -> str | None:
-    if not value:
-        return None
-    m = re.search(r'filename="([^"]+)"', value)
-    return m.group(1) if m else None
-
-
-def _normalize_base(raw: str) -> str:
-    raw = raw.rstrip("/")
-    if "://" not in raw:
-        # Default to https:// — the viewer is virtually always behind
-        # TLS termination and copy-pasting just the hostname is the
-        # common ergonomic mistake.
-        raw = f"https://{raw}"
-    return raw
-
-
-def fetch(audit_id: int, dest_root: pathlib.Path) -> pathlib.Path:
-    base = _normalize_base(_env_any("ADAPY_API_BASE", "ADAPY_BASE_URL"))
-    token = _env("ADAPY_API_TOKEN")
-    dest = dest_root / str(audit_id)
-    dest.mkdir(parents=True, exist_ok=True)
-
-    # Metadata first — gives us target_format and the error context to
-    # save alongside the source so repro is self-contained.
-    meta_bytes, _ = _api_get(f"{base}/api/admin/audit/{audit_id}", token)
-    meta = json.loads(meta_bytes)
-    (dest / "audit.json").write_text(json.dumps(meta, indent=2))
-
-    # Source blob. The endpoint passes through any storage-layer
-    # Content-Encoding (e.g. files stored gzipped land here with
-    # `Content-Encoding: gzip`). Browsers decompress transparently;
-    # urllib doesn't, so do it here so the on-disk file is always
-    # the real source the converter will see — not a gzip wrapper.
-    source_bytes, headers = _api_get(f"{base}/api/admin/audit/{audit_id}/source", token)
-    if (headers.get("content-encoding") or "").lower() == "gzip":
-        source_bytes = gzip.decompress(source_bytes)
-    name = (
-        _filename_from_disposition(headers.get("content-disposition"))
-        or (meta.get("key") or "").rsplit("/", 1)[-1]
-        or f"audit-{audit_id}.bin"
-    )
-    src = dest / name
-    src.write_bytes(source_bytes)
-    return src
+from ada_cli.audit import cmd_fetch  # noqa: E402
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("audit_id", type=int)
-    ap.add_argument(
-        "--out",
-        default="./audit_repro",
-        help="Root directory for downloaded sources (default: ./audit_repro)",
-    )
-    args = ap.parse_args()
-
-    dest_root = pathlib.Path(args.out)
-    src = fetch(args.audit_id, dest_root)
-    sys.stdout.write(f"{src}\n")
+    ap.add_argument("--out", default="./audit_repro")
+    ap.add_argument("--url", default=None)
+    ap.add_argument("--token", default=None)
+    raise SystemExit(cmd_fetch(ap.parse_args()))
 
 
 if __name__ == "__main__":

--- a/scripts/audit_repro.py
+++ b/scripts/audit_repro.py
@@ -1,86 +1,30 @@
-"""Reproduce a failed viewer conversion locally without going through
-the REST API or queue.
+"""Thin shim for ``ada audit repro`` — run an audit's conversion locally.
 
-Downloads the source blob via :mod:`audit_fetch` (idempotent — skips
-the network call when the file already exists) and invokes
-:func:`ada.comms.rest.converter.convert` directly with the original
-``target_format``. The traceback lands on stderr in seconds, which is
-the whole point — fast iteration on a failing conversion without a
-running viewer-api stack.
+Downloads the source blob (idempotent) and invokes the converter directly so
+a failing conversion's traceback lands on stderr in seconds. Kept so the
+``pixi run audit-repro`` task keeps working; the implementation now lives in
+:mod:`ada_cli.audit`.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import pathlib
 import sys
-import traceback
 
-sys.path.insert(0, str(pathlib.Path(__file__).parent))
-import audit_fetch  # noqa: E402
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-
-def _ensure_local(audit_id: int, root: pathlib.Path) -> tuple[pathlib.Path, dict]:
-    dest = root / str(audit_id)
-    meta_path = dest / "audit.json"
-    if meta_path.exists() and any(p for p in dest.iterdir() if p.name != "audit.json"):
-        meta = json.loads(meta_path.read_text())
-        # Pick the source file by matching the key tail; fall back to
-        # any non-metadata file in the dir.
-        key_tail = (meta.get("key") or "").rsplit("/", 1)[-1]
-        candidate = dest / key_tail if key_tail else None
-        if candidate and candidate.exists():
-            return candidate, meta
-        for p in dest.iterdir():
-            if p.name != "audit.json":
-                return p, meta
-    src = audit_fetch.fetch(audit_id, root)
-    meta = json.loads((dest / "audit.json").read_text())
-    return src, meta
+from ada_cli.audit import cmd_repro  # noqa: E402
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("audit_id", type=int)
-    ap.add_argument(
-        "--out",
-        default="./audit_repro",
-        help="Root directory for downloaded sources (default: ./audit_repro)",
-    )
-    ap.add_argument(
-        "--target",
-        default=None,
-        help="Override the target_format from the audit row.",
-    )
-    args = ap.parse_args()
-
-    root = pathlib.Path(args.out)
-    src, meta = _ensure_local(args.audit_id, root)
-    target = args.target or meta.get("target_format") or "glb"
-
-    # Imported lazily so plain `audit-fetch` doesn't pay the
-    # import-time cost of the converter (and its FEM stack).
-    from ada.comms.rest.converter import convert
-
-    sys.stdout.write(f"repro audit_id={args.audit_id} src={src} target={target}\n")
-    sys.stdout.write(f"original status={meta.get('status')} error={meta.get('error')!r}\n")
-    sys.stdout.flush()
-
-    def on_progress(stage: str, frac: float) -> None:
-        sys.stdout.write(f"  [{frac:5.1%}] {stage}\n")
-        sys.stdout.flush()
-
-    try:
-        out = convert(src, str(src), target, on_progress)
-    except Exception:
-        sys.stderr.write("\n--- repro raised ---\n")
-        traceback.print_exc()
-        sys.exit(1)
-
-    out_path = src.with_suffix(f".out.{target.lstrip('.')}")
-    out_path.write_bytes(out)
-    sys.stdout.write(f"ok: wrote {out_path} ({len(out)} bytes)\n")
+    ap.add_argument("--out", default="./audit_repro")
+    ap.add_argument("--target", default=None, help="Override the audit's target_format.")
+    ap.add_argument("--url", default=None)
+    ap.add_argument("--token", default=None)
+    raise SystemExit(cmd_repro(ap.parse_args()))
 
 
 if __name__ == "__main__":

--- a/src/ada/api/curves.py
+++ b/src/ada/api/curves.py
@@ -346,6 +346,84 @@ class CurvePoly2d(CurveOpen2d):
             points = [points[0]] + [p for p in reversed(points[1:])]
         return points
 
+    @classmethod
+    def from_fem_shell(cls, points3d, tol=1e-3, parent=None) -> CurvePoly2d:
+        """Fast constructor for flat FEM shell elements (3- or 4-gon, no arcs/radii).
+
+        Geometrically equivalent to ``from_3d_points`` for a radius-free polygon,
+        but it (a) computes the orientation once and injects it via
+        :meth:`Placement.from_dirs_precomputed`, so the computed-placement LRU is
+        never touched (it thrashes on per-element placements), and (b) builds the
+        closed line loop directly instead of running ``build_polycurve`` /
+        ``SegCreator``. Used only by the FEM shell -> Plate conversion; the general
+        ``from_3d_points`` path (arcs, fillets, radii) is unchanged.
+        """
+        from ada.core.vector_transforms import (
+            compute_orientation_vec,
+            normal_to_points_in_plane,
+            transform_3x3,
+        )
+        from ada.core.vector_utils import calc_yvec
+
+        pts = np.array([p[:3] for p in points3d], dtype=float)
+        if pts.shape[0] < 3:
+            raise ValueError("At least three points are required to define a shell plate.")
+        origin = pts[0]
+
+        # Orientation -- mirrors Placement.from_co_linear_points feeding the
+        # xdir/zdir-only orientation that CurveOpen2d builds. compute_orientation_vec
+        # is the pure function the LRU wraps, so calling it directly is byte-for-byte
+        # identical to the general path yet never touches get_computed_placement_cached.
+        n = normal_to_points_in_plane(pts)
+        xdir_raw = Direction(pts[1] - pts[0]).get_normalized()
+        ydir_raw = Direction(calc_yvec(xdir_raw, n)).get_normalized()
+        x1, y1, z1 = compute_orientation_vec(
+            tuple(map(float, xdir_raw)), tuple(map(float, ydir_raw)), tuple(map(float, n))
+        )
+        rot1 = np.array([x1, y1, z1])
+
+        # final orientation == Placement(origin, xdir=P1.xdir, zdir=P1.zdir)
+        xf, yf, zf = compute_orientation_vec(x1, None, z1)
+        xf, yf, zf = Direction(*xf), Direction(*yf), Direction(*zf)
+        orientation = Placement.from_dirs_precomputed(origin, xf, yf, zf)
+        rotf = np.array([xf, yf, zf])
+
+        # 3D -> 2D using P1 (== transform_global_points_to_local)
+        local = transform_3x3(rot1, pts - origin, inverse=False)[:, :2]
+
+        # winding (CurvePoly2d._points_fix): keep first point, reverse the rest if CCW
+        local_list = [p for p in local]
+        if is_clockwise(local_list) is False:
+            local_list = [local_list[0]] + list(reversed(local_list[1:]))
+
+        points2d = [Point(p[0], p[1]) for p in local_list]
+        # 3D points via the final orientation (== CurveOpen2d._points3d back-transform)
+        back = transform_3x3(rotf, np.array([np.asarray(p) for p in points2d]), inverse=True) + origin
+        points3d_pts = [Point(p) for p in back]
+
+        # Segment order matches build_polycurve: closing edge first
+        # ((p[-1]->p[0]), (p[0]->p[1]), ...), so seg_global_points / seg_index
+        # come out identical to the general from_3d_points path.
+        npts = len(points2d)
+        segs2d = [LineSegment(points2d[i - 1], points2d[i]) for i in range(npts)]
+        segs3d = [LineSegment(points3d_pts[i - 1], points3d_pts[i]) for i in range(npts)]
+        seg_global_points, seg_index = segments_to_indexed_lists(segs3d)
+
+        self = cls.__new__(cls)
+        self._tol = tol
+        self._parent = parent
+        self._orientation = orientation
+        self._placement = Placement()
+        self._radiis = {}
+        self._points2d = points2d
+        self._points3d = points3d_pts
+        self._segments = segs2d
+        self._segments3d = segs3d
+        self._seg_global_points = seg_global_points
+        self._seg_index = seg_index
+        self._nodes = [Node(p) for p in points3d_pts]
+        return self
+
     def get_face_geom(self) -> ArbitraryProfileDef:
         outer_curve = self.curve_geom()
         return ArbitraryProfileDef(ProfileType.AREA, outer_curve, [])

--- a/src/ada/api/plates/base_pl.py
+++ b/src/ada/api/plates/base_pl.py
@@ -97,6 +97,17 @@ class Plate(BackendGeom):
         return Plate(name, poly, t, mat=mat, color=color, metadata=metadata, **kwargs)
 
     @staticmethod
+    def from_fem_shell(name, points, t, mat="S420", color=None, metadata=None, parent=None, **kwargs) -> Plate:
+        """Fast Plate constructor for flat FEM shell elements (no arcs/radii).
+
+        Equivalent geometry to ``from_3d_points`` but routed through
+        ``CurvePoly2d.from_fem_shell``, which skips ``build_polycurve`` and the
+        computed-placement LRU. See :meth:`CurvePoly2d.from_fem_shell`.
+        """
+        poly = CurvePoly2d.from_fem_shell(points, parent=parent)
+        return Plate(name, poly, t, mat=mat, color=color, metadata=metadata, parent=parent, **kwargs)
+
+    @staticmethod
     def from_extruded_area_solid(name, solid: ExtrudedAreaSolid): ...
 
     def __hash__(self):

--- a/src/ada/api/transforms.py
+++ b/src/ada/api/transforms.py
@@ -116,6 +116,26 @@ class Placement:
         return Placement(origin=origin, xdir=xdir, ydir=ydir, zdir=n)
 
     @staticmethod
+    def from_dirs_precomputed(origin, xdir: Direction, ydir: Direction, zdir: Direction) -> Placement:
+        """Build a Placement whose ``ComputedPlacement`` is injected directly.
+
+        The lazy ``xdir``/``ydir``/``zdir`` getters short-circuit on a populated
+        ``_computed_placement`` (see :meth:`xdir`), so accessing the directions
+        never calls the global ``get_computed_placement_cached`` LRU. That cache
+        thrashes on FEM meshes (a distinct placement per element), so the fast
+        shell path computes the orientation once and injects it here.
+
+        The three directions must already be normalized and rounded to match the
+        output of ``compute_orientation_vec`` (i.e. what the LRU path would have
+        produced), otherwise geometry will not match the general construction.
+        """
+        from ada.api.computed_placement import ComputedPlacement
+
+        place = Placement(origin=origin, xdir=xdir, ydir=ydir, zdir=zdir)
+        place._computed_placement = ComputedPlacement(xdir=xdir, ydir=ydir, zdir=zdir)
+        return place
+
+    @staticmethod
     def from_axis3d(axis: Axis2Placement3D) -> Placement:
         return Placement(origin=axis.location, xdir=axis.ref_direction, zdir=axis.axis)
 

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -971,13 +971,25 @@ def _via_ada_to_step(
     through OCC's parser.
     """
 
+    from ada.config import logger
+
     on_progress("parsing", 0.15)
     model = _load_with_ada(src_path, source_ext)
     _apply_fem_to_objects(model, source_ext, "step", fem_to_objects, merge_fem_objects, reconstruct_surfaces)
     on_progress("writing-step", 0.55)
     out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
     try:
-        model.to_stp(str(out_path))
+        if source_ext.lower() in _FEM_SOURCE_EXTS:
+            # A FEM mesh rebuilds into extruded plates/straight beams, which the
+            # streaming AP242 writer emits one-at-a-time at constant memory. The
+            # default OCC XCAF writer instead accumulates every solid plus a full
+            # entity-graph copy and OOMs the worker on large jackets/ships.
+            stats = model.to_stp(str(out_path), writer="stream")
+            skipped = (stats or {}).get("skipped", 0)
+            if skipped:
+                logger.warning(f"streaming STEP writer skipped {skipped} non-extrudable object(s)")
+        else:
+            model.to_stp(str(out_path))
         on_progress("ready", 1.0)
         return out_path.read_bytes()
     finally:

--- a/src/ada/fem/formats/concept_merge.py
+++ b/src/ada/fem/formats/concept_merge.py
@@ -82,9 +82,67 @@ def _plate_plane_key(plate: "Plate", ndigits: int):
     return (plate.material.name, round(float(plate.t), ndigits), ncanon, offset)
 
 
+def _segments_cross(a1, a2, b1, b2, eps: float) -> bool:
+    """True if open segments a1a2 and b1b2 properly cross (share interior point)."""
+
+    def orient(p, q, r):
+        return (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0])
+
+    d1 = orient(b1, b2, a1)
+    d2 = orient(b1, b2, a2)
+    d3 = orient(a1, a2, b1)
+    d4 = orient(a1, a2, b2)
+    # Proper crossing only: each segment straddles the other's supporting line.
+    # Collinear / endpoint-touching cases are left to the degree-2/edge-length
+    # guards so we don't reject a legitimately-shared vertex.
+    return ((d1 > eps) != (d2 > eps)) and ((d3 > eps) != (d4 > eps)) and abs(d1) > eps and abs(d2) > eps
+
+
+def _loop_is_simple_2d(pts2d, tol: float = 1e-6) -> bool:
+    """True if a closed 2D polygon is non-degenerate and non-self-intersecting.
+
+    The edge-cancellation merge only guarantees a *topologically* single,
+    degree-2 boundary (at the rounding grid). Two edges can still cross
+    geometrically without sharing a rounded vertex — a non-simple polygon that
+    ``from_3d_points`` accepts but OCC's wire/face builder rejects ("Segments do
+    not form a closed loop"). This catches that before it corrupts the export.
+    """
+    n = len(pts2d)
+    if n < 3:
+        return False
+    xs = [p[0] for p in pts2d]
+    ys = [p[1] for p in pts2d]
+    scale = max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+    tol_len = tol * scale
+
+    for i in range(n):
+        a = pts2d[i]
+        b = pts2d[(i + 1) % n]
+        if ((b[0] - a[0]) ** 2 + (b[1] - a[1]) ** 2) ** 0.5 <= tol_len:
+            return False  # near-zero-length edge
+
+    area2 = sum(pts2d[i][0] * pts2d[(i + 1) % n][1] - pts2d[(i + 1) % n][0] * pts2d[i][1] for i in range(n))
+    if abs(area2) * 0.5 <= tol_len * scale:
+        return False  # degenerate / near-zero area
+
+    eps = (tol_len * scale) * 1e-3
+    for i in range(n):
+        a1, a2 = pts2d[i], pts2d[(i + 1) % n]
+        for j in range(i + 1, n):
+            if j == i or (j + 1) % n == i or (i + 1) % n == j:
+                continue  # adjacent edges share a vertex by construction
+            b1, b2 = pts2d[j], pts2d[(j + 1) % n]
+            if _segments_cross(a1, a2, b1, b2, eps):
+                return False
+    return True
+
+
 def _merge_coplanar_component(plates: list["Plate"], parent: "Part", ndigits: int) -> list["Plate"]:
     from ada import Plate
-    from ada.core.vector_utils import merge_coplanar_loops_by_edge_cancellation
+    from ada.core.vector_utils import (
+        merge_coplanar_loops_by_edge_cancellation,
+        project_points_to_local_2d,
+    )
 
     loops = [list(pl.poly.points3d) for pl in plates]
     merged = merge_coplanar_loops_by_edge_cancellation(loops, ndigits=ndigits)
@@ -92,6 +150,20 @@ def _merge_coplanar_component(plates: list["Plate"], parent: "Part", ndigits: in
         # Hole, non-manifold vertex, or multiple disjoint loops — not a
         # single clean boundary, so keep the originals.
         return list(plates)
+
+    # The topological merge can still yield a geometrically self-intersecting or
+    # degenerate boundary. Validate the projected 2D loop before building the
+    # plate; a bad merge silently produces geometry that crashes the STEP export
+    # downstream, so fall back to the originals instead (best-effort contract).
+    try:
+        pts2d, _ = project_points_to_local_2d(merged)
+    except Exception as exc:
+        logger.debug(f"coplanar merge skipped for {plates[0].name!r}: {exc}")
+        return list(plates)
+    if not _loop_is_simple_2d(pts2d):
+        logger.debug(f"coplanar merge skipped for {plates[0].name!r}: non-simple/degenerate merged loop")
+        return list(plates)
+
     ref = plates[0]
     try:
         return [Plate.from_3d_points(f"{ref.name}_m", merged, ref.t, mat=ref.material, parent=parent)]

--- a/src/ada/fem/formats/utils.py
+++ b/src/ada/fem/formats/utils.py
@@ -501,16 +501,16 @@ def convert_shell_elem_to_plates(elem: Elem, parent: Part, mat_dict: dict | None
             *elem.nodes[3].p,
         ):
             plates.append(
-                Plate.from_3d_points(
+                Plate.from_fem_shell(
                     f"sh{elem.id}", [n.p for n in elem.nodes], fem_sec.thickness, mat=new_mat, parent=parent
                 )
             )
         else:
             el_n1 = [elem.nodes[0].p, elem.nodes[1].p, elem.nodes[2].p]
             el_n2 = [elem.nodes[0].p, elem.nodes[2].p, elem.nodes[3].p]
-            plates.append(Plate.from_3d_points(f"sh{elem.id}", el_n1, fem_sec.thickness, mat=new_mat, parent=parent))
+            plates.append(Plate.from_fem_shell(f"sh{elem.id}", el_n1, fem_sec.thickness, mat=new_mat, parent=parent))
             plates.append(
-                Plate.from_3d_points(
+                Plate.from_fem_shell(
                     f"sh{elem.id}_1",
                     el_n2,
                     fem_sec.thickness,
@@ -521,7 +521,7 @@ def convert_shell_elem_to_plates(elem: Elem, parent: Part, mat_dict: dict | None
     else:
         try:
             plates.append(
-                Plate.from_3d_points(
+                Plate.from_fem_shell(
                     f"sh{elem.id}",
                     [n.p for n in elem.nodes],
                     fem_sec.thickness,

--- a/src/ada_cli/__init__.py
+++ b/src/ada_cli/__init__.py
@@ -1,0 +1,39 @@
+"""adapy ``ada`` CLI package."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def load_dotenv_cwd(path: str | os.PathLike | None = None) -> bool:
+    """Load ``KEY=VALUE`` pairs from a ``.env`` in the current directory.
+
+    Best-effort and dependency-free: blank lines and ``#`` comments are
+    skipped, a leading ``export`` is tolerated, and surrounding quotes are
+    stripped. Existing environment variables win (so a real env var or one
+    exported in the shell is never clobbered). Returns True if a file was read.
+    """
+    env_path = pathlib.Path(path) if path is not None else pathlib.Path.cwd() / ".env"
+    if not env_path.is_file():
+        return False
+    try:
+        lines = env_path.read_text().splitlines()
+    except OSError:
+        return False
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key and key not in os.environ:
+            os.environ[key] = val
+    return True

--- a/src/ada_cli/audit.py
+++ b/src/ada_cli/audit.py
@@ -1,0 +1,441 @@
+"""``ada audit`` — query, fetch, and locally re-run viewer audit conversions.
+
+A read-only client over the admin audit API. It consolidates what used to be
+ad-hoc ``curl`` calls plus the ``scripts/audit_fetch.py`` / ``audit_repro.py``
+helpers:
+
+    ada audit runs                     list recent regression-sweep runs
+    ada audit run <run_id> [--failed]  show a run's per-cell jobs
+    ada audit log [--target step ...]  query the per-conversion audit log
+    ada audit perf [--source-ext .fem] function-level hot paths in a cell
+    ada audit fetch <audit_id>         download a conversion's source blob
+    ada audit repro <audit_id>         run that conversion locally (the local
+                                       run option for a given audit)
+
+Auth: ``ADAPY_API_TOKEN`` (a CLI token from the admin panel). Base URL:
+``ADAPY_API_BASE`` or ``ADAPY_BASE_URL`` (host or full URL) — same env pair
+the audit scripts already use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_OUT = "./audit_repro"
+
+
+# ── config / http ────────────────────────────────────────────────────────
+
+
+def _normalize_base(raw: str) -> str:
+    raw = raw.rstrip("/")
+    # The viewer is virtually always behind TLS; bare-hostname copy-paste is
+    # the common ergonomic mistake, so default the scheme to https://.
+    return raw if "://" in raw else f"https://{raw}"
+
+
+def _config(args: argparse.Namespace) -> tuple[str, str]:
+    # Honour a .env in the CWD even when called outside `ada audit`
+    # (e.g. the scripts/ shims), without ever clobbering a real env var.
+    from ada_cli import load_dotenv_cwd
+
+    load_dotenv_cwd()
+    base = (getattr(args, "url", None) or "").strip()
+    if not base:
+        for name in ("ADAPY_API_BASE", "ADAPY_BASE_URL"):
+            val = os.environ.get(name, "").strip()
+            if val:
+                base = val
+                break
+    token = (getattr(args, "token", None) or os.environ.get("ADAPY_API_TOKEN", "")).strip()
+    missing = []
+    if not base:
+        missing.append("ADAPY_API_BASE or ADAPY_BASE_URL (or --url), e.g. https://viewer.example.com")
+    if not token:
+        missing.append("ADAPY_API_TOKEN (or --token) — mint a CLI token in the admin panel")
+    if missing:
+        for m in missing:
+            print(f"missing: {m}", file=sys.stderr)
+        sys.exit(2)
+    return _normalize_base(base), token
+
+
+def _get(base: str, token: str, path: str) -> tuple[bytes, dict[str, str]]:
+    req = urllib.request.Request(f"{base}{path}", headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.read(), {k.lower(): v for k, v in r.headers.items()}
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} on {path}: {body[:300]}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _get_json(base: str, token: str, path: str) -> dict:
+    body, _ = _get(base, token, path)
+    return json.loads(body)
+
+
+def _qs(params: dict) -> str:
+    items = {k: v for k, v in params.items() if v not in (None, "")}
+    return ("?" + urllib.parse.urlencode(items)) if items else ""
+
+
+def _short(text: str | None, n: int = 80) -> str:
+    return (text or "").replace("\n", " ").strip()[:n]
+
+
+# ── commands ─────────────────────────────────────────────────────────────
+
+
+def cmd_runs(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    d = _get_json(base, token, "/api/admin/audit/runs" + _qs({"limit": args.limit, "before_started_at": args.before}))
+    runs = d.get("runs", [])
+    if args.json:
+        print(json.dumps(runs, indent=2))
+        return 0
+    print(f"{'run_id':36}  {'status':9}  {'started':25}  {'total':>6}  {'failed':>6}")
+    for r in runs:
+        print(
+            f"{str(r.get('id')):36}  {str(r.get('status')):9}  {str(r.get('started_at'))[:25]:25}  "
+            f"{str(r.get('total') or 0):>6}  {str(r.get('failed') or 0):>6}"
+        )
+    if not runs:
+        print("(no runs)", file=sys.stderr)
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    d = _get_json(base, token, f"/api/admin/audit/runs/{args.run_id}")
+    run = d.get("run") or {}
+    jobs = d.get("jobs", [])
+    if args.failed:
+        jobs = [j for j in jobs if j.get("status") == "error"]
+    if args.format:
+        jobs = [j for j in jobs if j.get("target_format") == args.format.lstrip(".")]
+    if args.json:
+        print(json.dumps({"run": run, "jobs": jobs}, indent=2))
+        return 0
+    print(
+        f"run {run.get('id')}  status={run.get('status')}  "
+        f"total={run.get('total')}  failed={run.get('failed')}  started={str(run.get('started_at'))[:25]}"
+    )
+    print(f"{'status':7}  {'target':6}  {'dur_s':>6}  {'rss_mb':>7}  {'key / error'}")
+    for j in jobs:
+        dur = (j.get("duration_ms") or 0) // 1000
+        rss = (j.get("peak_rss_kb") or 0) // 1024
+        tail = j.get("key") or ""
+        if j.get("status") == "error":
+            tail = f"{tail}  :: {_short(j.get('error'), 100)}"
+        print(f"{str(j.get('status')):7}  {str(j.get('target_format')):6}  {dur:>6}  {rss:>7}  {tail}")
+    if not jobs:
+        print("(no matching jobs)", file=sys.stderr)
+    return 0
+
+
+def cmd_log(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    # The list endpoint filters by action/scope only; source/target/status/grep
+    # are matched client-side, paging back until the row budget is met.
+    source = (args.source or "").lstrip(".").lower()
+    target = (args.target or "").lstrip(".").lower()
+    rows: list[dict] = []
+    before = None
+    for _ in range(max(1, args.pages)):
+        d = _get_json(base, token, "/api/admin/audit" + _qs({"limit": 200, "before_id": before}))
+        entries = d.get("entries", [])
+        if not entries:
+            break
+        for r in entries:
+            key = (r.get("key") or "").lower()
+            err = r.get("error") or ""
+            if source and not key.endswith(f".{source}"):
+                continue
+            if target and (r.get("target_format") or "").lower() != target:
+                continue
+            if args.status and (r.get("status") or "") != args.status:
+                continue
+            if args.key and args.key.lower() not in key:
+                continue
+            if args.grep and args.grep.lower() not in err.lower():
+                continue
+            rows.append(r)
+            if len(rows) >= args.limit:
+                break
+        if len(rows) >= args.limit:
+            break
+        before = d.get("next_before_id")
+        if not before:
+            break
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return 0
+    print(f"{'id':>8}  {'status':7}  {'target':6}  {'key / error'}")
+    for r in rows:
+        tail = r.get("key") or ""
+        if r.get("status") == "error":
+            tail = f"{tail}  :: {_short(r.get('error'), 100)}"
+        print(f"{str(r.get('id')):>8}  {str(r.get('status')):7}  {str(r.get('target_format')):6}  {tail}")
+    if not rows:
+        print("(no matching audit rows)", file=sys.stderr)
+    return 0
+
+
+def cmd_perf(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+
+    # Run-scoped view: the function-level hotspots endpoint aggregates over a
+    # time window only, so when the caller pins a run / worker build / trigger
+    # we switch to the cell-level snapshot, which the server can lock to a run.
+    if args.run or args.worker_tag or args.trigger:
+        d = _get_json(
+            base,
+            token,
+            "/api/admin/audit/perf"
+            + _qs(
+                {
+                    "audit_run_id": args.run,
+                    "worker_image_tag": args.worker_tag,
+                    "trigger": args.trigger or "all",
+                    "since": args.since,
+                }
+            ),
+        )
+        if args.json:
+            print(json.dumps(d, indent=2))
+            return 0
+        print(
+            f"run={d.get('audit_run_id')} worker={d.get('worker_image_tag')} "
+            f"trigger={d.get('trigger')} since={d.get('since_days')}d"
+        )
+        cells = d.get("cells", [])
+        if args.source_ext:
+            cells = [c for c in cells if (c.get("source_ext") or "").lstrip(".") == args.source_ext.lstrip(".")]
+        if args.target:
+            cells = [c for c in cells if (c.get("target_format") or "") == args.target.lstrip(".")]
+        print(f"{'cell':16}  {'n':>4}  {'fail%':>5}  {'dur_p95_s':>9}  {'rss_p95_mb':>10}  {'rss_max_mb':>10}  stream?")
+        for c in cells:
+            cell = f"{c.get('source_ext')}->{c.get('target_format')}"
+            fail = (c.get("failure_rate") or 0) * 100
+            durp95 = (c.get("duration_ms_p95") or 0) / 1000
+            rssp95 = (c.get("peak_rss_kb_p95") or 0) / 1024
+            rssmax = (c.get("peak_rss_max_kb") or 0) / 1024
+            stream = c.get("streaming")
+            stream_flag = "yes" if (isinstance(stream, dict) and stream.get("is_candidate")) else "no"
+            print(
+                f"{cell:16}  {c.get('sample_count') or 0:>4}  {fail:>5.0f}  "
+                f"{durp95:>9.1f}  {rssp95:>10.0f}  {rssmax:>10.0f}  {stream_flag}"
+            )
+        if not cells:
+            print("(no matching cells)", file=sys.stderr)
+        return 0
+
+    d = _get_json(
+        base,
+        token,
+        "/api/admin/audit/perf/hotspots"
+        + _qs(
+            {
+                "source_ext": args.source_ext,
+                "target_format": args.target,
+                "since": args.since,
+                "limit": args.limit,
+            }
+        ),
+    )
+    if args.json:
+        print(json.dumps(d, indent=2))
+        return 0
+    print(
+        f"source_ext={d.get('source_ext')} target={d.get('target_format')} "
+        f"profiles_in_window={d.get('profiles_in_window')}"
+    )
+    hotspots = d.get("functions") or d.get("hotspots") or d.get("rows") or []
+    print(f"{'cumtime_s':>10}  {'calls':>12}  {'function'}")
+    for h in hotspots:
+        cum = h.get("agg_cumtime") or h.get("cumtime") or h.get("cumulative") or 0
+        calls = h.get("agg_ncalls") or h.get("ncalls") or h.get("calls") or 0
+        func = h.get("func") or h.get("function") or ""
+        loc = f"  ({h.get('file')}:{h.get('line')})" if h.get("file") is not None else ""
+        print(f"{float(cum):>10.1f}  {str(calls):>12}  {func}{loc}")
+    return 0
+
+
+def cmd_profile(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    d = _get_json(base, token, f"/api/admin/audit/{args.audit_id}/profile/stats" + _qs({"limit": args.limit}))
+    if args.json:
+        print(json.dumps(d, indent=2))
+        return 0
+    if "detail" in d:
+        print(d["detail"], file=sys.stderr)
+        return 1
+    print(
+        f"audit_id={d.get('audit_id')} total_tottime={float(d.get('total_tottime') or 0):.1f}s "
+        f"rows={d.get('row_count')}"
+    )
+    rows = sorted(d.get("rows", []), key=lambda r: r.get(args.sort) or 0, reverse=True)
+    print(f"{'cumtime_s':>10}  {'tottime_s':>10}  {'ncalls':>10}  function")
+    for r in rows:
+        loc = f"  ({r.get('file')}:{r.get('line')})" if r.get("file") is not None else ""
+        print(
+            f"{float(r.get('cumtime') or 0):>10.2f}  {float(r.get('tottime') or 0):>10.2f}  "
+            f"{str(r.get('ncalls')):>10}  {r.get('func')}{loc}"
+        )
+    return 0
+
+
+# ── fetch / repro (the local-run path for a given audit) ──────────────────
+
+
+def fetch(base: str, token: str, audit_id: int, out_root: pathlib.Path) -> tuple[pathlib.Path, dict]:
+    """Download a conversion's metadata + source blob to ``out_root/<id>/``.
+
+    Idempotent: re-uses an already-downloaded source. Returns (src_path, meta).
+    """
+    dest = out_root / str(audit_id)
+    meta_path = dest / "audit.json"
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text())
+        key_tail = (meta.get("key") or "").rsplit("/", 1)[-1]
+        candidate = dest / key_tail if key_tail else None
+        if candidate and candidate.exists():
+            return candidate, meta
+
+    dest.mkdir(parents=True, exist_ok=True)
+    meta_bytes, _ = _get(base, token, f"/api/admin/audit/{audit_id}")
+    meta = json.loads(meta_bytes)
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+    source_bytes, headers = _get(base, token, f"/api/admin/audit/{audit_id}/source")
+    if (headers.get("content-encoding") or "").lower() == "gzip":
+        source_bytes = gzip.decompress(source_bytes)
+    name = (meta.get("key") or "").rsplit("/", 1)[-1] or f"audit-{audit_id}.bin"
+    src = dest / name
+    src.write_bytes(source_bytes)
+    return src, meta
+
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    src, meta = fetch(base, token, args.audit_id, pathlib.Path(args.out))
+    print(f"{src}  (target={meta.get('target_format')} status={meta.get('status')})")
+    return 0
+
+
+def cmd_repro(args: argparse.Namespace) -> int:
+    base, token = _config(args)
+    src, meta = fetch(base, token, args.audit_id, pathlib.Path(args.out))
+    target = args.target or meta.get("target_format") or "glb"
+
+    print(f"repro audit_id={args.audit_id} src={src} target={target}")
+    print(f"original status={meta.get('status')} error={_short(meta.get('error'), 160)!r}")
+
+    # Lazy import — keeps the rest of `ada audit` free of the FEM/CAD stack.
+    from ada.comms.rest.converter import convert
+
+    def on_progress(stage: str, frac: float) -> None:
+        print(f"  [{frac:5.1%}] {stage}")
+
+    try:
+        out = convert(src, str(src), target, on_progress)
+    except Exception:
+        import traceback
+
+        sys.stderr.write("\n--- repro raised ---\n")
+        traceback.print_exc()
+        return 1
+
+    out_path = src.with_suffix(f".out.{target.lstrip('.')}")
+    out_path.write_bytes(out)
+    print(f"ok: wrote {out_path} ({len(out)} bytes)")
+    return 0
+
+
+# ── parser wiring ────────────────────────────────────────────────────────
+
+
+def add_parser(sub: argparse._SubParsersAction) -> None:
+    audit = sub.add_parser(
+        "audit",
+        help="Query/fetch/repro viewer audit runs (needs ADAPY_API_TOKEN + ADAPY_BASE_URL).",
+    )
+    asub = audit.add_subparsers(dest="audit_command", required=True)
+
+    def _remote(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--url", default=None, help="Viewer base URL (default: $ADAPY_API_BASE/$ADAPY_BASE_URL).")
+        p.add_argument("--token", default=None, help="Bearer token (default: $ADAPY_API_TOKEN).")
+        p.add_argument("--json", action="store_true", help="Emit raw JSON instead of a table.")
+
+    runs = asub.add_parser("runs", help="List recent regression-sweep runs.")
+    _remote(runs)
+    runs.add_argument("--limit", type=int, default=20)
+    runs.add_argument("--before", default=None, help="Page cursor: started_at of the oldest row seen.")
+    runs.set_defaults(func=cmd_runs)
+
+    run = asub.add_parser("run", help="Show a run's per-cell jobs.")
+    _remote(run)
+    run.add_argument("run_id")
+    run.add_argument("--failed", action="store_true", help="Only failed cells.")
+    run.add_argument("--format", default=None, help="Only this target format, e.g. step.")
+    run.set_defaults(func=cmd_run)
+
+    log = asub.add_parser("log", help="Query the per-conversion audit log.")
+    _remote(log)
+    log.add_argument("--limit", type=int, default=50, help="Max rows to return.")
+    log.add_argument("--pages", type=int, default=12, help="Max 200-row pages to scan.")
+    log.add_argument("--source", default=None, help="Source extension, e.g. .fem.")
+    log.add_argument("--target", default=None, help="Target format, e.g. step.")
+    log.add_argument("--status", default=None, help="Status, e.g. error / done.")
+    log.add_argument("--key", default=None, help="Substring match on the source key.")
+    log.add_argument("--grep", default=None, help="Substring match on the error text.")
+    log.set_defaults(func=cmd_log)
+
+    perf = asub.add_parser(
+        "perf",
+        help="Perf hot paths (function-level by default; cell-level when --run/--worker-tag/--trigger is given).",
+    )
+    _remote(perf)
+    perf.add_argument("--source-ext", default=None, help="e.g. .fem.")
+    perf.add_argument("--target", default=None, help="e.g. step.")
+    perf.add_argument("--since", type=int, default=30, help="Window in days (default 30).")
+    perf.add_argument("--limit", type=int, default=25)
+    perf.add_argument("--run", default=None, help="Lock to one sweep (audit_run_id) — cell-level snapshot.")
+    perf.add_argument("--worker-tag", default=None, help="Lock to one worker image tag (cell-level snapshot).")
+    perf.add_argument("--trigger", default=None, help="all | audit | user (cell-level snapshot).")
+    perf.set_defaults(func=cmd_perf)
+
+    profile = asub.add_parser("profile", help="Per-conversion function stats (one audit row's cProfile).")
+    _remote(profile)
+    profile.add_argument("audit_id", type=int)
+    profile.add_argument("--limit", type=int, default=50)
+    profile.add_argument(
+        "--sort",
+        default="cumtime",
+        choices=["cumtime", "tottime", "ncalls"],
+        help="Sort key (default cumtime).",
+    )
+    profile.set_defaults(func=cmd_profile)
+
+    fetch_p = asub.add_parser("fetch", help="Download a conversion's source blob.")
+    _remote(fetch_p)
+    fetch_p.add_argument("audit_id", type=int)
+    fetch_p.add_argument("--out", default=DEFAULT_OUT, help=f"Download root (default: {DEFAULT_OUT}).")
+    fetch_p.set_defaults(func=cmd_fetch)
+
+    repro = asub.add_parser("repro", help="Run a given audit's conversion locally.")
+    _remote(repro)
+    repro.add_argument("audit_id", type=int)
+    repro.add_argument("--out", default=DEFAULT_OUT, help=f"Download root (default: {DEFAULT_OUT}).")
+    repro.add_argument("--target", default=None, help="Override the audit's target_format.")
+    repro.set_defaults(func=cmd_repro, needs_ada_logging=True)

--- a/src/ada_cli/main.py
+++ b/src/ada_cli/main.py
@@ -176,6 +176,12 @@ def _add_files(sub: argparse._SubParsersAction) -> None:
     dl.set_defaults(func=_cmd_files_download)
 
 
+def _add_audit(sub: argparse._SubParsersAction) -> None:
+    from ada_cli.audit import add_parser
+
+    add_parser(sub)
+
+
 def _add_serve(sub: argparse._SubParsersAction) -> None:
     serve = sub.add_parser("serve", help="Run a long-lived server process.")
     serve_sub = serve.add_subparsers(dest="serve_command", required=True)
@@ -203,12 +209,20 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_view(sub)
     _add_build(sub)
     _add_files(sub)
+    _add_audit(sub)
     _add_serve(sub)
 
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Pick up a .env in the CWD so remote commands (files/audit/build) find
+    # their URL/token without the caller having to export them first. Real
+    # environment variables always win.
+    from ada_cli import load_dotenv_cwd
+
+    load_dotenv_cwd()
+
     parser = _build_parser()
     args = parser.parse_args(argv)
 

--- a/tests/comms/rest/test_audit_cli.py
+++ b/tests/comms/rest/test_audit_cli.py
@@ -1,0 +1,150 @@
+"""Unit tests for the `ada audit` CLI client (HTTP mocked)."""
+
+import argparse
+
+import pytest
+
+from ada_cli import audit as ac
+from ada_cli import load_dotenv_cwd
+
+
+def _args(**kw):
+    base = dict(url="https://v.example", token="tok", json=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+# ── .env loading ──────────────────────────────────────────────────────────
+
+
+def test_load_dotenv_cwd(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text(
+        "# a comment\n" "export ADAPY_BASE_URL=viewer.example.com\n" 'ADAPY_API_TOKEN="secret-token"\n' "\n" "EMPTY=\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ADAPY_BASE_URL", raising=False)
+    monkeypatch.delenv("ADAPY_API_TOKEN", raising=False)
+
+    assert load_dotenv_cwd() is True
+    import os
+
+    assert os.environ["ADAPY_BASE_URL"] == "viewer.example.com"
+    assert os.environ["ADAPY_API_TOKEN"] == "secret-token"  # quotes stripped
+
+
+def test_load_dotenv_does_not_override_existing(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("ADAPY_API_TOKEN=from-dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ADAPY_API_TOKEN", "from-shell")
+    load_dotenv_cwd()
+    import os
+
+    assert os.environ["ADAPY_API_TOKEN"] == "from-shell"  # real env wins
+
+
+# ── config ────────────────────────────────────────────────────────────────
+
+
+def test_config_missing_exits(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # no .env here
+    monkeypatch.delenv("ADAPY_BASE_URL", raising=False)
+    monkeypatch.delenv("ADAPY_API_BASE", raising=False)
+    monkeypatch.delenv("ADAPY_API_TOKEN", raising=False)
+    with pytest.raises(SystemExit):
+        ac._config(argparse.Namespace(url=None, token=None))
+
+
+def test_config_normalizes_bare_host():
+    base, token = ac._config(argparse.Namespace(url="viewer.example.com", token="t"))
+    assert base == "https://viewer.example.com"
+    assert token == "t"
+
+
+# ── filtering logic (mock the HTTP layer) ─────────────────────────────────
+
+
+def test_cmd_log_filters(monkeypatch, capsys):
+    page = {
+        "entries": [
+            {"id": 1, "key": "fem/a.fem", "target_format": "step", "status": "error", "error": "closed loop"},
+            {"id": 2, "key": "fem/b.fem", "target_format": "step", "status": "done", "error": ""},
+            {"id": 3, "key": "cad/c.ifc", "target_format": "step", "status": "error", "error": "other"},
+            {"id": 4, "key": "fem/d.fem", "target_format": "glb", "status": "error", "error": "closed loop"},
+        ],
+        "next_before_id": None,
+    }
+    monkeypatch.setattr(ac, "_get_json", lambda b, t, p: page)
+    rc = ac.cmd_log(_args(limit=50, pages=1, source=".fem", target="step", status="error", key=None, grep="closed"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "fem/a.fem" in out  # matches all filters
+    assert "b.fem" not in out  # status done
+    assert "c.ifc" not in out  # not .fem
+    assert "d.fem" not in out  # target glb
+
+
+def test_cmd_run_failed_and_format(monkeypatch, capsys):
+    payload = {
+        "run": {"id": "r1", "status": "finished", "total": 3, "failed": 1, "started_at": "2026-06-06"},
+        "jobs": [
+            {"status": "done", "target_format": "step", "key": "ok.fem"},
+            {"status": "error", "target_format": "step", "key": "bad.fem", "error": "boom"},
+            {"status": "error", "target_format": "glb", "key": "x.fem", "error": "nope"},
+        ],
+    }
+    monkeypatch.setattr(ac, "_get_json", lambda b, t, p: payload)
+    rc = ac.cmd_run(_args(run_id="r1", failed=True, format="step"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bad.fem" in out and "boom" in out
+    assert "ok.fem" not in out  # not failed
+    assert "x.fem" not in out  # wrong format
+
+
+def test_cmd_perf_run_mode_hits_cell_endpoint(monkeypatch, capsys):
+    seen = {}
+
+    def fake(base, token, path):
+        seen["path"] = path
+        return {
+            "audit_run_id": "r1",
+            "trigger": "all",
+            "since_days": 30,
+            "cells": [
+                {
+                    "source_ext": "fem",
+                    "target_format": "step",
+                    "sample_count": 2,
+                    "failure_rate": 1.0,
+                    "duration_ms_p95": 222000,
+                    "peak_rss_kb_p95": 3000000,
+                    "peak_rss_max_kb": 3200000,
+                    "streaming": {"is_candidate": True},
+                },
+            ],
+        }
+
+    monkeypatch.setattr(ac, "_get_json", fake)
+    rc = ac.cmd_perf(_args(run="r1", worker_tag=None, trigger=None, source_ext="fem", target=None, since=30, limit=25))
+    assert rc == 0
+    assert "/api/admin/audit/perf?" in seen["path"]
+    assert "audit_run_id=r1" in seen["path"]
+    out = capsys.readouterr().out
+    assert "fem->step" in out and "yes" in out  # streaming candidate flag
+
+
+# ── parser wiring ─────────────────────────────────────────────────────────
+
+
+def test_add_parser_routes_subcommands():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    ac.add_parser(sub)
+    for name, fn in [
+        ("runs", ac.cmd_runs),
+        ("log", ac.cmd_log),
+        ("perf", ac.cmd_perf),
+        ("profile", ac.cmd_profile),
+    ]:
+        ns = parser.parse_args(["audit", name] + (["1"] if name == "profile" else []))
+        assert ns.func is fn

--- a/tests/comms/rest/test_converter_step_routing.py
+++ b/tests/comms/rest/test_converter_step_routing.py
@@ -1,0 +1,45 @@
+"""FEM sources must be routed through the streaming STEP writer.
+
+The OCC XCAF writer OOMs on large FEM meshes; the streaming AP242 writer holds
+constant memory. `_via_ada_to_step` should select `writer="stream"` for FEM
+sources and keep the default OCC writer for everything else.
+"""
+
+import pathlib
+
+import ada
+from ada.api.spatial.part import Part
+from ada.comms.rest import converter as conv
+
+
+def _captured_writer(monkeypatch, source_ext: str) -> str:
+    model = ada.Assembly("a") / (ada.Part("p") / ada.Plate("pl", [(0, 0), (1, 0), (1, 1), (0, 1)], 0.01))
+
+    monkeypatch.setattr(conv, "_load_with_ada", lambda src, ext: model)
+    monkeypatch.setattr(conv, "_apply_fem_to_objects", lambda *a, **k: None)
+
+    recorded = {}
+
+    def fake_to_stp(self, dest, *args, writer="occ", **kwargs):
+        recorded["writer"] = writer
+        pathlib.Path(dest).write_text("ISO-10303-21;\nENDSEC;\nEND-ISO-10303-21;\n")
+        return {"emitted": 1, "skipped": 0}
+
+    monkeypatch.setattr(Part, "to_stp", fake_to_stp)
+
+    out = conv._via_ada_to_step(pathlib.Path(f"dummy{source_ext}"), source_ext, lambda *a, **k: None)
+    assert out  # bytes returned
+    return recorded["writer"]
+
+
+def test_fem_source_uses_stream_writer(monkeypatch):
+    assert _captured_writer(monkeypatch, ".fem") == "stream"
+
+
+def test_inp_source_uses_stream_writer(monkeypatch):
+    assert _captured_writer(monkeypatch, ".inp") == "stream"
+
+
+def test_non_fem_source_uses_occ_writer(monkeypatch):
+    assert _captured_writer(monkeypatch, ".step") == "occ"
+    assert _captured_writer(monkeypatch, ".ifc") == "occ"

--- a/tests/core/fem/test_merge_plate_guard.py
+++ b/tests/core/fem/test_merge_plate_guard.py
@@ -1,0 +1,58 @@
+"""Guard against degenerate / self-intersecting merged coplanar plates.
+
+The edge-cancellation merge only guarantees a topologically single, degree-2
+boundary. A geometrically self-intersecting result still slips through and later
+crashes the STEP export ("Segments do not form a closed loop"). The guard
+validates the merged 2D loop and falls back to the unmerged plates.
+"""
+
+import ada
+from ada import Plate
+from ada.fem.formats import concept_merge as cm
+from ada.fem.formats.concept_merge import _loop_is_simple_2d, merge_coplanar_plates
+
+
+def test_loop_is_simple_2d_accepts_valid_polygons():
+    square = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    concave_l = [(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)]
+    assert _loop_is_simple_2d(square)
+    assert _loop_is_simple_2d(concave_l)
+
+
+def test_loop_is_simple_2d_rejects_self_intersection():
+    bowtie = [(0, 0), (1, 1), (1, 0), (0, 1)]  # classic figure-8
+    assert not _loop_is_simple_2d(bowtie)
+
+
+def test_loop_is_simple_2d_rejects_degenerate():
+    sliver = [(0, 0), (1, 0), (2, 0)]  # collinear -> zero area
+    too_few = [(0, 0), (1, 0)]
+    assert not _loop_is_simple_2d(sliver)
+    assert not _loop_is_simple_2d(too_few)
+
+
+def test_valid_adjacent_plates_still_merge():
+    """Two edge-adjacent coplanar plates of matching material/thickness merge."""
+    a = Plate.from_3d_points("a", [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], 0.01)
+    b = Plate.from_3d_points("b", [(1, 0, 0), (2, 0, 0), (2, 1, 0), (1, 1, 0)], 0.01)
+    parent = ada.Part("p")
+    out = merge_coplanar_plates([a, b], parent)
+    assert len(out) == 1
+    assert out[0].name.endswith("_m")
+
+
+def test_self_intersecting_merge_falls_back(monkeypatch):
+    """A self-intersecting merged loop must fall back to the original plates."""
+    a = Plate.from_3d_points("a", [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], 0.01)
+    b = Plate.from_3d_points("b", [(1, 0, 0), (2, 0, 0), (2, 1, 0), (1, 1, 0)], 0.01)
+    parent = ada.Part("p")
+
+    # Force the edge-cancellation step to return a bowtie (planar, z=0).
+    # _merge_coplanar_component imports the symbol from vector_utils at call time.
+    import ada.core.vector_utils as vu
+
+    bowtie3d = [(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    monkeypatch.setattr(vu, "merge_coplanar_loops_by_edge_cancellation", lambda loops, ndigits=6: bowtie3d)
+
+    out = cm._merge_coplanar_component([a, b], parent, ndigits=6)
+    assert out == [a, b]  # fell back to originals, did not emit a corrupt _m plate

--- a/tests/core/geom/test_fem_shell_fast_path.py
+++ b/tests/core/geom/test_fem_shell_fast_path.py
@@ -1,0 +1,118 @@
+"""Fast-path FEM-shell Plate constructor (``from_fem_shell``).
+
+The fast path skips ``build_polycurve``/``SegCreator`` and the computed-placement
+LRU (which thrashes on per-element placements). These tests assert it is
+geometrically identical to the general ``from_3d_points`` path for flat shells,
+and that it really does bypass the hot spots.
+"""
+
+import numpy as np
+import pytest
+
+from ada import Plate
+from ada.api.curves import CurvePoly2d
+
+# tri, axis-aligned quad, tilted (non-axis-aligned) quad, offset tri, and a
+# reversed-winding quad -- exercises all the orientation / winding branches.
+CASES = {
+    "quad": [(0, 0, 0), (2, 0, 0), (2, 1, 0), (0, 1, 0)],
+    "tri": [(0, 0, 0), (3, 0, 0), (0, 2, 0)],
+    "tilted_quad": [(0, 0, 0), (2, 0, 1), (2, 1, 1.5), (0, 1, 0.5)],
+    "offset_tri": [(5, 5, 5), (8, 5, 5), (5, 9, 5)],
+    "ccw_quad": [(0, 0, 0), (0, 1, 0), (2, 1, 0), (2, 0, 0)],
+}
+
+
+@pytest.mark.parametrize("name", list(CASES))
+def test_from_fem_shell_matches_from_3d_points(name):
+    pts = CASES[name]
+    a = CurvePoly2d.from_3d_points(pts)
+    b = CurvePoly2d.from_fem_shell(pts)
+
+    for attr in ("origin", "xdir", "ydir", "normal"):
+        assert np.allclose(np.asarray(getattr(a, attr)), np.asarray(getattr(b, attr)), atol=1e-9), attr
+
+    assert np.allclose(np.asarray(a.points2d), np.asarray(b.points2d), atol=1e-9)
+    assert np.allclose(np.asarray(a.points3d), np.asarray(b.points3d), atol=1e-9)
+
+    # The polyline that drives IFC/STEP export: indexed point list + index map.
+    assert np.allclose(np.asarray(a.seg_global_points), np.asarray(b.seg_global_points), atol=1e-9)
+    assert a.seg_index == b.seg_index
+
+    # 2D segments feed solid_geom's outer curve -- order + endpoints must match.
+    a_segs = [(np.asarray(s.p1), np.asarray(s.p2)) for s in a.segments]
+    b_segs = [(np.asarray(s.p1), np.asarray(s.p2)) for s in b.segments]
+    assert len(a_segs) == len(b_segs)
+    for (a1, a2), (b1, b2) in zip(a_segs, b_segs):
+        assert np.allclose(a1, b1, atol=1e-9) and np.allclose(a2, b2, atol=1e-9)
+
+
+@pytest.mark.parametrize("name", list(CASES))
+def test_solid_geom_parity(name):
+    pts = CASES[name]
+    fast = Plate.from_fem_shell("p", pts, 0.02)
+    gen = Plate.from_3d_points("p", pts, 0.02)
+
+    gf = fast.solid_geom().geometry
+    gg = gen.solid_geom().geometry
+    assert type(gf).__name__ == type(gg).__name__ == "ExtrudedAreaSolid"
+    assert gf.depth == gg.depth
+    assert np.allclose(np.asarray(gf.position.location), np.asarray(gg.position.location), atol=1e-9)
+    assert np.allclose(np.asarray(gf.position.axis), np.asarray(gg.position.axis), atol=1e-9)
+
+
+def test_from_fem_shell_bypasses_lru_and_segcreator(monkeypatch):
+    """The fast path must not touch get_computed_placement_cached or SegCreator."""
+    import ada.api.computed_placement as cp
+    import ada.core.curve_utils as cu
+
+    counts = {"lru": 0, "segcreator": 0}
+
+    orig_cached = cp.get_computed_placement_cached
+
+    def counting_cached(*a, **k):
+        counts["lru"] += 1
+        return orig_cached(*a, **k)
+
+    # create_computed_placement_from_placement calls the module-level symbol
+    monkeypatch.setattr(cp, "get_computed_placement_cached", counting_cached)
+
+    orig_segc = cu.SegCreator
+
+    class CountingSegCreator(orig_segc):
+        def __init__(self, *a, **k):
+            counts["segcreator"] += 1
+            super().__init__(*a, **k)
+
+    monkeypatch.setattr(cu, "SegCreator", CountingSegCreator)
+
+    pts = CASES["tilted_quad"]
+    for _ in range(50):
+        CurvePoly2d.from_fem_shell(pts)
+    assert counts["lru"] == 0
+    assert counts["segcreator"] == 0
+
+    # Sanity: the general path DOES hit both (guards against a no-op monkeypatch).
+    counts.update(lru=0, segcreator=0)
+    for _ in range(50):
+        CurvePoly2d.from_3d_points(pts)
+    assert counts["lru"] > 0
+    assert counts["segcreator"] > 0
+
+
+def test_fem_conversion_uses_fast_path():
+    """End-to-end: a meshed plate converted from FEM yields valid plates."""
+    import ada
+
+    pl = Plate("pl", [(0, 0), (1, 0), (1, 1), (0, 1)], 0.01)
+    p = ada.Part("p") / pl
+    p.fem = pl.to_fem_obj(0.25, "shell")
+    a = ada.Assembly("a") / p
+    a.create_objects_from_fem()
+
+    plates = list(p.get_all_physical_objects(by_type=Plate))
+    assert len(plates) > 0
+    # every converted shell plate builds a valid extruded solid
+    for cpl in plates:
+        g = cpl.solid_geom().geometry
+        assert type(g).__name__ == "ExtrudedAreaSolid"


### PR DESCRIPTION
Three improvements to FEM→CAD conversion (all surfaced by the latest viewer audit), plus a read-only `ada audit` CLI.

## A. Fast FEM-shell Plate constructor
`Plate.from_fem_shell` / `CurvePoly2d.from_fem_shell` — a dedicated constructor for flat shell elements (3/4-gon, no arcs/radii). It:
- computes the orientation **once** and injects it via the new `Placement.from_dirs_precomputed`, so the computed-placement LRU (`get_computed_placement_cached`) is never touched — that cache thrashes on a mesh of distinct per-element placements and dominated shell→plate construction;
- builds the closed line loop directly, skipping `build_polycurve`/`SegCreator`.

Geometrically **identical** to `from_3d_points` (parity-tested to 1e-9, including `seg_global_points`/`seg_index` and the 2D segment loop), with **0** LRU calls and **0** `SegCreator` instantiations vs. 2 + 1 per plate on the old path. Wired into `convert_shell_elem_to_plates`; the general `from_3d_points` path (arcs/fillets/radii) is untouched.

## B. Stream FEM→STEP
`converter._via_ada_to_step` now routes FEM sources through the streaming AP242 writer (`writer="stream"`), which emits one extruded solid at a time at constant memory. The default OCC XCAF writer buffers the whole entity graph and OOMs the worker on large meshes. Non-FEM STEP keeps the OCC writer (it may carry curved/B-spline geometry the streamer skips).

## C. Merged-plate degenerate-loop guard
The topological edge-cancellation merge only guarantees a single degree-2 boundary; it can still emit a geometrically **self-intersecting** loop that `from_3d_points` accepts but OCC's wire builder rejects ("Segments do not form a closed loop"), aborting the whole conversion. `_merge_coplanar_component` now validates the merged 2D loop (simple, non-degenerate) and falls back to the unmerged plates otherwise — honoring the module's "best-effort, never corrupt geometry" contract.

## D. `ada audit` CLI (read-only client)
Consolidates the ad-hoc admin-API queries + the `audit_fetch`/`audit_repro` scripts: `runs`, `run [--failed --format]`, `log [--source --target --status --key --grep]`, `perf` (function hot paths; `--run`/`--worker-tag`/`--trigger` switch to the run-scoped cell snapshot), `profile <id>` (per-conversion stats), `fetch <id>`, and `repro <id>` (run a given audit's conversion locally). Auto-loads a `.env` from the CWD (real env vars win). The old scripts become thin shims so the pixi tasks keep working.

## Verification
- New tests: fast-path parity + hot-spot bypass, converter routing, merge-guard (incl. self-intersection fallback), and the audit CLI (filters, config/.env, parser).
- Full `tests/core` suite green (762 passed).
- Reproduced the actual failing FEM→STEP audit conversion end-to-end: it now completes (was: hard error). On that model the guard removes exactly the degenerate merge while preserving 6,093 valid merges — **0** merged plates fail an OCC build.
- Measured peak memory of the large-jacket FEM→STEP end-to-end: **1142 MB** (was OOM > 3355 MB limit). The streaming write adds ~6 MB; the peak is now concept-object construction.