### PR TITLE
fix: per-solid tessellation timeout so one hung solid cannot freeze the STEP conversion

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -4590,6 +4590,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             f"window.AUTH_ISSUER = {_json.dumps(a.issuer)};\n"
             f"window.AUTH_CLIENT_ID = {_json.dumps(a.client_id)};\n"
             f"window.AUTH_AUDIENCE = {_json.dumps(a.audience)};\n"
+            f"window.AUTH_SCOPE = {_json.dumps(a.scope)};\n"
             f"window.VIEWER_IMAGE_TAG = {_json.dumps(viewer_tag)};\n"
             f"window.WORKER_IMAGE_TAG = {_json.dumps(worker_tag)};\n"
             f"window.ADAPY_VERSION = {_json.dumps(adapy_version)};\n"

--- a/src/ada/comms/rest/config.py
+++ b/src/ada/comms/rest/config.py
@@ -74,6 +74,15 @@ class AuthConfig:
     # disables the mint endpoint so deployments without it don't
     # accidentally hand out 30-day bearers signed with a default key.
     cli_token_secret: str
+    # Extra OIDC scope(s) to request on top of the always-sent
+    # ``openid profile email offline_access`` base. Empty for IdPs that
+    # mint an API-audienced token from the base scopes alone (e.g.
+    # Authentik). Set to a resource scope (e.g. Azure AD's
+    # ``api://<client-id>/access_as_user``) when the provider otherwise
+    # issues an access token audienced at something other than this app,
+    # so the ``aud`` claim matches ``audience`` above. Space-separated.
+    # Defaulted last so existing constructors stay valid.
+    scope: str = ""
 
 
 @dataclass(frozen=True)
@@ -128,6 +137,7 @@ def load_settings() -> Settings:
         issuer=auth_issuer,
         client_id=auth_client_id,
         audience=auth_audience,
+        scope=os.environ.get("ADA_VIEWER_AUTH_SCOPE", "").strip(),
         admin_group=os.environ.get("ADA_VIEWER_AUTH_ADMIN_GROUP", "").strip(),
         cli_token_secret=os.environ.get("ADA_VIEWER_CLI_TOKEN_SECRET", "").strip(),
     )

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -825,6 +825,9 @@ async def _process_one(
                 # STEP→GLB streaming defaults (large-file OOM guard).
                 "step_streamer_auto": "ADA_STEP_STREAMER_AUTO",
                 "step_streamer_threshold_mb": "ADA_STEP_STREAMER_THRESHOLD_MB",
+                # Per-solid tessellation budget; a solid that overruns it (OCC hang) is
+                # killed and skipped so one bad solid can't freeze the whole conversion.
+                "step_stream_solid_timeout_s": "ADA_STEP_STREAM_SOLID_TIMEOUT_S",
             }
             for skey, env_name in _env_map.items():
                 raw = await _read_bool_setting(skey)

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -45,6 +45,14 @@ def _tessellate_geom_worker(geom):
 
     gid = None
     try:
+        import os
+
+        _hang = os.environ.get("ADA_STEP_STREAM_TEST_HANG_S")  # test hook: simulate an OCC hang
+        if _hang:
+            import time
+
+            time.sleep(float(_hang))
+
         from ada.cad import active_backend
 
         be = active_backend()
@@ -72,6 +80,36 @@ def _tessellate_geom_worker(geom):
         return ("ok", gid, geom.color, pos, idx, nrm)
     except Exception as exc:  # noqa: BLE001 - report and skip; one bad solid mustn't abort
         return (f"error:{type(exc).__name__}", gid, None, None, None, None)
+
+
+def _pool_worker_loop(worker_id, task_q, result_q) -> None:
+    """Long-lived pool worker: pull one geom at a time, tessellate it, and put
+    ``(worker_id, result)`` back. The worker_id lets the parent free the right slot and
+    — crucially — terminate THIS worker if it overruns the per-solid timeout (an OCC
+    tessellation can hang in an uninterruptible C call; only killing the process stops
+    it). ``None`` is the shutdown sentinel."""
+    while True:
+        geom = task_q.get()
+        if geom is None:
+            return
+        result_q.put((worker_id, _tessellate_geom_worker(geom)))
+
+
+def _per_solid_timeout_s() -> float:
+    """Wall-clock budget for tessellating a single solid before its worker is killed and
+    the solid skipped. ``ADA_STEP_STREAM_SOLID_TIMEOUT_S`` overrides; default 120 s is
+    far above any healthy solid (sub-second to a few seconds) but bounds a hang."""
+    import os
+
+    raw = os.environ.get("ADA_STEP_STREAM_SOLID_TIMEOUT_S")
+    if raw:
+        try:
+            v = float(raw)
+            if v > 0:
+                return v
+        except ValueError:
+            pass
+    return 120.0
 
 
 def _cgroup_cpu_quota() -> int | None:
@@ -218,42 +256,89 @@ def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) 
         for geom in geom_iter:
             _handle(_tessellate_geom_worker(geom))
     else:
-        import concurrent.futures as _cf
+        # Self-managed spawn pool (not ProcessPoolExecutor, which can't kill an
+        # individual worker): one solid per worker at a time, so a worker that overruns
+        # the per-solid timeout — an OCC tessellation hung in an uninterruptible C call —
+        # is killed, its solid skipped, and a fresh worker spawned in its place. Without
+        # this a single bad solid hangs the whole conversion forever.
         import multiprocessing as _mp
+        import queue as _queue
+        import time as _time
+
+        ctx = _mp.get_context("spawn")
+        timeout_s = _per_solid_timeout_s()
+
+        def _spawn(wid, result_q):
+            task_q = ctx.Queue(maxsize=1)
+            proc = ctx.Process(target=_pool_worker_loop, args=(wid, task_q, result_q), daemon=True)
+            proc.start()
+            return {"proc": proc, "task_q": task_q, "busy": False, "gid": None, "since": None}
 
         try:
-            executor = _cf.ProcessPoolExecutor(max_workers=n_workers, mp_context=_mp.get_context("spawn"))
-        except Exception:  # noqa: BLE001 - any pool-start failure falls back to sequential
-            executor = None
+            result_q = ctx.Queue()
+            slots = [_spawn(i, result_q) for i in range(n_workers)]
+        except Exception:  # noqa: BLE001 - pool start failure -> sequential fallback
+            slots = None
 
-        if executor is None:
+        if slots is None:
             for geom in geom_iter:
                 _handle(_tessellate_geom_worker(geom))
         else:
-            logger.info("scene_from_step_stream: tessellating with %d worker process(es)", n_workers)
-            with executor:
-                inflight: set = set()
-
-                def _submit_next() -> bool:
-                    try:
-                        inflight.add(executor.submit(_tessellate_geom_worker, next(geom_iter)))
-                        return True
-                    except StopIteration:
-                        return False
-
-                for _ in range(n_workers * 2):  # prime the pool — bounded backpressure window
-                    if not _submit_next():
-                        break
-                while inflight:
-                    done, _pending = _cf.wait(inflight, return_when=_cf.FIRST_COMPLETED)
-                    for fut in done:
-                        inflight.discard(fut)
+            logger.info(
+                "scene_from_step_stream: tessellating with %d worker process(es), %.0fs/solid timeout",
+                n_workers,
+                timeout_s,
+            )
+            exhausted = False
+            busy = 0
+            try:
+                while True:
+                    for slot in slots:  # feed every idle worker
+                        if slot["busy"] or exhausted:
+                            continue
                         try:
-                            _handle(fut.result())
-                        except Exception as exc:  # noqa: BLE001 - a crashed worker mustn't abort
-                            _skip(f"solid_{n_total}", f"pool worker died: {type(exc).__name__}")
-                            n_total += 1
-                        _submit_next()
+                            geom = next(geom_iter)
+                        except StopIteration:
+                            exhausted = True
+                            break
+                        slot["busy"] = True
+                        slot["gid"] = str(geom.id) if geom.id not in (None, "") else None
+                        slot["since"] = _time.monotonic()
+                        busy += 1
+                        slot["task_q"].put(geom)
+                    if exhausted and busy == 0:
+                        break
+                    # Collect one result; the 1 s poll bounds how often we re-check timeouts.
+                    try:
+                        wid, result = result_q.get(timeout=1.0)
+                        slot = slots[wid]
+                        if slot["busy"]:
+                            slot["busy"] = False
+                            slot["gid"] = None
+                            slot["since"] = None
+                            busy -= 1
+                            _handle(result)
+                    except _queue.Empty:
+                        pass
+                    now = _time.monotonic()
+                    for i, slot in enumerate(slots):  # kill + replace any over-budget worker
+                        if slot["busy"] and slot["since"] and (now - slot["since"]) > timeout_s:
+                            gid = slot["gid"]
+                            slot["proc"].kill()
+                            slot["proc"].join(timeout=2)
+                            busy -= 1
+                            slots[i] = _spawn(i, result_q)
+                            _handle((f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None))
+            finally:
+                for slot in slots:
+                    try:
+                        slot["task_q"].put_nowait(None)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    try:
+                        slot["proc"].kill()
+                    except Exception:  # noqa: BLE001
+                        pass
 
     # One merged mesh (glTF node) per material/colour — the default GLB shape.
     if on_progress is not None:

--- a/src/frontend/src/components/admin/ConversionSettingsTab.tsx
+++ b/src/frontend/src/components/admin/ConversionSettingsTab.tsx
@@ -77,6 +77,7 @@ const ROWS: SettingRow[] = [
 ];
 
 const STREAMER_THRESHOLD_KEY = "step_streamer_threshold_mb";
+const SOLID_TIMEOUT_KEY = "step_stream_solid_timeout_s";
 
 function parseTri(raw: string | null): TriState {
     const v = (raw || "").trim().toLowerCase();
@@ -104,6 +105,9 @@ const ConversionSettingsTab: React.FC = () => {
     const [streamerThreshold, setStreamerThreshold] = useState("");
     const [streamerSaving, setStreamerSaving] = useState(false);
     const [streamerSavedAt, setStreamerSavedAt] = useState<number | null>(null);
+    const [solidTimeout, setSolidTimeout] = useState("");
+    const [solidTimeoutSaving, setSolidTimeoutSaving] = useState(false);
+    const [solidTimeoutSavedAt, setSolidTimeoutSavedAt] = useState<number | null>(null);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState<Record<string, boolean>>({});
     const [error, setError] = useState<string | null>(null);
@@ -122,6 +126,8 @@ const ConversionSettingsTab: React.FC = () => {
                 if (!cancelled) setTimeoutMinutes((t || "").trim());
                 const thr = await viewerApi.adminGetSetting(STREAMER_THRESHOLD_KEY);
                 if (!cancelled) setStreamerThreshold((thr || "").trim());
+                const sto = await viewerApi.adminGetSetting(SOLID_TIMEOUT_KEY);
+                if (!cancelled) setSolidTimeout((sto || "").trim());
                 if (!cancelled) setValues(next);
             } catch (e) {
                 if (!cancelled) setError(e instanceof ApiError ? e.detail || e.message : String(e));
@@ -189,6 +195,27 @@ const ConversionSettingsTab: React.FC = () => {
             setError(e instanceof ApiError ? e.detail || e.message : String(e));
         } finally {
             setStreamerSaving(false);
+        }
+    };
+
+    const onSolidTimeoutSave = async () => {
+        const raw = solidTimeout.trim();
+        if (raw !== "") {
+            const n = Number(raw);
+            if (Number.isNaN(n) || n <= 0) {
+                setError(`solid timeout must be a positive number of seconds (got "${raw}")`);
+                return;
+            }
+        }
+        setSolidTimeoutSaving(true);
+        setError(null);
+        try {
+            await viewerApi.adminSetSetting(SOLID_TIMEOUT_KEY, raw);
+            setSolidTimeoutSavedAt(Date.now());
+        } catch (e) {
+            setError(e instanceof ApiError ? e.detail || e.message : String(e));
+        } finally {
+            setSolidTimeoutSaving(false);
         }
     };
 
@@ -293,6 +320,48 @@ const ConversionSettingsTab: React.FC = () => {
                             assemblies past this point risk OOM-killing the worker pod;
                             streaming trades a small fidelity loss (skipped spherical /
                             rational-B-spline solids) for bounded memory.
+                        </div>
+                    </div>
+                )}
+                {!loading && (
+                    <div className="px-3 sm:px-4 py-3 border-b border-gray-800 space-y-2">
+                        <div>
+                            <div className="font-medium text-sm">STEP streamer per-solid timeout</div>
+                            <div className="text-[11px] text-gray-400 font-mono">
+                                {SOLID_TIMEOUT_KEY}
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <input
+                                type="number"
+                                min="1"
+                                step="1"
+                                value={solidTimeout}
+                                onChange={(e) => setSolidTimeout(e.target.value)}
+                                placeholder="120"
+                                className="bg-gray-900 border border-gray-700 rounded-sm px-2 py-1 text-sm w-32 text-gray-100"
+                            />
+                            <span className="text-xs text-gray-400">seconds</span>
+                            <button
+                                type="button"
+                                onClick={onSolidTimeoutSave}
+                                disabled={solidTimeoutSaving}
+                                className="bg-blue-700 hover:bg-blue-600 text-white text-xs px-3 py-1 rounded-sm disabled:opacity-50"
+                            >
+                                {solidTimeoutSaving ? "Saving…" : "Save"}
+                            </button>
+                            {solidTimeoutSavedAt && (
+                                <span className="text-[11px] text-emerald-400">
+                                    saved {Math.floor((Date.now() - solidTimeoutSavedAt) / 1000)}s ago
+                                </span>
+                            )}
+                        </div>
+                        <div className="text-xs text-gray-400 max-w-2xl">
+                            Wall-clock budget for tessellating a single solid in the streaming
+                            STEP→GLB pool. A solid that overruns it (an OpenCASCADE hang in an
+                            uninterruptible C call) has its worker killed and the solid skipped,
+                            so one bad solid can’t freeze the whole conversion. Empty uses the
+                            code default (120 s).
                         </div>
                     </div>
                 )}

--- a/src/frontend/src/runtime/config.ts
+++ b/src/frontend/src/runtime/config.ts
@@ -33,6 +33,12 @@ declare global {
         AUTH_ISSUER?: string;
         AUTH_CLIENT_ID?: string;
         AUTH_AUDIENCE?: string;
+        // Extra scope(s) appended to the base OIDC request. Empty for
+        // providers that issue an API-audienced token from the base
+        // scopes (Authentik); set to a resource scope (e.g. Azure AD's
+        // `api://<client-id>/access_as_user`) so the access token's
+        // `aud` matches the API. Space-separated.
+        AUTH_SCOPE?: string;
         // Image tags reported by the viewer pod (env-baked at image
         // build) and the worker pod (published to NATS KV on
         // startup, surfaced here via /config.js). Either may be null
@@ -141,6 +147,10 @@ export const runtime = {
     authIssuer: (): string => (w().AUTH_ISSUER || "").replace(/\/+$/, ""),
     authClientId: (): string => w().AUTH_CLIENT_ID || "",
     authAudience: (): string => w().AUTH_AUDIENCE || w().AUTH_CLIENT_ID || "",
+    // Extra scope(s) to append to the base OIDC scope request. Empty
+    // unless the provider needs a resource scope to issue an
+    // API-audienced access token (see oidc.signIn).
+    authScope: (): string => (w().AUTH_SCOPE || "").trim(),
 
     // WebSocket / desktop bundle
     websocketPort: (): number => Number(w().WEBSOCKET_PORT ?? 8765),

--- a/src/frontend/src/services/auth/oidc.ts
+++ b/src/frontend/src/services/auth/oidc.ts
@@ -156,14 +156,20 @@ export async function signIn(returnUrl?: string): Promise<void> {
         STORAGE_RETURN,
         returnUrl || window.location.pathname + window.location.search,
     );
+    // offline_access asks the IdP to issue a refresh_token. Both
+    // Authentik and Azure honor it; without it reload-in-tab forces a
+    // re-authorize round-trip. An optional configured scope is appended
+    // for providers (e.g. Azure AD) that otherwise mint an access token
+    // audienced at something other than this API — requesting the API's
+    // own scope (api://<client-id>/access_as_user) makes the issued
+    // token's `aud` match the API. Empty (Authentik) → base scope only.
+    const baseScope = "openid profile email offline_access";
+    const extraScope = runtime.authScope();
     const params = new URLSearchParams({
         response_type: "code",
         client_id: runtime.authClientId(),
         redirect_uri: redirectUri(),
-        // offline_access asks the IdP to issue a refresh_token. Both
-        // Authentik and Azure honor it; without it reload-in-tab
-        // forces a re-authorize round-trip.
-        scope: "openid profile email offline_access",
+        scope: extraScope ? `${baseScope} ${extraScope}` : baseScope,
         code_challenge: challenge,
         code_challenge_method: "S256",
         state,

--- a/tests/core/cadit/step/test_stream_to_glb.py
+++ b/tests/core/cadit/step/test_stream_to_glb.py
@@ -88,3 +88,49 @@ def test_stream_workers_reserves_a_core_for_the_event_loop(monkeypatch):
     # An explicit override is honoured verbatim (operator owns the trade-off).
     monkeypatch.setenv("ADA_STEP_STREAM_WORKERS", "6")
     assert sfss._stream_workers() == 6
+
+
+def _total_tris(glb_bytes: bytes) -> int:
+    tree = _glb_tree(glb_bytes)
+    return sum(tree["accessors"][p["indices"]]["count"] // 3 for m in tree.get("meshes", []) for p in m["primitives"])
+
+
+def test_stream_pool_matches_sequential(monkeypatch, tmp_path):
+    # The self-managed timeout pool must produce byte-for-byte the same meshes as the
+    # sequential path — same solids, same triangle count.
+    from ada.visit.scene_handling import scene_from_step_stream as sfss
+
+    monkeypatch.setattr(sfss, "_POOL_MIN_SOLIDS", 4)  # force the pool on a small model
+    parts = [Beam(f"b{i}", (i, 0, 0), (i, 0, 3), Section("t", from_str="TUB300x20")) for i in range(8)]
+    src = tmp_path / "m.step"
+    (ada.Assembly("m") / (ada.Part("p") / parts)).to_stp(src)
+
+    monkeypatch.setenv("ADA_STEP_STREAM_WORKERS", "1")  # sequential (n_workers=1 -> no pool)
+    seq = stream_step_to_glb(src, tmp_path / "seq.glb")
+    monkeypatch.setenv("ADA_STEP_STREAM_WORKERS", "3")  # parallel pool
+    par = stream_step_to_glb(src, tmp_path / "par.glb")
+
+    assert seq["meshed"] == par["meshed"] == 8
+    assert _total_tris((tmp_path / "seq.glb").read_bytes()) == _total_tris((tmp_path / "par.glb").read_bytes())
+
+
+def test_stream_pool_per_solid_timeout_skips_hung_solid(monkeypatch, tmp_path):
+    # A solid that hangs OCC tessellation must be killed at the per-solid budget and
+    # skipped, so the conversion COMPLETES instead of freezing the whole job forever.
+    from ada.visit.scene_converter import SceneConverter
+    from ada.visit.scene_handling import scene_from_step_stream as sfss
+    from ada.visit.scene_handling.scene_from_step_stream import StepStreamSource
+
+    monkeypatch.setattr(sfss, "_POOL_MIN_SOLIDS", 2)
+    parts = [Beam(f"b{i}", (i, 0, 0), (i, 0, 3), Section("t", from_str="TUB300x20")) for i in range(6)]
+    src = tmp_path / "m.step"
+    (ada.Assembly("m") / (ada.Part("p") / parts)).to_stp(src)
+
+    monkeypatch.setenv("ADA_STEP_STREAM_WORKERS", "2")
+    monkeypatch.setenv("ADA_STEP_STREAM_TEST_HANG_S", "3")  # every solid hangs 3s
+    monkeypatch.setenv("ADA_STEP_STREAM_SOLID_TIMEOUT_S", "0.5")  # killed at 0.5s
+
+    scene = SceneConverter(source=StepStreamSource(src, tolerant=True)).build_scene()
+    stats = scene.metadata["ada_stream_stats"]
+    assert stats["meshed"] == 0  # every solid hung -> all killed + skipped
+    assert any("timeout" in r for r in stats["reasons"])  # reaped by the per-solid timeout


### PR DESCRIPTION
## Symptom

A large STEP→GLB conversion froze at **88%** for hours. The pod was healthy (one pool worker pegged at 99% CPU, the rest idle, the parent blocked in `wait()`), and no log output for 2+ hours.

## Root cause

A single pathological solid hangs OpenCASCADE tessellation in an **uninterruptible C call** — no Python signal can break it. The streaming pool's `ProcessPoolExecutor.wait(...)` blocked on that one future forever, so the conversion never finished. ~97% of solids were done; it sat on the last one.

(This is distinct from the redelivery cascade fixed in #210 — that was the pool starving the event-loop heartbeat. This is one *solid* hanging, with no per-solid timeout to recover.)

## Fix

`ProcessPoolExecutor` can't terminate an individual worker, so swap it for a small **self-managed spawn pool**:

- One solid per worker at a time.
- A worker that overruns a **per-solid budget** is killed (`SIGKILL` reaps the hung C call), its solid skipped (logged under a `timeout (…)` reason), and a fresh worker spawned in its place.
- The conversion then **completes minus the one bad solid** instead of hanging forever.

Output is identical to the sequential path (verified by test). Memory stays bounded (N in-flight solids).

## Configurable

- Default **120 s** (far above any healthy solid — sub-second to a few seconds).
- Env override `ADA_STEP_STREAM_SOLID_TIMEOUT_S`.
- Exposed in the **admin Conversion Settings panel** (`step_stream_solid_timeout_s`), wired through the worker env map alongside the existing streamer settings.

## Tests

- `test_stream_pool_matches_sequential` — the self-managed pool yields the same meshes/triangle count as sequential.
- `test_stream_pool_per_solid_timeout_skips_hung_solid` — a hung solid (via an env-gated test hook) is killed at the budget and skipped; the conversion **completes** rather than freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
