### PR TITLE
fix: bound runaway faces in streaming STEP tessellation

### DIFF
--- a/src/ada/cadit/step/read/stream_reader.py
+++ b/src/ada/cadit/step/read/stream_reader.py
@@ -307,8 +307,41 @@ def _rep_rel_edge(pool_get, rep_rel_rec):
     return rep_1, rep_2, idt.id
 
 
-def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids):
-    """Map each root solid id -> list of world 4x4 matrices (one per placed instance).
+def _build_product_name_map(pool_get, sdr_ids):
+    """rep id -> product name, via SHAPE_DEFINITION_REPRESENTATION -> PRODUCT_DEFINITION_SHAPE
+    -> PRODUCT_DEFINITION -> FORMATION -> PRODUCT. Used to label assembly-tree group nodes;
+    any unresolvable link just leaves the rep unnamed (caller falls back to ``asm_<rep>``)."""
+    name_of_rep: dict[int, str] = {}
+    for sid in sdr_ids:
+        rec = pool_get(sid)
+        if rec is None or len(rec.args) < 2:
+            continue
+        defn, rep = rec.args[0], rec.args[1]
+        if not (isinstance(defn, _Ref) and isinstance(rep, _Ref)) or rep.id in name_of_rep:
+            continue
+        name = None
+        try:
+            pds = pool_get(defn.id)  # PRODUCT_DEFINITION_SHAPE(name, desc, #pd)
+            pd = pool_get(pds.args[2].id) if pds and isinstance(pds.args[2], _Ref) else None
+            pdf = pool_get(pd.args[2].id) if pd and isinstance(pd.args[2], _Ref) else None
+            prod = pool_get(pdf.args[2].id) if pdf and isinstance(pdf.args[2], _Ref) else None
+            if prod is not None:
+                for cand in (prod.args[1], prod.args[0]):
+                    if isinstance(cand, str) and cand.strip():
+                        name = cand.strip()
+                        break
+        except Exception:  # noqa: BLE001 - naming is best-effort metadata
+            name = None
+        if name:
+            name_of_rep[rep.id] = name
+    return name_of_rep
+
+
+def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids, sdr_ids=()):
+    """Map each root solid id -> (matrices, paths): one world 4x4 matrix per placed
+    instance, plus the matching assembly path — a root-first tuple of
+    ``(rep_id, product_name)`` levels — so the scene graph can group instances the way
+    the STEP product tree does.
 
     Resilient: any unresolved entity simply leaves a solid with the identity ([None]
     handled by the caller); never raises.
@@ -366,14 +399,20 @@ def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids):
             continue
         edges.setdefault(rep_1, []).append((rep_2, i1.id, i2.id))
 
+    name_of_rep = _build_product_name_map(pool_get, sdr_ids)
+
+    def _path_level(rep_id: int) -> tuple:
+        return (rep_id, name_of_rep.get(rep_id) or f"asm_{rep_id}")
+
     def _world_matrices(rep_id: int, _seen: frozenset) -> list:
-        """All world matrices reaching ``rep_id`` (a rep that is rep_1 of edges).
-        Each edge T_edge maps this rep's coords -> its parent rep; recurse to root."""
+        """All ``(matrix, path)`` pairs reaching ``rep_id`` (a rep that is rep_1 of
+        edges); path is root-first. Each edge T_edge maps this rep's coords -> its
+        parent rep; recurse to root."""
         out_edges = edges.get(rep_id)
         if not out_edges:
-            return [np.eye(4)]  # root rep: identity (its own coords ARE world)
+            return [(np.eye(4), (_path_level(rep_id),))]  # root rep: its coords ARE world
         if rep_id in _seen:
-            return [np.eye(4)]  # cycle guard
+            return [(np.eye(4), (_path_level(rep_id),))]  # cycle guard
         seen2 = _seen | {rep_id}
         mats: list = []
         for rep_2, i1, i2 in out_edges:
@@ -383,11 +422,11 @@ def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids):
                 t_edge = np.linalg.inv(m_child) @ m_parent
             except np.linalg.LinAlgError:
                 t_edge = np.eye(4)
-            for t_parent in _world_matrices(rep_2, seen2):
-                mats.append(t_parent @ t_edge)
+            for t_parent, parent_path in _world_matrices(rep_2, seen2):
+                mats.append((t_parent @ t_edge, parent_path + (_path_level(rep_id),)))
         return mats
 
-    tmap: dict[int, list] = {}
+    tmap: dict[int, tuple] = {}
     for sid in root_ids:
         geom_rep = geomrep_of_solid.get(sid)
         # Flat/baked file: no ABSR item linkage at all -> identity, yield once.
@@ -398,15 +437,89 @@ def _build_transform_map(pool_get, root_ids, cdsr_ids, srr_ids, absr_ids):
         # geom rep so its outgoing edges are found directly.
         place_rep = place_rep_of_geom.get(geom_rep, geom_rep)
         try:
-            mats = _world_matrices(place_rep, frozenset())
+            pairs = _world_matrices(place_rep, frozenset())
         except Exception:  # noqa: BLE001 - never crash a read over a placement chain
-            mats = [np.eye(4)]
+            pairs = [(np.eye(4), None)]
+        mats = [m for m, _p in pairs]
         # Drop pure-identity lists to a no-op (single instance, transform=None).
         nontrivial = [m for m in mats if not np.allclose(m, np.eye(4), atol=1e-12)]
         if not nontrivial and len(mats) <= 1:
             continue
-        tmap[sid] = mats
+        tmap[sid] = (mats, [p for _m, p in pairs])
     return tmap
+
+
+# SI prefix -> factor relative to the unprefixed unit (we only resolve METRE).
+_SI_PREFIX_SCALE = {
+    "KILO": 1e3,
+    "DECI": 1e-1,
+    "CENTI": 1e-2,
+    "MILLI": 1e-3,
+    "MICRO": 1e-6,
+    "NANO": 1e-9,
+}
+# CONVERSION_BASED_UNIT names -> metres. The exact factor lives in a referenced
+# MEASURE_WITH_UNIT record; resolving it cross-statement isn't worth it when the
+# unit *name* already pins the factor exactly. Some writers (e.g. Abaqus) express
+# even plain millimetres this way rather than via an SI prefix.
+_CONV_UNIT_SCALE = {
+    "MILLIMETRE": 1e-3,
+    "MILLIMETER": 1e-3,
+    "MM": 1e-3,
+    "CENTIMETRE": 1e-2,
+    "CENTIMETER": 1e-2,
+    "CM": 1e-2,
+    "METRE": 1.0,
+    "METER": 1.0,
+    "M": 1.0,
+    "INCH": 0.0254,
+    "INCHES": 0.0254,
+    "IN": 0.0254,
+    "FOOT": 0.3048,
+    "FEET": 0.3048,
+    "FT": 0.3048,
+    "YARD": 0.9144,
+    "MILE": 1609.344,
+}
+
+# Both arg forms occur in the wild: SI_UNIT(.MILLI.,.METRE.) and SI_UNIT(.METRE.).
+_SI_LEN_RE = re.compile(r"SI_UNIT\(\s*(?:(\.\w+\.|\$)\s*,\s*)?\.METRE\.\s*\)")
+_CONV_NAME_RE = re.compile(r"CONVERSION_BASED_UNIT\(\s*'([^']*)'")
+
+
+def detect_step_length_unit_scale(filepath) -> float:
+    """Factor converting the file's declared length unit to METRES, read from the
+    first ``LENGTH_UNIT`` record in the data section (e.g. the ubiquitous
+    ``( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) )`` -> 0.001).
+
+    glTF mandates metres, so the streaming GLB path multiplies positions by this;
+    the OCC reader does the same conversion internally via ``xstep.cascade.unit``.
+    Returns 1.0 when the file is already in metres or the unit is undetectable
+    (logged at warning in the latter case)."""
+    import mmap as _mmap
+
+    try:
+        with open(filepath, "rb") as fh, _mmap.mmap(fh.fileno(), 0, access=_mmap.ACCESS_READ) as mm:
+            i = mm.find(b"LENGTH_UNIT")
+            if i < 0:
+                return 1.0
+            start = mm.rfind(b";", 0, i) + 1
+            stmt = mm[start : _stmt_end(mm, start, len(mm))].decode("ascii", "replace")
+    except (OSError, ValueError):
+        return 1.0
+    m = _SI_LEN_RE.search(stmt)
+    if m is not None:
+        prefix = m.group(1)
+        if prefix is None or prefix == "$":
+            return 1.0
+        return _SI_PREFIX_SCALE.get(prefix.strip("."), 1.0)
+    m = _CONV_NAME_RE.search(stmt)
+    if m is not None:
+        scale = _CONV_UNIT_SCALE.get(m.group(1).strip().upper())
+        if scale is not None:
+            return scale
+    logger.warning("detect_step_length_unit_scale: unrecognised LENGTH_UNIT record %r — assuming metres", stmt[:120])
+    return 1.0
 
 
 _HEADER_RE = re.compile(r"^\s*#(\d+)\s*=\s*([A-Z0-9_]+)\s*\(", re.S)
@@ -948,18 +1061,20 @@ def _solid_name(args: list, n_solids: int) -> str:
     return args[0] if args and isinstance(args[0], str) and args[0] else f"solid_{n_solids + 1}"
 
 
