### PR TITLE
feat: array-backed FEM mesh substrate with lazy node/elem proxies

### DIFF
--- a/src/ada/api/mesh/__init__.py
+++ b/src/ada/api/mesh/__init__.py
@@ -1,0 +1,12 @@
+"""Array-backed FEM mesh substrate (``MeshArrays``) with lazy ``Node`` proxies.
+
+The analysis-side FEM mesh historically stores millions of Python ``Node``/``Elem``
+objects. This package provides a packed-numpy substrate (coords + id->index map +
+per-type int32 connectivity) that the same ``Node``/``Elem`` API can sit on as thin
+lazy proxies — ~4-6x less memory on large meshes. Gated by
+``Config().meshing_array_backed`` while it is rolled out and parity-tested.
+"""
+
+from ada.api.mesh.store import ElemArrayBlock, MeshArrays
+
+__all__ = ["MeshArrays", "ElemArrayBlock"]

--- a/src/ada/api/mesh/adjacency.py
+++ b/src/ada/api/mesh/adjacency.py
@@ -1,0 +1,70 @@
+"""Lazy node->element adjacency (CSR) built from a substrate's connectivity.
+
+Replaces the per-node ``Node._refs`` Python lists (the dominant memory cost after
+coordinates) for the *element* subset of refs. Non-element refs (Beam/Csys/FemSet)
+are not derivable from connectivity and are kept in a small side-table on the store.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ada.api.mesh.store import MeshArrays
+
+
+class CSRAdjacency:
+    """Compressed sparse-row node->element incidence.
+
+    ``incident(node_row)`` yields ``(ctype, elem_row)`` pairs. Built vectorized from
+    every element block's connectivity in one pass.
+    """
+
+    def __init__(self, indptr: np.ndarray, block_ids: np.ndarray, elem_rows: np.ndarray, ctypes: list):
+        self._indptr = indptr  # (n_nodes + 1,)
+        self._block_ids = block_ids  # (nnz,) -> index into ctypes
+        self._elem_rows = elem_rows  # (nnz,) -> row within that block
+        self._ctypes = ctypes  # list[ElemTypeKey] parallel to block order
+
+    @classmethod
+    def build(cls, store: "MeshArrays") -> "CSRAdjacency":
+        n = store.n_nodes
+        ctypes = list(store.blocks.keys())
+        if not ctypes:
+            empty = np.zeros((0,), dtype=np.int64)
+            return cls(np.zeros(n + 1, dtype=np.int64), empty, empty, [])
+
+        node_rows = []  # which node each incidence belongs to
+        blk_ids = []
+        el_rows = []
+        for bidx, ctype in enumerate(ctypes):
+            blk = store.blocks[ctype]
+            conn = blk.conn  # (m, k) node row indices
+            m, k = conn.shape
+            node_rows.append(conn.reshape(-1))
+            blk_ids.append(np.full(m * k, bidx, dtype=np.int64))
+            el_rows.append(np.repeat(np.arange(m, dtype=np.int64), k))
+
+        node_rows = np.concatenate(node_rows)
+        blk_ids = np.concatenate(blk_ids)
+        el_rows = np.concatenate(el_rows)
+
+        order = np.argsort(node_rows, kind="stable")
+        node_rows = node_rows[order]
+        blk_ids = blk_ids[order]
+        el_rows = el_rows[order]
+
+        counts = np.bincount(node_rows, minlength=n)
+        indptr = np.zeros(n + 1, dtype=np.int64)
+        np.cumsum(counts, out=indptr[1:])
+        return cls(indptr, blk_ids, el_rows, ctypes)
+
+    def degree(self, node_row: int) -> int:
+        return int(self._indptr[node_row + 1] - self._indptr[node_row])
+
+    def incident(self, node_row: int):
+        lo, hi = int(self._indptr[node_row]), int(self._indptr[node_row + 1])
+        for i in range(lo, hi):
+            yield self._ctypes[int(self._block_ids[i])], int(self._elem_rows[i])

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -329,7 +329,15 @@ class ArrayElements(FemElements):
 def to_array_backed(fem):
     """Swap a FEM's object-model ``nodes``/``elements`` for substrate-backed facades
     sharing one ``MeshArrays``. The proxies are transient, so after this the mesh is
-    held as packed arrays. Returns the same FEM for chaining."""
+    held as packed arrays. Returns the same FEM for chaining.
+
+    Any FemSet that still holds object members is flipped to id-backed first, so the
+    object Node/Elem become unreferenced and are reclaimed."""
+    # Flip sets to id-backed BEFORE building the store / dropping object containers,
+    # otherwise the sets keep the object mesh alive.
+    for fs in list(fem.sets):
+        fs.to_id_backed()
+
     store = MeshArrays.from_fem(fem)
     fem.nodes = ArrayNodes(store, parent=fem)
     fem.elements = ArrayElements(store, fem_obj=fem)

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -303,8 +303,23 @@ class ArrayElements(FemElements):
         return max(store_max, ov_max)
 
     def build_sets(self):
-        # element sets are built lazily/id-backed in the array path; no-op
-        pass
+        """Create id-backed element sets from each element's ``elset`` name (mirrors
+        the object FemElements.build_sets, which sections/masses reference by name)."""
+        from collections import defaultdict
+
+        from ada.fem import FemSet
+
+        by_elset: dict[str, list[int]] = defaultdict(list)
+        for e in self:
+            es = e.elset
+            if es is None:
+                continue
+            name = es if isinstance(es, str) else getattr(es, "name", None)
+            if name:
+                by_elset[name].append(e.id)
+        for name, ids in by_elset.items():
+            if self._fem_obj is not None:
+                self._fem_obj.sets.add(FemSet(name, ids, "elset", parent=self._fem_obj))
 
     @property
     def masses(self):

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -257,6 +257,13 @@ class ArrayElements(FemElements):
     def __len__(self) -> int:
         return self._store.n_elems() + len(self._overflow)
 
+    def __repr__(self) -> str:
+        by_type = ", ".join(f'"{ctype}": {len(blk)}' for ctype, blk in self._store.blocks.items())
+        if self._overflow:
+            extra = f"overflow: {len(self._overflow)}"
+            by_type = f"{by_type}, {extra}" if by_type else extra
+        return f"ArrayElements(Elements: {len(self)}, By Type: {by_type or 'none'})"
+
     def __iter__(self):
         yield from self._store.iter_elem_proxies()
         yield from self._overflow

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -1,0 +1,336 @@
+"""Array-backed container facades over a shared :class:`MeshArrays` store.
+
+``ArrayNodes``/``ArrayElements`` subclass the object-model ``Nodes``/``FemElements``
+(so ``isinstance`` and every type check keep working) but store nothing per-entity —
+they serve lazy proxies from one store shared via the owning ``FEM``. The object-model
+containers are left completely untouched; these only run when
+``Config().meshing_array_backed`` is on.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+import numpy as np
+
+from ada.api.containers.nodes import Nodes
+from ada.api.mesh.store import MeshArrays
+from ada.config import Config, logger
+from ada.core.vector_utils import points_in_cylinder, vector_length
+from ada.fem.containers import FemElements
+
+if TYPE_CHECKING:
+    from ada.api.mesh.proxies import NodeProxy
+
+
+class ArrayNodes(Nodes):
+    def __init__(self, store: MeshArrays, parent=None):
+        self._store = store
+        self._parent = parent
+        self._point_tol = Config().general_point_tol
+        self._sorted = None  # lazy lexsorted row order (by x,y,z)
+
+    # ── construction ─────────────────────────────────────────────────────
+    @classmethod
+    def from_nodes(cls, nodes, parent=None) -> "ArrayNodes":
+        return cls(MeshArrays.from_nodes(list(nodes)), parent)
+
+    @property
+    def store(self) -> MeshArrays:
+        return self._store
+
+    @property
+    def _sorted_rows(self) -> np.ndarray:
+        if self._sorted is None:
+            c = self._store.coords
+            if c.shape[0] == 0:
+                self._sorted = np.zeros(0, dtype=np.int64)
+            else:
+                self._sorted = np.lexsort((c[:, 2], c[:, 1], c[:, 0]))
+        return self._sorted
+
+    def _invalidate_order(self):
+        self._sorted = None
+
+    # ── sequence protocol ────────────────────────────────────────────────
+    def __len__(self) -> int:
+        return self._store.n_nodes
+
+    def __iter__(self) -> Iterable["NodeProxy"]:
+        for r in self._sorted_rows:
+            yield self._store.node_proxy(int(r))
+
+    def __getitem__(self, index):
+        rows = self._sorted_rows
+        if isinstance(index, slice):
+            return Nodes([self._store.node_proxy(int(r)) for r in rows[index]])
+        return self._store.node_proxy(int(rows[index]))
+
+    def __contains__(self, item) -> bool:
+        return self._store.has_node(item.id) and self._store.node_proxy_by_id(item.id) == item
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Nodes):
+            return NotImplemented
+        return list(self) == list(other)
+
+    def __add__(self, other: "Nodes") -> "Nodes":
+        merged = list(self) + list(other)
+        return ArrayNodes.from_nodes(merged, self.parent)
+
+    def __repr__(self) -> str:
+        return f"ArrayNodes({len(self)}, min_id: {self.min_nid}, max_id: {self.max_nid})"
+
+    # ── lookups ──────────────────────────────────────────────────────────
+    def from_id(self, nid: int):
+        if not self._store.has_node(nid):
+            raise ValueError(f'The node id "{nid}" is not found')
+        return self._store.node_proxy_by_id(nid)
+
+    def index(self, item) -> int:
+        rows = self._sorted_rows
+        target = self._store.node_index(item.id)
+        hits = np.nonzero(rows == target)[0]
+        if hits.size == 0:
+            raise ValueError(f"{item!r} not found")
+        return int(hits[0])
+
+    def count(self, item) -> int:
+        return int(item in self)
+
+    # ── properties ───────────────────────────────────────────────────────
+    @property
+    def dmap(self) -> dict:
+        return {self._store.node_id(r): self._store.node_proxy(r) for r in range(self._store.n_nodes)}
+
+    @property
+    def nodes(self) -> list:
+        return list(self)
+
+    @property
+    def max_nid(self) -> int:
+        return int(self._store.node_ids.max()) if self._store.n_nodes else 0
+
+    @property
+    def min_nid(self) -> int:
+        return int(self._store.node_ids.min()) if self._store.n_nodes else 0
+
+    def bbox(self):
+        return self._store.bbox()
+
+    def vol_cog(self):
+        bx, by, bz = self.bbox()
+        return ((bx[0] + bx[1]) / 2, (by[0] + by[1]) / 2, (bz[0] + bz[1]) / 2)
+
+    def to_np_array(self, include_id: bool = False) -> np.ndarray:
+        if include_id:
+            return np.column_stack([self._store.node_ids.astype(float), self._store.coords])
+        return self._store.coords.copy()
+
+    def to_fem_nodes(self):
+        return self._store.to_fem_nodes()
+
+    # ── bulk ops ─────────────────────────────────────────────────────────
+    def renumber(self, start_id: int = 1, renumber_map: dict[int, int] | None = None) -> None:
+        self._store.renumber_nodes(start_id=start_id, renumber_map=renumber_map)
+
+    def move(self, move=None, rotate=None) -> None:
+        if rotate is not None:
+            self._store.rotate(rotate.to_rot_matrix(), np.array(rotate.origin))
+        if move is not None:
+            self._store.translate(np.array(move))
+        self._invalidate_order()
+
+    def rounding_node_points(self, precision: int = None) -> None:
+        if precision is None:
+            precision = Config().general_precision
+        self._store.coords = np.round(self._store.coords, precision)
+        self._store._bbox = None
+        self._invalidate_order()
+
+    # ── queries ──────────────────────────────────────────────────────────
+    def get_by_volume(self, p=None, vol_box=None, vol_cyl=None, tol=None, single_member=False):
+        if tol is None:
+            tol = self._point_tol
+        p_arr = np.array(p) if p is not None else None
+        if p_arr is not None and vol_box is None and vol_cyl is None:
+            vol_min, vol_max = p_arr - tol, p_arr + tol
+        elif vol_box is not None and p_arr is not None:
+            vol_min, vol_max = np.array(p), np.array(vol_box)
+        elif vol_cyl is not None and p_arr is not None:
+            r, h, t = vol_cyl
+            vol_min = np.array([p_arr[0] - r - tol, p_arr[1] - r - tol, p_arr[2] - tol])
+            vol_max = np.array([p_arr[0] + r + tol, p_arr[1] + r + tol, p_arr[2] + tol + h])
+        else:
+            raise Exception("No valid search input provided. None is returned")
+
+        rows = self._store.rows_in_box(vol_min, vol_max)
+        if vol_cyl is not None:
+            r, h, t = vol_cyl
+            pt1, pt2 = p_arr + np.array([0, 0, -h]), p_arr + np.array([0, 0, h])
+            keep = []
+            for rr in rows:
+                pnt = self._store.coords[rr]
+                if t == r:
+                    if points_in_cylinder(pt1, pt2, r, pnt):
+                        keep.append(rr)
+                else:
+                    if points_in_cylinder(pt1, pt2, r + t, pnt) and not points_in_cylinder(pt1, pt2, r - t, pnt):
+                        keep.append(rr)
+            rows = keep
+
+        # order matches the (x,y,z) lexsort the object path uses
+        rows = sorted(rows, key=lambda rr: tuple(self._store.coords[rr]))
+        result = [self._store.node_proxy(int(rr)) for rr in rows]
+        if not result:
+            logger.info(f"No nodes found in volume {vol_min}, {vol_max}, tol={tol}")
+            return result
+        if single_member:
+            return result[0]
+        return result
+
+    # ── edits ────────────────────────────────────────────────────────────
+    def add(self, node, point_tol: float = None, allow_coincident: bool = False):
+        tol = point_tol if point_tol is not None else self._point_tol
+        p = np.asarray(node.p, dtype=float)
+        if self._store.n_nodes and not allow_coincident:
+            for rr in self._store.rows_in_box(p - tol, p + tol):
+                if vector_length(self._store.coords[rr] - p) < tol:
+                    return self._store.node_proxy(int(rr))
+        nid = node.id
+        if nid is None or self._store.has_node(nid):
+            nid = (self.max_nid + 1) if self._store.n_nodes else 1
+        row = self._store.add_node(p, nid)
+        self._invalidate_order()
+        proxy = self._store.node_proxy(row)
+        if proxy.parent is None:
+            proxy.parent = self.parent
+        return proxy
+
+    def remove(self, nodes) -> None:
+        from ada.api.nodes import Node
+
+        nodes_list = [nodes] if isinstance(nodes, Node) else list(nodes)
+        rows = [self._store.node_index(n.id) for n in nodes_list if self._store.has_node(n.id)]
+        self._store.remove_nodes(rows)
+        self._invalidate_order()
+        self.renumber()
+
+    def remove_standalones(self) -> None:
+        self.remove([n for n in self if not n.has_refs])
+
+    def merge_coincident(self, tol: float = None) -> None:
+        from ada.fem.utils import replace_node
+
+        tol = tol if tol is not None else self._point_tol
+        for n in list(self):
+            if not n.has_refs:
+                continue
+            if not self._store.has_node(n.id):
+                continue
+            dups = sorted(
+                [m for m in self.get_by_volume(tuple(n.p), tol=tol) if m.id != n.id],
+                key=lambda x: len(x.refs),
+            )
+            if dups:
+                primary = max([n] + dups, key=lambda x: len(x.refs))
+                for dup in dups:
+                    replace_node(dup, primary)
+                    self.remove(dup)
+        self._invalidate_order()
+
+
+class ArrayElements(FemElements):
+    def __init__(self, store: MeshArrays, fem_obj=None):
+        self._store = store
+        self._fem_obj = fem_obj
+        self._sort_funcs = []
+
+    @property
+    def store(self) -> MeshArrays:
+        return self._store
+
+    def __len__(self) -> int:
+        return self._store.n_elems()
+
+    def __iter__(self):
+        return self._store.iter_elem_proxies()
+
+    def __contains__(self, item) -> bool:
+        try:
+            self._store.elem_loc(item.id)
+            return True
+        except ValueError:
+            return False
+
+    def __getitem__(self, index):
+        return list(self)[index]
+
+    def from_id(self, el_id: int):
+        return self._store.elem_proxy_by_id(el_id)
+
+    @property
+    def elements(self) -> list:
+        return list(self)
+
+    @property
+    def idmap(self) -> dict:
+        return {e.id: e for e in self}
+
+    def group_by_type(self):
+        for ctype, blk in self._store.blocks.items():
+            yield ctype, [self._store.elem_proxy(ctype, r) for r in range(len(blk))]
+
+    # type-filtered views (mirror the object-model properties)
+    def _of_group(self, group_cls):
+        from ada.fem.elements import Elem
+
+        for ctype, blk in self._store.blocks.items():
+            if isinstance(ctype, group_cls):
+                for r in range(len(blk)):
+                    yield self._store.elem_proxy(ctype, r)
+        _ = Elem  # keep import local-safe
+
+    @property
+    def shell(self):
+        from ada.fem.elements import Elem
+
+        return self._of_group(Elem.EL_TYPES.SHELL_SHAPES)
+
+    @property
+    def lines(self):
+        from ada.fem.elements import Elem
+
+        return self._of_group(Elem.EL_TYPES.LINE_SHAPES)
+
+    @property
+    def solids(self):
+        from ada.fem.elements import Elem
+
+        return self._of_group(Elem.EL_TYPES.SOLID_SHAPES)
+
+    @property
+    def stru_elements(self):
+        return iter(self)
+
+    def renumber(self, start_id=1, renumber_map: dict = None):
+        self._store.renumber_elems(start_id=start_id, renumber_map=renumber_map)
+
+    def to_elem_blocks(self):
+        from ada.fem.results.common import ElementBlock, ElementInfo, FEATypes
+
+        out = []
+        for ctype, blk in self._store.blocks.items():
+            info = ElementInfo(ctype, FEATypes.GMSH, None)
+            out.append(ElementBlock(info, blk.conn.copy(), blk.el_ids.copy()))
+        return out
+
+
+def to_array_backed(fem):
+    """Swap a FEM's object-model ``nodes``/``elements`` for substrate-backed facades
+    sharing one ``MeshArrays``. The proxies are transient, so after this the mesh is
+    held as packed arrays. Returns the same FEM for chaining."""
+    store = MeshArrays.from_fem(fem)
+    fem.nodes = ArrayNodes(store, parent=fem)
+    fem.elements = ArrayElements(store, fem_obj=fem)
+    return fem

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -17,7 +17,7 @@ from ada.api.containers.nodes import Nodes
 from ada.api.mesh.store import MeshArrays
 from ada.config import Config, logger
 from ada.core.vector_utils import points_in_cylinder, vector_length
-from ada.fem.containers import FemElements
+from ada.fem.containers import FemElements, LazyElemSeq
 
 if TYPE_CHECKING:
     from ada.api.mesh.proxies import NodeProxy
@@ -332,13 +332,13 @@ class ArrayElements(FemElements):
     def masses(self):
         from ada.fem.elements import Mass
 
-        return (e for e in self._overflow if isinstance(e, Mass))
+        return LazyElemSeq(lambda: (e for e in self._overflow if isinstance(e, Mass)))
 
     @property
     def connectors(self):
         from ada.fem.elements import Connector
 
-        return (e for e in self._overflow if isinstance(e, Connector))
+        return LazyElemSeq(lambda: (e for e in self._overflow if isinstance(e, Connector)))
 
     @property
     def elements(self) -> list:
@@ -352,37 +352,41 @@ class ArrayElements(FemElements):
         for ctype, blk in self._store.blocks.items():
             yield ctype, [self._store.elem_proxy(ctype, r) for r in range(len(blk))]
 
-    # type-filtered views (mirror the object-model properties)
+    # type-filtered views (mirror the object-model properties): re-iterable +
+    # cheap len() from block sizes (no materialisation).
     def _of_group(self, group_cls):
-        from ada.fem.elements import Elem
-
         for ctype, blk in self._store.blocks.items():
             if isinstance(ctype, group_cls):
                 for r in range(len(blk)):
                     yield self._store.elem_proxy(ctype, r)
-        _ = Elem  # keep import local-safe
+
+    def _count_group(self, group_cls) -> int:
+        return sum(len(blk) for ctype, blk in self._store.blocks.items() if isinstance(ctype, group_cls))
+
+    def _group_view(self, group_cls) -> LazyElemSeq:
+        return LazyElemSeq(lambda: self._of_group(group_cls), counter=lambda: self._count_group(group_cls))
 
     @property
     def shell(self):
         from ada.fem.elements import Elem
 
-        return self._of_group(Elem.EL_TYPES.SHELL_SHAPES)
+        return self._group_view(Elem.EL_TYPES.SHELL_SHAPES)
 
     @property
     def lines(self):
         from ada.fem.elements import Elem
 
-        return self._of_group(Elem.EL_TYPES.LINE_SHAPES)
+        return self._group_view(Elem.EL_TYPES.LINE_SHAPES)
 
     @property
     def solids(self):
         from ada.fem.elements import Elem
 
-        return self._of_group(Elem.EL_TYPES.SOLID_SHAPES)
+        return self._group_view(Elem.EL_TYPES.SOLID_SHAPES)
 
     @property
     def stru_elements(self):
-        return iter(self)
+        return LazyElemSeq(lambda: iter(self), counter=lambda: len(self))
 
     def renumber(self, start_id=1, renumber_map: dict = None):
         self._store.renumber_elems(start_id=start_id, renumber_map=renumber_map)

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -27,6 +27,8 @@ class ArrayNodes(Nodes):
     def __init__(self, store: MeshArrays, parent=None):
         self._store = store
         self._parent = parent
+        if parent is not None:
+            store._fem = parent
         self._point_tol = Config().general_point_tol
         self._sorted = None  # lazy lexsorted row order (by x,y,z)
 
@@ -244,6 +246,8 @@ class ArrayElements(FemElements):
     def __init__(self, store: MeshArrays, fem_obj=None):
         self._store = store
         self._fem_obj = fem_obj
+        if fem_obj is not None:
+            store._fem = fem_obj
         self._sort_funcs = []
         # Special elements that don't sit in the array blocks (Mass / Spring /
         # Connector). Few in number, kept as objects; the millions of structural
@@ -279,6 +283,11 @@ class ArrayElements(FemElements):
         return list(self)[index]
 
     def __add__(self, other):
+        # Mirror FemElements.__add__: renumber the incoming elements above the current
+        # max so appended elements (e.g. mass objects, which share an id with the
+        # MASS-type Elem find_bnmass already added) don't collide.
+        if hasattr(other, "renumber"):
+            other.renumber(self.max_el_id + 1)
         for e in other:
             self.add(e)
         return self

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -386,7 +386,9 @@ class ArrayElements(FemElements):
         out = []
         for ctype, blk in self._store.blocks.items():
             info = ElementInfo(ctype, FEATypes.GMSH, None)
-            out.append(ElementBlock(info, blk.conn.copy(), blk.el_ids.copy()))
+            # Zero-copy: hand over the store's index connectivity + ids directly
+            # (node_refs are already 0-based row indices into FemNodes.coords).
+            out.append(ElementBlock(info, blk.conn, blk.el_ids, node_refs_are_indices=True))
         return out
 
 

--- a/src/ada/api/mesh/containers.py
+++ b/src/ada/api/mesh/containers.py
@@ -245,29 +245,78 @@ class ArrayElements(FemElements):
         self._store = store
         self._fem_obj = fem_obj
         self._sort_funcs = []
+        # Special elements that don't sit in the array blocks (Mass / Spring /
+        # Connector). Few in number, kept as objects; the millions of structural
+        # elements live in the store's blocks.
+        self._overflow: list = []
 
     @property
     def store(self) -> MeshArrays:
         return self._store
 
     def __len__(self) -> int:
-        return self._store.n_elems()
+        return self._store.n_elems() + len(self._overflow)
 
     def __iter__(self):
-        return self._store.iter_elem_proxies()
+        yield from self._store.iter_elem_proxies()
+        yield from self._overflow
 
     def __contains__(self, item) -> bool:
         try:
             self._store.elem_loc(item.id)
             return True
         except ValueError:
-            return False
+            return any(e.id == item.id for e in self._overflow)
 
     def __getitem__(self, index):
         return list(self)[index]
 
+    def __add__(self, other):
+        for e in other:
+            self.add(e)
+        return self
+
     def from_id(self, el_id: int):
-        return self._store.elem_proxy_by_id(el_id)
+        try:
+            return self._store.elem_proxy_by_id(el_id)
+        except ValueError:
+            for e in self._overflow:
+                if e.id == el_id:
+                    return e
+            raise ValueError(f'The elem id "{el_id}" is not found')
+
+    def add(self, elem, skip_grouping=False):
+        if elem.id is None:
+            elem._el_id = self.max_el_id + 1
+        if elem.parent is None:
+            elem.parent = self._fem_obj
+        self._overflow.append(elem)
+        return elem
+
+    @property
+    def max_el_id(self) -> int:
+        store_max = 0
+        for blk in self._store.blocks.values():
+            if blk.el_ids.size:
+                store_max = max(store_max, int(blk.el_ids.max()))
+        ov_max = max((e.id for e in self._overflow if e.id is not None), default=0)
+        return max(store_max, ov_max)
+
+    def build_sets(self):
+        # element sets are built lazily/id-backed in the array path; no-op
+        pass
+
+    @property
+    def masses(self):
+        from ada.fem.elements import Mass
+
+        return (e for e in self._overflow if isinstance(e, Mass))
+
+    @property
+    def connectors(self):
+        from ada.fem.elements import Connector
+
+        return (e for e in self._overflow if isinstance(e, Connector))
 
     @property
     def elements(self) -> list:

--- a/src/ada/api/mesh/proxies.py
+++ b/src/ada/api/mesh/proxies.py
@@ -258,11 +258,51 @@ class ElemProxy(Elem):
         view[view.index(old_node)] = new_node
         self._shape = None
 
+    @property
+    def refs(self) -> "ElemRefsView":
+        return ElemRefsView(self._store, self._ctype, self._row)
+
+    def add_obj_to_refs(self, item) -> None:
+        self._store.add_elem_ref(self._ctype, self._row, item)
+
+    def remove_obj_from_refs(self, item) -> None:
+        self._store.remove_elem_ref(self._ctype, self._row, item)
+
     def __repr__(self):
         return f'ElemProxy(ID: {self.id}, Type: {self.type}, NodeIds: "{[n.id for n in self.nodes]}")'
 
     def __reduce__(self):
         return (_rebuild_elem_proxy, (self._store, self._ctype, self._row))
+
+
+class ElemRefsView:
+    """``Elem.refs`` backed by the store's element-refs side-table (FemSet/Beam/...)."""
+
+    def __init__(self, store: "MeshArrays", ctype, row: int):
+        self._store = store
+        self._ctype = ctype
+        self._row = row
+
+    def __iter__(self):
+        return iter(self._store.elem_refs(self._ctype, self._row))
+
+    def __len__(self) -> int:
+        return len(self._store.elem_refs(self._ctype, self._row))
+
+    def __contains__(self, item) -> bool:
+        return item in self._store.elem_refs(self._ctype, self._row)
+
+    def __getitem__(self, i):
+        return self._store.elem_refs(self._ctype, self._row)[i]
+
+    def append(self, item) -> None:
+        self._store.add_elem_ref(self._ctype, self._row, item)
+
+    def remove(self, item) -> None:
+        self._store.remove_elem_ref(self._ctype, self._row, item)
+
+    def copy(self) -> list:
+        return list(self)
 
 
 def _rebuild_elem_proxy(store: "MeshArrays", ctype, row: int) -> ElemProxy:

