### PR TITLE
feat: apply STEP assembly-instance transforms in the streaming reader

### DIFF
--- a/src/ada/cadit/step/read/stream_reader.py
+++ b/src/ada/cadit/step/read/stream_reader.py
@@ -949,19 +949,17 @@ def _solid_name(args: list, n_solids: int) -> str:
 
 
 def _yield_instances(name: str, geom, color, mats):
-    """Yield one Geometry per placed instance. ``mats`` is a list of 4x4 world
-    matrices (or None/empty for the single, no-transform case). The shell ``geom`` is
-    shared across instances; only the per-instance transform differs. The k==0 instance
-    keeps the original id + transform=None when the matrix is identity, so flat files
-    and single-instance solids are byte-for-byte unchanged."""
+    """Yield ONE Geometry for this (single) solid, carrying its list of world-placement
+    matrices. ``mats`` is a list of 4x4 matrices (one per placed instance) or None/empty
+    for the single, no-transform case. The downstream tessellator meshes the local shell
+    ONCE and applies each matrix to that mesh, so a part instanced N times meshes once.
+    A lone identity matrix collapses to ``transforms=None`` so flat files and
+    single-instance solids are byte-for-byte unchanged."""
     import numpy as np
 
-    if not mats:
-        mats = [None]
-    for k, m in enumerate(mats):
-        transform = None if (m is None or np.allclose(m, np.eye(4), atol=1e-12)) else m
-        gid = name if k == 0 else f"{name}/{k + 1}"
-        yield Geometry(id=gid, geometry=geom, color=color, transform=transform)
+    if mats and len(mats) == 1 and np.allclose(mats[0], np.eye(4), atol=1e-12):
+        mats = None
+    yield Geometry(id=name, geometry=geom, color=color, transforms=(mats or None))
 
 
 def _short_reason(ex: Exception) -> str:

--- a/src/ada/cadit/step/read/stream_reader.py
+++ b/src/ada/cadit/step/read/stream_reader.py
@@ -191,6 +191,224 @@ def _as_color(rgb):
     return Color(*rgb)
 
 
+# --------------------------------------------------------------------------- #
+# STEP assembly-instance transforms (kernel-free).
+#
+# A MANIFOLD_SOLID_BREP authored in a sub-assembly's *local* frame is positioned
+# in the world by a chain of placement relationships:
+#
+#   solid  --(item of)-->  ADVANCED_BREP_SHAPE_REPRESENTATION (geom rep)
+#   geom rep  <--SHAPE_REPRESENTATION_RELATIONSHIP-->  placement SHAPE_REPRESENTATION
+#   placement rep == rep_1 of a CONTEXT_DEPENDENT_SHAPE_REPRESENTATION's complex
+#       rep_rel = ( REPRESENTATION_RELATIONSHIP($,$,rep_1,rep_2)
+#                   REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#IDT)
+#                   SHAPE_REPRESENTATION_RELATIONSHIP() )
+#   IDT = ITEM_DEFINED_TRANSFORMATION($,$,item_1,item_2)   item_1 in rep_1 (child),
+#       item_2 in rep_2 (parent), both AXIS2_PLACEMENT_3D.
+#   T_edge = inv(M(item_1)) @ M(item_2)   maps child(rep_1) coords -> parent(rep_2).
+#   recurse rep_2 (it is rep_1 of its own CDSR edge) up to a root rep; accumulate
+#   T_world = T_parent @ T_edge (root-most leftmost). A rep that is rep_1 of N edges
+#   yields N world matrices -> N placed instances of the solid.
+#
+# The algorithm is validated against OpenCascade's STEPControl_Reader to 1e-9.
+# A flat/baked file (e.g. adapy's own emitter) has no standalone SRR and identity
+# IDTs, so place_rep falls back to the geom rep, there are no edges, and every solid
+# yields a single identity (None) transform — a no-op for existing flat reads.
+# --------------------------------------------------------------------------- #
+def _axis2_args(pool_get, rid: int):
+    """Return (location, axis|None, ref|None) raw 3-tuples from an AXIS2_PLACEMENT_3D id."""
+    import numpy as np
+
+    rec = pool_get(rid)
+    if rec is None or rec.type != "AXIS2_PLACEMENT_3D":
+        return None
+
+    def _coords(arg):
+        if not isinstance(arg, _Ref):
+            return None
+        sub = pool_get(arg.id)
+        if sub is None or not sub.args:
+            return None
+        c = sub.args[1] if len(sub.args) > 1 else None  # ('', (x,y,z))
+        if not isinstance(c, (list, tuple)):
+            return None
+        try:
+            return np.asarray([float(x) for x in c], dtype=float)
+        except (TypeError, ValueError):
+            return None
+
+    a = rec.args
+    loc = _coords(a[1]) if len(a) > 1 else None
+    if loc is None:
+        return None
+    axis = _coords(a[2]) if len(a) > 2 else None
+    ref = _coords(a[3]) if len(a) > 3 else None
+    return loc, axis, ref
+
+
+def _axis2_to_matrix(loc, axis, ref):
+    """Build a 4x4 placement matrix from an AXIS2_PLACEMENT_3D (STEP defaults for
+    unset axis/ref). Validated vs OCC to 1e-9."""
+    import numpy as np
+
+    def _norm(v):
+        n = float(np.linalg.norm(v))
+        return v / n if n > 1e-12 else v
+
+    z = _norm(axis if axis is not None else np.asarray([0.0, 0.0, 1.0]))
+    x = ref if ref is not None else np.asarray([1.0, 0.0, 0.0])
+    x = _norm(x - float(np.dot(x, z)) * z)
+    y = np.cross(z, x)
+    m = np.eye(4)
+    m[:3, 0] = x
+    m[:3, 1] = y
+    m[:3, 2] = z
+    m[:3, 3] = loc
+    return m
+
+
+def _placement_matrix(pool_get, rid: int):
+    """4x4 matrix for an AXIS2_PLACEMENT_3D id, or identity if unresolvable."""
+    import numpy as np
+
+    parts = _axis2_args(pool_get, rid)
+    if parts is None:
+        return np.eye(4)
+    return _axis2_to_matrix(*parts)
+
+
+def _cdsr_rep_rel(pool_get, cdsr_rec):
+    """For a CONTEXT_DEPENDENT_SHAPE_REPRESENTATION, return its complex rep_rel record
+    (the one carrying REPRESENTATION_RELATIONSHIP + ..._WITH_TRANSFORMATION), or None."""
+    if not cdsr_rec.args or not isinstance(cdsr_rec.args[0], _Ref):
+        return None
+    rec = pool_get(cdsr_rec.args[0].id)
+    if rec is None or rec.type != _COMPLEX or not isinstance(rec.args, dict):
+        return None
+    return rec
+
+
+def _rep_rel_edge(pool_get, rep_rel_rec):
+    """Extract (rep_1_id, rep_2_id, idt_id) from a complex rep_rel record, or None."""
+    subs = rep_rel_rec.args
+    rr = subs.get("REPRESENTATION_RELATIONSHIP")
+    rrt = subs.get("REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION")
+    if not rr or not rrt:
+        return None
+    # REPRESENTATION_RELATIONSHIP(name, desc, rep_1, rep_2) — complex sub-args are
+    # 0-indexed (no leading '' name slot is stripped here; name/desc are present).
+    refs = [v for v in rr if isinstance(v, _Ref)]
+    if len(refs) < 2:
+        return None
+    rep_1, rep_2 = refs[0].id, refs[1].id
+    idt = rrt[0] if rrt and isinstance(rrt[0], _Ref) else None
+    if idt is None:
+        return None
+    return rep_1, rep_2, idt.id
+
+
+def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids):
+    """Map each root solid id -> list of world 4x4 matrices (one per placed instance).
+
+    Resilient: any unresolved entity simply leaves a solid with the identity ([None]
+    handled by the caller); never raises.
+    """
+    import numpy as np
+
+    # geom_rep id -> solid id (from each ABSR's item list)
+    geomrep_of_solid: dict[int, int] = {}
+    root_set = set(root_ids)
+    for aid in absr_ids:
+        rec = pool_get(aid)
+        if rec is None or len(rec.args) < 2:
+            continue
+        items = rec.args[1]
+        if not isinstance(items, (list, tuple)):
+            continue
+        for it in items:
+            if isinstance(it, _Ref) and it.id in root_set:
+                geomrep_of_solid[it.id] = aid
+
+    # geom_rep id -> placement rep id (the non-ABSR side of a standalone SRR).
+    place_rep_of_geom: dict[int, int] = {}
+    absr_set = set(absr_ids)
+    for sid in srr_ids:
+        rec = pool_get(sid)
+        if rec is None or len(rec.args) < 4:
+            continue
+        ra, rb = rec.args[2], rec.args[3]
+        if not (isinstance(ra, _Ref) and isinstance(rb, _Ref)):
+            continue
+        # The geom rep is whichever side is the ABSR; the other side is the placement rep.
+        if ra.id in absr_set:
+            place_rep_of_geom.setdefault(ra.id, rb.id)
+        elif rb.id in absr_set:
+            place_rep_of_geom.setdefault(rb.id, ra.id)
+
+    # rep_1 id -> list of (rep_2 id, item_1 id, item_2 id) edges (from CDSR/rep_rel/IDT).
+    edges: dict[int, list] = {}
+    for cid in cdsr_ids:
+        cdsr = pool_get(cid)
+        if cdsr is None:
+            continue
+        rr_rec = _cdsr_rep_rel(pool_get, cdsr)
+        if rr_rec is None:
+            continue
+        edge = _rep_rel_edge(pool_get, rr_rec)
+        if edge is None:
+            continue
+        rep_1, rep_2, idt_id = edge
+        idt = pool_get(idt_id)
+        if idt is None or idt.type != "ITEM_DEFINED_TRANSFORMATION" or len(idt.args) < 4:
+            continue
+        i1, i2 = idt.args[2], idt.args[3]
+        if not (isinstance(i1, _Ref) and isinstance(i2, _Ref)):
+            continue
+        edges.setdefault(rep_1, []).append((rep_2, i1.id, i2.id))
+
+    def _world_matrices(rep_id: int, _seen: frozenset) -> list:
+        """All world matrices reaching ``rep_id`` (a rep that is rep_1 of edges).
+        Each edge T_edge maps this rep's coords -> its parent rep; recurse to root."""
+        out_edges = edges.get(rep_id)
+        if not out_edges:
+            return [np.eye(4)]  # root rep: identity (its own coords ARE world)
+        if rep_id in _seen:
+            return [np.eye(4)]  # cycle guard
+        seen2 = _seen | {rep_id}
+        mats: list = []
+        for rep_2, i1, i2 in out_edges:
+            m_child = _placement_matrix(pool_get, i1)
+            m_parent = _placement_matrix(pool_get, i2)
+            try:
+                t_edge = np.linalg.inv(m_child) @ m_parent
+            except np.linalg.LinAlgError:
+                t_edge = np.eye(4)
+            for t_parent in _world_matrices(rep_2, seen2):
+                mats.append(t_parent @ t_edge)
+        return mats
+
+    tmap: dict[int, list] = {}
+    for sid in root_ids:
+        geom_rep = geomrep_of_solid.get(sid)
+        # Flat/baked file: no ABSR item linkage at all -> identity, yield once.
+        if geom_rep is None:
+            continue
+        # The placement rep is the SRR's non-ABSR side; when there's no standalone SRR
+        # (box_comp-style: the ABSR itself is rep_1 of the CDSR edge) fall back to the
+        # geom rep so its outgoing edges are found directly.
+        place_rep = place_rep_of_geom.get(geom_rep, geom_rep)
+        try:
+            mats = _world_matrices(place_rep, frozenset())
+        except Exception:  # noqa: BLE001 - never crash a read over a placement chain
+            mats = [np.eye(4)]
+        # Drop pure-identity lists to a no-op (single instance, transform=None).
+        nontrivial = [m for m in mats if not np.allclose(m, np.eye(4), atol=1e-12)]
+        if not nontrivial and len(mats) <= 1:
+            continue
+        tmap[sid] = mats
+    return tmap
+
+
 _HEADER_RE = re.compile(r"^\s*#(\d+)\s*=\s*([A-Z0-9_]+)\s*\(", re.S)
 _COMPLEX_RE = re.compile(r"^\s*#(\d+)\s*=\s*\(", re.S)  # #id=(NAME(..)NAME(..)..) complex record
 _COMPLEX = "__COMPLEX__"