-def _yield_instances(name: str, geom, color, mats):
+def _yield_instances(name: str, geom, color, tmap_entry):
     """Yield ONE Geometry for this (single) solid, carrying its list of world-placement
-    matrices. ``mats`` is a list of 4x4 matrices (one per placed instance) or None/empty
-    for the single, no-transform case. The downstream tessellator meshes the local shell
-    ONCE and applies each matrix to that mesh, so a part instanced N times meshes once.
-    A lone identity matrix collapses to ``transforms=None`` so flat files and
-    single-instance solids are byte-for-byte unchanged."""
+    matrices plus the matching assembly paths. ``tmap_entry`` is ``(mats, paths)`` (one
+    4x4 + one root-first path per placed instance) or None for the single, no-transform
+    case. The downstream tessellator meshes the local shell ONCE and applies each matrix
+    to that mesh, so a part instanced N times meshes once. A lone identity matrix
+    collapses to ``transforms=None`` so flat files and single-instance solids are
+    byte-for-byte unchanged."""
     import numpy as np
 
+    mats, paths = tmap_entry if tmap_entry else (None, None)
     if mats and len(mats) == 1 and np.allclose(mats[0], np.eye(4), atol=1e-12):
-        mats = None
-    yield Geometry(id=name, geometry=geom, color=color, transforms=(mats or None))
+        mats, paths = None, None
+    yield Geometry(id=name, geometry=geom, color=color, transforms=(mats or None), instance_paths=(paths or None))
 
 
 def _short_reason(ex: Exception) -> str:
@@ -1032,6 +1147,7 @@ def _read_two_pass_dict(filepath: Path, *, tolerant: bool, skipped, on_total=Non
     cdsr_ids: list[int] = []
     srr_ids: list[int] = []
     absr_ids: list[int] = []
+    sdr_ids: list[int] = []
     with filepath.open("r", encoding="utf-8", errors="replace") as fh:
         for stmt in _iter_statements(fh):
             parsed = _parse_statement(stmt)
@@ -1049,9 +1165,11 @@ def _read_two_pass_dict(filepath: Path, *, tolerant: bool, skipped, on_total=Non
                 srr_ids.append(inst_id)
             elif etype == "ADVANCED_BREP_SHAPE_REPRESENTATION":
                 absr_ids.append(inst_id)
+            elif etype == "SHAPE_DEFINITION_REPRESENTATION":
+                sdr_ids.append(inst_id)
 
     colour_map = _build_colour_map(pool.get, styled_ids)
-    tmap = _build_transform_map(pool.get, root_ids, cdsr_ids, srr_ids, absr_ids)
+    tmap = _build_transform_map(pool.get, root_ids, cdsr_ids, srr_ids, absr_ids, sdr_ids)
     if on_total is not None:
         on_total(len(root_ids))
     resolver = _Resolver(pool)
@@ -1103,6 +1221,7 @@ def _scan_offset_index(mm):
     cdsr: list[int] = []  # CONTEXT_DEPENDENT_SHAPE_REPRESENTATION ids — assembly transforms
     srr: list[int] = []  # standalone SHAPE_REPRESENTATION_RELATIONSHIP ids
     absr: list[int] = []  # ADVANCED_BREP_SHAPE_REPRESENTATION ids (solid -> geom rep)
+    sdr: list[int] = []  # SHAPE_DEFINITION_REPRESENTATION ids (rep -> product, for tree names)
     n = len(mm)
     pos = 0
     while pos < n:
@@ -1144,8 +1263,10 @@ def _scan_offset_index(mm):
                             srr.append(rid)
                         elif kw == "ADVANCED_BREP_SHAPE_REPRESENTATION":
                             absr.append(rid)
+                        elif kw == "SHAPE_DEFINITION_REPRESENTATION":
+                            sdr.append(rid)
         pos = end + 1
-    return ids, offs, roots, styled, cdsr, srr, absr
+    return ids, offs, roots, styled, cdsr, srr, absr, sdr
 
 
 class _OffsetPool:
@@ -1184,7 +1305,7 @@ def _read_two_pass_lazy(filepath: Path, *, tolerant: bool, skipped, on_total=Non
     mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
     idx_tmp: list[str] = []  # sorted-index temp files, unlinked in finally
     try:
-        ids_arr, offs_arr, roots, styled, cdsr, srr, absr = _scan_offset_index(mm)
+        ids_arr, offs_arr, roots, styled, cdsr, srr, absr, sdr = _scan_offset_index(mm)
         ids_np = np.frombuffer(ids_arr, dtype=np.int64)
         offs_np = np.frombuffer(offs_arr, dtype=np.int64)
         order = np.argsort(ids_np, kind="stable")
@@ -1210,7 +1331,7 @@ def _read_two_pass_lazy(filepath: Path, *, tolerant: bool, skipped, on_total=Non
             ids_mm, offs_mm = ids_sorted, offs_sorted
         pool = _OffsetPool(mm, ids_mm, offs_mm)
         colour_map = _build_colour_map(pool.get, styled)
-        tmap = _build_transform_map(pool.get, roots, cdsr, srr, absr)
+        tmap = _build_transform_map(pool.get, roots, cdsr, srr, absr, sdr)
         if on_total is not None:
             on_total(len(roots))
         resolver = _Resolver(pool)

--- a/src/ada/geom/core.py
+++ b/src/ada/geom/core.py
@@ -28,3 +28,7 @@ class Geometry(Generic[T]):
     # The solid is tessellated ONCE in its local frame; each transform is applied to the
     # resulting mesh (not the B-rep), so a part instanced N times meshes once.
     transforms: list[np.ndarray] | None = None
+    # Aligned 1:1 with ``transforms``: each instance's assembly path, a root-first tuple
+    # of (rep_id, product_name) levels, so a scene builder can group instances the way
+    # the source assembly tree does. None = no hierarchy information.
+    instance_paths: list[tuple] | None = None

--- a/src/ada/occ/geom/surfaces.py
+++ b/src/ada/occ/geom/surfaces.py
@@ -1,13 +1,15 @@
 import math
 
+from OCC.Core.Bnd import Bnd_Box
 from OCC.Core.BRep import BRep_Builder, BRep_Tool
 from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
+from OCC.Core.BRepBndLib import brepbndlib
 from OCC.Core.BRepBuilderAPI import (
     BRepBuilderAPI_MakeEdge,
     BRepBuilderAPI_MakeFace,
     BRepBuilderAPI_MakeWire,
 )
-from OCC.Core.BRepTools import BRepTools_WireExplorer
+from OCC.Core.BRepTools import BRepTools_WireExplorer, breptools
 from OCC.Core.Geom import (
     Geom_BSplineSurface,
     Geom_ConicalSurface,
@@ -767,9 +769,9 @@ def _has_full_circle_edge(advanced_face: geo_su.AdvancedFace) -> bool:
 
 
 def _sample_edge_points(oe):
-    """World-space sample points along one oriented edge. A full circle (start==end)
-    is sampled all the way round so the projected parameter range captures the full
-    closed direction; other edges contribute their endpoints."""
+    """World-space sample points along one oriented edge. A circular edge is sampled
+    along its arc (the full period for a closed circle) so the projected parameter
+    range captures the swept direction; other edges contribute their endpoints."""
     import math
 
     pts = [
@@ -778,15 +780,31 @@ def _sample_edge_points(oe):
     ]
     ec = getattr(oe, "edge_element", oe)
     g = getattr(ec, "edge_geometry", None)
-    if isinstance(g, geo_cu.Circle) and _points_close(oe.start, oe.end):
+    if isinstance(g, geo_cu.Circle):
         pos = g.position
         c = [float(x) for x in pos.location]
         z = [float(x) for x in pos.axis]
         xd = [float(x) for x in pos.ref_direction]
         yd = (z[1] * xd[2] - z[2] * xd[1], z[2] * xd[0] - z[0] * xd[2], z[0] * xd[1] - z[1] * xd[0])
         r = float(g.radius)
-        for k in range(12):
-            a = 2.0 * math.pi * k / 12.0
+        if _points_close(oe.start, oe.end):
+            a0, a1 = 0.0, 2.0 * math.pi
+        else:
+            # Partial arc: sample between the endpoint angles. The traversal sense
+            # isn't recovered here, so the complement arc may be sampled instead —
+            # harmless for parameter-extent estimation (it can only widen coverage).
+            def _ang(p):
+                d = (p[0] - c[0], p[1] - c[1], p[2] - c[2])
+                return math.atan2(
+                    d[0] * yd[0] + d[1] * yd[1] + d[2] * yd[2],
+                    d[0] * xd[0] + d[1] * xd[1] + d[2] * xd[2],
+                )
+
+            a0, a1 = _ang(pts[0]), _ang(pts[1])
+            if a1 <= a0:
+                a1 += 2.0 * math.pi
+        for k in range(13):
+            a = a0 + (a1 - a0) * k / 12.0
             ca, sa = math.cos(a), math.sin(a)
             pts.append(
                 (
@@ -820,28 +838,13 @@ def _param_extent(vals: list[float], periodic: bool, period: float) -> tuple[flo
     return s[best_i + 1], s[best_i] + period
 
 
-def _try_make_closed_revolution_face(advanced_face: geo_su.AdvancedFace, face_surface):
-    """Build a face that is *closed* in a parametric direction (full cylinder / cone /
-    torus tube — signalled by a full-circle boundary edge) directly from the surface's
-    parametric bounds, so OCC generates the seam itself. ``make_wire_from_face_bound``
-    can't build a wire out of full-circle edges plus a doubled seam, which is why these
-    faces (~5% of real-CAD curved faces — pipe walls, elbows) otherwise drop. Returns a
-    face or None."""
-    import math
-
-    from OCC.Core.Geom import (
-        Geom_ConicalSurface,
-        Geom_CylindricalSurface,
-        Geom_ToroidalSurface,
-    )
-
-    if not isinstance(face_surface, (Geom_CylindricalSurface, Geom_ConicalSurface, Geom_ToroidalSurface)):
-        return None
-    if not _has_full_circle_edge(advanced_face):
-        return None
-
+def _make_face_from_param_extent(advanced_face: geo_su.AdvancedFace, face_surface):
+    """Build a face directly from the projected parameter extent of its boundary
+    samples — for faces whose boundary wire cannot trim the surface (closed
+    revolution faces, seam-crossing arc wires). Inner bounds are filled (the face
+    over-covers slightly). Returns a face or None."""
     # Recover (u, v) parameter ranges by projecting the boundary samples onto the
-    # surface; the closed direction(s) snap to the full period via _param_extent.
+    # surface; a closed direction snaps to the full period via _param_extent.
     us: list[float] = []
     vs: list[float] = []
     for fb in advanced_face.bounds:
@@ -865,6 +868,59 @@ def _try_make_closed_revolution_face(advanced_face: geo_su.AdvancedFace, face_su
     if not mk.IsDone():
         return None
     return mk.Face()
+
+
+def _try_make_closed_revolution_face(advanced_face: geo_su.AdvancedFace, face_surface):
+    """Build a face that is *closed* in a parametric direction (full cylinder / cone /
+    torus tube — signalled by a full-circle boundary edge) directly from the surface's
+    parametric bounds, so OCC generates the seam itself. ``make_wire_from_face_bound``
+    can't build a wire out of full-circle edges plus a doubled seam, which is why these
+    faces (~5% of real-CAD curved faces — pipe walls, elbows) otherwise drop. Returns a
+    face or None."""
+    if not isinstance(face_surface, (Geom_CylindricalSurface, Geom_ConicalSurface, Geom_ToroidalSurface)):
+        return None
+    if not _has_full_circle_edge(advanced_face):
+        return None
+    return _make_face_from_param_extent(advanced_face, face_surface)
+
+
+_UV_FINITE_LIM = 1.0e50  # OCC marks an untrimmed natural bound as ±Precision::Infinite (~1e100)
+
+
+def _face_uv_unbounded(face) -> bool:
+    """True when the face still carries the surface's natural (infinite) parameter
+    bounds — i.e. its boundary wire failed to trim the surface."""
+    try:
+        umin, umax, vmin, vmax = breptools.UVBounds(face)
+    except Exception:  # noqa: BLE001 - treat an unqueryable face as unbounded
+        return True
+    return any((not math.isfinite(x)) or abs(x) > _UV_FINITE_LIM for x in (umin, umax, vmin, vmax))
+
+
+def _shape_diag(shape) -> float:
+    """Geometric bounding-box diagonal of any shape (no triangulation required)."""
+    box = Bnd_Box()
+    try:
+        brepbndlib.Add(shape, box, False)
+    except Exception:  # noqa: BLE001
+        return math.inf
+    if box.IsVoid():
+        return 0.0
+    xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
+    return math.dist((xmin, ymin, zmin), (xmax, ymax, zmax))
+
+
+# A trimmed face cannot legitimately extend far beyond its own outer boundary wire.
+# 10x leaves generous slack for curvature bulge (a half-cylinder face's bbox is at
+# most ~2x its wire's) while catching runaway trims that are orders of magnitude off.
+_FACE_OVERRUN_FACTOR = 10.0
+
+
+def _face_overruns_wire(face, wire_diag: float) -> bool:
+    fd = _shape_diag(face)
+    if not math.isfinite(fd):
+        return True
+    return fd > _FACE_OVERRUN_FACTOR * max(wire_diag, 1e-6)
 
 
 def make_face_from_geom(advanced_face: geo_su.AdvancedFace) -> TopoDS_Face:
@@ -1040,6 +1096,29 @@ def make_face_from_geom(advanced_face: geo_su.AdvancedFace) -> TopoDS_Face:
         raise Exception(f"Failed to create face from surface type {type(advanced_face.face_surface)}")
 
     face = face_maker.Face()
+
+    # A wire that fails to close in UV on an infinite revolution surface — e.g. a
+    # cylinder/cone face whose boundary circles are split into arcs and the wire
+    # crosses the parametric seam — leaves the face with the surface's NATURAL bounds:
+    # infinite (or absurdly large) along the axis. BRepMesh then emits vertices
+    # millions of units out, so a single such face explodes the whole model's bounding
+    # box in the viewer. Detect it by comparing the face's geometric extent against
+    # its own boundary wire (a trimmed face cannot legitimately overrun its boundary
+    # by 10x) and rebuild from the boundary's projected parameter extent; if that
+    # fails too, drop the face — a hole beats a kilometres-long sliver. The check is
+    # gated to cylinder/cone: those are the only surfaces here with an infinite
+    # direction (gp_Pln UV-projects exactly; sphere/torus/B-spline are bounded), and
+    # the gate keeps the cost off the hot path. NOTE: ShapeFix_Face must NOT be used
+    # to repair these — it segfaults on many real-world unbounded cone faces.
+    if isinstance(face_surface, (Geom_CylindricalSurface, Geom_ConicalSurface)):
+        wire_diag = _shape_diag(outer_wire)
+        if _face_overruns_wire(face, wire_diag):
+            rebuilt = _make_face_from_param_extent(advanced_face, face_surface)
+            if rebuilt is None or _face_overruns_wire(rebuilt, wire_diag):
+                raise UnableToCreateTesselationFromSolidOCCGeom(
+                    f"unbounded face after wire trim on {type(advanced_face.face_surface).__name__}; skipping"
+                )
+            face = rebuilt
 
     # ShapeFix runs only on the regenerative-pcurve path — the
     # SAT-pcurve path produces clean topology and ShapeFix would

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -112,6 +112,71 @@ def tessellate_advanced_face(face: TopoDS_Shape, linear_deflection=0.1, angular_
     mesh.Perform()
 
 
+def _edge_hull_box(shape):
+    """Union bbox of the shape's edge curves plus its bounded closed surfaces
+    (sphere/torus). Face interiors are excluded on purpose: a face whose wire
+    failed to trim an infinite surface (cylinder/cone) poisons any face-inclusive
+    bbox, while its boundary edges remain finite. Returns (xmin..zmax) or None."""
+    from OCC.Core.Bnd import Bnd_Box
+    from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
+    from OCC.Core.BRepBndLib import brepbndlib
+    from OCC.Core.GeomAbs import GeomAbs_Sphere, GeomAbs_Torus
+    from OCC.Core.TopAbs import TopAbs_EDGE, TopAbs_FACE
+    from OCC.Core.TopExp import TopExp_Explorer
+
+    box = Bnd_Box()
+    exp = TopExp_Explorer(shape, TopAbs_EDGE)
+    while exp.More():
+        try:
+            brepbndlib.Add(exp.Current(), box, False)
+        except Exception:  # noqa: BLE001 - one bad edge must not void the hull
+            pass
+        exp.Next()
+    fexp = TopExp_Explorer(shape, TopAbs_FACE)
+    while fexp.More():
+        try:
+            ad = BRepAdaptor_Surface(fexp.Current())
+            t = ad.GetType()
+            if t in (GeomAbs_Sphere, GeomAbs_Torus):
+                if t == GeomAbs_Sphere:
+                    s = ad.Sphere()
+                    c, r = s.Location(), s.Radius()
+                else:
+                    s = ad.Torus()
+                    c, r = s.Location(), s.MajorRadius() + s.MinorRadius()
+                box.Update(c.X() - r, c.Y() - r, c.Z() - r, c.X() + r, c.Y() + r, c.Z() + r)
+        except Exception:  # noqa: BLE001
+            pass
+        fexp.Next()
+    if box.IsVoid():
+        return None
+    return box.Get()
+
+
+def _drop_runaway_triangles(shape, np_vertices, np_normals):
+    """ShapeTesselator output is an unindexed triangle soup. A face whose wire
+    failed to trim an infinite surface can mesh with interior vertices flying
+    kilometres out (worst on sewn solids, where ShapeFix/sewing rebuilds pcurves) —
+    a single such face explodes the converted model's bounding box. Drop every
+    triangle with a vertex outside the shape's edge hull inflated by 10x its
+    diagonal; legitimate surface bulge between edges is well under 1x."""
+    hull = _edge_hull_box(shape)
+    if hull is None:
+        return np_vertices, np_normals
+    xmin, ymin, zmin, xmax, ymax, zmax = hull
+    lo = np.array([xmin, ymin, zmin], dtype="float64")
+    hi = np.array([xmax, ymax, zmax], dtype="float64")
+    pad = 10.0 * max(float(np.linalg.norm(hi - lo)), 1e-6)
+    tri = np_vertices.reshape(-1, 3, 3)
+    ok = ((tri >= (lo - pad)) & (tri <= (hi + pad))).all(axis=(1, 2))
+    if bool(ok.all()):
+        return np_vertices, np_normals
+    np_vertices = np.ascontiguousarray(tri[ok].reshape(-1))
+    if np_normals is not None and np_normals.size:
+        np_normals = np.ascontiguousarray(np_normals.reshape(-1, 3, 3)[ok].reshape(-1))
+    return np_vertices, np_normals
+
+
 def tessellate_shape(shape: TopoDS_Shape, quality=1.0, render_edges=False, parallel=True) -> TriangleMesh:
     # Backend dispatch: a pythonocc TopoDS uses the rich ShapeTesselator
     # (normals + edges). Any other handle (e.g. an adacpp ShapeHandle) is
@@ -147,8 +212,9 @@ def tessellate_shape(shape: TopoDS_Shape, quality=1.0, render_edges=False, paral
 
     # then we build the vertex and faces collections as numpy ndarrays
     np_vertices = np.array(vertices_position, dtype="float32")
-    np_faces = np.arange(number_of_triangles * 3, dtype="uint32")
     np_normals = np.array(tess.GetNormalsAsTuple(), dtype="float32")
+    np_vertices, np_normals = _drop_runaway_triangles(shape, np_vertices, np_normals)
+    np_faces = np.arange(np_vertices.size // 3, dtype="uint32")
     edges = np.array(
         map(
             lambda i_edge: [tess.GetEdgeVertex(i_edge, i_vert) for i_vert in range(tess.ObjEdgeGetVertexCount(i_edge))],

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -73,9 +73,10 @@ def _tessellate_geom_worker(geom):
     """Pool subprocess entry: build + tessellate ONE solid and return raw mesh arrays
     plus the solid's colour — the parent assigns a consistent material id (each
     subprocess has its own material store). Returns