--- a/src/ada/api/mesh/proxies.py
+++ b/src/ada/api/mesh/proxies.py
@@ -122,6 +122,11 @@ class RefsView:
     def copy(self) -> list:
         return list(self)
 
+    def __repr__(self) -> str:
+        n_el = self._store.node_to_elem().degree(self._row)
+        n_extra = len(self._store.extra_refs(self._row))
+        return f"RefsView(node_row={self._row}: {n_el} elems, {n_extra} other)"
+
 
 class NodeListView:
     """``Elem.nodes`` backed by a block connectivity row; mints node proxies lazily
@@ -160,6 +165,9 @@ class NodeListView:
 
     def __eq__(self, other) -> bool:
         return list(self) == list(other)
+
+    def __repr__(self) -> str:
+        return f"NodeListView({[int(n.id) for n in self]})"
 
 
 class ElemProxy(Elem):
@@ -303,6 +311,9 @@ class ElemRefsView:
 
     def copy(self) -> list:
         return list(self)
+
+    def __repr__(self) -> str:
+        return f"ElemRefsView({self._ctype}#{self._row}: {len(self)} refs)"
 
 
 def _rebuild_elem_proxy(store: "MeshArrays", ctype, row: int) -> ElemProxy:

--- a/src/ada/api/mesh/proxies.py
+++ b/src/ada/api/mesh/proxies.py
@@ -238,6 +238,21 @@ class ElemProxy(Elem):
             self._block.ecc[self._row] = value
 
     @property
+    def metadata(self) -> dict:
+        # Per-element metadata dict, lazily materialised on the block's side-table so
+        # that in-place mutations (e.g. the Sesam writer's el.metadata["transno"]=...)
+        # persist. Elem stores this in self._metadata; the array path keeps it by row.
+        md = self._block.metadata.get(self._row)
+        if md is None:
+            md = {}
+            self._block.metadata[self._row] = md
+        return md
+
+    @metadata.setter
+    def metadata(self, value):
+        self._block.metadata[self._row] = value
+
+    @property
     def hinge_prop(self):
         return self._block.hinge.get(self._row)
 

--- a/src/ada/api/mesh/proxies.py
+++ b/src/ada/api/mesh/proxies.py
@@ -1,0 +1,77 @@
+"""Lazy proxies over :class:`~ada.api.mesh.store.MeshArrays`.
+
+``NodeProxy`` is a :class:`~ada.api.nodes.Node` subclass (so ``isinstance(x, Node)``
+and value-equality keep working) that holds only ``(store, row)`` and reads/writes
+its coordinates and id straight through to the substrate arrays. No per-node Point or
+coordinate copy is stored — ``.p`` mints an interned ``Point`` on access.
+
+Identity: the store hands out the *same* proxy for a given row while it is alive (a
+``WeakValueDictionary`` cache), so ``from_id(5) is from_id(5)`` holds within a live
+window. Equality/hash/ordering are value-based (``(*p, id)``), matching ``Node``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ada.api.nodes import Node
+from ada.base.units import Units
+from ada.config import Config
+from ada.geom.points import Point
+
+if TYPE_CHECKING:
+    from ada.api.mesh.store import MeshArrays
+
+
+class NodeProxy(Node):
+    """A ``Node`` backed by a row of a :class:`MeshArrays` substrate."""
+
+    def __init__(self, store: "MeshArrays", row: int, parent=None, units=Units.M):
+        # Deliberately do NOT call Node.__init__ — there is no per-node coordinate
+        # or id data; those live in the substrate arrays.
+        self._store = store
+        self._row = int(row)
+        self._r = None
+        self._parent = parent
+        self._units = units
+        self._refs = []
+        self._precision = Config().general_precision
+
+    # ── coordinates / id read+write straight through to the arrays ───────
+    @property
+    def p(self) -> Point:
+        return Point(self._store.coords[self._row])
+
+    @p.setter
+    def p(self, value):
+        self._store.set_node_coord(self._row, np.asarray(value, dtype=float))
+
+    @property
+    def id(self) -> int:
+        return int(self._store.node_ids[self._row])
+
+    @id.setter
+    def id(self, value: int):
+        self._store.set_node_id(self._row, int(value))
+
+    @property
+    def row(self) -> int:
+        return self._row
+
+    @property
+    def store(self) -> "MeshArrays":
+        return self._store
+
+    # x/y/z, r, units, parent, refs, has_refs, p_roundoff, comparisons, hash,
+    # __len__/__getitem__/__repr__ are all inherited from Node and work unchanged
+    # because they go through the .p / .id / ._refs accessors above.
+
+    def __reduce__(self):
+        # Pickle as a reference into the owning store rather than duplicating it.
+        return (_rebuild_node_proxy, (self._store, self._row))
+
+
+def _rebuild_node_proxy(store: "MeshArrays", row: int) -> NodeProxy:
+    return store.node_proxy(row)

--- a/src/ada/api/mesh/proxies.py
+++ b/src/ada/api/mesh/proxies.py
@@ -19,10 +19,11 @@ import numpy as np
 from ada.api.nodes import Node
 from ada.base.units import Units
 from ada.config import Config
+from ada.fem.elements import Elem
 from ada.geom.points import Point
 
 if TYPE_CHECKING:
-    from ada.api.mesh.store import MeshArrays
+    from ada.api.mesh.store import ElemArrayBlock, MeshArrays
 
 
 class NodeProxy(Node):
@@ -36,7 +37,6 @@ class NodeProxy(Node):
         self._r = None
         self._parent = parent
         self._units = units
-        self._refs = []
         self._precision = Config().general_precision
 
     # ── coordinates / id read+write straight through to the arrays ───────
@@ -64,9 +64,15 @@ class NodeProxy(Node):
     def store(self) -> "MeshArrays":
         return self._store
 
-    # x/y/z, r, units, parent, refs, has_refs, p_roundoff, comparisons, hash,
+    @property
+    def refs(self) -> "RefsView":
+        # Element refs come from the connectivity (CSR); Beam/Csys/FemSet from the
+        # store's side-table. Replaces the per-node Python list.
+        return RefsView(self._store, self._row)
+
+    # x/y/z, r, units, parent, has_refs, p_roundoff, comparisons, hash,
     # __len__/__getitem__/__repr__ are all inherited from Node and work unchanged
-    # because they go through the .p / .id / ._refs accessors above.
+    # because they go through the .p / .id / .refs accessors above.
 
     def __reduce__(self):
         # Pickle as a reference into the owning store rather than duplicating it.
@@ -75,3 +81,189 @@ class NodeProxy(Node):
 
 def _rebuild_node_proxy(store: "MeshArrays", row: int) -> NodeProxy:
     return store.node_proxy(row)
+
+
+class RefsView:
+    """``Node.refs`` backed by the substrate: CSR-derived element proxies chained
+    with the side-table of non-element refs (Beam/Csys/FemSet)."""
+
+    def __init__(self, store: "MeshArrays", row: int):
+        self._store = store
+        self._row = row
+
+    def _elems(self):
+        adj = self._store.node_to_elem()
+        for ctype, erow in adj.incident(self._row):
+            yield self._store.elem_proxy(ctype, erow)
+
+    def __iter__(self):
+        yield from self._elems()
+        yield from self._store.extra_refs(self._row)
+
+    def __len__(self) -> int:
+        return self._store.node_to_elem().degree(self._row) + len(self._store.extra_refs(self._row))
+
+    def __contains__(self, item) -> bool:
+        return any(item == x for x in self)
+
+    def __getitem__(self, i):
+        return list(self)[i]
+
+    def append(self, item) -> None:
+        # Element membership is implied by connectivity -> no-op; only non-element
+        # refs go to the side-table.
+        if not isinstance(item, Elem):
+            self._store.add_extra_ref(self._row, item)
+
+    def remove(self, item) -> None:
+        if not isinstance(item, Elem):
+            self._store.remove_extra_ref(self._row, item)
+
+    def copy(self) -> list:
+        return list(self)
+
+
+class NodeListView:
+    """``Elem.nodes`` backed by a block connectivity row; mints node proxies lazily
+    and writes through on item assignment."""
+
+    def __init__(self, store: "MeshArrays", block: "ElemArrayBlock", row: int):
+        self._store = store
+        self._block = block
+        self._row = row
+
+    def __len__(self) -> int:
+        return int(self._block.conn.shape[1])
+
+    def __getitem__(self, i):
+        conn_row = self._block.conn[self._row]
+        if isinstance(i, slice):
+            return [self._store.node_proxy(int(r)) for r in conn_row[i]]
+        return self._store.node_proxy(int(conn_row[i]))
+
+    def __setitem__(self, i, node) -> None:
+        self._block.conn[self._row, i] = self._store.node_index(node.id)
+        self._block._eid2row = self._block._eid2row  # unaffected
+        self._store.conn_changed()
+
+    def __iter__(self):
+        for r in self._block.conn[self._row]:
+            yield self._store.node_proxy(int(r))
+
+    def index(self, node) -> int:
+        target = self._store.node_index(node.id)
+        row = self._block.conn[self._row]
+        hits = np.nonzero(row == target)[0]
+        if hits.size == 0:
+            raise ValueError(f"{node!r} not in element")
+        return int(hits[0])
+
+    def __eq__(self, other) -> bool:
+        return list(self) == list(other)
+
+
+class ElemProxy(Elem):
+    """An ``Elem`` backed by a row of an :class:`ElemArrayBlock`."""
+
+    def __init__(self, store: "MeshArrays", ctype, row: int, parent=None):
+        self._store = store
+        self._ctype = ctype
+        self._row = int(row)
+        self._parent = parent
+        self._shape = None
+        self._refs = []
+        self._mass_props = None
+        self._formulation_override = None
+
+    @property
+    def _block(self) -> "ElemArrayBlock":
+        return self._store.blocks[self._ctype]
+
+    @property
+    def id(self) -> int:
+        return int(self._block.el_ids[self._row])
+
+    @id.setter
+    def id(self, value):
+        self._block.el_ids[self._row] = int(value)
+        self._block._eid2row = None
+
+    @property
+    def type(self):
+        return self._ctype
+
+    @property
+    def nodes(self) -> NodeListView:
+        return NodeListView(self._store, self._block, self._row)
+
+    @property
+    def fem_sec(self):
+        secs = self._block.fem_secs
+        return secs[self._row] if secs is not None else None
+
+    @fem_sec.setter
+    def fem_sec(self, value):
+        if self._block.fem_secs is None:
+            self._block.fem_secs = [None] * len(self._block)
+        self._block.fem_secs[self._row] = value
+
+    @property
+    def elset(self):
+        els = self._block.elsets
+        return els[self._row] if els is not None else None
+
+    @elset.setter
+    def elset(self, value):
+        if self._block.elsets is None:
+            self._block.elsets = [None] * len(self._block)
+        self._block.elsets[self._row] = value
+
+    @property
+    def eccentricity(self):
+        return self._block.ecc.get(self._row)
+
+    @eccentricity.setter
+    def eccentricity(self, value):
+        if value is None:
+            self._block.ecc.pop(self._row, None)
+        else:
+            self._block.ecc[self._row] = value
+
+    @property
+    def hinge_prop(self):
+        return self._block.hinge.get(self._row)
+
+    @hinge_prop.setter
+    def hinge_prop(self, value):
+        if value is None:
+            self._block.hinge.pop(self._row, None)
+        else:
+            self._block.hinge[self._row] = value
+
+    @property
+    def shape(self):
+        from ada.fem.shapes import ElemShape
+
+        if self._shape is None:
+            self._shape = ElemShape(self.type, list(self.nodes))
+        return self._shape
+
+    def updating_nodes(self, old_node: Node, new_node: Node) -> None:
+        view = self.nodes
+        view[view.index(old_node)] = new_node
+        self._shape = None
+
+    def replace_node_with_other_node(self, old_node: Node, new_node: Node):
+        view = self.nodes
+        view[view.index(old_node)] = new_node
+        self._shape = None
+
+    def __repr__(self):
+        return f'ElemProxy(ID: {self.id}, Type: {self.type}, NodeIds: "{[n.id for n in self.nodes]}")'
+
+    def __reduce__(self):
+        return (_rebuild_elem_proxy, (self._store, self._ctype, self._row))
+
+
+def _rebuild_elem_proxy(store: "MeshArrays", ctype, row: int) -> ElemProxy:
+    return store.elem_proxy(ctype, row)

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -241,7 +241,18 @@ class MeshArrays:
             if id_conn.ndim != 2:
                 continue
             el_ids = np.array([e.id for e in elems], dtype=np.int64)
