### PR TITLE
fix: derive loft-face normal from wire geometry when face_plane is None

### DIFF
--- a/src/ada/topology/extraction.py
+++ b/src/ada/topology/extraction.py
@@ -26,6 +26,26 @@ from ada.topology.graph import (
 )
 
 
+def _newell_normal(points) -> "ada.Direction | None":
+    """Unit polygon normal via Newell's method (robust for slightly
+    non-planar / arbitrarily ordered loops). Returns ``None`` for a
+    degenerate loop. Used as a fallback when the kernel cannot fit a
+    plane to a face (e.g. a ruled ThruSections loft side, where
+    ``face_plane`` returns ``None``)."""
+    p = np.asarray(points, dtype=float)
+    if len(p) < 3:
+        return None
+    nxt = np.roll(p, -1, axis=0)
+    nx = float(np.sum((p[:, 1] - nxt[:, 1]) * (p[:, 2] + nxt[:, 2])))
+    ny = float(np.sum((p[:, 2] - nxt[:, 2]) * (p[:, 0] + nxt[:, 0])))
+    nz = float(np.sum((p[:, 0] - nxt[:, 0]) * (p[:, 1] + nxt[:, 1])))
+    n = np.array([nx, ny, nz])
+    mag = float(np.linalg.norm(n))
+    if mag == 0.0:
+        return None
+    return ada.Direction(*(n / mag))
+
+
 @dataclass
 class GraphCellExtractor:
     cells_in: list[GraphCell]
@@ -60,7 +80,19 @@ class GraphCellExtractor:
             cell_centroid = np.asarray(be.center_of_mass(cell.handle), dtype=float)
             for i, fh in enumerate(be.faces(cell.handle)):
                 plane = be.face_plane(fh)
-                normal = plane[1] if plane is not None else ada.Direction(0, 0, 1)
+                if plane is not None:
+                    normal = plane[1]
+                else:
+                    # The kernel returns no plane for ruled/lofted faces
+                    # (ThruSections sides). Defaulting to +Z collapses every
+                    # such face onto the same side, so get_side() yields the
+                    # same bucket for all of them and stable_face_id is
+                    # assigned by raw centroid order — scrambling FACE_IDX
+                    # targeting (e.g. jacket loft walls). Derive the normal
+                    # from the wire geometry instead.
+                    normal = _newell_normal(be.wire_points(fh))
+                    if normal is None:
+                        normal = ada.Direction(0, 0, 1)
                 centroid = be.center_of_mass(fh)
                 # Orient outward: the face normal points away from the cell centre
                 # (the kernel's geometric plane normal carries no consistent side).


### PR DESCRIPTION
## Problem

`GraphCellExtractor.extract_faces` reads each face normal from `be.face_plane(fh)`, falling back to a fixed `+Z` when the backend returns `None`:

```python
plane = be.face_plane(fh)
normal = plane[1] if plane is not None else ada.Direction(0, 0, 1)
```

The CAD backend returns **no plane** for ruled `ThruSections` faces (the tapered side walls of a lofted cell), so *every* such face got the same `+Z` normal. That collapses the whole cell's faces onto one side: `GraphFace.get_side()` buckets them identically, `source_feature_id` is the same for all, and `_assign_feature_ids` then orders them by raw centroid — so `stable_face_id` no longer maps to a fixed physical side. Downstream, `FACE_IDX`-based face modifications land on the wrong face (a lofted cell applying a wall config to the wrong elevation, dropping that elevation's bracing).

## Fix

When `face_plane` returns `None`, compute the normal from the face's wire points with **Newell's method** (oriented outward by the existing cell-centroid dot-product check) instead of defaulting to `+Z`.

- Axis-aligned faces are **unaffected** — `face_plane` still returns their plane, so the new branch never fires. Existing box/deck models are byte-identical.
- Only previously-misclassified ruled/loft faces change.

## Testing

- `tests/core/topology` + `tests/core/api/test_loft.py` pass (the only failures are a pre-existing subprocess-import artifact in the no-kernel-import tests, identical on `main` in a local editable setup).
- `test-all` native-backend (adacpp) leg: green.
- A downstream loft-based model now resolves `FACE_IDX` modifications to the correct faces (all elevations braced symmetrically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)