-    ``(status, gid, color, positions, indices, normals, transforms)`` where ``status``
-    is "ok", "degenerate", "empty" or "error:<Type>"; ``transforms`` is the solid's list
-    of world-placement matrices (or None) — the parent meshes once and places per matrix.
+    ``(status, gid, color, positions, indices, normals, transforms, paths)`` where
+    ``status`` is "ok", "degenerate", "empty" or "error:<Type>"; ``transforms`` is the
+    solid's list of world-placement matrices (or None) — the parent meshes once and
+    places per matrix — and ``paths`` the matching per-instance assembly paths.
     OCC isn't thread-safe, so the unit of parallelism is a process."""
     import numpy as np
 
@@ -103,14 +104,14 @@ def _tessellate_geom_worker(geom):
         except Exception:
             diag = 0.0
         if diag < 1e-7:
-            return ("degenerate", gid, geom.color, None, None, None, None)
+            return ("degenerate", gid, geom.color, None, None, None, None, None)
         mesh = be.tessellate(occ)
         idx = getattr(mesh, "indices", None)
         if idx is None:
             idx = getattr(mesh, "faces", None)
         pos = getattr(mesh, "positions", None)
         if pos is None or idx is None or len(idx) == 0:
-            return ("empty", gid, geom.color, None, None, None, None)
+            return ("empty", gid, geom.color, None, None, None, None, None)
         nrm = getattr(mesh, "normals", None)
         # ascontiguousarray(+dtype) COPIES, so pos/idx/nrm no longer reference any OCC
         # buffer — the shape + its triangulation can be dropped immediately below.
