### PR TITLE
fix: reserve a CPU for the STEP tessellation pool to stop the redelivery cascade

### DIFF
--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -98,9 +98,17 @@ def _cgroup_cpu_quota() -> int | None:
 
 
 def _stream_workers() -> int:
-    """Number of tessellation worker processes. ``ADA_STEP_STREAM_WORKERS`` overrides;
-    otherwise the pod's cgroup CPU limit (falling back to schedulable CPUs), capped at
-    8 — each worker holds one solid's OCC shape, so this also bounds memory."""
+    """Number of tessellation worker processes. ``ADA_STEP_STREAM_WORKERS`` overrides
+    (verbatim); otherwise the pod's cgroup CPU limit (falling back to schedulable CPUs)
+    MINUS one, capped at 8.
+
+    The ``- 1`` is load-bearing, not just polite: when this runs inside the conversion
+    worker, the parent process must keep its asyncio event loop responsive to refresh
+    the JetStream ``in_progress`` lease (every 30 s, within a 180 s ``ack_wait``). A pool
+    that pins every core starves that loop, the lease expires, JetStream redelivers the
+    still-running job, the worker spawns ANOTHER conversion + pool, and it cascades into
+    a redelivery storm. Reserving a core keeps the heartbeat alive. (Each worker also
+    holds one solid's OCC shape, so the cap bounds memory too.)"""
     import os
 
     env = os.environ.get("ADA_STEP_STREAM_WORKERS")
@@ -115,7 +123,7 @@ def _stream_workers() -> int:
             n = len(os.sched_getaffinity(0))
         except (AttributeError, OSError):
             n = os.cpu_count() or 1
-    return max(1, min(n, 8))
+    return max(1, min(n - 1, 8))
 
 
 def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) -> trimesh.Scene:

--- a/tests/core/cadit/step/test_stream_to_glb.py
+++ b/tests/core/cadit/step/test_stream_to_glb.py
@@ -67,3 +67,24 @@ def test_stream_step_to_glb_extracts_colour_merges_and_emits_ada_ext(tmp_path):
     # red box colour survives the STEP round-trip into a material baseColorFactor
     base_colors = [m.get("pbrMetallicRoughness", {}).get("baseColorFactor") for m in tree["materials"]]
     assert [1.0, 0.0, 0.0, 1.0] in base_colors
+
+
+def test_stream_workers_reserves_a_core_for_the_event_loop(monkeypatch):
+    # The tessellation pool must leave one CPU free: when this runs inside the
+    # conversion worker, the parent asyncio loop has to refresh the JetStream
+    # in_progress lease (every 30s, within a 180s ack_wait). A pool that pins every
+    # core starves that loop -> lease expires -> the still-running job is redelivered
+    # -> another conversion + pool spawns -> redelivery cascade. So workers == cpus-1.
+    from ada.visit.scene_handling import scene_from_step_stream as sfss
+
+    monkeypatch.delenv("ADA_STEP_STREAM_WORKERS", raising=False)
+    monkeypatch.setattr(sfss, "_cgroup_cpu_quota", lambda: 4)
+    assert sfss._stream_workers() == 3  # 4-core pod -> 3 workers, 1 core for the loop
+    monkeypatch.setattr(sfss, "_cgroup_cpu_quota", lambda: 2)
+    assert sfss._stream_workers() == 1
+    monkeypatch.setattr(sfss, "_cgroup_cpu_quota", lambda: 1)
+    assert sfss._stream_workers() == 1  # never below 1
+
+    # An explicit override is honoured verbatim (operator owns the trade-off).
+    monkeypatch.setenv("ADA_STEP_STREAM_WORKERS", "6")
+    assert sfss._stream_workers() == 6


### PR DESCRIPTION
## Symptom

A large STEP→GLB conversion appeared to "quit and restart" on a loop on the conversion worker, and cancelling it didn't help — it came straight back.

## Root cause

The parallel tessellation pool (`scene_from_step_stream._stream_workers`) sized itself to the **full** cgroup CPU count. On an N-core conversion pod it spawned N pool workers and **pinned every core**. That starves the worker's asyncio event loop, which has to refresh the JetStream `in_progress` lease every 30 s (within a 180 s `ack_wait`). When the lease lapses:

1. JetStream redelivers the **still-running** job.
2. The worker forks **another** conversion → **another** full pool.
3. CPU contention gets worse → more lapses → cascade.

The consumer has **no `max_deliver` cap**, so the redelivery storm never converges. Observed live: a 4-CPU pod ran 4 pool workers and looped.

## Fix

Size the pool to **`cpus − 1`** so the parent always keeps a core for its event loop and the lease heartbeat stays alive. Explicit `ADA_STEP_STREAM_WORKERS` overrides are still honoured verbatim.

| cgroup CPUs | workers before | workers after |
|---|---|---|
| 4 | 4 | 3 |
| 2 | 2 | 1 |
| 1 | 1 | 1 |
| 16 | 8 (cap) | 8 (cap) |

Unit test added (`test_stream_workers_reserves_a_core_for_the_event_loop`).

## Recommended follow-ups (not in this PR — kept focused)

- **`max_deliver` cap** on the JetStream consumer (`queue.py`) so *any* future redelivery dead-letters after N attempts instead of looping forever. This is the backstop that would have bounded the incident regardless of cause. (Changing it may require recreating the durable consumers.)
- **Surface `in_progress` refresh failures** — they're currently swallowed at `DEBUG` (`worker.py`), which hid the lease lapses. Bump to `WARNING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