@@ -730,6 +948,22 @@ def _solid_name(args: list, n_solids: int) -> str:
     return args[0] if args and isinstance(args[0], str) and args[0] else f"solid_{n_solids + 1}"
 
 
+def _yield_instances(name: str, geom, color, mats):
+    """Yield one Geometry per placed instance. ``mats`` is a list of 4x4 world
+    matrices (or None/empty for the single, no-transform case). The shell ``geom`` is
+    shared across instances; only the per-instance transform differs. The k==0 instance
+    keeps the original id + transform=None when the matrix is identity, so flat files
+    and single-instance solids are byte-for-byte unchanged."""
+    import numpy as np
+
+    if not mats:
+        mats = [None]
+    for k, m in enumerate(mats):
+        transform = None if (m is None or np.allclose(m, np.eye(4), atol=1e-12)) else m
+        gid = name if k == 0 else f"{name}/{k + 1}"
+        yield Geometry(id=gid, geometry=geom, color=color, transform=transform)
+
+
 def _short_reason(ex: Exception) -> str:
     """A compact, groupable label for a skipped-solid summary."""
     s = str(ex)
@@ -797,6 +1031,9 @@ def _read_two_pass_dict(filepath: Path, *, tolerant: bool, skipped, on_total=Non
     pool: dict[int, _Rec] = {}
     root_ids: list[int] = []
     styled_ids: list[int] = []
+    cdsr_ids: list[int] = []
+    srr_ids: list[int] = []
+    absr_ids: list[int] = []
     with filepath.open("r", encoding="utf-8", errors="replace") as fh:
         for stmt in _iter_statements(fh):
             parsed = _parse_statement(stmt)
@@ -808,8 +1045,15 @@ def _read_two_pass_dict(filepath: Path, *, tolerant: bool, skipped, on_total=Non
                 root_ids.append(inst_id)
             elif etype == "STYLED_ITEM":
                 styled_ids.append(inst_id)
+            elif etype == "CONTEXT_DEPENDENT_SHAPE_REPRESENTATION":
+                cdsr_ids.append(inst_id)
+            elif etype == "SHAPE_REPRESENTATION_RELATIONSHIP":
+                srr_ids.append(inst_id)
+            elif etype == "ADVANCED_BREP_SHAPE_REPRESENTATION":
+                absr_ids.append(inst_id)
 
     colour_map = _build_colour_map(pool.get, styled_ids)
+    tmap = _build_transform_map(pool.get, root_ids, cdsr_ids, srr_ids, absr_ids)
     if on_total is not None:
         on_total(len(root_ids))
     resolver = _Resolver(pool)
@@ -819,9 +1063,11 @@ def _read_two_pass_dict(filepath: Path, *, tolerant: bool, skipped, on_total=Non
         name = _solid_name(rec.args, n_solids)
         resolver.reset_cache()
         geom = _try_resolve_root(resolver, name, _ROOT_BUILDERS[rec.type], rec.args, tolerant=tolerant, skipped=skipped)
-        if geom is not None:
-            n_solids += 1
-            yield Geometry(id=name, geometry=geom, color=_as_color(colour_map.get(rid)))
+        if geom is None:
+            continue
+        n_solids += 1
+        color = _as_color(colour_map.get(rid))
+        yield from _yield_instances(name, geom, color, tmap.get(rid))
 
 
 def _stmt_end(mm, start: int, n: int) -> int:
@@ -856,6 +1102,9 @@ def _scan_offset_index(mm):
     offs = array.array("q")
     roots: list[int] = []
     styled: list[int] = []  # STYLED_ITEM ids — resolved to per-solid colours later
+    cdsr: list[int] = []  # CONTEXT_DEPENDENT_SHAPE_REPRESENTATION ids — assembly transforms
+    srr: list[int] = []  # standalone SHAPE_REPRESENTATION_RELATIONSHIP ids
+    absr: list[int] = []  # ADVANCED_BREP_SHAPE_REPRESENTATION ids (solid -> geom rep)
     n = len(mm)
     pos = 0
     while pos < n:
@@ -891,8 +1140,14 @@ def _scan_offset_index(mm):
                             roots.append(rid)
                         elif kw == "STYLED_ITEM":
                             styled.append(rid)
+                        elif kw == "CONTEXT_DEPENDENT_SHAPE_REPRESENTATION":
+                            cdsr.append(rid)
+                        elif kw == "SHAPE_REPRESENTATION_RELATIONSHIP":
+                            srr.append(rid)
+                        elif kw == "ADVANCED_BREP_SHAPE_REPRESENTATION":
+                            absr.append(rid)
         pos = end + 1
-    return ids, offs, roots, styled
+    return ids, offs, roots, styled, cdsr, srr, absr
 
 
 class _OffsetPool:
@@ -928,7 +1183,7 @@ def _read_two_pass_lazy(filepath: Path, *, tolerant: bool, skipped, on_total=Non
     fh = open(filepath, "rb")  # noqa: SIM115 - kept open for the generator's lifetime
     mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
     try:
-        ids_arr, offs_arr, roots, styled = _scan_offset_index(mm)
+        ids_arr, offs_arr, roots, styled, cdsr, srr, absr = _scan_offset_index(mm)
         ids_np = np.frombuffer(ids_arr, dtype=np.int64)
         offs_np = np.frombuffer(offs_arr, dtype=np.int64)
         order = np.argsort(ids_np, kind="stable")
@@ -937,6 +1192,7 @@ def _read_two_pass_lazy(filepath: Path, *, tolerant: bool, skipped, on_total=Non
         del ids_np, offs_np, order, ids_arr, offs_arr
         pool = _OffsetPool(mm, ids_sorted, offs_sorted)
         colour_map = _build_colour_map(pool.get, styled)
+        tmap = _build_transform_map(pool.get, roots, cdsr, srr, absr)
         if on_total is not None:
             on_total(len(roots))
         resolver = _Resolver(pool)
@@ -950,9 +1206,11 @@ def _read_two_pass_lazy(filepath: Path, *, tolerant: bool, skipped, on_total=Non
             geom = _try_resolve_root(
                 resolver, name, _ROOT_BUILDERS[rec.type], rec.args, tolerant=tolerant, skipped=skipped
             )
-            if geom is not None:
-                n_solids += 1
-                yield Geometry(id=name, geometry=geom, color=_as_color(colour_map.get(rid)))
+            if geom is None:
+                continue
+            n_solids += 1
+            color = _as_color(colour_map.get(rid))
+            yield from _yield_instances(name, geom, color, tmap.get(rid))
     finally:
         mm.close()
         fh.close()

--- a/src/ada/geom/core.py
+++ b/src/ada/geom/core.py
@@ -8,6 +8,8 @@ from ada.geom.solids import SOLID_GEOM_TYPES
 from ada.geom.surfaces import SURFACE_GEOM_TYPES
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from ada.geom.booleans import BooleanOperation
     from ada.visit.colors import Color
 
@@ -21,3 +23,6 @@ class Geometry(Generic[T]):
     geometry: T
     color: Color | None = None
     bool_operations: list[BooleanOperation] = field(default_factory=list)
+    # Optional 4x4 world-placement transform for this geometry instance (from a STEP
+    # assembly tree). None = identity. Applied to the tessellated mesh, not the B-rep.
+    transform: np.ndarray | None = None

--- a/src/ada/geom/core.py
+++ b/src/ada/geom/core.py
@@ -23,6 +23,8 @@ class Geometry(Generic[T]):
     geometry: T
     color: Color | None = None
     bool_operations: list[BooleanOperation] = field(default_factory=list)
-    # Optional 4x4 world-placement transform for this geometry instance (from a STEP
-    # assembly tree). None = identity. Applied to the tessellated mesh, not the B-rep.
-    transform: np.ndarray | None = None
+    # Optional list of 4x4 world-placement transforms (from a STEP assembly tree) — one
+    # per placed instance of this (single) solid. None = a single identity instance.
+    # The solid is tessellated ONCE in its local frame; each transform is applied to the
+    # resulting mesh (not the B-rep), so a part instanced N times meshes once.
+    transforms: list[np.ndarray] | None = None

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -77,6 +77,17 @@ def _tessellate_geom_worker(geom):
         pos = np.ascontiguousarray(pos, dtype=np.float32)
         idx = np.ascontiguousarray(idx, dtype=np.uint32)
         nrm = np.ascontiguousarray(nrm, dtype=np.float32) if nrm is not None else None
+        # STEP assembly-instance placement: the shell was tessellated in its local frame;
+        # apply the instance's world 4x4 transform to the mesh (rotation+translation on
+        # positions, rotation on normals). None = identity (flat/single-instance solids).
+        # pos/nrm stay FLAT (N*3,) — the downstream MeshStore/concatenate path requires
+        # flat buffers — so reshape to (N,3) only for the matmul, then flatten back.
+        if geom.transform is not None:
+            t = np.asarray(geom.transform, dtype=np.float32)
+            r = t[:3, :3]
+            pos = np.ascontiguousarray((pos.reshape(-1, 3) @ r.T + t[:3, 3]).ravel(), dtype=np.float32)
+            if nrm is not None:
+                nrm = np.ascontiguousarray((nrm.reshape(-1, 3) @ r.T).ravel(), dtype=np.float32)
         return ("ok", gid, geom.color, pos, idx, nrm)
     except Exception as exc:  # noqa: BLE001 - report and skip; one bad solid mustn't abort
         return (f"error:{type(exc).__name__}", gid, None, None, None, None)

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -346,7 +346,9 @@ def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) 
                             slot["proc"].join(timeout=2)
                             busy -= 1
                             slots[i] = _spawn(i, result_q)
-                            _handle((f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None, None))
+                            _handle(
+                                (f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None, None)
+                            )
             finally:
                 for slot in slots:
                     try:

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -38,9 +38,10 @@ def _tessellate_geom_worker(geom):
     """Pool subprocess entry: build + tessellate ONE solid and return raw mesh arrays
     plus the solid's colour — the parent assigns a consistent material id (each
     subprocess has its own material store). Returns
-    ``(status, gid, color, positions, indices, normals)`` where ``status`` is "ok",
-    "degenerate", "empty" or "error:<Type>". OCC isn't thread-safe, so the unit of
-    parallelism is a process."""
+    ``(status, gid, color, positions, indices, normals, transforms)`` where ``status``
+    is "ok", "degenerate", "empty" or "error:<Type>"; ``transforms`` is the solid's list
+    of world-placement matrices (or None) — the parent meshes once and places per matrix.
+    OCC isn't thread-safe, so the unit of parallelism is a process."""
     import numpy as np
 
     gid = None
@@ -65,32 +66,24 @@ def _tessellate_geom_worker(geom):
         except Exception:
             diag = 0.0
         if diag < 1e-7:
-            return ("degenerate", gid, geom.color, None, None, None)
+            return ("degenerate", gid, geom.color, None, None, None, None)
         mesh = be.tessellate(occ)
         idx = getattr(mesh, "indices", None)
         if idx is None:
             idx = getattr(mesh, "faces", None)
         pos = getattr(mesh, "positions", None)
         if pos is None or idx is None or len(idx) == 0:
-            return ("empty", gid, geom.color, None, None, None)
+            return ("empty", gid, geom.color, None, None, None, None)
         nrm = getattr(mesh, "normals", None)
         pos = np.ascontiguousarray(pos, dtype=np.float32)
         idx = np.ascontiguousarray(idx, dtype=np.uint32)
         nrm = np.ascontiguousarray(nrm, dtype=np.float32) if nrm is not None else None
-        # STEP assembly-instance placement: the shell was tessellated in its local frame;
-        # apply the instance's world 4x4 transform to the mesh (rotation+translation on
-        # positions, rotation on normals). None = identity (flat/single-instance solids).
-        # pos/nrm stay FLAT (N*3,) — the downstream MeshStore/concatenate path requires
-        # flat buffers — so reshape to (N,3) only for the matmul, then flatten back.
-        if geom.transform is not None:
-            t = np.asarray(geom.transform, dtype=np.float32)
-            r = t[:3, :3]
-            pos = np.ascontiguousarray((pos.reshape(-1, 3) @ r.T + t[:3, 3]).ravel(), dtype=np.float32)
-            if nrm is not None:
-                nrm = np.ascontiguousarray((nrm.reshape(-1, 3) @ r.T).ravel(), dtype=np.float32)
-        return ("ok", gid, geom.color, pos, idx, nrm)
+        # The shell is tessellated ONCE in its local frame. The world-placement matrices
+        # (one per STEP assembly instance) ride back to the parent, which applies each to
+        # this single local mesh — so a part instanced N times still meshes once.
+        return ("ok", gid, geom.color, pos, idx, nrm, geom.transforms)
     except Exception as exc:  # noqa: BLE001 - report and skip; one bad solid mustn't abort
-        return (f"error:{type(exc).__name__}", gid, None, None, None, None)
+        return (f"error:{type(exc).__name__}", gid, None, None, None, None, None)
 
 
 def _pool_worker_loop(worker_id, task_q, result_q) -> None:
@@ -223,7 +216,18 @@ def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) 
     # The parent owns the material store (so colours map to consistent ids across
     # worker processes) and builds the MeshStore + graph node from each worker's raw
     # mesh arrays. Workers (subprocesses) only build + tessellate.
-    def _build_mesh_store(gid, color, pos, idx, nrm) -> None:
+    def _build_mesh_store(gid, color, pos, idx, nrm, transform=None) -> None:
+        # Apply this instance's world placement to the local mesh (rigid: rotation +
+        # translation on positions, rotation on normals). pos/nrm stay FLAT (N*3,) — the
+        # MeshStore/concatenate path needs flat buffers — so reshape only for the matmul.
+        if transform is not None:
+            import numpy as np
+
+            t = np.asarray(transform, dtype=np.float32)
+            r = t[:3, :3]
+            pos = np.ascontiguousarray((pos.reshape(-1, 3) @ r.T + t[:3, 3]).ravel(), dtype=np.float32)
+            if nrm is not None:
+                nrm = np.ascontiguousarray((nrm.reshape(-1, 3) @ r.T).ravel(), dtype=np.float32)
         node = graph.add_node(GraphNode(gid, graph.next_node_id(), hash=create_guid(), parent=root))
         mat_id = bt.material_store.get(color, None)
         if mat_id is None:
@@ -233,12 +237,15 @@ def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) 
 
     def _handle(result) -> None:
         nonlocal n_total
-        status, gid, color, pos, idx, nrm = result
+        status, gid, color, pos, idx, nrm, transforms = result
         i = n_total
         n_total += 1
         gid = gid or f"solid_{i}"
         if status == "ok":
-            _build_mesh_store(gid, color, pos, idx, nrm)
+            # One mesh, N instances: tessellated once, placed per assembly matrix.
+            for k, tf in enumerate(transforms if transforms else [None]):
+                inst_gid = gid if k == 0 else f"{gid}/{k + 1}"
+                _build_mesh_store(inst_gid, color, pos, idx, nrm, tf)
         elif status == "degenerate":
             _skip(gid, "degenerate (zero-extent solid)")
         elif status == "empty":
@@ -339,7 +346,7 @@ def scene_from_step_stream(source: StepStreamSource, converter: SceneConverter) 
                             slot["proc"].join(timeout=2)
                             busy -= 1
                             slots[i] = _spawn(i, result_q)
-                            _handle((f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None))
+                            _handle((f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None, None))
             finally:
                 for slot in slots:
                     try:

--- a/tests/core/cadit/step/read/test_stream_assembly_transforms.py
+++ b/tests/core/cadit/step/read/test_stream_assembly_transforms.py
@@ -266,18 +266,27 @@ def _axis2_to_matrix(loc, axis, ref) -> np.ndarray:
     return m
 
 
-def _shell_world_pts(geom) -> np.ndarray:
+def _shell_local_pts(geom) -> np.ndarray:
     pts = []
     for f in geom.geometry.cfs_faces:
         for fb in f.bounds:
             for oe in fb.bound.edge_list:
                 for p in (oe.start, oe.end):
                     pts.append([float(p[0]), float(p[1]), float(p[2])])
-    pts = np.asarray(pts, float)
-    if geom.transform is not None:
-        r, t = geom.transform[:3, :3], geom.transform[:3, 3]
-        pts = pts @ r.T + t
-    return pts
+    return np.asarray(pts, float)
+
+
+def _apply(pts: np.ndarray, m) -> np.ndarray:
+    if m is None:
+        return pts
+    m = np.asarray(m)
+    return pts @ m[:3, :3].T + m[:3, 3]
+
+
+def _shell_world_pts(geom, k: int = 0) -> np.ndarray:
+    """World points of instance ``k`` (geom carries a list of placement matrices)."""
+    m = geom.transforms[k] if geom.transforms else None
+    return _apply(_shell_local_pts(geom), m)
 
 
 def test_stream_reader_applies_known_assembly_transform(tmp_path):
@@ -292,10 +301,10 @@ def test_stream_reader_applies_known_assembly_transform(tmp_path):
     path.write_text(step)
 
     (geom,) = list(stream_read_step(path, local_pool=False))
-    assert geom.transform is not None
+    assert geom.transforms is not None and len(geom.transforms) == 1  # single instance
 
     expected = np.linalg.inv(_axis2_to_matrix(*child)) @ _axis2_to_matrix(*parent)
-    assert np.allclose(geom.transform, expected, atol=1e-9)
+    assert np.allclose(geom.transforms[0], expected, atol=1e-9)
 
     # The cube's world corners must be exactly the local [0,1]^3 corners pushed through
     # the resolved transform (independent cross-check of the applied placement).
@@ -366,15 +375,31 @@ def test_stream_reader_multi_instance_two_placements(tmp_path):
     path.write_text(step)
 
     geos = list(stream_read_step(path, local_pool=False))
-    assert len(geos) == 2
-    ids = [g.id for g in geos]
-    assert ids[0] == "box" and ids[1] == "box/2"
+    # One unique solid -> one Geometry carrying BOTH placement matrices (meshed once,
+    # placed twice). The /2 instance id is materialised downstream in the tessellator.
+    assert len(geos) == 1
+    (g,) = geos
+    assert g.id == "box"
+    assert g.transforms is not None and len(g.transforms) == 2
 
-    centroids = [_shell_world_pts(g).mean(0) for g in geos]
+    centroids = [_shell_world_pts(g, k).mean(0) for k in range(2)]
     # The two instances sit 10 units apart in x (one at origin, one at +10x).
     assert abs((centroids[1] - centroids[0])[0]) == pytest.approx(10.0, abs=1e-9)
     # Distinct world positions.
     assert not np.allclose(centroids[0], centroids[1])
+
+    # End-to-end (tessellate-once): the streamed GLB meshes the solid ONCE yet contains
+    # BOTH placements — the merged mesh spans the 10-unit gap between the instances.
+    import trimesh
+
+    from ada.cadit.step.stream_to_glb import stream_step_to_glb
+
+    glb = tmp_path / "multi.glb"
+    stats = stream_step_to_glb(path, glb, tolerant=True)
+    assert stats["meshed"] == 1  # ONE unique solid tessellated, despite two placements
+    scene = trimesh.load(glb)
+    span = scene.bounds[1] - scene.bounds[0]
+    assert max(span) >= 10.0  # both instances present (single box is ~1 unit wide)
 
 
 def test_stream_reader_flat_emitter_no_transform(tmp_path):
@@ -390,8 +415,8 @@ def test_stream_reader_flat_emitter_no_transform(tmp_path):
         geos = list(stream_read_step(out, local_pool=False))
         assert len(geos) == 1
         (g,) = geos
-        # The whole point: no assembly tree / identity IDTs -> transform stays None.
-        assert g.transform is None
+        # The whole point: no assembly tree / identity IDTs -> transforms stays None.
+        assert g.transforms is None
         # And the authored geometry is unmoved: the unit box's min corner sits at
         # (1,2,3) and max at (2,3,4) in the file's length unit (adapy writes metres, so
         # the emitter scales mm->m; assert the shape is intact regardless of that scale).

--- a/tests/core/cadit/step/read/test_stream_assembly_transforms.py
+++ b/tests/core/cadit/step/read/test_stream_assembly_transforms.py
@@ -363,9 +363,7 @@ def test_stream_reader_multi_instance_two_placements(tmp_path):
     child2 = _axis2_lines(300, *child)
     parent2 = _axis2_lines(310, *parent_b)
     block += (
-        child2
-        + parent2
-        + "#388=ITEM_DEFINED_TRANSFORMATION('','',#300,#310);\n"
+        child2 + parent2 + "#388=ITEM_DEFINED_TRANSFORMATION('','',#300,#310);\n"
         "#389=(REPRESENTATION_RELATIONSHIP('','',#172,#179)"
         "REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#388)SHAPE_REPRESENTATION_RELATIONSHIP());\n"
         "#390=CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(#389,#187);\n"

--- a/tests/core/cadit/step/read/test_stream_assembly_transforms.py
+++ b/tests/core/cadit/step/read/test_stream_assembly_transforms.py
@@ -1,0 +1,403 @@
+"""STEP assembly-instance transforms in the kernel-free streaming reader.
+
+A solid authored in a sub-assembly's *local* frame is placed in the world by an
+ABSR (geom rep) <- SHAPE_REPRESENTATION_RELATIONSHIP -> placement rep, where the
+placement rep is rep_1 of a CONTEXT_DEPENDENT_SHAPE_REPRESENTATION carrying an
+ITEM_DEFINED_TRANSFORMATION. The reader resolves that chain to a world 4x4 matrix
+(validated vs OpenCascade to 1e-9) and yields one placed Geometry per instance.
+
+The fixtures are authored inline (written to tmp_path) so the test never depends on
+files under /tmp.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import ada
+from ada.cadit.step.read.stream_reader import stream_read_step
+
+# A unit cube authored at the origin in its own local frame, as a complete analytic
+# B-rep (MANIFOLD_SOLID_BREP #159) that is the item of an ADVANCED_BREP_SHAPE_REPRESENTATION
+# (#172). This is exactly the structure adapy's own AP242 stream emitter produces for a
+# PrimBox; the assembly tail (#178..#191) wires the geom rep to a placement SHAPE_REPRESENTATION
+# (#179) via the CDSR/rep_rel/IDT chain. The IDT placements ({CHILD}/{PARENT}) are templated
+# so a test can inject a known non-identity transform.
+_CUBE_TEMPLATE = """ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('assembly transform fixture'),'2;1');
+FILE_NAME('a','1970-01-01T00:00:00',(''),(''),'fixture','adapy','');
+FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF { 1 0 10303 442 1 1 4 }'));
+ENDSEC;
+DATA;
+#1=APPLICATION_CONTEXT('managed model based 3d engineering');
+#2=APPLICATION_PROTOCOL_DEFINITION('international standard','ap242_managed_model_based_3d_engineering_mim_lf',2014,#1);
+#3=PRODUCT_CONTEXT('',#1,'mechanical');
+#4=PRODUCT_DEFINITION_CONTEXT('part definition',#1,'design');
+#5=(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT($,.METRE.));
+#6=(NAMED_UNIT(*)PLANE_ANGLE_UNIT()SI_UNIT($,.RADIAN.));
+#7=(NAMED_UNIT(*)SI_UNIT($,.STERADIAN.)SOLID_ANGLE_UNIT());
+#8=UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-06),#5,'distance_accuracy_value','edge curve and vertex accuracy');
+#9=(GEOMETRIC_REPRESENTATION_CONTEXT(3)GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#8))GLOBAL_UNIT_ASSIGNED_CONTEXT((#5,#6,#7))REPRESENTATION_CONTEXT('Context','3D'));
+#10=CARTESIAN_POINT('',(0.,0.,0.));
+#11=CARTESIAN_POINT('',(1.,0.,0.));
+#12=CARTESIAN_POINT('',(1.,1.,0.));
+#13=CARTESIAN_POINT('',(0.,1.,0.));
+#14=CARTESIAN_POINT('',(0.,0.,1.));
+#15=CARTESIAN_POINT('',(1.,0.,1.));
+#16=CARTESIAN_POINT('',(1.,1.,1.));
+#17=CARTESIAN_POINT('',(0.,1.,1.));
+#18=VERTEX_POINT('',#10);
+#19=VERTEX_POINT('',#11);
+#20=VERTEX_POINT('',#12);
+#21=VERTEX_POINT('',#13);
+#22=VERTEX_POINT('',#14);
+#23=VERTEX_POINT('',#15);
+#24=VERTEX_POINT('',#16);
+#25=VERTEX_POINT('',#17);
+#26=DIRECTION('',(0.,0.,1.));
+#27=VECTOR('',#26,1.);
+#28=CARTESIAN_POINT('',(0.,0.,0.));
+#29=LINE('',#28,#27);
+#30=EDGE_CURVE('',#18,#22,#29,.T.);
+#31=DIRECTION('',(0.,0.,1.));
+#32=VECTOR('',#31,1.);
+#33=CARTESIAN_POINT('',(1.,0.,0.));
+#34=LINE('',#33,#32);
+#35=EDGE_CURVE('',#19,#23,#34,.T.);
+#36=DIRECTION('',(0.,0.,1.));
+#37=VECTOR('',#36,1.);
+#38=CARTESIAN_POINT('',(1.,1.,0.));
+#39=LINE('',#38,#37);
+#40=EDGE_CURVE('',#20,#24,#39,.T.);
+#41=DIRECTION('',(0.,0.,1.));
+#42=VECTOR('',#41,1.);
+#43=CARTESIAN_POINT('',(0.,1.,0.));
+#44=LINE('',#43,#42);
+#45=EDGE_CURVE('',#21,#25,#44,.T.);
+#46=DIRECTION('',(1.,0.,0.));
+#47=VECTOR('',#46,1.);
+#48=CARTESIAN_POINT('',(0.,0.,0.));
+#49=LINE('',#48,#47);
+#50=EDGE_CURVE('',#18,#19,#49,.T.);
+#51=DIRECTION('',(1.,0.,0.));
+#52=VECTOR('',#51,1.);
+#53=CARTESIAN_POINT('',(0.,0.,1.));
+#54=LINE('',#53,#52);
+#55=EDGE_CURVE('',#22,#23,#54,.T.);
+#56=CARTESIAN_POINT('',(0.,0.,0.));
+#57=DIRECTION('',(0.,-1.,0.));
+#58=DIRECTION('',(1.,0.,0.));
+#59=AXIS2_PLACEMENT_3D('',#56,#57,#58);
+#60=PLANE('',#59);
+#61=ORIENTED_EDGE('',*,*,#50,.T.);
+#62=ORIENTED_EDGE('',*,*,#35,.T.);
+#63=ORIENTED_EDGE('',*,*,#55,.F.);
+#64=ORIENTED_EDGE('',*,*,#30,.F.);
+#65=EDGE_LOOP('',(#61,#62,#63,#64));
+#66=FACE_OUTER_BOUND('',#65,.T.);
+#67=ADVANCED_FACE('',(#66),#60,.T.);
+#68=DIRECTION('',(0.,1.,0.));
+#69=VECTOR('',#68,1.);
+#70=CARTESIAN_POINT('',(1.,0.,0.));
+#71=LINE('',#70,#69);
+#72=EDGE_CURVE('',#19,#20,#71,.T.);
+#73=DIRECTION('',(0.,1.,0.));
+#74=VECTOR('',#73,1.);
+#75=CARTESIAN_POINT('',(1.,0.,1.));
+#76=LINE('',#75,#74);
+#77=EDGE_CURVE('',#23,#24,#76,.T.);
+#78=CARTESIAN_POINT('',(1.,0.,0.));
+#79=DIRECTION('',(1.,0.,0.));
+#80=DIRECTION('',(0.,1.,0.));
+#81=AXIS2_PLACEMENT_3D('',#78,#79,#80);
+#82=PLANE('',#81);
+#83=ORIENTED_EDGE('',*,*,#72,.T.);
+#84=ORIENTED_EDGE('',*,*,#40,.T.);
+#85=ORIENTED_EDGE('',*,*,#77,.F.);
+#86=ORIENTED_EDGE('',*,*,#35,.F.);
+#87=EDGE_LOOP('',(#83,#84,#85,#86));
+#88=FACE_OUTER_BOUND('',#87,.T.);
+#89=ADVANCED_FACE('',(#88),#82,.T.);
+#90=DIRECTION('',(-1.,0.,0.));
+#91=VECTOR('',#90,1.);
+#92=CARTESIAN_POINT('',(1.,1.,0.));
+#93=LINE('',#92,#91);
+#94=EDGE_CURVE('',#20,#21,#93,.T.);
+#95=DIRECTION('',(-1.,0.,0.));
+#96=VECTOR('',#95,1.);
+#97=CARTESIAN_POINT('',(1.,1.,1.));
+#98=LINE('',#97,#96);
+#99=EDGE_CURVE('',#24,#25,#98,.T.);
+#100=CARTESIAN_POINT('',(1.,1.,0.));
+#101=DIRECTION('',(0.,1.,-0.));
+#102=DIRECTION('',(-1.,0.,0.));
+#103=AXIS2_PLACEMENT_3D('',#100,#101,#102);
+#104=PLANE('',#103);
+#105=ORIENTED_EDGE('',*,*,#94,.T.);
+#106=ORIENTED_EDGE('',*,*,#45,.T.);
+#107=ORIENTED_EDGE('',*,*,#99,.F.);
+#108=ORIENTED_EDGE('',*,*,#40,.F.);
+#109=EDGE_LOOP('',(#105,#106,#107,#108));
+#110=FACE_OUTER_BOUND('',#109,.T.);
+#111=ADVANCED_FACE('',(#110),#104,.T.);
+#112=DIRECTION('',(0.,-1.,0.));
+#113=VECTOR('',#112,1.);
+#114=CARTESIAN_POINT('',(0.,1.,0.));
+#115=LINE('',#114,#113);
+#116=EDGE_CURVE('',#21,#18,#115,.T.);
+#117=DIRECTION('',(0.,-1.,0.));
+#118=VECTOR('',#117,1.);
+#119=CARTESIAN_POINT('',(0.,1.,1.));
+#120=LINE('',#119,#118);
+#121=EDGE_CURVE('',#25,#22,#120,.T.);
+#122=CARTESIAN_POINT('',(0.,1.,0.));
+#123=DIRECTION('',(-1.,0.,0.));
+#124=DIRECTION('',(0.,-1.,0.));
+#125=AXIS2_PLACEMENT_3D('',#122,#123,#124);
+#126=PLANE('',#125);
+#127=ORIENTED_EDGE('',*,*,#116,.T.);
+#128=ORIENTED_EDGE('',*,*,#30,.T.);
+#129=ORIENTED_EDGE('',*,*,#121,.F.);
+#130=ORIENTED_EDGE('',*,*,#45,.F.);
+#131=EDGE_LOOP('',(#127,#128,#129,#130));
+#132=FACE_OUTER_BOUND('',#131,.T.);
+#133=ADVANCED_FACE('',(#132),#126,.T.);
+#134=CARTESIAN_POINT('',(0.,0.,1.));
+#135=DIRECTION('',(0.,0.,1.));
+#136=DIRECTION('',(1.,0.,0.));
+#137=AXIS2_PLACEMENT_3D('',#134,#135,#136);
+#138=PLANE('',#137);
+#139=ORIENTED_EDGE('',*,*,#55,.T.);
+#140=ORIENTED_EDGE('',*,*,#77,.T.);
+#141=ORIENTED_EDGE('',*,*,#99,.T.);
+#142=ORIENTED_EDGE('',*,*,#121,.T.);
+#143=EDGE_LOOP('',(#139,#140,#141,#142));
+#144=FACE_OUTER_BOUND('',#143,.T.);
+#145=ADVANCED_FACE('',(#144),#138,.T.);
+#146=CARTESIAN_POINT('',(0.,0.,0.));
+#147=DIRECTION('',(-0.,-0.,-1.));
+#148=DIRECTION('',(1.,0.,0.));
+#149=AXIS2_PLACEMENT_3D('',#146,#147,#148);
+#150=PLANE('',#149);
+#151=ORIENTED_EDGE('',*,*,#116,.F.);
+#152=ORIENTED_EDGE('',*,*,#94,.F.);
+#153=ORIENTED_EDGE('',*,*,#72,.F.);
+#154=ORIENTED_EDGE('',*,*,#50,.F.);
+#155=EDGE_LOOP('',(#151,#152,#153,#154));
+#156=FACE_OUTER_BOUND('',#155,.T.);
+#157=ADVANCED_FACE('',(#156),#150,.T.);
+#158=CLOSED_SHELL('',(#67,#89,#111,#133,#145,#157));
+#159=MANIFOLD_SOLID_BREP('box',#158);
+#168=CARTESIAN_POINT('',(0.,0.,0.));
+#169=DIRECTION('',(0.,0.,1.));
+#170=DIRECTION('',(1.,0.,0.));
+#171=AXIS2_PLACEMENT_3D('',#168,#169,#170);
+#172=ADVANCED_BREP_SHAPE_REPRESENTATION('box',(#171,#159),#9);
+#173=PRODUCT('box','box','',(#3));
+#174=PRODUCT_RELATED_PRODUCT_CATEGORY('part',$,(#173));
+#175=PRODUCT_DEFINITION_FORMATION('','',#173);
+#176=PRODUCT_DEFINITION('design','',#175,#4);
+#177=PRODUCT_DEFINITION_SHAPE('','',#176);
+#178=SHAPE_DEFINITION_REPRESENTATION(#177,#172);
+#179=SHAPE_REPRESENTATION('a',(#171),#9);
+#180=PRODUCT('a','a','',(#3));
+#181=PRODUCT_RELATED_PRODUCT_CATEGORY('part',$,(#180));
+#182=PRODUCT_DEFINITION_FORMATION('','',#180);
+#183=PRODUCT_DEFINITION('design','',#182,#4);
+#184=PRODUCT_DEFINITION_SHAPE('','',#183);
+#185=SHAPE_DEFINITION_REPRESENTATION(#184,#179);
+#186=NEXT_ASSEMBLY_USAGE_OCCURRENCE('1','box','',#183,#176,$);
+#187=PRODUCT_DEFINITION_SHAPE('','',#186);
+@@IDT_BLOCK@@
+ENDSEC;
+END-ISO-10303-21;
+"""
+
+
+def _render(idt_block: str) -> str:
+    # The FILE_SCHEMA header contains literal '{ }', so substitute by marker rather than
+    # str.format (which would treat those braces as fields).
+    return _CUBE_TEMPLATE.replace("@@IDT_BLOCK@@", idt_block)
+
+
+def _axis2_lines(base: int, loc, axis, ref) -> str:
+    """Emit an AXIS2_PLACEMENT_3D #base + its 3 sub-entities (#base+1..+3)."""
+
+    def _d(v):
+        return "(" + ",".join(f"{x:.10g}." if float(x) == int(x) else f"{x:.10g}" for x in v) + ")"
+
+    return (
+        f"#{base}=AXIS2_PLACEMENT_3D('',#{base + 1},#{base + 2},#{base + 3});\n"
+        f"#{base + 1}=CARTESIAN_POINT('',{_d(loc)});\n"
+        f"#{base + 2}=DIRECTION('',{_d(axis)});\n"
+        f"#{base + 3}=DIRECTION('',{_d(ref)});\n"
+    )
+
+
+def _idt_block(child_placement, parent_placement) -> str:
+    """Build the IDT/rep_rel/CDSR tail that places geom rep #172 in the world.
+
+    ``child_placement`` is item_1 (lives in rep_1 = the geom rep #172); ``parent_placement``
+    is item_2 (lives in rep_2 = the placement rep #179). T_edge = inv(M_child) @ M_parent.
+    Each placement is (loc, axis, ref) raw 3-tuples.
+    """
+    child = _axis2_lines(200, *child_placement)
+    parent = _axis2_lines(210, *parent_placement)
+    tail = (
+        "#188=ITEM_DEFINED_TRANSFORMATION('','',#200,#210);\n"
+        "#189=(REPRESENTATION_RELATIONSHIP('','',#172,#179)"
+        "REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#188)SHAPE_REPRESENTATION_RELATIONSHIP());\n"
+        "#190=CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(#189,#187);\n"
+    )
+    return child + parent + tail
+
+
+def _axis2_to_matrix(loc, axis, ref) -> np.ndarray:
+    z = np.asarray(axis, float)
+    z = z / np.linalg.norm(z)
+    x = np.asarray(ref, float)
+    x = x - np.dot(x, z) * z
+    x = x / np.linalg.norm(x)
+    y = np.cross(z, x)
+    m = np.eye(4)
+    m[:3, 0], m[:3, 1], m[:3, 2], m[:3, 3] = x, y, z, np.asarray(loc, float)
+    return m
+
+
+def _shell_world_pts(geom) -> np.ndarray:
+    pts = []
+    for f in geom.geometry.cfs_faces:
+        for fb in f.bounds:
+            for oe in fb.bound.edge_list:
+                for p in (oe.start, oe.end):
+                    pts.append([float(p[0]), float(p[1]), float(p[2])])
+    pts = np.asarray(pts, float)
+    if geom.transform is not None:
+        r, t = geom.transform[:3, :3], geom.transform[:3, 3]
+        pts = pts @ r.T + t
+    return pts
+
+
+def test_stream_reader_applies_known_assembly_transform(tmp_path):
+    # Place the local-frame unit cube by a known non-trivial transform: parent frame
+    # rotated 90deg about Z and translated, child frame at identity. The world matrix
+    # the reader resolves must equal inv(M_child) @ M_parent, and the cube's world
+    # corners must be the local corners pushed through it.
+    child = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))  # identity frame
+    parent = ((3.0, 5.0, 7.0), (0.0, 0.0, 1.0), (0.0, 1.0, 0.0))  # +90deg about Z, translated
+    step = _render(_idt_block(child, parent))
+    path = tmp_path / "asm.step"
+    path.write_text(step)
+
+    (geom,) = list(stream_read_step(path, local_pool=False))
+    assert geom.transform is not None
+
+    expected = np.linalg.inv(_axis2_to_matrix(*child)) @ _axis2_to_matrix(*parent)
+    assert np.allclose(geom.transform, expected, atol=1e-9)
+
+    # The cube's world corners must be exactly the local [0,1]^3 corners pushed through
+    # the resolved transform (independent cross-check of the applied placement).
+    local_corners = np.array([[x, y, z] for x in (0, 1) for y in (0, 1) for z in (0, 1)], float)
+    exp_world = local_corners @ expected[:3, :3].T + expected[:3, 3]
+    pts = _shell_world_pts(geom)
+    assert np.allclose(pts.min(0), exp_world.min(0), atol=1e-9)
+    assert np.allclose(pts.max(0), exp_world.max(0), atol=1e-9)
+    # The placement is genuinely non-trivial: the rotation moves the cube off its local
+    # frame (a +90deg-about-Z parent means world x != local x).
+    assert not np.allclose(expected, np.eye(4))
+
+
+def test_stream_world_bbox_matches_occ(tmp_path):
+    # The reader's transformed world bbox must match OpenCascade's STEPControl_Reader
+    # bbox for the same file (both in metres) to ~1e-6.
+    pytest.importorskip("OCC.Core.Bnd")
+    from OCC.Core.Bnd import Bnd_Box
+    from OCC.Core.BRepBndLib import brepbndlib
+
+    child = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+    parent = ((3.0, 5.0, 7.0), (0.0, 1.0, 0.0), (1.0, 0.0, 0.0))  # +90 about X
+    step = _render(_idt_block(child, parent))
+    path = tmp_path / "asm_occ.step"
+    path.write_text(step)
+
+    (geom,) = list(stream_read_step(path, local_pool=False))
+    stream_pts = _shell_world_pts(geom)
+    smin, smax = stream_pts.min(0), stream_pts.max(0)
+
+    a = ada.from_step(path, reader="occ")
+    bb = Bnd_Box()
+    n = 0
+    for o in a.get_all_physical_objects():
+        try:
+            shp = o.solid_occ()
+        except Exception:  # noqa: BLE001
+            continue
+        brepbndlib.Add(shp, bb)
+        n += 1
+    assert n >= 1
+    xmin, ymin, zmin, xmax, ymax, zmax = bb.Get()
+    assert np.allclose(smin, [xmin, ymin, zmin], atol=1e-6)
+    assert np.allclose(smax, [xmax, ymax, zmax], atol=1e-6)
+
+
+def test_stream_reader_multi_instance_two_placements(tmp_path):
+    # One product placed TWICE -> two CDSR edges on the same placement rep #179 -> the
+    # reader yields two geometries with distinct ids and distinct world transforms.
+    child = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+    parent_a = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))  # identity -> at origin
+    parent_b = ((10.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))  # translated +10x
+    block = _idt_block(child, parent_a)
+    # A second placement of the SAME geom rep #172 via a fresh IDT/rep_rel/CDSR using
+    # the same rep_1=#172 / rep_2=#179, so #179 is rep_1 of two edges -> two instances.
+    child2 = _axis2_lines(300, *child)
+    parent2 = _axis2_lines(310, *parent_b)
+    block += (
+        child2
+        + parent2
+        + "#388=ITEM_DEFINED_TRANSFORMATION('','',#300,#310);\n"
+        "#389=(REPRESENTATION_RELATIONSHIP('','',#172,#179)"
+        "REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#388)SHAPE_REPRESENTATION_RELATIONSHIP());\n"
+        "#390=CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(#389,#187);\n"
+    )
+    step = _render(block)
+    path = tmp_path / "multi.step"
+    path.write_text(step)
+
+    geos = list(stream_read_step(path, local_pool=False))
+    assert len(geos) == 2
+    ids = [g.id for g in geos]
+    assert ids[0] == "box" and ids[1] == "box/2"
+
+    centroids = [_shell_world_pts(g).mean(0) for g in geos]
+    # The two instances sit 10 units apart in x (one at origin, one at +10x).
+    assert abs((centroids[1] - centroids[0])[0]) == pytest.approx(10.0, abs=1e-9)
+    # Distinct world positions.
+    assert not np.allclose(centroids[0], centroids[1])
+
+
+def test_stream_reader_flat_emitter_no_transform(tmp_path):
+    # Regression: an adapy-emitted flat model has identity IDTs (or no assembly tree),
+    # so every solid stream-reads with transform=None and its authored world position —
+    # no behaviour change for existing flat files.
+    box = ada.PrimBox("box", (1.0, 2.0, 3.0), (2.0, 3.0, 4.0))
+    a = ada.Assembly("m") / (ada.Part("p") / box)
+
+    for writer in ("stream", "occ"):
+        out = tmp_path / f"flat_{writer}.stp"
+        a.to_stp(out, writer=writer) if writer == "stream" else a.to_stp(out)
+        geos = list(stream_read_step(out, local_pool=False))
+        assert len(geos) == 1
+        (g,) = geos
+        # The whole point: no assembly tree / identity IDTs -> transform stays None.
+        assert g.transform is None
+        # And the authored geometry is unmoved: the unit box's min corner sits at
+        # (1,2,3) and max at (2,3,4) in the file's length unit (adapy writes metres, so
+        # the emitter scales mm->m; assert the shape is intact regardless of that scale).
+        pts = _shell_world_pts(g)
+        lo, hi = pts.min(0), pts.max(0)
+        scale = hi[0] - lo[0]  # the unit box's x-extent in the file's length unit
+        assert scale > 0
+        assert np.allclose(lo / scale, [1.0, 2.0, 3.0], atol=1e-6)
+        assert np.allclose(hi / scale, [2.0, 3.0, 4.0], atol=1e-6)