@@ -120,9 +121,9 @@ def _tessellate_geom_worker(geom):
         # The shell is tessellated ONCE in its local frame. The world-placement matrices
         # (one per STEP assembly instance) ride back to the parent, which applies each to
         # this single local mesh — so a part instanced N times still meshes once.
-        return ("ok", gid, geom.color, pos, idx, nrm, geom.transforms)
+        return ("ok", gid, geom.color, pos, idx, nrm, geom.transforms, geom.instance_paths)
     except Exception as exc:  # noqa: BLE001 - report and skip; one bad solid mustn't abort
-        return (f"error:{type(exc).__name__}", gid, None, None, None, None, None)
+        return (f"error:{type(exc).__name__}", gid, None, None, None, None, None, None)
     finally:
         # Purge this task's OCC instances now (refcount-0 frees the native shape +
         # triangulation) rather than relying on end-of-call scope cleanup — keeps a
@@ -241,6 +242,15 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
     # explicit so a prior in-process conversion can't leak into this one).
     clear_all()
 
+    # glTF mandates metres; STEP files are very often authored in millimetres. The OCC
+    # reader converts via xstep.cascade.unit — mirror that here or a mm model renders
+    # 1000x too big, kilometres off-centre, and the viewer's depth precision collapses.
+    from ada.cadit.step.read.stream_reader import detect_step_length_unit_scale
+
+    unit_scale = detect_step_length_unit_scale(source.path)
+    if unit_scale != 1.0:
+        logger.info("scene_from_step_stream: scaling length unit to metres (factor %g)", unit_scale)
+
     root = graph.top_level
     on_progress = source.on_progress
 
@@ -258,10 +268,30 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
     def _on_total(n: int) -> None:
         n_roots["total"] = n
 
+    # Assembly-tree group nodes, keyed by the path's rep-id prefix (names alone can
+    # repeat across branches). Created lazily as instances arrive, so the GLB's
+    # id_hierarchy mirrors the STEP product tree and the viewer can fold whole
+    # sub-assemblies instead of scrolling a flat list of thousands of solids.
+    asm_nodes: dict[tuple, object] = {}
+
+    def _group_parent(path) -> object:
+        parent = root
+        if not path:
+            return parent
+        prefix = ()
+        for rep_id, name in path:
+            prefix += (rep_id,)
+            node_g = asm_nodes.get(prefix)
+            if node_g is None:
+                node_g = graph.add_node(GraphNode(name, graph.next_node_id(), hash=create_guid(), parent=parent))
+                asm_nodes[prefix] = node_g
+            parent = node_g
+        return parent
+
     # The parent owns the material store (so colours map to consistent ids across worker
     # processes), creates the graph node from each worker's raw mesh arrays, and hands
     # the result to the caller's sink. Workers (subprocesses) only build + tessellate.
-    def _build(gid, color, pos, idx, nrm, transform=None) -> None:
+    def _build(gid, color, pos, idx, nrm, transform=None, path=None) -> None:
         # Apply this instance's world placement to the local mesh (rigid: rotation +
         # translation on positions, rotation on normals). pos/nrm stay FLAT (N*3,) — the
         # MeshStore/spill path needs flat buffers — so reshape only for the matmul.
@@ -271,7 +301,16 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
             pos = np.ascontiguousarray((pos.reshape(-1, 3) @ r.T + t[:3, 3]).ravel(), dtype=np.float32)
             if nrm is not None:
                 nrm = np.ascontiguousarray((nrm.reshape(-1, 3) @ r.T).ravel(), dtype=np.float32)
-        node = graph.add_node(GraphNode(gid, graph.next_node_id(), hash=create_guid(), parent=root))
+        if unit_scale != 1.0:
+            # Placement translations and positions are both in file units, so scaling
+            # once AFTER the transform keeps them consistent. Normals are unaffected
+            # by a uniform scale.
+            pos = np.ascontiguousarray(pos * np.float32(unit_scale), dtype=np.float32)
+        # Resolve (and lazily create) the group chain BEFORE asking for the next node
+        # id — next_node_id() is len(nodes), so the reverse order would hand the leaf
+        # an id that the first new group node then claims, silently evicting it.
+        parent = _group_parent(path)
+        node = graph.add_node(GraphNode(gid, graph.next_node_id(), hash=create_guid(), parent=parent))
         mat_id = bt.material_store.get(color, None)
         if mat_id is None:
             mat_id = len(bt.material_store)
@@ -280,15 +319,17 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
 
     def _handle(result) -> None:
         nonlocal n_total
-        status, gid, color, pos, idx, nrm, transforms = result
+        status, gid, color, pos, idx, nrm, transforms, paths = result
         i = n_total
         n_total += 1
         gid = gid or f"solid_{i}"
         if status == "ok":
             # One mesh, N instances: tessellated once, placed per assembly matrix.
-            for k, tf in enumerate(transforms if transforms else [None]):
+            tfs = transforms if transforms else [None]
+            paths = paths if paths and len(paths) == len(tfs) else [None] * len(tfs)
+            for k, (tf, path) in enumerate(zip(tfs, paths)):
                 inst_gid = gid if k == 0 else f"{gid}/{k + 1}"
-                _build(inst_gid, color, pos, idx, nrm, tf)
+                _build(inst_gid, color, pos, idx, nrm, tf, path)
         elif status == "degenerate":
             _skip(gid, "degenerate (zero-extent solid)")
         elif status == "empty":
@@ -406,7 +447,9 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
                             slot["proc"].join(timeout=2)
                             busy -= 1
                             slots[i] = _spawn(i, result_q)
-                            _handle(("error:WorkerCrashed (native crash in OCC)", gid, None, None, None, None, None))
+                            _handle(
+                                ("error:WorkerCrashed (native crash in OCC)", gid, None, None, None, None, None, None)
+                            )
                             continue
                         if slot["since"] and (now - slot["since"]) > timeout_s:
                             gid = slot["gid"]
@@ -415,7 +458,16 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
                             busy -= 1
                             slots[i] = _spawn(i, result_q)
                             _handle(
-                                (f"timeout (>{timeout_s:.0f}s; OCC hang, killed)", gid, None, None, None, None, None)
+                                (
+                                    f"timeout (>{timeout_s:.0f}s; OCC hang, killed)",
+                                    gid,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                )
                             )
             finally:
                 for slot in slots:

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -394,8 +394,21 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
                     except _queue.Empty:
                         pass
                     now = _time.monotonic()
-                    for i, slot in enumerate(slots):  # kill + replace any over-budget worker
-                        if slot["busy"] and slot["since"] and (now - slot["since"]) > timeout_s:
+                    for i, slot in enumerate(slots):  # replace dead or over-budget workers
+                        if not slot["busy"]:
+                            continue
+                        # A worker that died mid-solid (OCC segfault/terminate — uncatchable
+                        # in-process) will never produce a result; without this liveness
+                        # check its slot would sit blocked for the full per-solid timeout,
+                        # and a model with many such solids burns hours of wall clock.
+                        if not slot["proc"].is_alive():
+                            gid = slot["gid"]
+                            slot["proc"].join(timeout=2)
+                            busy -= 1
+                            slots[i] = _spawn(i, result_q)
+                            _handle(("error:WorkerCrashed (native crash in OCC)", gid, None, None, None, None, None))
+                            continue
+                        if slot["since"] and (now - slot["since"]) > timeout_s:
                             gid = slot["gid"]
                             slot["proc"].kill()
                             slot["proc"].join(timeout=2)

--- a/src/ada_cli/files.py
+++ b/src/ada_cli/files.py
@@ -1,15 +1,16 @@
-"""``ada files`` — list and download blobs in a scope.
+"""``ada files`` — list, download, and upload blobs in a scope.
 
-Both commands talk to adapy-viewer via the same ``ADAPY_VIEWER_URL`` /
+All commands talk to adapy-viewer via the same ``ADAPY_VIEWER_URL`` /
 ``ADAPY_VIEWER_TOKEN`` env pair the existing ``ada build upload`` uses;
 the scope is supplied per invocation (``--scope project:<slug>`` or
 ``ADAPY_VIEWER_SCOPE``) since cli/bot tokens can address multiple
 scopes.
 
-``download`` tries the presigned-URL flow first so large files go
-S3-direct without pinning an API worker for the duration of the
-transfer. Local-storage deployments respond 503 to the presign request,
-in which case we fall back to streaming through ``GET /blobs/{key}``.
+``download`` and ``upload`` try the presigned-URL flow first so large
+files go S3-direct without pinning an API worker for the duration of
+the transfer. Local-storage deployments respond 503 to the presign
+request, in which case we fall back to streaming through the
+``/blobs/{key}`` API route (subject to its direct-upload size cap).
 """
 
 from __future__ import annotations
@@ -154,6 +155,72 @@ def _download_via_api(
         _write_stream(resp, dest)
     _print_done(dest, None)
     return 0
+
+
+def cmd_upload(args: argparse.Namespace) -> int:
+    import httpx
+
+    base_url, token, scope = _config(args)
+    src = pathlib.Path(args.src)
+    if not src.is_file():
+        print(f"not a file: {src}", file=sys.stderr)
+        return 2
+    key = (args.key or src.name).strip().lstrip("/")
+    size = src.stat().st_size
+
+    with httpx.Client(timeout=_TRANSFER_TIMEOUT_SECONDS) as client:
+        if not args.via_api:
+            url_resp = client.post(
+                f"{base_url}/api/scopes/{scope}/upload-url",
+                json={"key": key},
+                headers={**_auth(token), "Content-Type": "application/json"},
+            )
+            if url_resp.status_code != 503:  # 503 = local backend can't presign; fall through
+                if url_resp.status_code >= 400:
+                    print(
+                        f"upload-url failed: {url_resp.status_code} {url_resp.text}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                # No Authorization on the signed URL (same SigV4 constraint as download).
+                with src.open("rb") as fh:
+                    put = client.put(
+                        url_resp.json()["url"],
+                        content=fh,
+                        headers={"Content-Length": str(size)},
+                    )
+                if put.status_code >= 400:
+                    print(
+                        f"presigned PUT failed: {put.status_code} {put.text[:200]}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                # Finalise: audit row + auto-conversion enqueue happen server-side here.
+                done = client.post(
+                    f"{base_url}/api/scopes/{scope}/upload-complete",
+                    json={"key": key},
+                    headers={**_auth(token), "Content-Type": "application/json"},
+                )
+                if done.status_code >= 400:
+                    print(
+                        f"upload-complete failed: {done.status_code} {done.text}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                print(f"  uploaded {src} -> {scope}/{key} ({done.json().get('size', size)} bytes)")
+                return 0
+
+        with src.open("rb") as fh:
+            resp = client.put(
+                f"{base_url}/api/scopes/{scope}/blobs/{key}",
+                content=fh,
+                headers={**_auth(token), "Content-Length": str(size)},
+            )
+        if resp.status_code >= 400:
+            print(f"upload failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
+            return 1
+        print(f"  uploaded {src} -> {scope}/{key} ({size} bytes)")
+        return 0
 
 
 def _write_stream(resp, dest: pathlib.Path) -> None:

--- a/src/ada_cli/main.py
+++ b/src/ada_cli/main.py
@@ -12,7 +12,7 @@ Subcommand layout:
     ada view IN [--renderer ...]      local web viewer
     ada build run|upload|run-and-upload
                                       build artefacts and push to viewer
-    ada files list|download           list / download blobs from a scope
+    ada files list|download|upload    list / transfer blobs in a scope
     ada serve api|worker              run the REST API / worker process
 """
 
