### PR TITLE
fix: orphaned last-deployed SHA must not brick the detect job

### DIFF
--- a/.forgejo/workflows/build.yaml
+++ b/.forgejo/workflows/build.yaml
@@ -186,12 +186,20 @@ jobs:
             BEFORE_GHE=""
           fi
 
-          # Resolves a sha-prefix to a full SHA; empty string when
-          # the prefix isn't in the local history.
+          # Resolves a sha-prefix to a full SHA; empty string when the prefix isn't in
+          # the local history. MUST always exit 0: under `set -e`, a failing
+          # `VAR=$(resolve ...)` aborts the whole step, and `git cat-file -e
+          # "<sha>^{commit}"` exits 128 (fatal, not a clean miss) when the sha is absent
+          # — which happens whenever a last-deployed SHA was orphaned (history rewrite /
+          # force-push / GC) and is no longer reachable from this branch. That would
+          # brick `detect` and skip every build. Swallow it and fall back to `before`.
           resolve() {
             sha="$1"
-            [ -z "$sha" ] && return
-            git cat-file -e "${sha}^{commit}" 2>/dev/null && git rev-parse "${sha}"
+            [ -z "$sha" ] && return 0
+            if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              git rev-parse "${sha}" 2>/dev/null || true
+            fi
+            return 0
           }
 
           VIEWER_BEFORE=$(resolve "$VIEWER_LAST_SHA")


### PR DESCRIPTION
## Symptom
Every CI run's `detect` job has been failing with **exit 128**, which marks all `*-build` jobs `skipped` on **every branch** — so nothing builds or deploys. The worker has been frozen on an old image for hours; merged fixes (#210, #211) couldn't ship.

## Root cause
`detect`'s `resolve()` runs `git cat-file -e "<sha>^{commit}"` on each image's last-deployed SHA read from gitops. A `^{commit}` peel on an **absent** object exits **128** (fatal — *"not a valid object name"*, not a clean miss). The deployed SHAs (`viewer:85ff739`, `worker:4ed395f`) were **orphaned by a history rewrite + force-push** and are no longer reachable from any branch, so a fresh clone doesn't have them. Under `set -e`, `VIEWER_BEFORE=$(resolve …)` then aborts the whole step.

## Fix
Make `resolve()` always exit 0 — emit the full SHA only when the prefix resolves, otherwise empty so the caller falls back to `before` (and finally "build everything"). A stale/orphaned deploy pointer now degrades to a full rebuild instead of a hard stop.

Verified under `set -e`: a present SHA resolves; an absent/orphaned SHA returns empty with exit 0 (no abort); `build.yaml` still parses. Pushing this branch self-heals its own `detect` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)