-            store.add_elem_block_from_id_conn(el_type, el_ids, id_conn)
+            blk = store.add_elem_block_from_id_conn(el_type, el_ids, id_conn)
+            # capture per-element attributes (shared ones as parallel lists,
+            # rare ones as sparse row dicts)
+            if any(getattr(e, "fem_sec", None) is not None for e in elems):
+                blk.fem_secs = [getattr(e, "fem_sec", None) for e in elems]
+            if any(getattr(e, "elset", None) is not None for e in elems):
+                blk.elsets = [getattr(e, "elset", None) for e in elems]
+            for i, e in enumerate(elems):
+                if getattr(e, "eccentricity", None) is not None:
+                    blk.ecc[i] = e.eccentricity
+                if getattr(e, "hinge_prop", None) is not None:
+                    blk.hinge[i] = e.hinge_prop
         return store
 
     # ── structural edits (atomic across nodes + connectivity) ────────────

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -217,11 +217,18 @@ class MeshArrays:
         return cls(coords, node_ids)
 
     def add_elem_block_from_id_conn(self, ctype, el_ids, id_conn: np.ndarray) -> ElemArrayBlock:
-        """Add a block whose connectivity is given as node *IDs*; converts to row indices."""
+        """Add a block whose connectivity is given as node *IDs*; converts to row indices
+        in bulk via ``searchsorted`` (vectorized — the reader hot path)."""
         id_conn = np.asarray(id_conn)
         flat = id_conn.reshape(-1)
-        idx = np.fromiter((self.node_index(int(x)) for x in flat), dtype=np.int32, count=flat.size)
-        conn = idx.reshape(id_conn.shape)
+        order = np.argsort(self.node_ids, kind="stable")
+        sorted_ids = self.node_ids[order]
+        pos = np.searchsorted(sorted_ids, flat)
+        # guard: every referenced id must exist
+        if np.any(pos >= sorted_ids.size) or np.any(sorted_ids[np.clip(pos, 0, sorted_ids.size - 1)] != flat):
+            missing = flat[(pos >= sorted_ids.size) | (sorted_ids[np.clip(pos, 0, sorted_ids.size - 1)] != flat)]
+            raise ValueError(f"element references unknown node id(s): {missing[:5].tolist()}")
+        conn = order[pos].astype(np.int32).reshape(id_conn.shape)
         blk = ElemArrayBlock(ctype, conn, np.asarray(el_ids, dtype=np.int64))
         self.blocks[ctype] = blk
         return blk

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -88,6 +88,10 @@ class MeshArrays:
         # Non-element refs (Beam/Csys/FemSet) that aren't derivable from
         # connectivity, keyed by node row. Element refs come from the CSR.
         self._extra_refs: dict[int, list] = {}
+        # Refs that point AT an element (FemSet/Beam/Plate...), keyed by
+        # (ctype, row). Connectivity edits don't move element rows, so these stay
+        # valid across node remove / renumber.
+        self._elem_refs: dict[tuple, list] = {}
 
     # ── node id <-> row index ────────────────────────────────────────────
     @property
@@ -358,6 +362,20 @@ class MeshArrays:
 
     def extra_refs(self, row: int) -> list:
         return self._extra_refs.get(int(row), [])
+
+    # element-level refs (things that reference an element, e.g. FemSet)
+    def add_elem_ref(self, ctype, row: int, item) -> None:
+        lst = self._elem_refs.setdefault((ctype, int(row)), [])
+        if item not in lst:
+            lst.append(item)
+
+    def remove_elem_ref(self, ctype, row: int, item) -> None:
+        lst = self._elem_refs.get((ctype, int(row)))
+        if lst and item in lst:
+            lst.remove(item)
+
+    def elem_refs(self, ctype, row: int) -> list:
+        return self._elem_refs.get((ctype, int(row)), [])
 
     # ── results-side bridge (zero-copy views) ────────────────────────────
     def to_fem_nodes(self) -> "FemNodes":

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -74,6 +74,12 @@ class MeshArrays:
         # Identity: from_id(x) returns the same proxy while it's alive (held by an
         # element list or a transient caller). Weak so untouched proxies are freed.
         self._proxy_cache: "weakref.WeakValueDictionary[int, NodeProxy]" = weakref.WeakValueDictionary()
+        # Node->element adjacency (lazy; rebuilt when connectivity changes).
+        self._adjacency = None
+        self._adj_epoch = 0
+        # Non-element refs (Beam/Csys/FemSet) that aren't derivable from
+        # connectivity, keyed by node row. Element refs come from the CSR.
+        self._extra_refs: dict[int, list] = {}
 
     # ── node id <-> row index ────────────────────────────────────────────
     @property
@@ -229,6 +235,83 @@ class MeshArrays:
             el_ids = np.array([e.id for e in elems], dtype=np.int64)
             store.add_elem_block_from_id_conn(el_type, el_ids, id_conn)
         return store
+
+    # ── structural edits (atomic across nodes + connectivity) ────────────
+    def add_node(self, p, nid: int | None = None) -> int:
+        """Append a node; returns its row. Connectivity (row-indexed) is unaffected."""
+        p = np.asarray(p, dtype=np.float64).reshape(3)
+        self.coords = np.vstack([self.coords, p]) if self.n_nodes else p.reshape(1, 3).copy()
+        if nid is None:
+            nid = int(self.node_ids.max()) + 1 if self.node_ids.size else 1
+        self.node_ids = np.append(self.node_ids, np.int64(nid))
+        self._id2idx = None
+        self._bbox = None
+        return self.coords.shape[0] - 1
+
+    def remove_nodes(self, rows) -> None:
+        """Remove node rows and remap every block's connectivity in one shot.
+
+        Removed rows must be unreferenced by any element (the caller — e.g.
+        ``merge_coincident`` after ``replace_node`` — guarantees this); otherwise
+        the dangling reference becomes ``-1``.
+        """
+        rows = np.atleast_1d(np.asarray(list(rows), dtype=np.int64))
+        if rows.size == 0:
+            return
+        keep = np.ones(self.n_nodes, dtype=bool)
+        keep[rows] = False
+        old2new = np.full(self.n_nodes, -1, dtype=np.int32)
+        old2new[keep] = np.arange(int(keep.sum()), dtype=np.int32)
+        self.coords = self.coords[keep]
+        self.node_ids = self.node_ids[keep]
+        for blk in self.blocks.values():
+            blk.conn = old2new[blk.conn].astype(np.int32)
+            blk._eid2row = None
+        self._id2idx = None
+        self._bbox = None
+        self._adjacency = None
+        self._adj_epoch += 1
+        # rows shifted -> any cached proxies now point at the wrong row.
+        self._proxy_cache.clear()
+        self._extra_refs = {}
+
+    def conn_changed(self) -> None:
+        """Signal that a block's connectivity was edited (invalidates adjacency)."""
+        self._adjacency = None
+        self._adj_epoch += 1
+
+    # ── element access ───────────────────────────────────────────────────
+    def elem_loc(self, eid: int):
+        """Return ``(ctype, row)`` for an element id, or raise ValueError."""
+        for ctype, blk in self.blocks.items():
+            row = blk.eid2row.get(int(eid))
+            if row is not None:
+                return ctype, row
+        raise ValueError(f'The elem id "{eid}" is not found')
+
+    def n_elems(self) -> int:
+        return sum(len(b) for b in self.blocks.values())
+
+    # ── node->element adjacency + refs side-table ────────────────────────
+    def node_to_elem(self):
+        from ada.api.mesh.adjacency import CSRAdjacency
+
+        if self._adjacency is None:
+            self._adjacency = CSRAdjacency.build(self)
+        return self._adjacency
+
+    def add_extra_ref(self, row: int, item) -> None:
+        lst = self._extra_refs.setdefault(int(row), [])
+        if item not in lst:
+            lst.append(item)
+
+    def remove_extra_ref(self, row: int, item) -> None:
+        lst = self._extra_refs.get(int(row))
+        if lst and item in lst:
+            lst.remove(item)
+
+    def extra_refs(self, row: int) -> list:
+        return self._extra_refs.get(int(row), [])
 
     # ── results-side bridge (zero-copy views) ────────────────────────────
     def to_fem_nodes(self) -> "FemNodes":

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -322,6 +322,10 @@ class MeshArrays:
     def n_elems(self) -> int:
         return sum(len(b) for b in self.blocks.values())
 
+    def __repr__(self) -> str:
+        by_type = ", ".join(f"{ctype}: {len(blk)}" for ctype, blk in self.blocks.items())
+        return f"MeshArrays(nodes: {self.n_nodes}, elems: {self.n_elems()}{', ' + by_type if by_type else ''})"
+
     def elem_proxy(self, ctype, row: int):
         key = (ctype, int(row))
         cached = self._elem_proxy_cache.get(key)

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -35,7 +35,7 @@ class ElemArrayBlock:
     ``conn`` rows are **node row-indices** into the owning store's ``coords``.
     """
 
-    __slots__ = ("ctype", "conn", "el_ids", "fem_secs", "elsets", "ecc", "hinge", "_eid2row")
+    __slots__ = ("ctype", "conn", "el_ids", "fem_secs", "elsets", "ecc", "hinge", "metadata", "_eid2row")
 
     def __init__(self, ctype, conn: np.ndarray, el_ids: np.ndarray, fem_secs=None, elsets=None):
         self.ctype = ctype
@@ -50,6 +50,7 @@ class ElemArrayBlock:
         self.elsets: list | None = elsets
         self.ecc: dict[int, object] = {}
         self.hinge: dict[int, object] = {}
+        self.metadata: dict[int, dict] = {}
         self._eid2row: dict[int, int] | None = None
 
     @property
@@ -76,6 +77,11 @@ class MeshArrays:
             raise ValueError("node_ids length must match coords")
         self.blocks: dict = dict(blocks) if blocks else {}
 
+        # Owning FEM, set by the ArrayNodes/ArrayElements facades. Minted proxies get
+        # it as their ``parent`` so writers/consumers that read ``node.parent``/
+        # ``elem.parent`` (e.g. abaqus instance-name resolution) behave like the object
+        # path where every Node/Elem carries its parent FEM.
+        self._fem = None
         self._id2idx: dict[int, int] | None = None
         self._bbox = None
         # Identity: from_id(x) returns the same proxy while it's alive (held by an
@@ -124,7 +130,7 @@ class MeshArrays:
             return cached
         from ada.api.mesh.proxies import NodeProxy
 
-        proxy = NodeProxy(self, row)
+        proxy = NodeProxy(self, row, parent=self._fem)
         self._proxy_cache[row] = proxy
         return proxy
 
@@ -333,7 +339,7 @@ class MeshArrays:
             return cached
         from ada.api.mesh.proxies import ElemProxy
 
-        proxy = ElemProxy(self, ctype, int(row))
+        proxy = ElemProxy(self, ctype, int(row), parent=self._fem)
         self._elem_proxy_cache[key] = proxy
         return proxy
 

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -35,14 +35,21 @@ class ElemArrayBlock:
     ``conn`` rows are **node row-indices** into the owning store's ``coords``.
     """
 
-    __slots__ = ("ctype", "conn", "el_ids", "_eid2row")
+    __slots__ = ("ctype", "conn", "el_ids", "fem_secs", "elsets", "ecc", "hinge", "_eid2row")
 
-    def __init__(self, ctype, conn: np.ndarray, el_ids: np.ndarray):
+    def __init__(self, ctype, conn: np.ndarray, el_ids: np.ndarray, fem_secs=None, elsets=None):
         self.ctype = ctype
         self.conn = np.ascontiguousarray(conn, dtype=np.int32)
         self.el_ids = np.ascontiguousarray(el_ids, dtype=np.int64)
         if self.conn.ndim != 2 or self.conn.shape[0] != self.el_ids.shape[0]:
             raise ValueError("conn must be (m,k) and match el_ids length")
+        # Per-element attributes. Shared/heavy ones (FemSection, FemSet) are stored
+        # as parallel reference lists (a handful of distinct objects shared across
+        # rows); rare ones (eccentricity, hinge) as sparse row-keyed dicts.
+        self.fem_secs: list | None = fem_secs
+        self.elsets: list | None = elsets
+        self.ecc: dict[int, object] = {}
+        self.hinge: dict[int, object] = {}
         self._eid2row: dict[int, int] | None = None
 
     @property
@@ -74,6 +81,7 @@ class MeshArrays:
         # Identity: from_id(x) returns the same proxy while it's alive (held by an
         # element list or a transient caller). Weak so untouched proxies are freed.
         self._proxy_cache: "weakref.WeakValueDictionary[int, NodeProxy]" = weakref.WeakValueDictionary()
+        self._elem_proxy_cache: "weakref.WeakValueDictionary[tuple, object]" = weakref.WeakValueDictionary()
         # Node->element adjacency (lazy; rebuilt when connectivity changes).
         self._adjacency = None
         self._adj_epoch = 0
@@ -291,6 +299,26 @@ class MeshArrays:
 
     def n_elems(self) -> int:
         return sum(len(b) for b in self.blocks.values())
+
+    def elem_proxy(self, ctype, row: int):
+        key = (ctype, int(row))
+        cached = self._elem_proxy_cache.get(key)
+        if cached is not None:
+            return cached
+        from ada.api.mesh.proxies import ElemProxy
+
+        proxy = ElemProxy(self, ctype, int(row))
+        self._elem_proxy_cache[key] = proxy
+        return proxy
+
+    def elem_proxy_by_id(self, eid: int):
+        ctype, row = self.elem_loc(eid)
+        return self.elem_proxy(ctype, row)
+
+    def iter_elem_proxies(self):
+        for ctype, blk in self.blocks.items():
+            for row in range(len(blk)):
+                yield self.elem_proxy(ctype, row)
 
     # ── node->element adjacency + refs side-table ────────────────────────
     def node_to_elem(self):

--- a/src/ada/api/mesh/store.py
+++ b/src/ada/api/mesh/store.py
@@ -1,0 +1,237 @@
+"""``MeshArrays`` — the packed-numpy substrate that backs the FEM mesh.
+
+A single per-FEM object owns the raw numeric data:
+
+* ``coords``   ``float64 (n, 3)``  — the single source of truth for ``Node.p``
+* ``node_ids`` ``int64   (n,)``    — source-file node labels
+* ``blocks``   ``{ElemTypeKey -> ElemArrayBlock}`` where each block holds an
+  ``int32 (m, k)`` connectivity array of **row indices into ``coords``** (not node
+  IDs) plus an ``int64 (m,)`` element-id array.
+
+Storing connectivity as row indices (not IDs) is the linchpin: renumbering nodes is
+then O(1) on ``node_ids`` alone (``conn`` is untouched), and the results-side
+``FemNodes``/``ElementBlock`` become zero-copy views.
+
+Derived structures (id->index map, voxel grid, bbox, node proxies) are lazy and
+invalidated on the relevant edit.
+"""
+
+from __future__ import annotations
+
+import weakref
+from typing import TYPE_CHECKING, Iterable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ada.api.mesh.proxies import NodeProxy
+    from ada.api.nodes import Node
+    from ada.fem.results.common import FemNodes
+
+
+class ElemArrayBlock:
+    """One element type's connectivity, packed.
+
+    ``conn`` rows are **node row-indices** into the owning store's ``coords``.
+    """
+
+    __slots__ = ("ctype", "conn", "el_ids", "_eid2row")
+
+    def __init__(self, ctype, conn: np.ndarray, el_ids: np.ndarray):
+        self.ctype = ctype
+        self.conn = np.ascontiguousarray(conn, dtype=np.int32)
+        self.el_ids = np.ascontiguousarray(el_ids, dtype=np.int64)
+        if self.conn.ndim != 2 or self.conn.shape[0] != self.el_ids.shape[0]:
+            raise ValueError("conn must be (m,k) and match el_ids length")
+        self._eid2row: dict[int, int] | None = None
+
+    @property
+    def nodes_per_elem(self) -> int:
+        return self.conn.shape[1]
+
+    @property
+    def eid2row(self) -> dict[int, int]:
+        if self._eid2row is None:
+            self._eid2row = {int(e): i for i, e in enumerate(self.el_ids)}
+        return self._eid2row
+
+    def __len__(self) -> int:
+        return self.conn.shape[0]
+
+
+class MeshArrays:
+    def __init__(self, coords: np.ndarray, node_ids: np.ndarray, blocks: dict | None = None):
+        self.coords = np.ascontiguousarray(coords, dtype=np.float64)
+        self.node_ids = np.ascontiguousarray(node_ids, dtype=np.int64)
+        if self.coords.ndim != 2 or self.coords.shape[1] != 3:
+            raise ValueError("coords must be (n, 3)")
+        if self.node_ids.shape[0] != self.coords.shape[0]:
+            raise ValueError("node_ids length must match coords")
+        self.blocks: dict = dict(blocks) if blocks else {}
+
+        self._id2idx: dict[int, int] | None = None
+        self._bbox = None
+        # Identity: from_id(x) returns the same proxy while it's alive (held by an
+        # element list or a transient caller). Weak so untouched proxies are freed.
+        self._proxy_cache: "weakref.WeakValueDictionary[int, NodeProxy]" = weakref.WeakValueDictionary()
+
+    # ── node id <-> row index ────────────────────────────────────────────
+    @property
+    def n_nodes(self) -> int:
+        return self.coords.shape[0]
+
+    @property
+    def id2idx(self) -> dict[int, int]:
+        if self._id2idx is None:
+            self._id2idx = {int(nid): i for i, nid in enumerate(self.node_ids)}
+        return self._id2idx
+
+    def node_index(self, nid: int) -> int:
+        try:
+            return self.id2idx[int(nid)]
+        except KeyError:
+            raise ValueError(f'The node id "{nid}" is not found')
+
+    def node_id(self, row: int) -> int:
+        return int(self.node_ids[row])
+
+    def has_node(self, nid: int) -> bool:
+        return int(nid) in self.id2idx
+
+    # ── proxy minting (identity-stable while alive) ──────────────────────
+    def node_proxy(self, row: int) -> "NodeProxy":
+        row = int(row)
+        cached = self._proxy_cache.get(row)
+        if cached is not None:
+            return cached
+        from ada.api.mesh.proxies import NodeProxy
+
+        proxy = NodeProxy(self, row)
+        self._proxy_cache[row] = proxy
+        return proxy
+
+    def node_proxy_by_id(self, nid: int) -> "NodeProxy":
+        return self.node_proxy(self.node_index(nid))
+
+    def iter_node_proxies(self) -> Iterable["NodeProxy"]:
+        for row in range(self.n_nodes):
+            yield self.node_proxy(row)
+
+    # ── single-element writes (write-through) ────────────────────────────
+    def set_node_coord(self, row: int, p) -> None:
+        self.coords[row] = np.asarray(p, dtype=np.float64)[:3]
+        self._bbox = None
+
+    def set_node_id(self, row: int, new_id: int) -> None:
+        self.node_ids[row] = int(new_id)
+        self._id2idx = None
+        # the cached proxy (if any) keeps the same row, so identity is preserved
+
+    # ── bulk vectorized ops ──────────────────────────────────────────────
+    def translate(self, vec) -> None:
+        self.coords += np.asarray(vec, dtype=np.float64)
+        self._bbox = None
+
+    def rotate(self, rot_mat: np.ndarray, origin) -> None:
+        o = np.asarray(origin, dtype=np.float64)
+        self.coords[:] = (self.coords - o) @ np.asarray(rot_mat, dtype=np.float64).T + o
+        self._bbox = None
+
+    def scale(self, factor: float) -> None:
+        self.coords *= float(factor)
+        self._bbox = None
+
+    def renumber_nodes(self, start_id: int = 1, renumber_map: dict[int, int] | None = None) -> None:
+        """Renumber node IDs. Connectivity is index-based, so it is untouched —
+        this is O(n) on ``node_ids`` alone (vs the per-object id-setter loop)."""
+        if renumber_map is not None:
+            self.node_ids = np.array([int(renumber_map[int(x)]) for x in self.node_ids], dtype=np.int64)
+        else:
+            # smallest old id -> start_id, in old-id order (matches the object path)
+            order = np.argsort(self.node_ids, kind="stable")
+            new = np.empty_like(self.node_ids)
+            new[order] = np.arange(start_id, start_id + self.node_ids.shape[0], dtype=np.int64)
+            self.node_ids = new
+        self._id2idx = None
+
+    def renumber_elems(self, start_id: int = 1, renumber_map: dict[int, int] | None = None) -> None:
+        """Renumber element IDs across all blocks (connectivity untouched)."""
+        if renumber_map is not None:
+            for blk in self.blocks.values():
+                blk.el_ids = np.array([int(renumber_map[int(x)]) for x in blk.el_ids], dtype=np.int64)
+                blk._eid2row = None
+        else:
+            nxt = start_id
+            # number in (block-insertion, id) order to be deterministic
+            for blk in self.blocks.values():
+                order = np.argsort(blk.el_ids, kind="stable")
+                new = np.empty_like(blk.el_ids)
+                new[order] = np.arange(nxt, nxt + blk.el_ids.shape[0], dtype=np.int64)
+                blk.el_ids = new
+                blk._eid2row = None
+                nxt += blk.el_ids.shape[0]
+
+    # ── queries ──────────────────────────────────────────────────────────
+    def bbox(self):
+        if self._bbox is None:
+            if self.n_nodes == 0:
+                raise ValueError("No Nodes are found")
+            mn = self.coords.min(axis=0)
+            mx = self.coords.max(axis=0)
+            self._bbox = ((mn[0], mx[0]), (mn[1], mx[1]), (mn[2], mx[2]))
+        return self._bbox
+
+    def rows_in_box(self, vol_min, vol_max) -> np.ndarray:
+        """Row indices whose coords lie within the [vol_min, vol_max] box (vectorized)."""
+        lo = np.asarray(vol_min, dtype=np.float64)
+        hi = np.asarray(vol_max, dtype=np.float64)
+        mask = np.all((self.coords >= lo) & (self.coords <= hi), axis=1)
+        return np.nonzero(mask)[0]
+
+    # ── construction ─────────────────────────────────────────────────────
+    @classmethod
+    def from_node_rows(cls, node_rows: np.ndarray, blocks: dict | None = None) -> "MeshArrays":
+        """``node_rows`` is ``(n, 4)`` of ``[id, x, y, z]``."""
+        arr = np.asarray(node_rows, dtype=np.float64)
+        return cls(arr[:, 1:4], arr[:, 0].astype(np.int64), blocks)
+
+    @classmethod
+    def from_nodes(cls, nodes: Iterable["Node"]) -> "MeshArrays":
+        nodes = list(nodes)
+        coords = np.array([n.p for n in nodes], dtype=np.float64) if nodes else np.zeros((0, 3))
+        node_ids = np.array([n.id for n in nodes], dtype=np.int64) if nodes else np.zeros((0,), dtype=np.int64)
+        return cls(coords, node_ids)
+
+    def add_elem_block_from_id_conn(self, ctype, el_ids, id_conn: np.ndarray) -> ElemArrayBlock:
+        """Add a block whose connectivity is given as node *IDs*; converts to row indices."""
+        id_conn = np.asarray(id_conn)
+        flat = id_conn.reshape(-1)
+        idx = np.fromiter((self.node_index(int(x)) for x in flat), dtype=np.int32, count=flat.size)
+        conn = idx.reshape(id_conn.shape)
+        blk = ElemArrayBlock(ctype, conn, np.asarray(el_ids, dtype=np.int64))
+        self.blocks[ctype] = blk
+        return blk
+
+    @classmethod
+    def from_fem(cls, fem) -> "MeshArrays":
+        """Build a substrate from an object-model ``FEM`` (the bridge a migrated
+        reader would produce directly). Element groups with a uniform node count
+        per type become blocks; ragged/non-structural groups are skipped."""
+        store = cls.from_nodes(list(fem.nodes))
+        for el_type, group in fem.elements.group_by_type():
+            elems = list(group)
+            try:
+                id_conn = np.array([[n.id for n in e.nodes] for e in elems], dtype=np.int64)
+            except ValueError:
+                continue  # mixed node counts within the group — skip for now
+            if id_conn.ndim != 2:
+                continue
+            el_ids = np.array([e.id for e in elems], dtype=np.int64)
+            store.add_elem_block_from_id_conn(el_type, el_ids, id_conn)
+        return store
+
+    # ── results-side bridge (zero-copy views) ────────────────────────────
+    def to_fem_nodes(self) -> "FemNodes":
+        from ada.fem.results.common import FemNodes
+
+        return FemNodes(self.coords, self.node_ids)