@@ -58,6 +58,12 @@ def _cmd_files_list(args: argparse.Namespace) -> int:
     from ada_cli.files import cmd_list
 
     return cmd_list(args)
+
+
+def _cmd_files_upload(args: argparse.Namespace) -> int:
+    from ada_cli.files import cmd_upload
+
+    return cmd_upload(args)
 
 
 def _cmd_files_download(args: argparse.Namespace) -> int:
@@ -142,7 +148,7 @@ def _add_build(sub: argparse._SubParsersAction) -> None:
 def _add_files(sub: argparse._SubParsersAction) -> None:
     files = sub.add_parser(
         "files",
-        help="List or download blobs in a scope (needs ADAPY_VIEWER_URL + ADAPY_VIEWER_TOKEN).",
+        help="List, download, or upload blobs in a scope (needs ADAPY_VIEWER_URL + ADAPY_VIEWER_TOKEN).",
     )
     files_sub = files.add_subparsers(dest="files_command", required=True)
 
@@ -174,6 +180,20 @@ def _add_files(sub: argparse._SubParsersAction) -> None:
         help="Force the API-tunneled GET path (skip presigned URL).",
     )
     dl.set_defaults(func=_cmd_files_download)
+
+    up = files_sub.add_parser(
+        "upload",
+        help="Upload a file. Goes S3-direct via a presigned URL when the backend supports it.",
+    )
+    _add_remote_opts(up)
+    up.add_argument("src", help="Local file to upload.")
+    up.add_argument("key", nargs="?", default=None, help="Destination blob key (default: basename of src).")
+    up.add_argument(
+        "--via-api",
+        action="store_true",
+        help="Force the API-tunneled PUT path (skip presigned URL; subject to the direct-upload size cap).",
+    )
+    up.set_defaults(func=_cmd_files_upload)
 
 
 def _add_audit(sub: argparse._SubParsersAction) -> None:

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -11,7 +11,7 @@
     "build:serve": "vite build --config vite.config.serve.ts --emptyOutDir",
     "build:embed": "vite build --config vite.config.embed.ts",
     "dev": "vite --force",
-    "test": "node --import tsx --test src/__tests__/services/feaManifestPoll.test.ts src/__tests__/services/feaFieldBlob.test.ts src/__tests__/services/feaElemFieldBlob.test.ts src/__tests__/services/feaMeshEdges.test.ts src/__tests__/services/feaMeshElements.test.ts src/__tests__/services/feaBeamSolidsWarp.test.ts"
+    "test": "node --import tsx --test src/__tests__/services/feaManifestPoll.test.ts src/__tests__/services/feaFieldBlob.test.ts src/__tests__/services/feaElemFieldBlob.test.ts src/__tests__/services/feaMeshEdges.test.ts src/__tests__/services/feaMeshElements.test.ts src/__tests__/services/feaBeamSolidsWarp.test.ts src/__tests__/utils/edgeShaderHelper.test.ts"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/frontend/src/__tests__/utils/edgeShaderHelper.test.ts
+++ b/src/frontend/src/__tests__/utils/edgeShaderHelper.test.ts
@@ -1,0 +1,66 @@
+/** buildEdgeGeometryWithRangeIds: single-pass typed-array edge extraction with
+ * EdgesGeometry semantics — position-welded soup vertices, boundary edges always
+ * emitted, shared edges only past the dihedral threshold, per-vertex rangeId. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as THREE from "three";
+import { buildEdgeGeometryWithRangeIds } from "../../utils/mesh_select/EdgeShaderHelper";
+
+/** Triangle-soup geometry (unique sequential indices, like the streamed GLB). */
+function soup(triangles: number[][][]): THREE.BufferGeometry {
+  const pos: number[] = [];
+  for (const tri of triangles) for (const v of tri) pos.push(...v);
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(pos), 3));
+  g.setIndex(new THREE.BufferAttribute(new Uint32Array(pos.length / 3).map((_, i) => i), 1));
+  return g;
+}
+
+test("coplanar quad emits only its boundary; folded quad also emits the crease", () => {
+  // Range A: two coplanar triangles sharing the diagonal (0,0,0)-(1,1,0).
+  const flatQuad = [
+    [[0, 0, 0], [1, 0, 0], [1, 1, 0]],
+    [[0, 0, 0], [1, 1, 0], [0, 1, 0]],
+  ];
+  // Range B (offset in y so welding can't bridge ranges): two triangles meeting
+  // at 90 degrees along the shared edge (0,5,0)-(1,5,0).
+  const folded = [
+    [[0, 5, 0], [1, 5, 0], [1, 6, 0]],
+    [[0, 5, 0], [1, 5, 1], [1, 5, 0]],
+  ];
+  const geom = soup([...flatQuad, ...folded]);
+  const ranges = new Map<string, [number, number]>([
+    ["A", [0, 6]],
+    ["B", [6, 6]],
+  ]);
+
+  const { geometry, rangeIdToIndex } = buildEdgeGeometryWithRangeIds(geom, ranges);
+  assert.deepEqual([...rangeIdToIndex.keys()], ["A", "B"]);
+
+  const rangeAttr = geometry.getAttribute("rangeId") as THREE.BufferAttribute;
+  const posAttr = geometry.getAttribute("position") as THREE.BufferAttribute;
+  assert.equal(posAttr.count % 2, 0, "line segments come in vertex pairs");
+
+  // Count segments per range.
+  const segs = new Map<number, number>();
+  for (let i = 0; i < rangeAttr.count; i += 2) {
+    const r = rangeAttr.getX(i);
+    segs.set(r, (segs.get(r) ?? 0) + 1);
+  }
+  // Flat quad: 4 boundary edges, diagonal suppressed (coplanar).
+  assert.equal(segs.get(rangeIdToIndex.get("A")!), 4);
+  // Folded pair: 4 boundary edges + the 90-degree crease.
+  assert.equal(segs.get(rangeIdToIndex.get("B")!), 5);
+
+  // The suppressed diagonal must not appear among range A's segments.
+  const aIdx = rangeIdToIndex.get("A")!;
+  for (let i = 0; i < rangeAttr.count; i += 2) {
+    if (rangeAttr.getX(i) !== aIdx) continue;
+    const p = [posAttr.getX(i), posAttr.getY(i), posAttr.getZ(i)];
+    const q = [posAttr.getX(i + 1), posAttr.getY(i + 1), posAttr.getZ(i + 1)];
+    const isDiag =
+      (p[0] === 0 && p[1] === 0 && q[0] === 1 && q[1] === 1) ||
+      (p[0] === 1 && p[1] === 1 && q[0] === 0 && q[1] === 0);
+    assert.ok(!isDiag, "coplanar shared diagonal must be suppressed");
+  }
+});