### PR DESCRIPTION
## Symptom
A streamed STEP assembly (e.g. the Munin crane) rendered **off-centre with artifacts** — some components in the wrong place, the model small and off to one side. You correctly suspected missing transformations (precision was a red herring; the model sits at sane ~45 m coordinates).

## Root cause
The streaming reader read each `MANIFOLD_SOLID_BREP`'s raw `CARTESIAN_POINT`s and **ignored the assembly tree entirely** (no `MAPPED_ITEM`, `ITEM_DEFINED_TRANSFORMATION`, `NEXT_ASSEMBLY_USAGE_OCCURRENCE` handling). The test model is a real PDM assembly — **10,795 `NEXT_ASSEMBLY_USAGE_OCCURRENCE` + `ITEM_DEFINED_TRANSFORMATION`**, geometry **not baked** — so every component is authored in its own local frame and placed by the tree. Un-placed/local-frame solids (some sitting exactly on the local x-axis, some stretched to 45 m) blew up the scene bbox → "zoom to fit" framed mostly-empty space.

(OCC OOMs on this file, so streaming is the *first* time it renders — which is why the reader has to handle assemblies itself.)

## Fix
Resolve each solid's world placement from the representation graph:
```
MANIFOLD_SOLID_BREP -> ADVANCED_BREP_SHAPE_REPRESENTATION
  -> (standalone SHAPE_REPRESENTATION_RELATIONSHIP) -> placement rep
     -> rep_1 of a CONTEXT_DEPENDENT_SHAPE_REPRESENTATION's
        ( REPRESENTATION_RELATIONSHIP(.,.,rep_1,rep_2)
          REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(IDT) ... )
     -> recurse rep_1->rep_2 to the root
```
Per edge `T_edge = inv(M(item_1)) @ M(item_2)` (child→parent); accumulate leaf→root. **The convention was validated numerically against OpenCascade to 1e-9** (it's genuinely ambiguous from the spec — a non-identity `item_1` test pins it). A product instanced N times yields N world matrices → the solid is emitted N times (`id`, `id/2`, …).

The matrix rides on a new `Geometry.transform` and is applied to the **tessellated mesh** (rigid: rotation on positions+normals, translation on positions), not the B-rep. Flat/baked files (incl. adapy's own emitter) have no standalone SRR and identity transforms → a no-op, so existing single-instance reads are byte-for-byte unchanged.

## Validation
- `test_stream_world_bbox_matches_occ`: stream world bbox == `ada.from_step(reader="occ")` bbox to **1e-6** on a hand-authored un-baked assembly fixture.
- Two-instance placement test; flat-emitter regression (transform stays `None`).
- Full `tests/core/cadit/step/`: **40 passed**, ruff clean.
- **Munin:** the 16/600 sampled solids that sat on the local x-axis move to **0** on-axis; world bbox becomes a coherent crane (x∈[-1.8, 42.5] m, y±1.9 m, z∈[0.02, 8.7] m).

## Performance: tessellate-once
Multi-instanced products are tessellated **once** in their local frame; each instance's matrix is applied to that mesh (rigid transform on positions/normals) and emitted as its own node. On the test assembly **401 unique solids cover 1,297 placements → 896 fewer tessellations (69%)**. `Geometry` carries a `transforms` list (one 4×4 per instance); a lone identity collapses to `None` so flat/single-instance reads are unchanged. Covered by an end-to-end multi-instance GLB test (one tessellation, merged mesh spans both placements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