--- a/src/ada/config.py
+++ b/src/ada/config.py
@@ -168,11 +168,12 @@ class Config:
                 # (warns); set raise_on_hanging_nodes to escalate to an exception.
                 ConfigEntry("check_hanging_nodes", bool, True, required=False),
                 ConfigEntry("raise_on_hanging_nodes", bool, False, required=False),
-                # Array-backed mesh substrate: store FEM nodes as packed numpy
-                # arrays with lazy Node proxies instead of millions of Python
-                # Node objects (~4-6x less memory on large meshes). Off by
-                # default while the substrate path is rolled out + parity-tested.
-                ConfigEntry("array_backed", bool, False, required=False),
+                # Array-backed mesh substrate: store FEM nodes/elements as packed
+                # numpy arrays with lazy Node/Elem proxies instead of millions of
+                # Python objects (40-130x smaller; readers ~22% faster). On by
+                # default; the full test suite passes on both CAD backends with the
+                # substrate active. Set ADA_MESHING_ARRAY_BACKED=false to opt out.
+                ConfigEntry("array_backed", bool, True, required=False),
             ],
         ),
         ConfigSection(

--- a/src/ada/config.py
+++ b/src/ada/config.py
@@ -168,6 +168,11 @@ class Config:
                 # (warns); set raise_on_hanging_nodes to escalate to an exception.
                 ConfigEntry("check_hanging_nodes", bool, True, required=False),
                 ConfigEntry("raise_on_hanging_nodes", bool, False, required=False),
+                # Array-backed mesh substrate: store FEM nodes as packed numpy
+                # arrays with lazy Node proxies instead of millions of Python
+                # Node objects (~4-6x less memory on large meshes). Off by
+                # default while the substrate path is rolled out + parity-tested.
+                ConfigEntry("array_backed", bool, False, required=False),
             ],
         ),
         ConfigSection(

--- a/src/ada/fem/containers.py
+++ b/src/ada/fem/containers.py
@@ -37,6 +37,44 @@ class COG:
     no_mass: float = None
 
 
+class LazyElemSeq:
+    """A re-iterable, lazy sequence of elements.
+
+    Wraps a zero-arg ``factory`` that returns a *fresh* iterator, so unlike a bare
+    generator/``filter`` it can be iterated more than once, supports ``len()`` /
+    truthiness / indexing, and never silently exhausts. ``counter`` (optional) gives
+    ``len()`` without materialising — the array path passes one backed by block sizes.
+    """
+
+    __slots__ = ("_factory", "_counter")
+
+    def __init__(self, factory, counter=None):
+        self._factory = factory
+        self._counter = counter
+
+    def __iter__(self):
+        return iter(self._factory())
+
+    def __len__(self) -> int:
+        return self._counter() if self._counter is not None else sum(1 for _ in self._factory())
+
+    def __bool__(self) -> bool:
+        for _ in self._factory():
+            return True
+        return False
+
+    def __getitem__(self, index):
+        if isinstance(index, slice) or (isinstance(index, int) and index < 0):
+            return list(self._factory())[index]
+        for k, item in enumerate(self._factory()):
+            if k == index:
+                return item
+        raise IndexError(index)
+
+    def __repr__(self) -> str:
+        return f"LazyElemSeq({len(self)} elems)"
+
+
 class FemElements:
     """Container class for FEM elements"""
 
@@ -328,37 +366,37 @@ class FemElements:
         return self._elements
 
     @property
-    def solids(self) -> Iterable[Elem]:
-        return filter(lambda x: isinstance(x.type, Elem.EL_TYPES.SOLID_SHAPES), self.stru_elements)
+    def solids(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x.type, Elem.EL_TYPES.SOLID_SHAPES), self.stru_elements))
 
     @property
-    def shell(self) -> Iterable[Elem]:
-        return filter(lambda x: isinstance(x.type, Elem.EL_TYPES.SHELL_SHAPES), self.stru_elements)
+    def shell(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x.type, Elem.EL_TYPES.SHELL_SHAPES), self.stru_elements))
 
     @property
-    def lines(self) -> Iterable[Elem]:
-        return filter(lambda x: isinstance(x.type, Elem.EL_TYPES.LINE_SHAPES), self.stru_elements)
+    def lines(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x.type, Elem.EL_TYPES.LINE_SHAPES), self.stru_elements))
 
     @property
-    def lines_hinged(self) -> Iterable[Elem]:
-        return filter(lambda x: x.hinge_prop is not None, self.lines)
+    def lines_hinged(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: x.hinge_prop is not None, self.lines))
 
     @property
-    def lines_ecc(self) -> Iterable[Elem]:
-        return filter(lambda x: x.eccentricity is not None, self.lines)
+    def lines_ecc(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: x.eccentricity is not None, self.lines))
 
     @property
-    def connectors(self) -> Iterable[Connector]:
-        return filter(lambda x: isinstance(x, Connector), self.elements)
+    def connectors(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x, Connector), self.elements))
 
     @property
-    def masses(self) -> Iterable[Mass]:
-        return filter(lambda x: isinstance(x, Mass), self.elements)
+    def masses(self) -> LazyElemSeq:
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x, Mass), self.elements))
 
     @property
-    def stru_elements(self) -> Iterable[Elem]:
+    def stru_elements(self) -> LazyElemSeq:
         not_strus = (Mass, Connector)
-        return filter(lambda x: isinstance(x, not_strus) is False, self._elements)
+        return LazyElemSeq(lambda: filter(lambda x: isinstance(x, not_strus) is False, self._elements))
 
     def connector_by_name(self, name: str):
         """Get Connector by name"""

--- a/src/ada/fem/containers.py
+++ b/src/ada/fem/containers.py
@@ -692,13 +692,13 @@ class FemSets:
         from ada.fem import Connector, Mass, Spring
 
         def get_nset(nref):
-            if type(nref) is Node:
+            if isinstance(nref, Node):
                 return nref
             else:
                 return fem_set.parent.nodes.from_id(nref)
 
         def get_elset(elref):
-            if type(elref) in (int, np.int32):
+            if type(elref) in (int, np.int32, np.int64):
                 return fem_set.parent.elements.from_id(elref)
             elif type(elref) is Elem:
                 if elref not in elref.parent.elements and len(elref.parent.elements) != 0:
@@ -706,6 +706,8 @@ class FemSets:
                 else:
                     return elref
             elif type(elref) in (Spring, Mass, Connector):
+                return elref
+            elif isinstance(elref, Elem):  # array-backed ElemProxy
                 return elref
             else:
                 raise ValueError(f"Elref type '{type(elref)}' is not recognized")
@@ -718,7 +720,7 @@ class FemSets:
                 el_type = Node
                 get_func = get_nset
 
-            res = list(filter(lambda x: type(x) is not el_type, fset.members))
+            res = list(filter(lambda x: not isinstance(x, el_type), fset.members))
             if len(res) > 0:
                 fset._members = [get_func(m) for m in fset.members]
 

--- a/src/ada/fem/elements.py
+++ b/src/ada/fem/elements.py
@@ -213,10 +213,41 @@ class HingeProp:
     beam_ref: Beam = None
 
 
-@dataclass
 class EccPoint:
-    node: Node
-    ecc_vector: np.ndarray
+    """An eccentricity end: a reference node + offset vector.
+
+    When given an array-backed node *proxy*, it stores only the node id (resolving the
+    proxy lazily via the store) so an eccentric element doesn't pin a Python object per
+    end. Object nodes are held directly (object path unchanged).
+    """
+
+    def __init__(self, node: Node = None, ecc_vector: np.ndarray = None):
+        self.ecc_vector = ecc_vector
+        self._store = None
+        self._node_id = None
+        self._node = None
+        self.node = node
+
+    @property
+    def node(self) -> Node:
+        if self._store is not None:
+            return self._store.node_proxy_by_id(self._node_id)
+        return self._node
+
+    @node.setter
+    def node(self, value):
+        store = getattr(value, "_store", None)
+        if store is not None:  # array-backed proxy -> keep the id only, not the proxy
+            self._store = store
+            self._node_id = int(value.id)
+            self._node = None
+        else:
+            self._store = None
+            self._node_id = None
+            self._node = value
+
+    def __repr__(self):
+        return f"EccPoint({self.node}, {self.ecc_vector})"
 
 
 @dataclass

--- a/src/ada/fem/formats/abaqus/read/read_elements.py
+++ b/src/ada/fem/formats/abaqus/read/read_elements.py
@@ -86,6 +86,50 @@ def grab_elements(match, fem: "FEM"):
         return elems
 
 
+def get_elem_arrays(bulk_str: str):
+    """Parse *Element blocks into per-type (el_ids, node-id conn) arrays without
+    building Elem objects. Blocks needing object handling (cross-instance node refs,
+    mass/rotaryi/connector) are returned as raw matches for the object fallback."""
+    from collections import defaultdict
+
+    by_type: dict = defaultdict(lambda: ([], [], []))  # ctype -> (el_ids, conns, elsets)
+    overflow: list = []
+
+    for match in cards.re_el.finditer(bulk_str):
+        d = match.groupdict()
+        eltype = d["eltype"]
+        try:
+            ada_el_type = abaqus_el_type_to_ada(eltype)
+        except UnsupportedAbaqusElementType as exc:
+            logger.warning("abaqus read: skipping element block — %s", exc)
+            continue
+
+        members = d["members"]
+        elset = d["elset"]
+        is_cubic = ada_el_type in [SolidShapes.HEX20, SolidShapes.HEX27]
+        has_letters = re.search("[a-zA-Z]", members) is not None
+        if eltype in ("MASS", "ROTARYI", "CONN3D2") or (has_letters and not is_cubic):
+            overflow.append(match)  # special / cross-instance -> object path
+            continue
+
+        if is_cubic:
+            elem_nodes_str = members.splitlines()
+            ntext = "".join(
+                [l1.strip() + "    " + l2.strip() + "\n" for l1, l2 in zip(elem_nodes_str[:-1:2], elem_nodes_str[1::2])]
+            )
+        else:
+            ntext = members
+        res = np.fromstring(ntext.replace("\n", ","), sep=",", dtype=int)
+        n = ShapeResolver.get_el_nodes_from_type(ada_el_type) + 1
+        res2d = res.reshape(int(res.size / n), n)
+        ids, conns, elsets = by_type[ada_el_type]
+        ids.extend(int(x) for x in res2d[:, 0])
+        conns.extend(res2d[:, 1:].tolist())
+        elsets.extend([elset] * res2d.shape[0])
+
+    return by_type, overflow
+
+
 def get_elem_nodes(elem_nodes_str, fem: "FEM"):
     elem_nodes = []
     for d in elem_nodes_str[1:]:
@@ -103,12 +147,12 @@ def get_elem_nodes(elem_nodes_str, fem: "FEM"):
             if par_ is None:
                 raise ValueError(f'Unable to find parent for "{par}"')
             r = par_.fem.nodes.from_id(str_to_int(setr))
-            if type(r) is not Node:
+            if not isinstance(r, Node):
                 raise ValueError("Node ID not found")
             elem_nodes.append(r)
         else:
             r = fem.nodes.from_id(str_to_int(d))
-            if type(r) is not Node:
+            if not isinstance(r, Node):
                 raise ValueError("Node ID not found")
             elem_nodes.append(r)
     return elem_nodes

--- a/src/ada/fem/formats/abaqus/read/reader.py
+++ b/src/ada/fem/formats/abaqus/read/reader.py
@@ -199,16 +199,22 @@ def add_fem_without_assembly(bulk_str, assembly: Assembly) -> Part:
 
 def get_fem_from_bulk_str(name, bulk_str, assembly: Assembly, instance_data: InstanceData) -> "Part":
     from ada import FEM, Part
+    from ada.config import Config
 
     instance_name = name if instance_data.instance_name is None else instance_data.instance_name
     if name in assembly.parts.keys():
         name = instance_name
     part = assembly.add_part(Part(name, fem=FEM(name=instance_name)))
     fem = part.fem
-    fem.nodes = get_nodes_from_inp(bulk_str, fem)
-    fem.nodes.move(move=instance_data.transform.translation, rotate=instance_data.transform.rotation)
-    fem.elements = get_elem_from_bulk_str(bulk_str, fem)
+
+    if Config().meshing_array_backed:
+        _build_array_nodes_elements(bulk_str, fem)
+    else:
+        fem.nodes = get_nodes_from_inp(bulk_str, fem)
+        fem.elements = get_elem_from_bulk_str(bulk_str, fem)
     fem.elements.build_sets()
+
+    fem.nodes.move(move=instance_data.transform.translation, rotate=instance_data.transform.rotation)
     fem.sets += get_sets_from_bulk(bulk_str, fem)
     fem.sections = get_sections_from_inp(bulk_str, fem)
     fem.bcs += get_bcs_from_bulk(bulk_str, fem)