--- a/src/frontend/src/state/modelState.ts
+++ b/src/frontend/src/state/modelState.ts
@@ -99,7 +99,18 @@ export const useModelState = create<ModelState>((set) => ({
         if (ext && gltf) {
             void import('@/utils/lineage/registerLineageFromExtension').then(({registerLineageFromExtension}) =>
                 registerLineageFromExtension({gltf, extension: ext, fileName: name, root: group}),
-            ).catch((err) => console.warn('lineage: register failed for', name, err));
+            ).catch((err) => console.warn('lineage: register failed for', name, err))
+                .finally(() => {
+                    // Lineage was the last consumer of the GLTFLoader parser. Dropping
+                    // the stashed reference releases the parser's caches INCLUDING the
+                    // raw GLB body ArrayBuffer (the geometry attributes own their own
+                    // copies) — on a multi-hundred-MB model this is the difference
+                    // between the binary staying resident forever and being GC'd.
+                    const holders = [(group as any)?.children?.[0]?.userData, (group as any)?.userData];
+                    for (const ud of holders) {
+                        if (ud && '__adaGltf' in ud) delete ud.__adaGltf;
+                    }
+                });
             // Build the reverse member→connection index so the
             // selection inspector can show "Connections (N)" for a
             // clicked beam/plate without re-reading the GLB.

--- a/src/frontend/src/utils/mesh_select/CustomBatchedMesh.ts
+++ b/src/frontend/src/utils/mesh_select/CustomBatchedMesh.ts
@@ -71,7 +71,11 @@ export class CustomBatchedMesh extends THREE.Mesh {
         is_design: boolean,
         ada_ext_data: SimulationDataExtensionMetadata | DesignDataExtension | null
     ) {
-        super(geometry.clone(), material.clone());
+        // Share the source geometry instead of clone()-ing it: the caller discards
+        // the original mesh right after this constructor, so the clone only doubled
+        // the model's buffers (~+0.8 GB on a big CAD GLB). Group/colour mutations on
+        // this.geometry are safe — nothing else renders the source geometry.
+        super(geometry, material.clone());
         this.originalGeometry = geometry;
         this.originalMaterial = material.clone();
         this.drawRanges = drawRanges;

--- a/src/frontend/src/utils/mesh_select/EdgeShaderHelper.ts
+++ b/src/frontend/src/utils/mesh_select/EdgeShaderHelper.ts
@@ -1,51 +1,151 @@
 // utils/mesh_select/EdgeShader.ts
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { useOptionsStore } from '@/state/optionsStore';
+
+// Above this many indices in one mesh, force the feature-edge threshold (30°)
+// even when the user hasn't enabled "hide tessellation edges": at 1° a curved
+// CAD surface emits a line pair for nearly EVERY triangle edge, so a ~30M-tri
+// merged mesh would produce a multi-GB line geometry that takes minutes to
+// build and crawls at render time.
+const FORCE_FEATURE_EDGES_INDEX_COUNT = 5_000_000;
 
 /**
  * Build one big LineSegments geometry where each vertex gets a 'rangeId' attribute.
+ *
+ * Single typed-array pass with the same semantics as per-range
+ * ``THREE.EdgesGeometry`` (boundary edges + edges whose dihedral angle exceeds
+ * the threshold). The previous implementation built a THREE sub-geometry per
+ * draw range — ``Array.from`` boxing every index into JS numbers, a full
+ * ``EdgesGeometry`` per range, and a final ``mergeGeometries`` over tens of
+ * thousands of geometries — which on big merged CAD meshes cost minutes of CPU
+ * and GBs of transient allocations.
  */
 export function buildEdgeGeometryWithRangeIds(
   baseGeo: THREE.BufferGeometry,
   drawRanges: Map<string,[number,number]>
 ): { geometry: THREE.BufferGeometry; rangeIdToIndex: Map<string,number> } {
-  const perRange: THREE.BufferGeometry[] = [];
   const rangeIdToIndex = new Map<string,number>();
-  let idx = 0;
   const posAttr = baseGeo.attributes.position as THREE.BufferAttribute;
+  const pos = posAttr.array as Float32Array;
+  const index = baseGeo.index!.array as Uint16Array | Uint32Array;
 
-  // ``EdgesGeometry``'s ``thresholdAngle`` controls which adjacent
-  // triangles emit a shared edge. The Three.js default of 1° emits
-  // an edge for every tessellated triangle pair on a curved surface,
-  // so a cylindrical or spherical face shows its full triangulation
-  // grid. 30° keeps real feature edges (corners, silhouettes) while
-  // dropping the near-coplanar tessellation lines. Smaller edge
-  // geometry also means fewer line-segments rendered each frame —
-  // strictly a perf win, no shader changes.
   const hideTess = useOptionsStore.getState().hideTessellationEdges;
-  const thresholdAngle = hideTess ? 30 : 1;
+  const forceFeature = index.length > FORCE_FEATURE_EDGES_INDEX_COUNT;
+  if (forceFeature && !hideTess) {
+    console.info(
+      `buildEdgeGeometryWithRangeIds: ${index.length} indices > ` +
+      `${FORCE_FEATURE_EDGES_INDEX_COUNT} — forcing 30° feature-edge threshold`,
+    );
+  }
+  const thresholdAngle = hideTess || forceFeature ? 30 : 1;
+  // EdgesGeometry's test: emit when dot(n1, n2) <= cos(threshold).
+  const thresholdDot = Math.cos(THREE.MathUtils.DEG2RAD * thresholdAngle);
 
-  drawRanges.forEach(([start,count], rangeId) => {
-    const slice = (baseGeo.index!.array as Uint16Array|Uint32Array)
-      .slice(start, start+count);
-    const sub = new THREE.BufferGeometry();
-    sub.setAttribute('position', posAttr);
-    sub.setIndex(Array.from(slice));
+  // Output accumulators: one position chunk per range (chunks are exact-sized,
+  // concatenated once at the end — no growable-array churn).
+  const posChunks: Float32Array[] = [];
+  const chunkRangeIdx: number[] = [];
+  let totalVerts = 0;
 
-    // EdgesGeometry is already non-indexed, so we can skip toNonIndexed()
-    const edges = new THREE.EdgesGeometry(sub, thresholdAngle);
+  // Reusable per-range scratch. The tessellated GLB is a triangle soup (every
+  // triangle owns unique sequential indices), so edge sharing must be detected
+  // by POSITION, exactly like THREE.EdgesGeometry's hash. Vertices are first
+  // welded per range via a quantised spatial hash (1e-4 model units, matching
+  // EdgesGeometry's 4-digit precision); edge keys then pack the welded (lo, hi)
+  // pair into one float-safe integer: lo * 2^26 + hi stays exact below 2^52 for
+  // meshes up to 67M vertices. The edge map stores the first face's index (+1,
+  // so 0 means "consumed"); boundary edges remain and are flushed at the end.
+  const weldMap = new Map<number, number>();
+  const edgeMap = new Map<number, number>();
+  const KEY_SHIFT = 1 << 26;
+  const INV_TOL = 1e4;
 
-    // attach a constant rangeId per-vertex
-    const verts = edges.attributes.position.count;
-    const idArr = new Float32Array(verts).fill(idx);
-    edges.setAttribute('rangeId', new THREE.BufferAttribute(idArr, 1));
+  const weld = (v: number): number => {
+    const o = v * 3;
+    // Spatial hash; sums stay well below 2^53 for coordinates within ~1e5 units.
+    const h =
+      Math.round(pos[o] * INV_TOL) * 73856093 +
+      Math.round(pos[o + 1] * INV_TOL) * 19349663 +
+      Math.round(pos[o + 2] * INV_TOL) * 83492791;
+    const found = weldMap.get(h);
+    if (found !== undefined) return found;
+    weldMap.set(h, v);
+    return v;
+  };
 
-    perRange.push(edges);
-    rangeIdToIndex.set(rangeId, idx++);
+  drawRanges.forEach(([start, count], rangeId) => {
+    const rangeIdx = rangeIdToIndex.size;
+    rangeIdToIndex.set(rangeId, rangeIdx);
+    const triCount = (count / 3) | 0;
+    if (triCount === 0) return;
+
+    // Pass 1: per-face normals for the dihedral test.
+    const normals = new Float32Array(triCount * 3);
+    for (let t = 0; t < triCount; t++) {
+      const o = start + t * 3;
+      const a = index[o] * 3, b = index[o + 1] * 3, c = index[o + 2] * 3;
+      const abx = pos[b] - pos[a], aby = pos[b + 1] - pos[a + 1], abz = pos[b + 2] - pos[a + 2];
+      const acx = pos[c] - pos[a], acy = pos[c + 1] - pos[a + 1], acz = pos[c + 2] - pos[a + 2];
+      let nx = aby * acz - abz * acy, ny = abz * acx - abx * acz, nz = abx * acy - aby * acx;
+      const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+      if (len > 1e-20) { nx /= len; ny /= len; nz /= len; }
+      const no = t * 3;
+      normals[no] = nx; normals[no + 1] = ny; normals[no + 2] = nz;
+    }
+
+    // Pass 2: dedupe shared edges; decide each pair as soon as its second face
+    // arrives. Collect emitted segment endpoints as vertex-index pairs.
+    weldMap.clear();
+    edgeMap.clear();
+    const emitted: number[] = [];
+    for (let t = 0; t < triCount; t++) {
+      const o = start + t * 3;
+      for (let e = 0; e < 3; e++) {
+        const v0 = weld(index[o + e]);
+        const v1 = weld(index[o + ((e + 1) % 3)]);
+        if (v0 === v1) continue; // degenerate edge after welding
+        const lo = v0 < v1 ? v0 : v1;
+        const hi = v0 < v1 ? v1 : v0;
+        const key = lo * KEY_SHIFT + hi;
+        const prev = edgeMap.get(key);
+        if (prev === undefined) {
+          edgeMap.set(key, t + 1);
+        } else if (prev > 0) {
+          const p = (prev - 1) * 3, q = t * 3;
+          const dot = normals[p] * normals[q] + normals[p + 1] * normals[q + 1] + normals[p + 2] * normals[q + 2];
+          if (dot <= thresholdDot) emitted.push(lo, hi);
+          edgeMap.set(key, 0); // consumed (3+-manifold repeats are ignored, as in EdgesGeometry)
+        }
+      }
+    }
+    // Boundary edges: seen exactly once.
+    edgeMap.forEach((v, key) => {
+      if (v > 0) emitted.push((key / KEY_SHIFT) | 0, key % KEY_SHIFT);
+    });
+
+    if (emitted.length === 0) return;
+    const chunk = new Float32Array(emitted.length * 3);
+    for (let i = 0; i < emitted.length; i++) {
+      const v = emitted[i] * 3, w = i * 3;
+      chunk[w] = pos[v]; chunk[w + 1] = pos[v + 1]; chunk[w + 2] = pos[v + 2];
+    }
+    posChunks.push(chunk);
+    chunkRangeIdx.push(rangeIdx);
+    totalVerts += emitted.length;
   });
 
-  const merged = mergeGeometries(perRange, false)!;
+  const outPos = new Float32Array(totalVerts * 3);
+  const outRange = new Float32Array(totalVerts);
+  let off = 0;
+  for (let i = 0; i < posChunks.length; i++) {
+    outPos.set(posChunks[i], off * 3);
+    outRange.fill(chunkRangeIdx[i], off, off + posChunks[i].length / 3);
+    off += posChunks[i].length / 3;
+  }
+
+  const merged = new THREE.BufferGeometry();
+  merged.setAttribute('position', new THREE.BufferAttribute(outPos, 3));
+  merged.setAttribute('rangeId', new THREE.BufferAttribute(outRange, 1));
   return { geometry: merged, rangeIdToIndex };
 }
 

--- a/src/frontend/src/utils/mesh_select/GpuMeshPicker.ts
+++ b/src/frontend/src/utils/mesh_select/GpuMeshPicker.ts
@@ -448,17 +448,21 @@ class GpuMeshPicker {
         // morph texture amplifies both layouts by ~2×). Auto-pick the
         // cheaper layout so a user enabling the toggle on the
         // Performance panel never gets a regression.
+        // Always auto-pick the cheaper layout — the cost model above is exact, so
+        // there is no reason to pay ~81 B/tri for a merged CAD mesh (α≈1) when the
+        // flat layout costs ~66 B/tri: on a 30M-tri model that's ~0.5 GB saved. The
+        // perf-store toggle is kept as a manual override to FORCE flat for
+        // experiments; it can no longer make picking more expensive.
         const wantFlat = usePerfStore.getState().useFlatPicker;
-        const flat = wantFlat && this.flatIsCheaper(
-            posAttr.count, nTris, morphTargetCount,
-        );
+        const cheaper = this.flatIsCheaper(posAttr.count, nTris, morphTargetCount);
+        const flat = wantFlat || cheaper;
 
-        if (wantFlat && !flat) {
+        if (wantFlat && !cheaper) {
             const alpha = posAttr.count / nTris;
             console.info(
-                `[GpuMeshPicker] flat-picker disabled for "${mesh.name}": ` +
+                `[GpuMeshPicker] flat-picker forced for "${mesh.name}" despite ` +
                 `vertex-sharing α=${alpha.toFixed(2)} ≥ 1.556 — ` +
-                `non-indexed picker is cheaper for this mesh`,
+                `non-indexed picker would be cheaper for this mesh`,
             );
         }
 

--- a/tests/core/cadit/step/read/test_stream_assembly_transforms.py
+++ b/tests/core/cadit/step/read/test_stream_assembly_transforms.py
@@ -424,3 +424,50 @@ def test_stream_reader_flat_emitter_no_transform(tmp_path):
         assert scale > 0
         assert np.allclose(lo / scale, [1.0, 2.0, 3.0], atol=1e-6)
         assert np.allclose(hi / scale, [2.0, 3.0, 4.0], atol=1e-6)
+
+
+def test_stream_glb_groups_instances_under_assembly_tree(tmp_path):
+    """The GLB's id_hierarchy must mirror the STEP product tree — group nodes named
+    from the PRODUCTs along each instance's placement chain ('a' -> 'box' here), with
+    the mesh instances parented under the deepest group — so a viewer can fold whole
+    sub-assemblies instead of scrolling a flat list."""
+    import json
+    import struct
+
+    from ada.cadit.step.stream_to_glb import stream_step_to_glb
+
+    child = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+    parent_a = ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+    parent_b = ((10.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
+    block = _idt_block(child, parent_a)
+    block += (
+        _axis2_lines(300, *child)
+        + _axis2_lines(310, *parent_b)
+        + "#388=ITEM_DEFINED_TRANSFORMATION('','',#300,#310);\n"
+        "#389=(REPRESENTATION_RELATIONSHIP('','',#172,#179)"
+        "REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#388)SHAPE_REPRESENTATION_RELATIONSHIP());\n"
+        "#390=CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(#389,#187);\n"
+    )
+    path = tmp_path / "multi.step"
+    path.write_text(_render(block))
+    glb = tmp_path / "multi.glb"
+    stream_step_to_glb(path, glb, tolerant=True)
+
+    raw = glb.read_bytes()
+    jlen = struct.unpack("<I", raw[12:16])[0]
+    meta = json.loads(raw[20 : 20 + jlen])["scenes"][0]["extras"]["id_hierarchy"]
+    by_name = {}
+    for nid, (name, pid) in meta.items():
+        by_name.setdefault(name, []).append((nid, pid))
+
+    assert "box/2" in by_name, f"missing second instance: {meta}"
+    # 'box' appears twice: the product group node and the first instance.
+    assert len(by_name["box"]) == 2, f"expected group + instance named 'box': {meta}"
+    (a_id, a_parent) = by_name["a"][0]
+    group_id = {pid for _nid, pid in (by_name["box"] + by_name["box/2"])} - {a_id}
+    # Both instances hang under the SAME 'box' group node, which hangs under 'a'.
+    inst_parents = [pid for name in ("box", "box/2") for nid, pid in by_name[name] if pid != a_parent]
+    box_group = [nid for nid, pid in by_name["box"] if str(pid) == str(a_id)]
+    assert box_group, f"'box' group not parented under 'a': {meta}"
+    leaf_parents = {str(pid) for nid, pid in by_name["box"] + by_name["box/2"] if str(nid) not in box_group}
+    assert leaf_parents == {str(box_group[0])}, f"instances not grouped under 'box': {meta}"

--- a/tests/core/cadit/step/read/test_stream_assembly_transforms.py
+++ b/tests/core/cadit/step/read/test_stream_assembly_transforms.py
@@ -463,10 +463,8 @@ def test_stream_glb_groups_instances_under_assembly_tree(tmp_path):
     assert "box/2" in by_name, f"missing second instance: {meta}"
     # 'box' appears twice: the product group node and the first instance.
     assert len(by_name["box"]) == 2, f"expected group + instance named 'box': {meta}"
-    (a_id, a_parent) = by_name["a"][0]
-    group_id = {pid for _nid, pid in (by_name["box"] + by_name["box/2"])} - {a_id}
+    (a_id, _a_parent) = by_name["a"][0]
     # Both instances hang under the SAME 'box' group node, which hangs under 'a'.
-    inst_parents = [pid for name in ("box", "box/2") for nid, pid in by_name[name] if pid != a_parent]
     box_group = [nid for nid, pid in by_name["box"] if str(pid) == str(a_id)]
     assert box_group, f"'box' group not parented under 'a': {meta}"
     leaf_parents = {str(pid) for nid, pid in by_name["box"] + by_name["box/2"] if str(nid) not in box_group}

--- a/tests/core/cadit/step/test_stream_to_glb.py
+++ b/tests/core/cadit/step/test_stream_to_glb.py
@@ -134,3 +134,38 @@ def test_stream_pool_per_solid_timeout_skips_hung_solid(monkeypatch, tmp_path):
     stats = scene.metadata["ada_stream_stats"]
     assert stats["meshed"] == 0  # every solid hung -> all killed + skipped
     assert any("timeout" in r for r in stats["reasons"])  # reaped by the per-solid timeout
+
+
+def test_detect_step_length_unit_scale(example_files):
+    from ada.cadit.step.read.stream_reader import detect_step_length_unit_scale
+
+    sf = example_files / "step_files"
+    assert detect_step_length_unit_scale(sf / "as1-oc-214.stp") == 0.001  # SI_UNIT(.MILLI.,.METRE.)
+    assert detect_step_length_unit_scale(sf / "flat_plate_abaqus_10x10_m.stp") == 1.0  # SI_UNIT(.METRE.)
+    # Abaqus expresses mm as CONVERSION_BASED_UNIT('MILLIMETRE', ...)
+    assert detect_step_length_unit_scale(sf / "flat_plate_abaqus_10x10_mm.stp") == 0.001
+
+
+def test_stream_glb_scales_millimetre_files_to_metres(tmp_path):
+    """glTF mandates metres. A mm-declared STEP must come out scaled 0.001 — unscaled
+    it renders 1000x too big, kilometres off-centre, and the viewer's depth precision
+    collapses into z-fighting artifacts."""
+    import trimesh
+
+    import ada
+
+    a = ada.Assembly("m") / (ada.Part("p") / Beam("bm", (0, 0, 0), (3, 0, 0), Section("s", from_str="IPE300")))
+    src = tmp_path / "m.step"
+    a.to_stp(src)
+
+    from ada.cadit.step.read.stream_reader import detect_step_length_unit_scale
+
+    scale = detect_step_length_unit_scale(src)
+    glb = tmp_path / "m.glb"
+    stats = stream_step_to_glb(src, glb, tolerant=True)
+    assert stats["meshed"] >= 1
+
+    scene = trimesh.load(glb)
+    span_x = float(scene.bounds[1][0] - scene.bounds[0][0])
+    # The 3 m beam must span ~3 in the GLB regardless of the units the writer declared.
+    assert abs(span_x - 3.0) < 0.1, f"beam spans {span_x} (file unit scale {scale})"

--- a/tests/core/geom/test_advanced_face_seam.py
+++ b/tests/core/geom/test_advanced_face_seam.py
@@ -1,0 +1,111 @@
+"""Regression: a cylinder face whose boundary circles are split into arcs and whose
+wire crosses the parametric seam kept the surface's NATURAL (infinite) bounds after
+``BRepBuilderAPI_MakeFace(surface, wire)`` — BRepMesh then emitted vertices millions
+of units out, so a single such face exploded the converted model's bounding box in
+the viewer (seen on assembly-placed STEP files read via the streaming reader).
+``make_face_from_geom`` must hand back a *bounded* face (ShapeFix_Face re-trim, then
+parameter-extent rebuild, else skip)."""
+
+import math
+
+import pytest
+
+from ada.geom.curves import Circle, EdgeCurve, EdgeLoop, Line, OrientedEdge
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+from ada.geom.surfaces import AdvancedFace, CylindricalSurface, FaceBound
+
+R = 10.0
+H = 20.0
+
+
+def _pt(angle_deg: float, z: float) -> Point:
+    a = math.radians(angle_deg)
+    return Point(R * math.cos(a), R * math.sin(a), z)
+
+
+def _arc(p1: Point, p2: Point, z: float) -> OrientedEdge:
+    circ = Circle(position=Axis2Placement3D(location=Point(0, 0, z)), radius=R)
+    ec = EdgeCurve(start=p1, end=p2, edge_geometry=circ, same_sense=True)
+    return OrientedEdge(start=p1, end=p2, edge_element=ec, orientation=True)
+
+
+def _line(p1: Point, p2: Point) -> OrientedEdge:
+    d = Direction(p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2])
+    ec = EdgeCurve(start=p1, end=p2, edge_geometry=Line(pnt=p1, dir=d), same_sense=True)
+    return OrientedEdge(start=p1, end=p2, edge_element=ec, orientation=True)
+
+
+def _seam_crossing_face() -> AdvancedFace:
+    a_t, b_t = _pt(45, H), _pt(200, H)
+    a_b, b_b = _pt(45, 0.0), _pt(200, 0.0)
+    edges = [
+        _arc(a_t, b_t, H),  # top arc 45 deg -> 200 deg (CCW, away from the seam)
+        _line(b_t, b_b),
+        _arc(b_b, a_b, 0.0),  # bottom arc 200 deg -> 45 deg CCW: crosses the seam at 0/360
+        _line(a_b, a_t),
+    ]
+    bound = FaceBound(bound=EdgeLoop(edge_list=edges), orientation=True)
+    surf = CylindricalSurface(position=Axis2Placement3D(location=Point(0, 0, 0)), radius=R)
+    return AdvancedFace(bounds=[bound], face_surface=surf, same_sense=True)
+
+
+def test_seam_crossing_arc_wire_yields_bounded_face():
+    from OCC.Core.Bnd import Bnd_Box
+    from OCC.Core.BRepBndLib import brepbndlib
+    from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+    from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
+
+    from ada.occ.geom.curves import make_wire_from_face_bound
+    from ada.occ.geom.surfaces import (
+        _face_uv_unbounded,
+        make_face_from_geom,
+        make_surface_from_geom,
+    )
+
+    af = _seam_crossing_face()
+
+    # Precondition: the naive wire trim leaves the face unbounded (the bug trigger).
+    surf = make_surface_from_geom(af.face_surface)
+    wire = make_wire_from_face_bound(af.bounds[0])
+    naive = BRepBuilderAPI_MakeFace(surf, wire).Face()
+    if not _face_uv_unbounded(naive):
+        pytest.skip("OCC trims this wire on its own; the regression precondition is gone")
+
+    face = make_face_from_geom(af)
+    assert not _face_uv_unbounded(face)
+
+    # The meshed face must stay inside the cylinder's true extent.
+    BRepMesh_IncrementalMesh(face, 0.5, False, 0.5, True)
+    box = Bnd_Box()
+    brepbndlib.Add(face, box, False)
+    xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
+    pad = 1.0
+    assert -R - pad <= xmin and xmax <= R + pad
+    assert -R - pad <= ymin and ymax <= R + pad
+    assert -pad <= zmin and zmax <= H + pad
+
+
+def test_runaway_triangles_dropped_from_tessellation():
+    """The tessellation-level safety net: a triangle soup with vertices far outside
+    the shape's edge hull (the signature of a face whose trim failed only after
+    sewing rebuilt its pcurves) must lose exactly those triangles."""
+    import numpy as np
+    from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+
+    from ada.occ.tessellating import _drop_runaway_triangles
+
+    shape = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape()
+    good = [0, 0, 0, 1, 0, 0, 0, 1, 0]
+    bad = [0, 0, 0, 1e9, 0, 0, 0, 1e9, 0]  # vertices ~1e8x the edge hull
+    verts = np.array(good + bad, dtype="float32")
+    nrms = np.array([0, 0, 1] * 6, dtype="float32")
+
+    fv, fn = _drop_runaway_triangles(shape, verts, nrms)
+    assert fv.tolist() == good
+    assert fn.size == 9
+
+    # An all-sane soup passes through unchanged.
+    fv2, _ = _drop_runaway_triangles(shape, np.array(good, dtype="float32"), None)
+    assert fv2.tolist() == good

--- a/tests/core/geom/test_advanced_face_seam.py
+++ b/tests/core/geom/test_advanced_face_seam.py
@@ -3,18 +3,28 @@ wire crosses the parametric seam kept the surface's NATURAL (infinite) bounds af
 ``BRepBuilderAPI_MakeFace(surface, wire)`` — BRepMesh then emitted vertices millions
 of units out, so a single such face exploded the converted model's bounding box in
 the viewer (seen on assembly-placed STEP files read via the streaming reader).
-``make_face_from_geom`` must hand back a *bounded* face (ShapeFix_Face re-trim, then
-parameter-extent rebuild, else skip)."""
+
+The end-to-end assertion goes through ``active_backend()`` so BOTH CAD backends are
+held to the same contract: tessellating this face must stay inside the cylinder's
+true extent. Only the bug-trigger precondition and the triangle-soup filter unit
+test are pythonocc-specific."""
 
 import math
 
+import numpy as np
 import pytest
 
 from ada.geom.curves import Circle, EdgeCurve, EdgeLoop, Line, OrientedEdge
 from ada.geom.direction import Direction
 from ada.geom.placement import Axis2Placement3D
 from ada.geom.points import Point
-from ada.geom.surfaces import AdvancedFace, CylindricalSurface, FaceBound
+from ada.geom.surfaces import (
+    AdvancedFace,
+    CylindricalSurface,
+    FaceBound,
+    OpenShell,
+    ShellBasedSurfaceModel,
+)
 
 R = 10.0
 H = 20.0
@@ -52,46 +62,46 @@ def _seam_crossing_face() -> AdvancedFace:
 
 
 def test_seam_crossing_arc_wire_yields_bounded_face():
-    from OCC.Core.Bnd import Bnd_Box
-    from OCC.Core.BRepBndLib import brepbndlib
-    from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
-    from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
-
-    from ada.occ.geom.curves import make_wire_from_face_bound
-    from ada.occ.geom.surfaces import (
-        _face_uv_unbounded,
-        make_face_from_geom,
-        make_surface_from_geom,
-    )
+    from ada.cad import active_backend
+    from ada.geom import Geometry
 
     af = _seam_crossing_face()
 
-    # Precondition: the naive wire trim leaves the face unbounded (the bug trigger).
-    surf = make_surface_from_geom(af.face_surface)
-    wire = make_wire_from_face_bound(af.bounds[0])
-    naive = BRepBuilderAPI_MakeFace(surf, wire).Face()
-    if not _face_uv_unbounded(naive):
-        pytest.skip("OCC trims this wire on its own; the regression precondition is gone")
+    # Bug-trigger precondition, pythonocc only: the naive wire trim leaves the face
+    # unbounded. If a future OCC trims this on its own the regression is moot there;
+    # the backend-agnostic assertion below still runs on adacpp.
+    try:
+        from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
 
-    face = make_face_from_geom(af)
-    assert not _face_uv_unbounded(face)
+        from ada.occ.geom.curves import make_wire_from_face_bound
+        from ada.occ.geom.surfaces import _face_uv_unbounded, make_surface_from_geom
+    except ImportError:
+        pass
+    else:
+        surf = make_surface_from_geom(af.face_surface)
+        wire = make_wire_from_face_bound(af.bounds[0])
+        naive = BRepBuilderAPI_MakeFace(surf, wire).Face()
+        assert _face_uv_unbounded(naive), "OCC now trims this wire on its own — precondition gone, simplify the fix?"
+
+    shell = ShellBasedSurfaceModel(sbsm_boundary=[OpenShell(cfs_faces=[af])])
+    be = active_backend()
+    handle = be.build(Geometry(id="seam-face", geometry=shell, color=None, transforms=None))
+    mesh = be.tessellate(handle)
+    pos = np.asarray(mesh.positions, dtype=float).reshape(-1, 3)
+    assert pos.size, "tessellation produced no vertices"
 
     # The meshed face must stay inside the cylinder's true extent.
-    BRepMesh_IncrementalMesh(face, 0.5, False, 0.5, True)
-    box = Bnd_Box()
-    brepbndlib.Add(face, box, False)
-    xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
     pad = 1.0
-    assert -R - pad <= xmin and xmax <= R + pad
-    assert -R - pad <= ymin and ymax <= R + pad
-    assert -pad <= zmin and zmax <= H + pad
+    assert pos[:, 0].min() >= -R - pad and pos[:, 0].max() <= R + pad
+    assert pos[:, 1].min() >= -R - pad and pos[:, 1].max() <= R + pad
+    assert pos[:, 2].min() >= -pad and pos[:, 2].max() <= H + pad
 
 
 def test_runaway_triangles_dropped_from_tessellation():
     """The tessellation-level safety net: a triangle soup with vertices far outside
     the shape's edge hull (the signature of a face whose trim failed only after
     sewing rebuilt its pcurves) must lose exactly those triangles."""
-    import numpy as np
+    pytest.importorskip("OCC", reason="unit test of the pythonocc tessellation filter internals")
     from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
 
     from ada.occ.tessellating import _drop_runaway_triangles


### PR DESCRIPTION
## Problem

Converting a large assembly-placed STEP model produced an "exploded" GLB: the model spanned hundreds of kilometres and sat far off-center in the viewer, even though the assembly-placement transforms (#213) were verified correct.

## Root causes

1. **Unbounded analytic faces.** A cylinder/cone face whose boundary circles are split into arcs crossing the parametric seam keeps the surface's *natural* (infinite) bounds after `BRepBuilderAPI_MakeFace(surface, wire)`. BRepMesh then emits vertices millions of units out — a single such face explodes the whole model's bounding box.
2. **Sewing-induced runaway vertices.** Even when every face builds bounded in isolation, sewing the shell can rebuild pcurves so the solid-level tessellation emits a handful of vertices kilometres out (mostly sane mesh + ~30 wild vertices).
3. **Pool blind spot on native crashes.** A tessellation worker that dies mid-solid (uncatchable OCC segfault) produced no result, so its slot sat blocked for the full 120 s per-solid timeout. Hundreds of such solids turned an 18-minute conversion into 90+ minutes.

## Fixes

- `make_face_from_geom`: detect a runaway by comparing the built face's geometric extent against its own boundary wire (a trimmed face cannot legitimately overrun its boundary 10x); rebuild from the boundary's projected parameter extent (arc-aware sampling); drop the face if that fails too. Gated to cylinder/cone faces — the only surfaces here with an infinite direction. `ShapeFix_Face` is deliberately **not** used as the repair: it segfaults on many real-world unbounded cone faces.
- `tessellate_shape`: safety net for everything else — drop any triangle with a vertex outside the shape's edge hull inflated 10x (edges stay finite even when a face's trim fails; sphere/torus surface extents are included for edge-poor faces).
- Tessellation pool: check worker liveness each poll and replace a dead worker immediately (`error:WorkerCrashed`) instead of burning the per-solid timeout.

## Results on the reference model (~7k solids, 779 MB STEP)

| | before | after |
|---|---|---|
| model extent | ±308,000 m | **±46 m (true extent)** |
| out-of-extent nodes | 15+ | **0** |
| solids meshed | 6,983 | **7,000** / 7,072 |
| wall clock | 18 min (3 workers) | **4.6 min (8 workers)** |

Existing STEP/geom/visual-parity suites green (115 tests); two new regression tests (synthetic seam-crossing arc wire reproduces the unbounded-face precondition on stock OCC; triangle-soup filter unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)