@@ -220,6 +226,79 @@ def get_fem_from_bulk_str(name, bulk_str, assembly: Assembly, instance_data: Ins
     print(8 * "-" + f'Imported "{part.fem.instance_name}"')
 
     return part
+
+
+def _build_array_nodes_elements(bulk_str, fem) -> None:
+    """Substrate-direct Abaqus node/element build: no object Node/Elem for the
+    structural mesh. Special blocks (mass/connector/cross-instance) fall back to the
+    object element parser as ArrayElements overflow."""
+    import numpy as np
+
+    from ada.api.mesh.containers import ArrayElements, ArrayNodes
+    from ada.api.mesh.store import MeshArrays
+
+    from .read_elements import get_elem_arrays, grab_elements
+
+    coords, node_ids, nsets = get_nodes_from_inp_arrays(bulk_str)
+    store = MeshArrays(coords, node_ids)
+    by_type, overflow = get_elem_arrays(bulk_str)
+    for ctype, (el_ids, conns, elsets) in by_type.items():
+        blk = store.add_elem_block_from_id_conn(
+            ctype, np.array(el_ids, dtype=np.int64), np.array(conns, dtype=np.int64)
+        )
+        if any(e is not None for e in elsets):
+            blk.elsets = elsets
+
+    fem.nodes = ArrayNodes(store, parent=fem)
+    fem.elements = ArrayElements(store, fem_obj=fem)
+
+    # node sets declared inline on *Node blocks (id-backed)
+    for set_name, ids in nsets:
+        fem.sets.add(FemSet(set_name, ids, "nset", parent=fem))
+
+    # special/cross-instance element blocks via the object parser -> overflow
+    for match in overflow:
+        elems = grab_elements(match, fem)
+        if elems:
+            for e in elems:
+                fem.elements.add(e)
+
+
+def get_nodes_from_inp_arrays(bulk_str):
+    """Parse *Node blocks into packed (coords (n,3), node_ids (n,)) arrays plus inline
+    nset declarations as ``(name, [ids])`` — no Node objects."""
+    import numpy as np
+
+    re_no = re.compile(
+        r"^\*Node\s*(?:,\s*nset=(?P<nset>.*?)\n|\n)(?P<members>(?:.*?)(?=\*|\Z))",
+        _re_in,
+    )
+    ids: list[int] = []
+    xyz: list = []
+    nsets: list = []
+    for m in re_no.finditer(bulk_str):
+        d = m.groupdict()
+        raw = "\n".join(line for line in d["members"].splitlines() if not line.lstrip().startswith("**"))
+        res = np.fromstring(list_cleanup(raw), sep=",", dtype=np.float64)
+        if res.size == 0:
+            continue
+        if res.size % 4 == 0:
+            res_ = res.reshape(int(res.size / 4), 4)
+            block_xyz = res_[:, 1:4]
+        elif res.size % 3 == 0:
+            res_ = res.reshape(int(res.size / 3), 3)
+            block_xyz = np.column_stack([res_[:, 1:3], np.zeros(res_.shape[0])])
+        else:
+            raise ValueError(f"Abaqus *Node block has {res.size} values; not divisible by 4 (3D) or 3 (2D)")
+        block_ids = [int(x) for x in res_[:, 0]]
+        ids.extend(block_ids)
+        xyz.extend(block_xyz.tolist())
+        if d["nset"] is not None:
+            nsets.append((d["nset"], block_ids))
+
+    coords = np.array(xyz, dtype=np.float64) if xyz else np.zeros((0, 3))
+    node_ids = np.array(ids, dtype=np.int64) if ids else np.zeros((0,), dtype=np.int64)
+    return coords, node_ids, nsets
 
 
 def get_initial_conditions_from_str(assembly: Assembly, bulk_str: str):

--- a/src/ada/fem/formats/abaqus/write/helper_utils.py
+++ b/src/ada/fem/formats/abaqus/write/helper_utils.py
@@ -6,7 +6,7 @@ def get_instance_name(obj, written_on_assembly_level: bool) -> str:
 
     parent: Union[FEM, Part] = obj.parent
     p = parent.parent if type(parent) is FEM else parent
-    obj_ref = obj.id if type(obj) is Node else obj.name
+    obj_ref = obj.id if isinstance(obj, Node) else obj.name
 
     if type(p) is Assembly:
         obj_on_assembly_level = True

--- a/src/ada/fem/formats/code_aster/read/reader.py
+++ b/src/ada/fem/formats/code_aster/read/reader.py
@@ -36,6 +36,10 @@ def read_fem(fem_file: os.PathLike, fem_name: str = None) -> Assembly:
 
 def med_to_fem(fem_file, fem_name) -> FEM:
     from ada import FEM, Node
+    from ada.config import Config
+
+    if Config().meshing_array_backed:
+        return _med_to_fem_array(fem_file, fem_name)
 
     with h5py.File(fem_file, "r") as f:
         # Mesh ensemble
@@ -135,6 +139,73 @@ def med_to_fem(fem_file, fem_name) -> FEM:
 
     elsets = _element_set_dict_to_list_of_femset(element_sets, fem)
 
+    fem.sets = FemSets(elsets + point_sets, parent=fem)
+    return fem
+
+
+def _med_to_fem_array(fem_file, fem_name) -> FEM:
+    """Substrate-direct MED read: MED is already h5py array-based, so build a
+    MeshArrays straight from the COO / NOD datasets (no object Node/Elem)."""
+    from ada import FEM
+    from ada.api.mesh.containers import ArrayElements, ArrayNodes
+    from ada.api.mesh.store import MeshArrays
+
+    with h5py.File(fem_file, "r") as f:
+        mesh_ensemble = f["ENS_MAA"]
+        meshes = list(mesh_ensemble.keys())
+        if len(meshes) != 1:
+            raise ValueError(f"Must only contain exactly 1 mesh, found {len(meshes)}.")
+        mesh_name = meshes[0]
+        mesh = mesh_ensemble[mesh_name]
+        dim = mesh.attrs["ESP"]
+        fem_name = fem_name if fem_name is not None else mesh_name
+        if "NOE" not in mesh:
+            time_step = list(mesh.keys())
+            if len(time_step) != 1:
+                raise ValueError(f"Must only contain exactly 1 time-step, found {len(time_step)}.")
+            mesh = mesh[time_step[0]]
+
+        pts_dataset = mesh["NOE"]["COO"]
+        n_points = pts_dataset.attrs["NBR"]
+        points = pts_dataset[()].reshape((n_points, dim), order="F")
+        if dim == 2:
+            points = np.column_stack([points, np.zeros(n_points)])
+        if "NUM" in mesh["NOE"]:
+            point_num = np.asarray(mesh["NOE"]["NUM"], dtype=np.int64)
+        else:
+            logger.warning("No node information is found on MED file")
+            point_num = np.arange(1, len(points) + 1, dtype=np.int64)
+
+        store = MeshArrays(np.ascontiguousarray(points, dtype=np.float64), point_num)
+
+        tags = mesh["NOE"]["FAM"][()] if "FAM" in mesh["NOE"] else None
+        fas = mesh["FAS"] if "FAS" in mesh else f["FAS"][mesh_name]
+        point_tags = _read_families(fas["NOEUD"]) if "NOEUD" in fas else {}
+        cell_tags = _read_families(fas["ELEME"]) if "ELEME" in fas else {}
+
+        element_sets: dict = {}
+        for med_cell_type, grp in mesh["MAI"].items():
+            if med_cell_type == "PO1":
+                logger.warning("Point elements are still not supported")
+                continue
+            cell_type = med_to_ada_type(med_cell_type)
+            nod = grp["NOD"]
+            n_cells = nod.attrs["NBR"]
+            nodes_in = nod[()].reshape(n_cells, -1, order="F")
+            num = np.asarray(grp["NUM"], dtype=np.int64) if "NUM" in grp.keys() else np.arange(n_cells, dtype=np.int64)
+            store.add_elem_block_from_id_conn(cell_type, num, np.asarray(nodes_in, dtype=np.int64))
+            if "FAM" in grp:
+                cell_type_sets = _cell_tag_to_set(grp["FAM"][()], cell_tags)
+                for key, rows in cell_type_sets.items():
+                    element_sets.setdefault(key, [])
+                    element_sets[key] += [int(num[i]) for i in set(rows)]
+
+    fem = FEM(fem_name)
+    fem.nodes = ArrayNodes(store, parent=fem)
+    fem.elements = ArrayElements(store, fem_obj=fem)
+
+    point_sets = _point_tags_to_sets(tags, point_tags, fem) if tags is not None else []
+    elsets = _element_set_dict_to_list_of_femset(element_sets, fem)
     fem.sets = FemSets(elsets + point_sets, parent=fem)
     return fem
 

--- a/src/ada/fem/formats/code_aster/write/helper_utils.py
+++ b/src/ada/fem/formats/code_aster/write/helper_utils.py
@@ -58,14 +58,17 @@ def resolve_ids_in_multiple(tags, tags_data, is_elem):
                     rmap[key] = new_int
                     fin_data[new_int] = []
                     seen_ids[new_int] = set()
-                rid = id(mem)
+                # Value-based dedup key (member id) rather than id(mem): array-backed
+                # proxies are minted per access, so object identity isn't stable; the
+                # entity id is unique within a node/element set context either way.
+                rid = int(mem.id)
                 bucket_ids = seen_ids[new_int]
                 if rid not in bucket_ids:
                     fin_data[new_int].append(mem)
                     bucket_ids.add(rid)
             else:
                 fin_data[t].append(mem)
-                seen_ids[t].add(id(mem))
+                seen_ids[t].add(int(mem.id))
     to_be_removed = [i for i, f in fin_data.items() if len(f) == 0]
     for t in to_be_removed:
         fin_data.pop(t)

--- a/src/ada/fem/formats/sesam/read/read_elements.py
+++ b/src/ada/fem/formats/sesam/read/read_elements.py
@@ -55,6 +55,39 @@ def get_elements(bulk_str: str, fem: FEM) -> tuple[FemElements, dict, dict, dict
     return elements, mass_elem, spring_elem, internal_external_element_map
 
 
+def get_elements_arrays(bulk_str: str):
+    """Parse GELMNT1 into per-type connectivity (node ids) without building Elem
+    objects. Mass/spring elements are split out for separate handling.
+
+    Returns ``(by_type, mass_elem, spring_elem, ext_map)`` where ``by_type`` maps a
+    canonical element type to ``(el_ids: list[int], conn: list[list[int]])`` of node
+    ids."""
+    from collections import defaultdict
+
+    by_type: dict = defaultdict(lambda: ([], []))
+    mass_elem: dict = {}
+    spring_elem: dict = {}
+    ext_map: dict = {}
+
+    for match in cards.GELMNT1.to_ff_re().finditer(bulk_str):
+        d = match.groupdict()
+        el_no = str_to_int(d["elno"])
+        ext_map[el_no] = str_to_int(d["elnox"])
+        nids = [x for x in map(str_to_int, d["nids"].replace("\n", "").split()) if x != 0]
+        el_type = sesam_eltype_2_general(str_to_int(d["eltyp"]))
+        if isinstance(el_type, SpringTypes):
+            spring_elem[el_no] = dict(gelmnt=d)
+            continue
+        if el_type == Elem.EL_TYPES.MASS_SHAPES.MASS:
+            mass_elem[el_no] = dict(gelmnt=d)
+            continue
+        el_ids, conns = by_type[el_type]
+        el_ids.append(el_no)
+        conns.append(nids)
+
+    return by_type, mass_elem, spring_elem, ext_map
+
+
 def get_mass(bulk_str: str, fem: FEM, mass_elem: dict) -> FemElements:
     def checkEqual2(iterator):
         return len(set(iterator)) <= 1

--- a/src/ada/fem/formats/sesam/read/read_elements.py
+++ b/src/ada/fem/formats/sesam/read/read_elements.py
@@ -88,7 +88,14 @@ def get_elements_arrays(bulk_str: str):
     return by_type, mass_elem, spring_elem, ext_map
 
 
-def get_mass(bulk_str: str, fem: FEM, mass_elem: dict) -> FemElements:
+def get_mass(bulk_str: str, fem: FEM, mass_elem: dict, renumber_map: dict | None = None) -> FemElements:
+    # Generated BNMASS element ids must clear BOTH the current (internal) element
+    # numbering AND the external ids structural elements will be renumbered into
+    # (renumber_map values) later — otherwise a generated mass id collides with a
+    # renumbered structural element. (Pre-existing: this bit both the object and array
+    # paths on decks whose external numbering reuses the internal-max+1 range.)
+    max_external = max(renumber_map.values()) if renumber_map else 0
+
     def checkEqual2(iterator):
         return len(set(iterator)) <= 1
 
@@ -113,7 +120,7 @@ def get_mass(bulk_str: str, fem: FEM, mass_elem: dict) -> FemElements:
 
         no = fem.nodes.from_id(nodeno)
         fem_set = fem.sets.add(FemSet(f"m{nodeno}", [no], FemSet.TYPES.NSET, parent=fem))
-        el_id = fem.elements.max_el_id + 1
+        el_id = max(fem.elements.max_el_id, max_external) + 1
         elem = fem.elements.add(Elem(el_id, [no], Elem.EL_TYPES.MASS_SHAPES.MASS, None, parent=fem), skip_grouping=True)
         mass = Mass(f"m{nodeno}", fem_set, masses, Mass.TYPES.MASS, ptype=mass_type, parent=fem, mass_id=el_id)
 

--- a/src/ada/fem/formats/sesam/read/read_nodes.py
+++ b/src/ada/fem/formats/sesam/read/read_nodes.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from ada.api.containers import Nodes
 from ada.api.nodes import Node
 from ada.fem.formats.utils import str_to_int
@@ -13,6 +15,20 @@ if TYPE_CHECKING:
 def get_nodes(bulk_str: str, parent: "FEM") -> Nodes:
     nodes = [get_node(m, parent) for m in cards.GCOORD.to_ff_re().finditer(bulk_str)]
     return Nodes(nodes, parent=parent)
+
+
+def get_nodes_arrays(bulk_str: str) -> tuple[np.ndarray, np.ndarray]:
+    """Parse GCOORD straight into packed (coords (n,3), node_ids (n,)) arrays — no
+    Node objects. The substrate-direct read path."""
+    ids: list[int] = []
+    xyz: list[tuple[float, float, float]] = []
+    for m in cards.GCOORD.to_ff_re().finditer(bulk_str):
+        d = m.groupdict()
+        ids.append(str_to_int(d["id"]))
+        xyz.append((float(d["x"]), float(d["y"]), float(d["z"])))
+    coords = np.array(xyz, dtype=np.float64) if xyz else np.zeros((0, 3))
+    node_ids = np.array(ids, dtype=np.int64) if ids else np.zeros((0,), dtype=np.int64)
+    return coords, node_ids
 
 
 def renumber_nodes(bulk_str: str, fem: "FEM") -> None:

--- a/src/ada/fem/formats/sesam/read/reader.py
+++ b/src/ada/fem/formats/sesam/read/reader.py
@@ -54,7 +54,7 @@ def read_sesam_fem(bulk_str, part_name) -> Part:
     fem.elements.build_sets()
     part._materials = get_materials(bulk_str, part)
     fem.sections = get_sections(bulk_str, fem, mass_elem, spring_elem)
-    fem.elements += get_mass(bulk_str, part.fem, mass_elem)
+    fem.elements += get_mass(bulk_str, part.fem, mass_elem, el_id_map)
     fem.springs = get_springs(bulk_str, fem, spring_elem)
     fem.sets = part.fem.sets + get_sets(bulk_str, fem)
     fem.constraints.update(get_constraints(bulk_str, fem))
@@ -85,7 +85,7 @@ def _build_array_fem(part, coords, node_ids, by_type, mass_elem, spring_elem, ex
 
     part._materials = get_materials(reader_text, part)
     fem.sections = get_sections(reader_text, fem, mass_elem, spring_elem)
-    fem.elements += get_mass(reader_text, part.fem, mass_elem)
+    fem.elements += get_mass(reader_text, part.fem, mass_elem, ext_map)
     fem.springs = get_springs(reader_text, fem, spring_elem)
     fem.sets = part.fem.sets + get_sets(reader_text, fem)
     fem.constraints.update(get_constraints(reader_text, fem))

--- a/src/ada/fem/formats/sesam/read/reader.py
+++ b/src/ada/fem/formats/sesam/read/reader.py
@@ -27,8 +27,15 @@ def read_fem(fem_file: os.PathLike, fem_name: str = None):
 def read_sesam_fem(bulk_str, part_name) -> Part:
     """Reads the content string of a Sesam input file and converts it to FEM objects"""
 
+    from ada.config import Config
+
     part = Part(part_name)
     fem = part.fem
+
+    if Config().meshing_array_backed:
+        _read_sesam_fem_array(bulk_str, part)
+        print(8 * "-" + f'Imported "{fem.instance_name}"')
+        return part
 
     fem.nodes = get_nodes(bulk_str, fem)
     elements, mass_elem, spring_elem, el_id_map = get_elements(bulk_str, fem)
@@ -46,3 +53,37 @@ def read_sesam_fem(bulk_str, part_name) -> Part:
 
     print(8 * "-" + f'Imported "{fem.instance_name}"')
     return part
+
+
+def _read_sesam_fem_array(bulk_str, part: Part) -> None:
+    """Substrate-direct Sesam read: build a MeshArrays straight from GCOORD/GELMNT1
+    (no object Node/Elem for the structural mesh), then reuse the object readers for
+    materials/sections/sets/constraints (which operate on proxies)."""
+    import numpy as np
+
+    from ada.api.mesh.containers import ArrayElements, ArrayNodes
+    from ada.api.mesh.store import MeshArrays
+
+    from .read_elements import get_elements_arrays
+    from .read_nodes import get_nodes_arrays
+
+    fem = part.fem
+
+    coords, node_ids = get_nodes_arrays(bulk_str)
+    store = MeshArrays(coords, node_ids)
+    by_type, mass_elem, spring_elem, el_id_map = get_elements_arrays(bulk_str)
+    for ctype, (el_ids, conns) in by_type.items():
+        store.add_elem_block_from_id_conn(ctype, np.array(el_ids, dtype=np.int64), np.array(conns, dtype=np.int64))
+
+    fem.nodes = ArrayNodes(store, parent=fem)
+    fem.elements = ArrayElements(store, fem_obj=fem)
+
+    part._materials = get_materials(bulk_str, part)
+    fem.sections = get_sections(bulk_str, fem, mass_elem, spring_elem)
+    fem.elements += get_mass(bulk_str, part.fem, mass_elem)
+    fem.springs = get_springs(bulk_str, fem, spring_elem)
+    fem.sets = part.fem.sets + get_sets(bulk_str, fem)
+    fem.constraints.update(get_constraints(bulk_str, fem))
+    fem.bcs += get_bcs(bulk_str, fem)
+    renumber_nodes(bulk_str, fem)
+    fem.elements.renumber(renumber_map=el_id_map)

--- a/src/ada/fem/formats/sesam/read/reader.py
+++ b/src/ada/fem/formats/sesam/read/reader.py
@@ -15,9 +15,20 @@ from .read_sets import get_sets
 
 def read_fem(fem_file: os.PathLike, fem_name: str = None):
     """Import contents from a Sesam fem file into an assembly object"""
+    from ada.config import Config
 
     logger.info("Starting import of Sesam input file")
     part_name = "T1" if fem_name is None else fem_name
+
+    if Config().meshing_array_backed:
+        # Stream the file: never hold the whole deck as a string (the GCOORD/GELMNT1
+        # bulk goes straight to arrays; the small remainder is bucketed for the
+        # object section/set/constraint readers).
+        part = Part(part_name)
+        _read_sesam_fem_array_stream(fem_file, part)
+        print(8 * "-" + f'Imported "{part.fem.instance_name}"')
+        return Assembly("TempAssembly") / part
+
     with open(fem_file, "r") as d:
         part = read_sesam_fem(d.read(), part_name)
 
@@ -55,35 +66,49 @@ def read_sesam_fem(bulk_str, part_name) -> Part:
     return part
 
 
-def _read_sesam_fem_array(bulk_str, part: Part) -> None:
-    """Substrate-direct Sesam read: build a MeshArrays straight from GCOORD/GELMNT1
-    (no object Node/Elem for the structural mesh), then reuse the object readers for
-    materials/sections/sets/constraints (which operate on proxies)."""
+def _build_array_fem(part, coords, node_ids, by_type, mass_elem, spring_elem, ext_map, reader_text) -> None:
+    """Assemble the array-backed FEM from parsed mesh arrays + a (small) text blob the
+    object section/set/constraint readers run over. Shared by the streaming and
+    bulk-string array paths."""
     import numpy as np
 
     from ada.api.mesh.containers import ArrayElements, ArrayNodes
     from ada.api.mesh.store import MeshArrays
 
-    from .read_elements import get_elements_arrays
-    from .read_nodes import get_nodes_arrays
-
     fem = part.fem
-
-    coords, node_ids = get_nodes_arrays(bulk_str)
     store = MeshArrays(coords, node_ids)
-    by_type, mass_elem, spring_elem, el_id_map = get_elements_arrays(bulk_str)
     for ctype, (el_ids, conns) in by_type.items():
         store.add_elem_block_from_id_conn(ctype, np.array(el_ids, dtype=np.int64), np.array(conns, dtype=np.int64))
 
     fem.nodes = ArrayNodes(store, parent=fem)
     fem.elements = ArrayElements(store, fem_obj=fem)
 
-    part._materials = get_materials(bulk_str, part)
-    fem.sections = get_sections(bulk_str, fem, mass_elem, spring_elem)
-    fem.elements += get_mass(bulk_str, part.fem, mass_elem)
-    fem.springs = get_springs(bulk_str, fem, spring_elem)
-    fem.sets = part.fem.sets + get_sets(bulk_str, fem)
-    fem.constraints.update(get_constraints(bulk_str, fem))
-    fem.bcs += get_bcs(bulk_str, fem)
-    renumber_nodes(bulk_str, fem)
-    fem.elements.renumber(renumber_map=el_id_map)
+    part._materials = get_materials(reader_text, part)
+    fem.sections = get_sections(reader_text, fem, mass_elem, spring_elem)
+    fem.elements += get_mass(reader_text, part.fem, mass_elem)
+    fem.springs = get_springs(reader_text, fem, spring_elem)
+    fem.sets = part.fem.sets + get_sets(reader_text, fem)
+    fem.constraints.update(get_constraints(reader_text, fem))
+    fem.bcs += get_bcs(reader_text, fem)
+    renumber_nodes(reader_text, fem)
+    fem.elements.renumber(renumber_map=ext_map)
+
+
+def _read_sesam_fem_array_stream(fem_file, part: Part) -> None:
+    """Streaming substrate-direct read: one pass over the file handle, mesh -> arrays,
+    everything else -> a small text blob. Never holds the whole deck as a string."""
+    from .stream import stream_fem_mesh
+
+    coords, node_ids, by_type, mass_elem, spring_elem, ext_map, other_text = stream_fem_mesh(fem_file)
+    _build_array_fem(part, coords, node_ids, by_type, mass_elem, spring_elem, ext_map, other_text)
+
+
+def _read_sesam_fem_array(bulk_str, part: Part) -> None:
+    """Substrate-direct read from a full bulk string (for direct callers that already
+    have the deck in memory). Prefer the streaming path via read_fem."""
+    from .read_elements import get_elements_arrays
+    from .read_nodes import get_nodes_arrays
+
+    coords, node_ids = get_nodes_arrays(bulk_str)
+    by_type, mass_elem, spring_elem, ext_map = get_elements_arrays(bulk_str)
+    _build_array_fem(part, coords, node_ids, by_type, mass_elem, spring_elem, ext_map, bulk_str)

--- a/src/ada/fem/formats/sesam/read/stream.py
+++ b/src/ada/fem/formats/sesam/read/stream.py
@@ -1,0 +1,111 @@
+"""Single-pass *streaming* read of a Sesam .FEM deck's mesh.
+
+The bulk of a .FEM file is GCOORD (nodes) and GELMNT1 (elements); everything else
+(GNODE, GELREF1, section/material/set/BC cards) is comparatively tiny. This reader
+iterates the file handle line-by-line (never holding the whole file as a string),
+sends the mesh cards straight into packed numpy arrays, and buckets every other line
+into a small text blob the existing object readers can still regex over.
+
+Mirrors the streaming flag-dispatch that the Sesam SIF *results* reader
+(``results/read_sif.py``) already uses — unifying the two paths on one model.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+
+from ada.fem import Elem
+from ada.fem.formats.sesam.common import sesam_eltype_2_general
+from ada.fem.formats.utils import str_to_int
+from ada.fem.shapes.lines import SpringTypes
+
+
+def _gelmnt_dict(vals: list[str]) -> dict:
+    # vals are the GELMNT1 fields after the card name: elnox, elno, eltyp, eltyad, nids...
+    return {
+        "elnox": vals[0],
+        "elno": vals[1],
+        "eltyp": vals[2],
+        "eltyad": vals[3],
+        "nids": " ".join(vals[4:]),
+    }
+
+
+def stream_fem_mesh(path):
+    """Stream a .FEM file once.
+
+    Returns ``(coords (n,3), node_ids (n,), by_type, mass_elem, spring_elem, ext_map,
+    other_text)`` where ``by_type`` maps a canonical element type to
+    ``(el_ids, node-id conn)`` and ``other_text`` is every non-mesh line joined (small).
+    """
+    coord_ids: list[int] = []
+    coord_xyz: list[tuple[float, float, float]] = []
+    by_type: dict = defaultdict(lambda: ([], []))
+    mass_elem: dict = {}
+    spring_elem: dict = {}
+    ext_map: dict = {}
+    other: list[str] = []
+
+    cur_card = None
+    # current structural GELMNT1 being accumulated across continuation lines:
+    cur_struct = None  # (el_type, el_no, [node-id floats...])
+
+    def flush_struct():
+        nonlocal cur_struct
+        if cur_struct is None:
+            return
+        el_type, el_no, vals = cur_struct
+        nids = [n for n in (str_to_int(x) for x in vals[4:]) if n != 0]
+        ids, conns = by_type[el_type]
+        ids.append(el_no)
+        conns.append(nids)
+        cur_struct = None
+
+    with open(path, "r") as f:
+        for line in f:
+            s = line.strip()
+            if not s:
+                continue
+            first = s[0]
+
+            if first.isdigit() or first == "-":
+                # continuation line — belongs to the current card
+                if cur_card == "GELMNT1" and cur_struct is not None:
+                    cur_struct[2].extend(s.split())
+                elif cur_card == "GCOORD":
+                    other.append(line.rstrip("\n"))  # GCOORD shouldn't wrap, but be safe
+                else:
+                    other.append(line.rstrip("\n"))
+                continue
+
+            tok = s.split(None, 1)[0]
+            if cur_card == "GELMNT1" and tok != "GELMNT1":
+                flush_struct()
+            cur_card = tok
+
+            if tok == "GCOORD":
+                p = s.split()
+                coord_ids.append(str_to_int(p[1]))
+                coord_xyz.append((float(p[2]), float(p[3]), float(p[4])))
+            elif tok == "GELMNT1":
+                flush_struct()
+                vals = s.split()[1:]
+                el_no = str_to_int(vals[1])
+                ext_map[el_no] = str_to_int(vals[0])
+                el_type = sesam_eltype_2_general(str_to_int(vals[2]))
+                if isinstance(el_type, SpringTypes):
+                    spring_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+                elif el_type == Elem.EL_TYPES.MASS_SHAPES.MASS:
+                    mass_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+                else:
+                    cur_struct = (el_type, el_no, vals)
+            else:
+                other.append(line.rstrip("\n"))
+
+    flush_struct()
+
+    coords = np.array(coord_xyz, dtype=np.float64) if coord_xyz else np.zeros((0, 3))
+    node_ids = np.array(coord_ids, dtype=np.int64) if coord_ids else np.zeros((0,), dtype=np.int64)
+    return coords, node_ids, by_type, mass_elem, spring_elem, ext_map, "\n".join(other)

--- a/src/ada/fem/formats/sesam/read/stream.py
+++ b/src/ada/fem/formats/sesam/read/stream.py
@@ -49,19 +49,27 @@ def stream_fem_mesh(path):
     other: list[str] = []
 
     cur_card = None
-    # current structural GELMNT1 being accumulated across continuation lines:
-    cur_struct = None  # (el_type, el_no, [node-id floats...])
+    # current GELMNT1 being accumulated across continuation lines. A single .FEM
+    # element record (structural, mass OR spring) can wrap onto continuation lines, so
+    # we accumulate every field and dispatch on flush — never leak continuation node
+    # ids into ``other``.
+    cur_gelmnt = None  # (kind, el_type, el_no, vals)  kind in {"struct","mass","spring"}
 
-    def flush_struct():
-        nonlocal cur_struct
-        if cur_struct is None:
+    def flush_gelmnt():
+        nonlocal cur_gelmnt
+        if cur_gelmnt is None:
             return
-        el_type, el_no, vals = cur_struct
-        nids = [n for n in (str_to_int(x) for x in vals[4:]) if n != 0]
-        ids, conns = by_type[el_type]
-        ids.append(el_no)
-        conns.append(nids)
-        cur_struct = None
+        kind, el_type, el_no, vals = cur_gelmnt
+        if kind == "struct":
+            nids = [n for n in (str_to_int(x) for x in vals[4:]) if n != 0]
+            ids, conns = by_type[el_type]
+            ids.append(el_no)
+            conns.append(nids)
+        elif kind == "mass":
+            mass_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+        else:  # spring
+            spring_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+        cur_gelmnt = None
 
     with open(path, "r") as f:
         for line in f:
@@ -72,17 +80,15 @@ def stream_fem_mesh(path):
 
             if first.isdigit() or first == "-":
                 # continuation line — belongs to the current card
-                if cur_card == "GELMNT1" and cur_struct is not None:
-                    cur_struct[2].extend(s.split())
-                elif cur_card == "GCOORD":
-                    other.append(line.rstrip("\n"))  # GCOORD shouldn't wrap, but be safe
+                if cur_card == "GELMNT1" and cur_gelmnt is not None:
+                    cur_gelmnt[3].extend(s.split())
                 else:
-                    other.append(line.rstrip("\n"))
+                    other.append(line.rstrip("\n"))  # continuation of a non-mesh card
                 continue
 
             tok = s.split(None, 1)[0]
             if cur_card == "GELMNT1" and tok != "GELMNT1":
-                flush_struct()
+                flush_gelmnt()
             cur_card = tok
 
             if tok == "GCOORD":
@@ -90,21 +96,21 @@ def stream_fem_mesh(path):
                 coord_ids.append(str_to_int(p[1]))
                 coord_xyz.append((float(p[2]), float(p[3]), float(p[4])))
             elif tok == "GELMNT1":
-                flush_struct()
+                flush_gelmnt()
                 vals = s.split()[1:]
                 el_no = str_to_int(vals[1])
                 ext_map[el_no] = str_to_int(vals[0])
                 el_type = sesam_eltype_2_general(str_to_int(vals[2]))
                 if isinstance(el_type, SpringTypes):
-                    spring_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+                    cur_gelmnt = ("spring", el_type, el_no, vals)
                 elif el_type == Elem.EL_TYPES.MASS_SHAPES.MASS:
-                    mass_elem[el_no] = dict(gelmnt=_gelmnt_dict(vals))
+                    cur_gelmnt = ("mass", el_type, el_no, vals)
                 else:
-                    cur_struct = (el_type, el_no, vals)
+                    cur_gelmnt = ("struct", el_type, el_no, vals)
             else:
                 other.append(line.rstrip("\n"))
 
-    flush_struct()
+    flush_gelmnt()
 
     coords = np.array(coord_xyz, dtype=np.float64) if coord_xyz else np.zeros((0, 3))
     node_ids = np.array(coord_ids, dtype=np.int64) if coord_ids else np.zeros((0,), dtype=np.int64)

--- a/src/ada/fem/formats/utils.py
+++ b/src/ada/fem/formats/utils.py
@@ -594,6 +594,16 @@ def line_elem_to_beam(elem: Elem, parent: Part, prefix="bm") -> Beam:
 
 def convert_part_objects(p: Part, skip_plates, skip_beams, merge=False, reconstruct_surfaces=False):
     from ada.api.containers import Beams, Plates
+    from ada.config import Config
+
+    # Hold the mesh as packed arrays during conversion (the peak-memory tier) when
+    # enabled, so a large FEM doesn't keep millions of Node/Elem objects resident
+    # alongside the Beams/Plates being built.
+    if Config().meshing_array_backed and p.fem is not None and len(p.fem.nodes) > 0:
+        from ada.api.mesh.containers import ArrayNodes, to_array_backed
+
+        if not isinstance(p.fem.nodes, ArrayNodes):
+            to_array_backed(p.fem)
 
     if skip_plates is False:
         if reconstruct_surfaces:

--- a/src/ada/fem/results/common.py
+++ b/src/ada/fem/results/common.py
@@ -79,6 +79,10 @@ class ElementBlock:
     elem_info: ElementInfo
     node_refs: np.ndarray
     identifiers: np.ndarray
+    # When True, ``node_refs`` are already 0-based row indices into ``FemNodes.coords``
+    # (the array-substrate convention), so consumers skip the id->index remap. Default
+    # False keeps the historical id-based convention (object/SIF producers).
+    node_refs_are_indices: bool = False
 
 
 @dataclass
@@ -199,8 +203,11 @@ class Mesh:
             if isinstance(el_type, shape_def.MassTypes):
                 continue
 
-            nodes_copy = cell_block.node_refs.copy()
-            nodes_copy[np.isin(nodes_copy, keys)] = np.vectorize(nmap.get)(nodes_copy[np.isin(nodes_copy, keys)])
+            if cell_block.node_refs_are_indices:
+                nodes_copy = cell_block.node_refs
+            else:
+                nodes_copy = cell_block.node_refs.copy()
+                nodes_copy[np.isin(nodes_copy, keys)] = np.vectorize(nmap.get)(nodes_copy[np.isin(nodes_copy, keys)])
 
             for elem in nodes_copy:
                 elem_shape = ElemShape(el_type, elem)
@@ -271,8 +278,11 @@ class Mesh:
             if isinstance(el_type, shape_def.MassTypes):
                 continue
 
-            nodes_copy = cell_block.node_refs.copy()
-            nodes_copy[np.isin(nodes_copy, keys)] = np.vectorize(nmap.get)(nodes_copy[np.isin(nodes_copy, keys)])
+            if cell_block.node_refs_are_indices:
+                nodes_copy = cell_block.node_refs
+            else:
+                nodes_copy = cell_block.node_refs.copy()
+                nodes_copy[np.isin(nodes_copy, keys)] = np.vectorize(nmap.get)(nodes_copy[np.isin(nodes_copy, keys)])
             if use_solid_beams and isinstance(el_type, (shape_def.LineShapes, shape_def.ConnectorTypes)):
                 continue
 

--- a/src/ada/fem/sets.py
+++ b/src/ada/fem/sets.py
@@ -67,6 +67,23 @@ class FemSet(FemBase):
             raise ValueError(f'set type "{set_type}" is not valid')
         self._refs = []
 
+        if self._member_ids is not None:
+            self.register_member_refs()
+
+    def register_member_refs(self) -> None:
+        """Register this set in each member's ``refs`` (mirrors the object path's
+        ``m.refs.append(self)``). Needed so consumers that detect set membership via
+        ``member.refs`` (e.g. the Code_Aster MED writer) work with id-backed sets. The
+        ref is stored on the substrate side-table, not on a pinned proxy. Best-effort:
+        a no-op if the parent FEM can't resolve the members yet."""
+        if self._member_ids is None or self.parent is None:
+            return
+        try:
+            for m in self.members:
+                m.add_obj_to_refs(self)
+        except Exception:
+            pass
+
     def _resolve(self, mid: int):
         fem = self.parent
         return fem.nodes.from_id(mid) if self.type == SetTypes.NSET else fem.elements.from_id(mid)
@@ -79,6 +96,7 @@ class FemSet(FemBase):
             return
         self._member_ids = [m.id for m in self._members]
         self._members = None
+        self.register_member_refs()
 
     def __len__(self):
         return len(self._member_ids) if self._member_ids is not None else len(self._members)

--- a/src/ada/fem/sets.py
+++ b/src/ada/fem/sets.py
@@ -57,10 +57,19 @@ class FemSet(FemBase):
         else:
             if set_type is None:
                 set_type = eval_set_type_from_members(members)
-            for m in members:
-                if isinstance(m, (Elem, Node)):
-                    m.refs.append(self)
-            self._members = members
+            if members and self._members_are_local_proxies(members, parent, set_type):
+                # Array-backed proxies belonging to THIS FEM's store -> store ids, not
+                # the proxies, so a per-element elset doesn't pin a Python object per
+                # member (Sesam emits ~one elset per element). refs are registered via
+                # register_member_refs below. Cross-instance proxies (different store)
+                # fall through to the object path so their ids stay resolvable.
+                self._member_ids = [int(m.id) for m in members]
+                self._members = None
+            else:
+                for m in members:
+                    if isinstance(m, (Elem, Node)):
+                        m.refs.append(self)
+                self._members = members
 
         self._set_type = set_type
         if self.type not in SetTypes.all:
@@ -69,6 +78,20 @@ class FemSet(FemBase):
 
         if self._member_ids is not None:
             self.register_member_refs()
+
+    @staticmethod
+    def _members_are_local_proxies(members, parent, set_type) -> bool:
+        """True if every member is an array-backed *element* proxy belonging to
+        ``parent``'s own store — i.e. safe to store id-only and re-resolve via the
+        parent FEM. Scoped to elsets: Sesam emits ~one elset per element (the dominant
+        proxy-pinning source); nsets are few and kept as proxy-member to avoid the
+        cross-instance / generated-set re-resolution edge cases."""
+        if parent is None or set_type != SetTypes.ELSET:
+            return False
+        if any(getattr(m, "_store", None) is None for m in members):
+            return False
+        store = getattr(parent.elements, "store", None)
+        return store is not None and all(m._store is store for m in members)
 
     def register_member_refs(self) -> None:
         """Register this set in each member's ``refs`` (mirrors the object path's

--- a/src/ada/fem/sets.py
+++ b/src/ada/fem/sets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Literal, Union
 
+import numpy as np
+
 from ada.api.nodes import Node
 
 from .common import FemBase
@@ -40,37 +42,64 @@ class FemSet(FemBase):
         super().__init__(name, metadata, parent)
         from ada.fem import Elem
 
-        if set_type is None:
-            set_type = eval_set_type_from_members(members)
-
         if members is None:
             members = []
 
-        for m in members:
-            if isinstance(m, (Elem, Node)):
-                m.refs.append(self)
+        # Id-backed mode: members given as plain ints (resolved to node/elem proxies
+        # lazily via the parent FEM). Keeps a FemSet from pinning object Node/Elem on
+        # the array-backed mesh path.
+        self._member_ids: list[int] | None = None
+        if members and all(isinstance(m, (int, np.integer)) for m in members):
+            if set_type is None:
+                raise ValueError("set_type is required when members are given as ids")
+            self._member_ids = [int(m) for m in members]
+            self._members = None
+        else:
+            if set_type is None:
+                set_type = eval_set_type_from_members(members)
+            for m in members:
+                if isinstance(m, (Elem, Node)):
+                    m.refs.append(self)
+            self._members = members
 
         self._set_type = set_type
         if self.type not in SetTypes.all:
             raise ValueError(f'set type "{set_type}" is not valid')
-        self._members = members
         self._refs = []
 
+    def _resolve(self, mid: int):
+        fem = self.parent
+        return fem.nodes.from_id(mid) if self.type == SetTypes.NSET else fem.elements.from_id(mid)
+
+    def to_id_backed(self) -> None:
+        """Drop object members, keep only their ids (resolved lazily). Used when the
+        owning FEM switches to the array-backed substrate so the set no longer pins
+        object Node/Elem."""
+        if self._member_ids is not None:
+            return
+        self._member_ids = [m.id for m in self._members]
+        self._members = None
+
     def __len__(self):
-        return len(self._members)
+        return len(self._member_ids) if self._member_ids is not None else len(self._members)
 
     def __contains__(self, item):
+        if self._member_ids is not None:
+            return item.id in self._member_ids
         return item.id in self._members
 
     def __getitem__(self, index):
-        return self._members[index]
+        return self.members[index]
 
     def __add__(self, other: FemSet) -> FemSet:
         self.add_members(other.members)
         return self
 
     def add_members(self, members: List[Union[Elem, Node]]):
-        self._members += members
+        if self._member_ids is not None:
+            self._member_ids += [m if isinstance(m, (int, np.integer)) else m.id for m in members]
+        else:
+            self._members += members
 
     @property
     def type(self) -> str:
@@ -78,6 +107,8 @@ class FemSet(FemBase):
 
     @property
     def members(self) -> list[Elem | Node]:
+        if self._member_ids is not None:
+            return [self._resolve(i) for i in self._member_ids]
         return self._members
 
     @property

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -208,3 +208,45 @@ def test_substrate_is_much_lighter_than_object_model():
     ratio = obj_mb / max(arr_mb, 0.5)
     print(f"\nobject={obj_mb:.0f}MB substrate={arr_mb:.0f}MB ratio={ratio:.1f}x")
     assert ratio >= 5.0, f"expected >=5x memory reduction, got {ratio:.1f}x"
+
+
+# ── structural edits + node->element adjacency ─────────────────────────────
+
+
+def _two_quad_store():
+    rows = np.array([[10, 0, 0, 0], [20, 1, 0, 0], [30, 1, 1, 0], [40, 0, 1, 0], [50, 2, 0, 0]], float)
+    store = MeshArrays.from_node_rows(rows)
+    store.add_elem_block_from_id_conn(ShellShapes.QUAD, [1, 2], [[10, 20, 30, 40], [20, 50, 30, 30]])
+    return store
+
+
+def test_csr_node_to_elem_adjacency():
+    store = _two_quad_store()
+    adj = store.node_to_elem()
+    blk = store.blocks[ShellShapes.QUAD]
+    # node 20 is shared by both quads
+    inc = [int(blk.el_ids[r]) for _, r in adj.incident(store.node_index(20))]
+    assert sorted(inc) == [1, 2]
+    assert adj.degree(store.node_index(50)) == 1  # node 50 only in quad 2
+
+
+def test_add_node_then_remove_keeps_connectivity_valid():
+    store = _two_quad_store()
+    before = {int(store.blocks[ShellShapes.QUAD].el_ids[0]): [10, 20, 30, 40]}
+    r = store.add_node([9, 9, 9], nid=60)
+    assert store.node_id(r) == 60 and store.has_node(60)
+    store.remove_nodes([store.node_index(60)])  # 60 is unreferenced
+    assert not store.has_node(60)
+    conn0 = store.blocks[ShellShapes.QUAD].conn[0]
+    resolved = {1: [store.node_id(x) for x in conn0]}
+    assert resolved[1] == before[1]  # quad 1 still resolves to the same physical nodes
+
+
+def test_extra_refs_side_table():
+    store = _two_quad_store()
+    row = store.node_index(10)
+    marker = object()
+    store.add_extra_ref(row, marker)
+    assert store.extra_refs(row) == [marker]
+    store.remove_extra_ref(row, marker)
+    assert store.extra_refs(row) == []

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -242,6 +242,22 @@ def test_add_node_then_remove_keeps_connectivity_valid():
     assert resolved[1] == before[1]  # quad 1 still resolves to the same physical nodes
 
 
+def test_local_proxy_elset_is_id_backed_no_pinning():
+    """An elset built from the FEM's own element proxies stores ids, not the proxies
+    (so a per-element elset doesn't pin a Python object per element)."""
+    from ada.api.mesh.containers import to_array_backed
+    from ada.fem import FemSet
+
+    fem = to_array_backed(_meshed_fem())
+    elems = list(fem.elements.shell)[:4]
+    fs = FemSet("g", elems, "elset", parent=fem)
+    assert fs._member_ids is not None  # id-backed
+    assert fs._members is None
+    assert [m.id for m in fs.members] == [e.id for e in elems]
+    # the set registered itself in each member's (store-backed) refs
+    assert all(fs in fem.elements.from_id(e.id).refs for e in elems)
+
+
 def test_to_mesh_is_zero_copy_and_matches_object():
     """FEM.to_mesh() on an array-backed FEM shares the store's arrays (no copy) and
     produces the same edges/faces as the object path."""

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -1,0 +1,210 @@
+"""Parity + memory tests for the array-backed mesh substrate (MeshArrays).
+
+The substrate must be behaviorally identical to the object-model
+``Nodes``/``FemElements`` for the helper methods consumers rely on (especially
+renumbering), and it must be dramatically lighter in memory. These tests build the
+same mesh both ways and compare.
+"""
+
+import gc
+import os
+
+import numpy as np
+import pytest
+
+import ada
+from ada.api.mesh.store import MeshArrays
+from ada.api.nodes import Node
+from ada.fem.shapes.definitions import ShellShapes
+
+
+def _meshed_fem(size=0.5):
+    pl = ada.Plate("pl", [(0, 0), (4, 0), (4, 3), (0, 3)], 0.02)
+    p = ada.Part("p") / pl
+    p.fem = pl.to_fem_obj(size, "shell")
+    return p.fem
+
+
+# ── construction / read parity ────────────────────────────────────────────
+
+
+def test_from_fem_read_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+
+    # node set parity (id -> coords), order-independent
+    obj = {n.id: tuple(round(float(x), 9) for x in n.p) for n in fem.nodes}
+    sub = {store.node_id(r): tuple(round(float(x), 9) for x in store.coords[r]) for r in range(store.n_nodes)}
+    assert obj == sub
+
+    # from_id parity for a sample
+    for nid in list(obj)[:: max(1, len(obj) // 25)]:
+        assert np.allclose(np.asarray(fem.nodes.from_id(nid).p), store.coords[store.node_index(nid)])
+
+    # bbox parity
+    assert np.allclose(np.asarray(fem.nodes.bbox()), np.asarray(store.bbox()))
+
+    # to_fem_nodes parity (coords + identifiers)
+    fn_obj = fem.nodes.to_fem_nodes()
+    fn_sub = store.to_fem_nodes()
+    # match rows by id then compare coords
+    obj_by_id = {int(i): c for i, c in zip(fn_obj.identifiers, fn_obj.coords)}
+    sub_by_id = {int(i): c for i, c in zip(fn_sub.identifiers, fn_sub.coords)}
+    assert obj_by_id.keys() == sub_by_id.keys()
+    for k in obj_by_id:
+        assert np.allclose(obj_by_id[k], sub_by_id[k])
+
+
+def test_element_block_connectivity_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+
+    # every object element's node-id set must equal the block row resolved back to ids
+    obj_elems = {e.id: tuple(n.id for n in e.nodes) for e in fem.elements.shell}
+    sub_elems = {}
+    for blk in store.blocks.values():
+        for row in range(len(blk)):
+            eid = int(blk.el_ids[row])
+            sub_elems[eid] = tuple(store.node_id(idx) for idx in blk.conn[row])
+    assert obj_elems == sub_elems
+
+
+# ── mutation parity (the helper methods, incl. renumbering) ────────────────
+
+
+def test_renumber_nodes_linear_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+
+    fem.nodes.renumber(start_id=1)
+    store.renumber_nodes(start_id=1)
+
+    obj = {tuple(round(float(x), 9) for x in n.p): n.id for n in fem.nodes}
+    sub = {tuple(round(float(x), 9) for x in store.coords[r]): store.node_id(r) for r in range(store.n_nodes)}
+    assert obj == sub
+
+
+def test_renumber_nodes_map_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+    ids = sorted(n.id for n in fem.nodes)
+    rmap = {old: old + 1000 for old in ids}
+
+    fem.nodes.renumber(renumber_map=rmap)
+    store.renumber_nodes(renumber_map=rmap)
+
+    obj = {tuple(round(float(x), 9) for x in n.p): n.id for n in fem.nodes}
+    sub = {tuple(round(float(x), 9) for x in store.coords[r]): store.node_id(r) for r in range(store.n_nodes)}
+    assert obj == sub
+
+
+def test_renumber_nodes_leaves_connectivity_valid():
+    """After renumbering, each element still resolves to the same physical nodes."""
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+    before = {int(b.el_ids[r]): b.conn[r].tolist() for b in store.blocks.values() for r in range(len(b))}
+    store.renumber_nodes(start_id=1)
+    after = {int(b.el_ids[r]): b.conn[r].tolist() for b in store.blocks.values() for r in range(len(b))}
+    assert before == after  # conn is index-based -> untouched by node renumber
+
+
+def test_translate_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+    mv = np.array([1.5, -2.0, 3.25])
+
+    fem.nodes.move(move=mv)
+    store.translate(mv)
+
+    obj = {n.id: np.asarray(n.p) for n in fem.nodes}
+    for r in range(store.n_nodes):
+        assert np.allclose(obj[store.node_id(r)], store.coords[r])
+
+
+def test_box_query_parity():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+    lo, hi = (1.0, 1.0, -0.1), (3.0, 2.0, 0.1)
+
+    obj_ids = {n.id for n in fem.nodes if all(lo[i] <= n.p[i] <= hi[i] for i in range(3))}
+    sub_ids = {store.node_id(r) for r in store.rows_in_box(lo, hi)}
+    assert obj_ids == sub_ids
+
+
+# ── proxy semantics ────────────────────────────────────────────────────────
+
+
+def test_proxy_identity_and_equality():
+    fem = _meshed_fem()
+    store = MeshArrays.from_fem(fem)
+    nid = sorted(n.id for n in fem.nodes)[len(list(fem.nodes)) // 2]
+
+    a = store.node_proxy_by_id(nid)
+    b = store.node_proxy_by_id(nid)
+    assert a is b  # identity stable while alive
+    assert isinstance(a, Node)
+    assert a == fem.nodes.from_id(nid)  # value-equality with an object Node
+    assert hash(a) == hash(Node(list(a.p), nid))
+
+
+def test_proxy_write_through():
+    store = MeshArrays.from_node_rows(np.array([[1, 0, 0, 0], [2, 1, 0, 0]], float))
+    p = store.node_proxy_by_id(2)
+    p.p = [5, 6, 7]
+    assert np.allclose(store.coords[store.node_index(2)], [5, 6, 7])
+    p.id = 99
+    assert store.has_node(99) and not store.has_node(2)
+
+
+# ── memory win (opt-in benchmark) ──────────────────────────────────────────
+
+
+def _rss_mb():
+    with open(f"/proc/{os.getpid()}/status") as f:
+        for ln in f:
+            if ln.startswith("VmRSS:"):
+                return int(ln.split()[1]) / 1024.0
+    return 0.0
+
+
+@pytest.mark.benchmark
+def test_substrate_is_much_lighter_than_object_model():
+    from ada.api.containers.nodes import Nodes
+    from ada.fem.containers import FemElements
+    from ada.fem.elements import Elem
+
+    N = 200  # ~40k nodes / ~40k quads — enough to dwarf fixed overhead, fast to build
+    xs, ys = np.meshgrid(np.arange(N), np.arange(N))
+    coords = np.column_stack([xs.ravel(), ys.ravel(), np.zeros(N * N)]).astype(float)
+    node_ids = np.arange(1, N * N + 1, dtype=np.int64)
+
+    def nid(i, j):
+        return i * N + j + 1
+
+    quads = [(nid(i, j), nid(i, j + 1), nid(i + 1, j + 1), nid(i + 1, j)) for i in range(N - 1) for j in range(N - 1)]
+    quad_conn = np.array(quads, dtype=np.int64)
+    quad_ids = np.arange(1, len(quads) + 1, dtype=np.int64)
+
+    gc.collect()
+    b0 = _rss_mb()
+    node_objs = [Node(coords[k], int(node_ids[k])) for k in range(N * N)]
+    nodes = Nodes(node_objs)
+    elems = [
+        Elem(int(quad_ids[e]), [nodes.from_id(int(c)) for c in quad_conn[e]], ShellShapes.QUAD)
+        for e in range(len(quads))
+    ]
+    fem_elems = FemElements(elems)
+    gc.collect()
+    obj_mb = _rss_mb() - b0
+    del node_objs, nodes, elems, fem_elems
+    gc.collect()
+
+    g0 = _rss_mb()
+    store = MeshArrays(coords.copy(), node_ids.copy())
+    store.add_elem_block_from_id_conn(ShellShapes.QUAD, quad_ids, quad_conn)
+    gc.collect()
+    arr_mb = _rss_mb() - g0
+
+    ratio = obj_mb / max(arr_mb, 0.5)
+    print(f"\nobject={obj_mb:.0f}MB substrate={arr_mb:.0f}MB ratio={ratio:.1f}x")
+    assert ratio >= 5.0, f"expected >=5x memory reduction, got {ratio:.1f}x"

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -298,6 +298,22 @@ def test_type_filtered_views_are_reiterable_and_have_len():
     assert len(obj.elements.shell) == len(arr.elements.shell)
 
 
+def test_proxies_carry_parent_and_writable_metadata():
+    """Minted proxies expose the owning FEM as ``.parent`` (writers read it, e.g. abaqus
+    instance-name resolution) and a writable per-element ``.metadata`` dict (the Sesam
+    writer mutates el.metadata in place) — both were missing and crashed FEM exports."""
+    from ada.api.mesh.containers import to_array_backed
+
+    fem = to_array_backed(_meshed_fem())
+    el = next(iter(fem.elements.shell))
+    node = el.nodes[0]
+    assert el.parent is fem
+    assert node.parent is fem
+    # per-element metadata is a real dict whose mutations persist on the substrate
+    el.metadata["transno"] = 7
+    assert fem.elements.from_id(el.id).metadata["transno"] == 7
+
+
 def test_eccpoint_id_backs_proxies_no_pinning():
     """EccPoint given an array-backed node proxy keeps only the id (no pinning) and
     resolves it lazily; an object node is held directly (object path unchanged)."""

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -302,3 +302,68 @@ def test_elem_node_setitem_write_through():
         store.node_index(30),
         store.node_index(50),
     ]
+
+
+# ── facade (ArrayNodes / ArrayElements) wired into a FEM ────────────────────
+
+
+def test_to_array_backed_swaps_facades_with_parity():
+    from ada.api.mesh.containers import ArrayElements, ArrayNodes, to_array_backed
+
+    fem = _meshed_fem()
+    obj_nodes = {n.id: tuple(round(float(x), 9) for x in n.p) for n in fem.nodes}
+    obj_shell = {e.id: tuple(n.id for n in e.nodes) for e in fem.elements.shell}
+
+    to_array_backed(fem)
+    assert isinstance(fem.nodes, ArrayNodes) and isinstance(fem.elements, ArrayElements)
+
+    assert {n.id: tuple(round(float(x), 9) for x in n.p) for n in fem.nodes} == obj_nodes
+    assert {e.id: tuple(n.id for n in e.nodes) for e in fem.elements.shell} == obj_shell
+    # a shell element resolves fem_sec (thickness) through the block
+    e0 = next(iter(fem.elements.shell))
+    assert e0.fem_sec is not None and e0.fem_sec.thickness == 0.02
+
+
+def test_array_backed_conversion_matches_object_path():
+    """create_objects_from_fem must yield identical plates on an array-backed FEM."""
+    import ada
+    from ada.api.mesh.containers import to_array_backed
+
+    def _plate_cogs(array_backed):
+        pl = ada.Plate("pl", [(0, 0), (4, 0), (4, 3), (0, 3)], 0.02)
+        p = ada.Part("p") / pl
+        p.fem = pl.to_fem_obj(0.5, "shell")
+        if array_backed:
+            to_array_backed(p.fem)
+        a = ada.Assembly("a") / p
+        a.create_objects_from_fem(merge=False)
+        plates = list(p.get_all_physical_objects(by_type=ada.Plate))
+        return sorted(tuple(round(float(x), 6) for x in pl.poly.get_centroid()) for pl in plates)
+
+    assert _plate_cogs(False) == _plate_cogs(True)
+
+
+def test_array_nodes_helpers_parity():
+    from ada.api.mesh.containers import to_array_backed
+
+    obj = _meshed_fem()
+    arr = to_array_backed(_meshed_fem())
+
+    # renumber (linear) -> same coord->id mapping
+    obj.nodes.renumber(start_id=1)
+    arr.nodes.renumber(start_id=1)
+    om = {tuple(round(float(x), 9) for x in n.p): n.id for n in obj.nodes}
+    am = {tuple(round(float(x), 9) for x in n.p): n.id for n in arr.nodes}
+    assert om == am
+
+    # move -> same coords
+    obj.nodes.move(move=[1, 2, 3])
+    arr.nodes.move(move=[1, 2, 3])
+    assert {n.id: tuple(round(float(x), 9) for x in n.p) for n in obj.nodes} == {
+        n.id: tuple(round(float(x), 9) for x in n.p) for n in arr.nodes
+    }
+
+    # box query -> same id set
+    obj_ids = {n.id for n in obj.nodes.get_by_volume((2, 3, 3), tol=1.0)}
+    arr_ids = {n.id for n in arr.nodes.get_by_volume((2, 3, 3), tol=1.0)}
+    assert obj_ids == arr_ids

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -242,6 +242,40 @@ def test_add_node_then_remove_keeps_connectivity_valid():
     assert resolved[1] == before[1]  # quad 1 still resolves to the same physical nodes
 
 
+def test_to_mesh_is_zero_copy_and_matches_object():
+    """FEM.to_mesh() on an array-backed FEM shares the store's arrays (no copy) and
+    produces the same edges/faces as the object path."""
+    import ada
+    from ada.api.mesh.containers import to_array_backed
+
+    def _build():
+        pl = ada.Plate("pl", [(0, 0), (3, 0), (3, 2), (0, 2)], 0.02)
+        p = ada.Part("p") / pl
+        p.fem = pl.to_fem_obj(0.4, "shell")
+        return p.fem
+
+    mesh_o = _build().to_mesh()
+    edges_o, faces_o = mesh_o.get_edges_and_faces_from_mesh()
+
+    fem_a = to_array_backed(_build())
+    mesh_a = fem_a.to_mesh()
+    store = fem_a.nodes.store
+
+    # zero-copy: the Mesh views share the store's buffers
+    assert np.shares_memory(mesh_a.nodes.coords, store.coords)
+    blk = mesh_a.elements[0]
+    assert blk.node_refs_are_indices
+    assert np.shares_memory(blk.node_refs, next(iter(store.blocks.values())).conn)
+
+    edges_a, faces_a = mesh_a.get_edges_and_faces_from_mesh()
+
+    def _norm(arr):
+        return set(tuple(sorted(int(x) for x in row)) for row in arr)
+
+    assert _norm(edges_o) == _norm(edges_a)
+    assert _norm(faces_o) == _norm(faces_a)
+
+
 def test_extra_refs_side_table():
     store = _two_quad_store()
     row = store.node_index(10)

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -258,6 +258,29 @@ def test_local_proxy_elset_is_id_backed_no_pinning():
     assert all(fs in fem.elements.from_id(e.id).refs for e in elems)
 
 
+def test_eccpoint_id_backs_proxies_no_pinning():
+    """EccPoint given an array-backed node proxy keeps only the id (no pinning) and
+    resolves it lazily; an object node is held directly (object path unchanged)."""
+    import gc
+
+    import ada
+    from ada.api.mesh.containers import to_array_backed
+    from ada.fem.elements import EccPoint
+
+    fem = to_array_backed(_meshed_fem())
+    proxy = next(iter(fem.elements.shell)).nodes[0]
+    nid = proxy.id
+    ecc = EccPoint(proxy, np.array([0, 0, 0.1]))
+    assert ecc._node is None and ecc._node_id == nid  # id-backed, not the proxy
+    assert ecc.node == proxy
+    del proxy
+    gc.collect()
+    assert ecc.node.id == nid  # still resolves from the store after the proxy is gone
+
+    obj_node = ada.Node([0, 0, 0], 999)
+    assert EccPoint(obj_node, np.zeros(3))._node is obj_node  # object path: held directly
+
+
 def test_to_mesh_is_zero_copy_and_matches_object():
     """FEM.to_mesh() on an array-backed FEM shares the store's arrays (no copy) and
     produces the same edges/faces as the object path."""

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -160,15 +160,27 @@ def test_proxy_write_through():
 
 
 def _rss_mb():
-    with open(f"/proc/{os.getpid()}/status") as f:
-        for ln in f:
-            if ln.startswith("VmRSS:"):
-                return int(ln.split()[1]) / 1024.0
-    return 0.0
+    """Current process RSS in MB, or None if the platform doesn't expose it cheaply
+    (no /proc on macOS/Windows; psutil isn't a hard dependency)."""
+    proc_status = f"/proc/{os.getpid()}/status"
+    if os.path.exists(proc_status):
+        with open(proc_status) as f:
+            for ln in f:
+                if ln.startswith("VmRSS:"):
+                    return int(ln.split()[1]) / 1024.0
+    try:
+        import psutil
+
+        return psutil.Process().memory_info().rss / (1024.0 * 1024.0)
+    except Exception:
+        return None
 
 
 @pytest.mark.benchmark
 def test_substrate_is_much_lighter_than_object_model():
+    if _rss_mb() is None:
+        pytest.skip("RSS measurement unavailable on this platform (no /proc, no psutil)")
+
     from ada.api.containers.nodes import Nodes
     from ada.fem.containers import FemElements
     from ada.fem.elements import Elem

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -250,3 +250,55 @@ def test_extra_refs_side_table():
     assert store.extra_refs(row) == [marker]
     store.remove_extra_ref(row, marker)
     assert store.extra_refs(row) == []
+
+
+# ── element proxies (ElemProxy / NodeListView / RefsView) ──────────────────
+
+
+def test_elem_proxy_attributes():
+    from ada.fem.elements import Elem
+
+    store = _two_quad_store()
+    store.blocks[ShellShapes.QUAD].fem_secs = ["secA", "secB"]
+    e = store.elem_proxy_by_id(1)
+    assert isinstance(e, Elem)
+    assert e.id == 1 and e.type == ShellShapes.QUAD
+    assert [n.id for n in e.nodes] == [10, 20, 30, 40]
+    assert e.fem_sec == "secA"
+    assert type(e.shape).__name__ == "ElemShape"
+    assert store.elem_proxy_by_id(1) is e  # identity stable
+
+
+def test_refsview_chains_elements_and_extras():
+    store = _two_quad_store()
+    n20 = store.node_proxy_by_id(20)  # shared by both quads
+    assert sorted(x.id for x in n20.refs) == [1, 2]
+    assert n20.has_refs
+
+    n10 = store.node_proxy_by_id(10)
+    n10.add_obj_to_refs("beamX")  # non-element ref -> side-table
+    refs = list(n10.refs)
+    assert refs[0].id == 1 and "beamX" in refs
+    n10.remove_obj_from_refs("beamX")
+    assert "beamX" not in list(n10.refs)
+
+
+def test_updating_nodes_rewires_adjacency():
+    store = _two_quad_store()
+    e1 = store.elem_proxy_by_id(1)
+    e1.updating_nodes(store.node_proxy_by_id(40), store.node_proxy_by_id(50))
+    assert [n.id for n in e1.nodes] == [10, 20, 30, 50]
+    assert [x.id for x in store.node_proxy_by_id(40).refs] == []  # 40 no longer referenced
+    assert sorted(x.id for x in store.node_proxy_by_id(50).refs) == [1, 2]
+
+
+def test_elem_node_setitem_write_through():
+    store = _two_quad_store()
+    e = store.elem_proxy_by_id(1)
+    e.nodes[3] = store.node_proxy_by_id(50)
+    assert store.blocks[ShellShapes.QUAD].conn[0].tolist() == [
+        store.node_index(10),
+        store.node_index(20),
+        store.node_index(30),
+        store.node_index(50),
+    ]

--- a/tests/core/api/mesh/test_substrate_parity.py
+++ b/tests/core/api/mesh/test_substrate_parity.py
@@ -270,6 +270,34 @@ def test_local_proxy_elset_is_id_backed_no_pinning():
     assert all(fs in fem.elements.from_id(e.id).refs for e in elems)
 
 
+def test_type_filtered_views_are_reiterable_and_have_len():
+    """shell/lines/solids are lazy but re-iterable (not one-shot generators): two passes
+    give the same result, len()/bool/indexing work, and array == object counts."""
+    import ada
+    from ada.api.mesh.containers import to_array_backed
+
+    def _build():
+        pl = ada.Plate("pl", [(0, 0), (3, 0), (3, 2), (0, 2)], 0.02)
+        p = ada.Part("p") / pl
+        p.fem = pl.to_fem_obj(0.5, "shell")
+        return p.fem
+
+    obj = _build()
+    arr = to_array_backed(_build())
+    for fem in (obj, arr):
+        sh = fem.elements.shell
+        first = [e.id for e in sh]
+        second = [e.id for e in sh]  # must not be exhausted
+        assert first and first == second
+        assert len(sh) == len(first)  # len() works without exhausting
+        assert bool(sh) is True
+        assert sh[0].id == first[0]
+        assert len(fem.elements.lines) == 0  # empty view still supports len/bool
+        assert bool(fem.elements.lines) is False
+
+    assert len(obj.elements.shell) == len(arr.elements.shell)
+
+
 def test_eccpoint_id_backs_proxies_no_pinning():
     """EccPoint given an array-backed node proxy keeps only the id (no pinning) and
     resolves it lazily; an object node is held directly (object path unchanged)."""

--- a/tests/core/fem/formats/code_aster/test_io_fem_code_aster.py
+++ b/tests/core/fem/formats/code_aster/test_io_fem_code_aster.py
@@ -3,22 +3,7 @@ from operator import attrgetter
 import pytest
 
 import ada
-from ada.config import Config
 from ada.param_models.fem_models import beam_ex1
-
-
-@pytest.fixture(autouse=True)
-def _object_mode_for_med_write():
-    """These are read->write->read MED round-trips. The Code_Aster MED *writer*
-    detects multi-set membership via element.refs, which the array-backed (lazy
-    id-set) path does not populate — array-backed MED *write* is a follow-up
-    (writer migration). The substrate-direct MED *reader* is covered by
-    test_med_array_read.py. Force object mode so these writer tests are
-    flag-independent."""
-    prev = Config().meshing_array_backed
-    Config().meshing_array_backed = False
-    yield
-    Config().meshing_array_backed = prev
 
 
 def test_read_write_cylinder(example_files, tmp_path):

--- a/tests/core/fem/formats/code_aster/test_io_fem_code_aster.py
+++ b/tests/core/fem/formats/code_aster/test_io_fem_code_aster.py
@@ -3,7 +3,22 @@ from operator import attrgetter
 import pytest
 
 import ada
+from ada.config import Config
 from ada.param_models.fem_models import beam_ex1
+
+
+@pytest.fixture(autouse=True)
+def _object_mode_for_med_write():
+    """These are read->write->read MED round-trips. The Code_Aster MED *writer*
+    detects multi-set membership via element.refs, which the array-backed (lazy
+    id-set) path does not populate — array-backed MED *write* is a follow-up
+    (writer migration). The substrate-direct MED *reader* is covered by
+    test_med_array_read.py. Force object mode so these writer tests are
+    flag-independent."""
+    prev = Config().meshing_array_backed
+    Config().meshing_array_backed = False
+    yield
+    Config().meshing_array_backed = prev
 
 
 def test_read_write_cylinder(example_files, tmp_path):

--- a/tests/core/fem/test_abaqus_array_read.py
+++ b/tests/core/fem/test_abaqus_array_read.py
@@ -10,8 +10,9 @@ from ada.config import Config
 
 @pytest.fixture
 def _restore_flag():
+    prev = Config().meshing_array_backed
     yield
-    Config().meshing_array_backed = False
+    Config().meshing_array_backed = prev
 
 
 def _abaqus_inp(tmp_path):

--- a/tests/core/fem/test_abaqus_array_read.py
+++ b/tests/core/fem/test_abaqus_array_read.py
@@ -1,0 +1,44 @@
+"""Substrate-direct Abaqus read must be byte-identical to the object-model read."""
+
+import pathlib
+
+import pytest
+
+import ada
+from ada.config import Config
+
+
+@pytest.fixture
+def _restore_flag():
+    yield
+    Config().meshing_array_backed = False
+
+
+def _abaqus_inp(tmp_path):
+    Config().meshing_array_backed = False
+    pl = ada.Plate("pl", [(0, 0), (2, 0), (2, 1.5), (0, 1.5)], 0.02)
+    p = ada.Part("p") / pl
+    p.fem = pl.to_fem_obj(0.4, "shell")
+    (ada.Assembly("a") / p).to_fem("m", fem_format="abaqus", scratch_dir=tmp_path)
+    return next(pathlib.Path(tmp_path).rglob("*.inp"))
+
+
+def _digest(path):
+    a = ada.from_fem(str(path))
+    fem = [p for p in a.get_all_parts_in_assembly() if p.fem is not None and len(p.fem.nodes) > 0][0].fem
+    nodes = sorted((int(n.id), *[round(float(x), 6) for x in n.p]) for n in fem.nodes)
+    shells = sorted((int(e.id), tuple(sorted(int(n.id) for n in e.nodes))) for e in fem.elements.shell)
+    return type(fem.nodes).__name__, nodes, shells
+
+
+def test_abaqus_array_read_parity(tmp_path, _restore_flag):
+    inp = _abaqus_inp(tmp_path)
+
+    Config().meshing_array_backed = False
+    obj = _digest(inp)
+    Config().meshing_array_backed = True
+    arr = _digest(inp)
+
+    assert obj[0] == "Nodes" and arr[0] == "ArrayNodes"
+    assert obj[1] == arr[1], "node coords differ"
+    assert obj[2] == arr[2], "shell connectivity differs"

--- a/tests/core/fem/test_med_array_read.py
+++ b/tests/core/fem/test_med_array_read.py
@@ -1,0 +1,44 @@
+"""Substrate-direct Code_Aster MED read must match the object-model read."""
+
+import pathlib
+
+import pytest
+
+import ada
+from ada.config import Config
+
+
+@pytest.fixture
+def _restore_flag():
+    yield
+    Config().meshing_array_backed = False
+
+
+def _med(tmp_path):
+    Config().meshing_array_backed = False
+    pl = ada.Plate("pl", [(0, 0), (2, 0), (2, 1.5), (0, 1.5)], 0.02)
+    p = ada.Part("p") / pl
+    p.fem = pl.to_fem_obj(0.4, "shell")
+    (ada.Assembly("a") / p).to_fem("m", fem_format="code_aster", scratch_dir=tmp_path)
+    return next(pathlib.Path(tmp_path).rglob("*.med"))
+
+
+def _digest(path):
+    a = ada.from_fem(str(path))
+    fem = [p for p in a.get_all_parts_in_assembly() if p.fem is not None and len(p.fem.nodes) > 0][0].fem
+    nodes = sorted((int(n.id), *[round(float(x), 6) for x in n.p]) for n in fem.nodes)
+    shells = sorted((int(e.id), tuple(sorted(int(n.id) for n in e.nodes))) for e in fem.elements.shell)
+    return type(fem.nodes).__name__, nodes, shells
+
+
+def test_med_array_read_parity(tmp_path, _restore_flag):
+    med = _med(tmp_path)
+
+    Config().meshing_array_backed = False
+    obj = _digest(med)
+    Config().meshing_array_backed = True
+    arr = _digest(med)
+
+    assert obj[0] == "Nodes" and arr[0] == "ArrayNodes"
+    assert obj[1] == arr[1], "node coords differ"
+    assert obj[2] == arr[2], "shell connectivity differs"

--- a/tests/core/fem/test_med_array_read.py
+++ b/tests/core/fem/test_med_array_read.py
@@ -10,8 +10,9 @@ from ada.config import Config
 
 @pytest.fixture
 def _restore_flag():
+    prev = Config().meshing_array_backed
     yield
-    Config().meshing_array_backed = False
+    Config().meshing_array_backed = prev
 
 
 def _med(tmp_path):

--- a/tests/core/fem/test_sesam_array_read.py
+++ b/tests/core/fem/test_sesam_array_read.py
@@ -1,0 +1,67 @@
+"""The substrate-direct Sesam read must be byte-identical to the object-model read.
+
+Loads the same Sesam deck with ``meshing_array_backed`` off (object Node/Elem) and on
+(MeshArrays + proxies) and compares node coords, element connectivity, and section
+thickness. Also checks the array path actually produced the array-backed containers.
+"""
+
+import pytest
+
+import ada
+from ada.config import Config
+
+
+@pytest.fixture
+def _restore_flag():
+    yield
+    Config().meshing_array_backed = False
+
+
+def _load_fem(path):
+    a = ada.from_fem(str(path))
+    parts = [p for p in a.get_all_parts_in_assembly() if p.fem is not None and len(p.fem.nodes) > 0]
+    return parts[0].fem
+
+
+def _digest(fem):
+    nodes = sorted((n.id, *[round(float(x), 6) for x in n.p]) for n in fem.nodes)
+    shells = sorted((e.id, tuple(sorted(n.id for n in e.nodes))) for e in fem.elements.shell)
+    lines = sorted((e.id, tuple(sorted(n.id for n in e.nodes))) for e in fem.elements.lines)
+    secs = sorted(
+        (e.id, round(float(getattr(e.fem_sec, "thickness", 0) or 0), 6))
+        for e in fem.elements.shell
+        if e.fem_sec is not None
+    )
+    return nodes, shells, lines, secs
+
+
+def _parity(path):
+    from ada.api.mesh.containers import ArrayNodes
+
+    Config().meshing_array_backed = False
+    obj = _digest(_load_fem(path))
+
+    Config().meshing_array_backed = True
+    arr_fem = _load_fem(path)
+    assert isinstance(arr_fem.nodes, ArrayNodes)
+    arr = _digest(arr_fem)
+
+    assert obj[0] == arr[0], "node coords differ"
+    assert obj[1] == arr[1], "shell connectivity differs"
+    assert obj[2] == arr[2], "line connectivity differs"
+    assert obj[3] == arr[3], "shell section thickness differs"
+
+
+def test_sesam_array_read_beam_mass(fem_files, _restore_flag):
+    # beam + mass deck -> exercises line elements + the mass overflow path
+    _parity(fem_files / "sesam" / "beamMassT1.FEM")
+
+
+def test_sesam_array_read_shell(tmp_path, _restore_flag):
+    Config().meshing_array_backed = False
+    pl = ada.Plate("pl", [(0, 0), (2, 0), (2, 1.5), (0, 1.5)], 0.02)
+    p = ada.Part("p") / pl
+    p.fem = pl.to_fem_obj(0.4, "shell")
+    a = ada.Assembly("a") / p
+    a.to_fem("m", fem_format="sesam", scratch_dir=tmp_path)
+    _parity(tmp_path / "m" / "mT1.FEM")

--- a/tests/core/fem/test_sesam_stream.py
+++ b/tests/core/fem/test_sesam_stream.py
@@ -1,0 +1,42 @@
+"""Streaming Sesam .FEM reader edge cases (stream_fem_mesh)."""
+
+from ada.fem.formats.sesam.read.stream import stream_fem_mesh
+
+
+def _f(*vals) -> str:
+    return "    " + "    ".join(f"{v:.8E}" for v in vals) + "\n"
+
+
+def test_stream_wrapping_mass_gelmnt1_does_not_leak(tmp_path):
+    """A mass/spring GELMNT1 whose node ids wrap onto a continuation line must not leak
+    those ids into ``other_text`` (regression: the continuation of a non-structural
+    GELMNT1 was bucketed as text, corrupting the following BNMASS card)."""
+    fem = tmp_path / "m.FEM"
+    lines = []
+    # GCOORD: GCOORD fieldno nodeno x y z
+    for nid in (1, 2, 3, 4, 10):
+        lines.append("GCOORD" + _f(nid, nid, float(nid), 0.0, 0.0))
+    # structural QUAD (eltyp 24), node ids on a continuation line
+    lines.append("GELMNT1" + _f(1, 1, 24, 0))
+    lines.append(_f(1, 2, 3, 4))
+    # MASS (eltyp 11) whose single node id wraps onto a continuation line — the bug
+    lines.append("GELMNT1" + _f(2, 2, 11, 0))
+    lines.append(_f(10))
+    # a following non-mesh card that previously got corrupted by the leaked node id
+    lines.append("BNMASS" + _f(10, 6, 1.5, 1.5, 1.5, 0.0, 0.0, 0.0))
+    fem.write_text("".join(lines))
+
+    coords, node_ids, by_type, mass_elem, spring_elem, ext_map, other = stream_fem_mesh(str(fem))
+
+    # the structural quad is parsed with its 4 nodes
+    assert sum(len(ids) for ids, _ in by_type.values()) == 1
+    (q_ids, q_conn) = next(iter(by_type.values()))
+    assert q_conn[0] == [1, 2, 3, 4]
+    # the mass record captured its (wrapped) node id, not leaked
+    assert 2 in mass_elem
+    assert int(float(mass_elem[2]["gelmnt"]["nids"].split()[0])) == 10
+    # the text bucket holds exactly the one non-mesh card (BNMASS) — no leaked GELMNT1
+    # continuation line of bare node ids alongside it
+    text_lines = [ln for ln in other.splitlines() if ln.strip()]
+    assert len(text_lines) == 1
+    assert text_lines[0].lstrip().startswith("BNMASS")


### PR DESCRIPTION
## Array-backed FEM mesh substrate with lazy Node/Elem proxies

Replaces the object-heavy analysis mesh (millions of Python `Node`/`Elem` objects + `_refs` back-pointer lists + id→object dicts + a spatial grid — ~4–6× the raw-number footprint) with a packed-array substrate, and **unifies it with the already-array-backed FEA-results mesh**. `Node`/`Elem` become lazy proxies over the arrays; the readers build the substrate directly so the object mesh is never materialized.

Single PR, separated into logical commits. Behind `Config().meshing_array_backed` throughout development — **now the default**; set `ADA_MESHING_ARRAY_BACKED=false` to opt back into the legacy object mesh.

### Results (measured on a real Sesam deck, ~41k nodes / 66k elements)
- **0 object `Node`, 0 object `Elem`, 0 pinned proxies** after read — the mesh is purely packed numpy arrays
- Parse RSS **211 MB → 109 MB**; reading **~22% faster** (skips millions of object `__init__`/back-ref/container-index ops)
- Substrate itself is **40–130× smaller** than the object model (e.g. 357 MB → 9 MB for 202k nodes + 201k quads)
- `FEM.to_mesh()` is now **zero-copy** (shares the store buffers; `np.shares_memory` holds for coords *and* connectivity)

### What's in it

**Substrate + proxies**
- `MeshArrays` (`api/mesh/store.py`): `coords` (n,3) + `node_ids` + per-type int32 connectivity holding **row indices** (so node renumber is O(1) — `conn` untouched). Structural edits (add/remove with atomic conn remap, renumber, move/rotate vectorized).
- `NodeProxy`/`ElemProxy` + `NodeListView`/`RefsView` (`api/mesh/proxies.py`): hold `(store, row)`, read/write through to the arrays; identity preserved while live via a `WeakValueDictionary` cache; equality/hash stay value-based.
- `_refs` replaced by a lazy node→element **CSR adjacency** + a side-table for non-connectivity refs (Beam/Csys/FemSet), plus an element-level refs side-table.
- `ArrayNodes`/`ArrayElements` facades sharing one store.

**Readers (substrate-direct, each parity-tested object-vs-array)**
- **Sesam `.FEM`** — single-pass **streaming** reader (mirrors the SIF results reader): mesh cards → arrays, everything else → a small text blob; never loads the whole deck as a string, so the win scales with file size.
- **Abaqus `.inp`** (and **Calculix `.inp`** via the shared reader).
- **Code_Aster `.med`** (h5py arrays straight into the substrate).
- Results readers (SIF/SIN/FRD/RMED) were already array-based.

**Graph + writers**
- `FemSet` is id-backed; `Bc`/`Constraint`/`FemSection` reference sets, and `EccPoint` lazily resolves its node by id — so the whole mesh-referencing graph is array-only with no proxy pinning.
- Writers round-trip array-backed FEMs (element-level refs side-table fixes the Code_Aster MED writer's shared-family logic).
- Results unification: `ElementBlock` gains an index convention flag so consumers skip the id→index remap; the analysis mesh and FEA-results `Mesh` now sit on one representation.

**Identity audit** — value-based `__eq__`/`__hash__` cover `in`/`index`/`set`/dict usage; the one object-identity site on the mesh path (MED dedup) is now value-keyed.

### Validation
Full `test-all` passes on **both CAD backends** with the substrate active **and** with the legacy opt-out, plus per-format object-vs-array parity tests and a zero-copy/residency test suite under `tests/core/api/mesh/`. End-to-end read → edit → write → results → FEM→CAD all covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
