### PR TITLE
feat: storage panel revamp with user file management and viewer UX fixes

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -50,6 +50,7 @@ from .queue import JobQueue
 from .scope import Scope
 from .scope import can_access as scope_can_access
 from .storage import Storage
+from .storage_ops import delete_blob_cascade, derived_source_of, move_keys_to_folder, rename_key_cascade
 
 # Text-heavy CAD/FEM formats compress 5–10× with gzip; binary mesh
 # formats already pack their geometry tightly so we skip them. The
@@ -70,6 +71,45 @@ _GZIP_UPLOAD_EXTS: frozenset[str] = frozenset(
 # for typical IFC/Genie XML/STEP work and low enough that buffering it
 # in Python doesn't blow the worker's RAM budget.
 _DIRECT_UPLOAD_THRESHOLD_BYTES: int = 200 * 1024 * 1024
+
+
+async def _parse_move_body(request: Request) -> tuple[list[str], str]:
+    """Validate the ``{"keys": [...], "folder": "..."}`` move payload."""
+    body = await request.json()
+    raw_keys = body.get("keys")
+    folder_raw = body.get("folder")
+
+    if not isinstance(raw_keys, list) or not raw_keys:
+        raise HTTPException(status_code=400, detail="keys must be a non-empty list")
+    if any(not isinstance(k, str) or not k.strip() for k in raw_keys):
+        raise HTTPException(status_code=400, detail="every key must be a non-empty string")
+    if not isinstance(folder_raw, str) or not folder_raw.strip():
+        raise HTTPException(status_code=400, detail="folder required")
+    folder = folder_raw.strip().strip("/")
+    if not folder:
+        raise HTTPException(status_code=400, detail="folder required")
+    return raw_keys, folder
+
+
+async def _parse_rename_body(request: Request) -> tuple[str, str]:
+    """Validate the ``{"old_key": str, "new_key": str}`` rename payload."""
+    body = await request.json()
+    old_raw = body.get("old_key")
+    new_raw = body.get("new_key")
+
+    if not isinstance(old_raw, str) or not old_raw.strip():
+        raise HTTPException(status_code=400, detail="old_key required")
+    if not isinstance(new_raw, str) or not new_raw.strip():
+        raise HTTPException(status_code=400, detail="new_key required")
+    old_key = old_raw.strip().lstrip("/")
+    new_key = new_raw.strip().lstrip("/")
+    if not old_key or not new_key:
+        raise HTTPException(status_code=400, detail="old_key and new_key required")
+    if new_key.endswith("/"):
+        raise HTTPException(status_code=400, detail="new_key must not end with /")
+    if new_key == old_key:
+        raise HTTPException(status_code=400, detail="new_key matches old_key")
+    return old_key, new_key
 
 
 def _content_encoding_for(key: str) -> str | None:
@@ -643,7 +683,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # Convert-page mode — group every derived blob under its
         # source so the page can list pre-existing conversions next
         # to fresh upload rows. Same grouping the admin storage list
-        # builds; same helpers reused (``_derived_source_of`` parses
+        # builds; same helpers reused (``derived_source_of`` parses
         # the full derived-key zoo including the streaming-FEA tree
         # and SIF step/field picks). Orphans (derived without a
         # source in this scope) are dropped here — the admin tab is
@@ -652,7 +692,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         derived_index: dict[str, list[dict]] = {}
         for f in files:
             if is_derived_key(f.key):
-                parsed = _derived_source_of(f.key)
+                parsed = derived_source_of(f.key)
                 if parsed is None:
                     continue
                 src_key, target = parsed
@@ -771,6 +811,105 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         await _audit(request, user, scope_obj, "upload", key=clean, status="ok")
         return JSONResponse({"key": clean, "size": len(data)}, status_code=201)
+
+    # ── User-level file management (personal scope only) ────────────
+    # Regular users manage their own files; shared/project scopes stay
+    # admin-managed (project scopes mix the CI versions/ tree with
+    # regular files and get their own treatment later). CI version
+    # blobs and the bake cache are protected even inside the personal
+    # scope — deleting a source still cascades its derived blobs via
+    # the shared storage_ops helpers.
+
+    def _require_personal(scope_obj: Scope) -> None:
+        if scope_obj.kind != "user":
+            raise HTTPException(
+                status_code=403,
+                detail="file management is personal-scope only",
+            )
+
+    def _reject_protected_key(key: str) -> None:
+        from .converter import is_derived_key, is_versions_artefact_key
+
+        if is_derived_key(key) or is_versions_artefact_key(key):
+            raise HTTPException(
+                status_code=400,
+                detail="versions/ and _derived/ keys are admin-managed",
+            )
+
+    @api.delete("/scopes/{scope}/blobs/{key:path}")
+    async def api_scope_blob_delete(
+        key: str,
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        _require_personal(scope_obj)
+        clean = key.lstrip("/")
+        if not clean:
+            raise HTTPException(status_code=400, detail="empty key")
+        _reject_protected_key(clean)
+        result = await delete_blob_cascade(storage, scope_obj, clean)
+        await _audit(
+            request,
+            user,
+            scope_obj,
+            "delete",
+            key=clean,
+            status="ok",
+            error="; ".join(result["errors"]) or None,
+        )
+        return JSONResponse(result)
+
+    @api.post("/scopes/{scope}/keys/move-to-folder")
+    async def api_scope_keys_move_to_folder(
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        _require_personal(scope_obj)
+        keys, folder = await _parse_move_body(request)
+        _reject_protected_key(folder + "/")
+        for k in keys:
+            _reject_protected_key(k.strip().lstrip("/"))
+        result = await move_keys_to_folder(storage, scope_obj, keys, folder)
+        for entry in result["moved"]:
+            await _audit(
+                request,
+                user,
+                scope_obj,
+                "move",
+                key=entry["old"],
+                status="ok",
+                error="; ".join(entry["siblings_failed"]) or None,
+            )
+        return JSONResponse(result)
+
+    @api.post("/scopes/{scope}/keys/rename")
+    async def api_scope_keys_rename(
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        _require_personal(scope_obj)
+        old_key, new_key = await _parse_rename_body(request)
+        _reject_protected_key(old_key)
+        _reject_protected_key(new_key)
+        result = await _rename_with_status(scope_obj, old_key, new_key)
+        await _audit(request, user, scope_obj, "rename", key=old_key, status="ok")
+        return JSONResponse(result)
+
+    async def _rename_with_status(scope_obj: Scope, old_key: str, new_key: str) -> dict:
+        """Run a single cascade rename, mapping helper failures to HTTP errors."""
+        live_keys = {f.key for f in await storage.list(scope_obj)}
+        result = await rename_key_cascade(storage, scope_obj, old_key, new_key, live_keys)
+        if "reason" in result:
+            reason = result["reason"]
+            if reason == "source not found":
+                raise HTTPException(status_code=404, detail=reason)
+            if reason.startswith("target already exists"):
+                raise HTTPException(status_code=409, detail=reason)
+            raise HTTPException(status_code=400, detail=reason)
+        return result
 
     @api.put("/scopes/{scope}/derived")
     async def api_scope_derived_put(
@@ -4075,69 +4214,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         ext = pathlib.PurePosixPath(key).suffix.lower()
         return _SOURCE_FORMAT_NAMES.get(ext, ext.lstrip(".").upper() or "—")
 
-    def _derived_source_of(derived_key: str) -> tuple[str, str] | None:
-        """Recover (source_key, target_label) from a derived key.
-
-        Handles the full derived-key zoo so the admin storage list
-        attributes every derived artefact to its real source instead
-        of dropping it (silently) or surfacing a fake source as an
-        orphan:
-
-        * ``<src>.fea/<file>`` — streaming-viewer artefact tree
-          (mesh GLB, manifest, mesh-edges sidecar, per-field blobs).
-        * ``<src>.meta.json`` — legacy result-meta cache.
-        * ``<src>.<job_id>.prof`` — per-job cProfile dump.
-        * ``<src>.s<N>.<field>.<fmt>`` — legacy SIF step/field pick.
-        * ``<src>.<fmt>`` — plain legacy convert output.
-        """
-
-        import re as _re
-
-        from .converter import TARGET_FORMATS, is_derived_key
-
-        if not is_derived_key(derived_key):
-            return None
-        stripped = derived_key[len("_derived/") :]
-
-        # Streaming-FEA artefact tree: `<src>.fea/<filename>`. The
-        # ".fea/" infix is anchored to the source's extension; finding
-        # it splits the key cleanly into source + artefact filename.
-        fea_idx = stripped.find(".fea/")
-        if fea_idx >= 0:
-            src_key = stripped[:fea_idx]
-            filename = stripped[fea_idx + len(".fea/") :]
-            return src_key, f"fea/{filename}"
-
-        # Legacy result-meta cache.
-        if stripped.endswith(".meta.json"):
-            return stripped[: -len(".meta.json")], "meta.json"
-
-        # Per-job profile blob: `<src>.<job_id>.prof`. job_id is
-        # uuid-hex (no dots) so the last dot before .prof bounds it.
-        if stripped.endswith(".prof"):
-            without_prof = stripped[: -len(".prof")]
-            last_dot = without_prof.rfind(".")
-            if last_dot > 0:
-                return without_prof[:last_dot], "prof"
-
-        # Legacy SIF step/field pick OR bare `<src>.<fmt>`. Try the
-        # step/field shape first when the candidate source ends in
-        # `.sif`; fall back to the bare match otherwise (avoids
-        # mis-attributing a non-SIF source whose name happens to
-        # contain `.s<digits>.`).
-        for tgt in TARGET_FORMATS:
-            suffix = "." + tgt
-            if stripped.endswith(suffix):
-                without_tgt = stripped[: -len(suffix)]
-                m = _re.search(r"\.s\d+\.", without_tgt)
-                if m:
-                    candidate_src = without_tgt[: m.start()]
-                    if candidate_src.lower().endswith(".sif"):
-                        return candidate_src, tgt
-                return without_tgt, tgt
-
-        return None
-
     @admin.get("/scopes/{scope}/files")
     async def admin_storage_list(
         request: Request,
@@ -4151,7 +4227,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         for f in files:
             if is_derived_key(f.key):
-                parsed = _derived_source_of(f.key)
+                parsed = derived_source_of(f.key)
                 if parsed is None:
                     continue  # malformed derived key — ignore quietly
                 src_key, target = parsed
@@ -4204,116 +4280,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         scope_obj: Scope = Depends(_scope_from_path),
         user: User = Depends(auth_module.current_user),
     ) -> JSONResponse:
-        from .converter import is_derived_key
-
-        clean = key.lstrip("/")
-        if not clean:
-            raise HTTPException(status_code=400, detail="empty key")
-
-        # If the admin pointed at a derived blob, only that blob goes;
-        # don't fan out and delete the source under their feet.
-        if is_derived_key(clean):
-            # Streaming-FEA artefacts (mesh GLB + manifest +
-            # mesh-edges sidecar + per-field blobs) form an
-            # interlocking tree: the manifest references every other
-            # file by name, so deleting just one blob leaves the
-            # picker rendering against a stale manifest pointing at
-            # missing data. Reap the whole `<src>.fea/` tree as a
-            # unit instead.
-            parsed = _derived_source_of(clean)
-            if parsed is not None and parsed[1].startswith("fea/"):
-                prefix = f"_derived/{parsed[0]}.fea/"
-                scope_keys = [f.key for f in await storage.list(scope_obj)]
-                tree_keys = [k for k in scope_keys if k.startswith(prefix)]
-                deleted_tree: list[str] = []
-                tree_errors: list[str] = []
-                for k in tree_keys:
-                    try:
-                        await storage.delete(scope_obj, k)
-                        deleted_tree.append(k)
-                    except FileNotFoundError:
-                        continue
-                    except Exception as exc:
-                        msg = str(exc).lower()
-                        if "not found" in msg or "no such" in msg:
-                            continue
-                        logger.warning(
-                            "admin: failed to delete %s in fea-tree reap: %s",
-                            k,
-                            exc,
-                        )
-                        tree_errors.append(f"{k}: {exc}")
-                await _audit(
-                    request,
-                    user,
-                    scope_obj,
-                    "delete",
-                    key=clean,
-                    status="ok",
-                    error="; ".join(tree_errors) or None,
-                )
-                return JSONResponse({"deleted": deleted_tree, "errors": tree_errors})
-
-            # Plain single-blob derived (legacy GLB, meta cache,
-            # profile, etc.) — drop just the one file.
-            try:
-                await storage.delete(scope_obj, clean)
-            except Exception as exc:
-                logger.exception("admin: delete failed for %s", clean)
-                raise HTTPException(status_code=500, detail=str(exc)) from exc
-            await _audit(request, user, scope_obj, "delete", key=clean, status="ok")
-            return JSONResponse({"deleted": [clean]})
-
-        # Source delete: also reap every derived blob keyed off this
-        # source. List the scope and filter via _derived_source_of so
-        # the full derived zoo (FEA artefact tree, result-meta cache,
-        # SIF step/field picks, profile blobs, plain converts) lands
-        # in the candidate set — the previous hardcoded enumeration
-        # only covered ``<src>.<fmt>`` and silently left the new
-        # streaming-bake artefacts behind.
-        candidates = [clean]
-        scope_keys = [f.key for f in await storage.list(scope_obj)]
-        for k in scope_keys:
-            if not is_derived_key(k):
-                continue
-            parsed = _derived_source_of(k)
-            if parsed is None:
-                continue
-            derived_src, _label = parsed
-            if derived_src == clean:
-                candidates.append(k)
-
-        deleted: list[str] = []
-        errors: list[str] = []
-        for k in candidates:
-            try:
-                await storage.delete(scope_obj, k)
-                deleted.append(k)
-            except FileNotFoundError:
-                # Derived blob just wasn't there — that's fine.
-                continue
-            except Exception as exc:
-                # Some backends raise a generic error for "not found";
-                # treat it as benign for derived siblings, but if the
-                # source itself can't be deleted, surface the failure.
-                msg = str(exc).lower()
-                if "not found" in msg or "no such" in msg:
-                    continue
-                if k == clean:
-                    logger.exception("admin: delete failed for source %s", clean)
-                    raise HTTPException(status_code=500, detail=str(exc)) from exc
-                errors.append(f"{k}: {exc}")
-
+        result = await delete_blob_cascade(storage, scope_obj, key)
         await _audit(
             request,
             user,
             scope_obj,
             "delete",
-            key=clean,
+            key=key.lstrip("/"),
             status="ok",
-            error="; ".join(errors) or None,
+            error="; ".join(result["errors"]) or None,
         )
-        return JSONResponse({"deleted": deleted, "errors": errors})
+        return JSONResponse(result)
 
     @admin.post("/scopes/{scope}/keys/move-to-folder")
     async def admin_keys_move_to_folder(
@@ -4325,168 +4302,36 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         Body: ``{"keys": [...], "folder": "..."}``. Each source key
         is renamed to ``<folder>/<basename(src_key)>`` within the
-        same scope. Derived siblings under ``_derived/<src_key>.*``
-        are renamed to follow so the bake cache survives the move
-        (re-baking a big SIF / RMED is expensive — losing the cache
-        on every reorganise would hurt).
-
-        Per-key outcome reporting: failures (target exists, rename
-        backend error, etc.) don't abort the batch — the caller
-        gets ``{moved, failed}`` and can re-attempt the failures.
+        same scope, with derived siblings cascading (see
+        storage_ops.move_keys_to_folder). Per-key failures don't
+        abort the batch — the caller gets ``{moved, failed}``.
         """
 
-        from .converter import is_derived_key
-
-        body = await request.json()
-        raw_keys = body.get("keys")
-        folder_raw = body.get("folder")
-
-        if not isinstance(raw_keys, list) or not raw_keys:
-            raise HTTPException(status_code=400, detail="keys must be a non-empty list")
-        if not isinstance(folder_raw, str) or not folder_raw.strip():
-            raise HTTPException(status_code=400, detail="folder required")
-        folder = folder_raw.strip().strip("/")
-        if not folder:
-            raise HTTPException(status_code=400, detail="folder required")
-        if any(not isinstance(k, str) or not k.strip() for k in raw_keys):
-            raise HTTPException(status_code=400, detail="every key must be a non-empty string")
-
-        # Dedup while preserving order.
-        seen: set[str] = set()
-        keys: list[str] = []
-        for raw in raw_keys:
-            cleaned = raw.strip().lstrip("/")
-            if cleaned and cleaned not in seen:
-                seen.add(cleaned)
-                keys.append(cleaned)
-
-        # Snapshot the scope's keyset so we can detect target collisions
-        # and find derived siblings without re-listing per file. We mutate
-        # the local set as renames happen so multiple moves into the same
-        # folder agree on what already exists.
-        live_keys = {f.key for f in await storage.list(scope_obj)}
-
-        # Source keys (non-derived) — used as the candidate set when
-        # disambiguating which source a derived blob belongs to. Refreshed
-        # implicitly via live_keys mutations during the loop.
-        def _source_keys() -> list[str]:
-            return [k for k in live_keys if not is_derived_key(k)]
-
-        def _owning_source(derived_key: str, candidates: list[str]) -> str | None:
-            """Return the longest source key whose derived prefix matches.
-
-            Derived blobs follow `_derived/<src>.<suffix>` (legacy GLB,
-            FEA artefacts, result-meta, etc.). When two source keys share
-            a string prefix (e.g. ``wall.rmed`` and ``wall.rmed.bak``),
-            naively matching the shorter prefix would steal the longer
-            source's derived blobs on rename. Pick the longest source-key
-            prefix followed by ``.`` or ``/`` and trust *that*.
-            """
-            if not derived_key.startswith("_derived/"):
-                return None
-            inner = derived_key[len("_derived/") :]
-            best: str | None = None
-            for src in candidates:
-                if inner.startswith(src + ".") or inner.startswith(src + "/"):
-                    if best is None or len(src) > len(best):
-                        best = src
-            return best
-
-        moved: list[dict] = []
-        failed: list[dict] = []
-        for old_src in keys:
-            if is_derived_key(old_src):
-                failed.append({"key": old_src, "reason": "cannot move derived blobs directly"})
-                continue
-            basename = old_src.rsplit("/", 1)[-1]
-            new_src = f"{folder}/{basename}"
-            if new_src == old_src:
-                failed.append({"key": old_src, "reason": "destination matches source"})
-                continue
-            if new_src in live_keys:
-                failed.append({"key": old_src, "reason": f"target already exists: {new_src}"})
-                continue
-            if old_src not in live_keys:
-                failed.append({"key": old_src, "reason": "source not found"})
-                continue
-
-            # We've already pre-checked `new_src in live_keys`, so the
-            # collision guard is at the application layer. Pass
-            # overwrite=True because S3-compatible backends raise
-            # ``copy-if-not-exists not supported`` for the safer
-            # default. The narrow remaining race (two admins moving
-            # to the same folder concurrently) would clobber, but
-            # this is an admin-only operation and the audit log
-            # records every move.
-            try:
-                await storage.rename(scope_obj, old_src, new_src, overwrite=True)
-            except Exception as exc:
-                logger.exception("admin: move failed for %s -> %s", old_src, new_src)
-                failed.append({"key": old_src, "reason": str(exc)})
-                continue
-
-            live_keys.discard(old_src)
-            live_keys.add(new_src)
-
-            # Derived siblings: keys under `_derived/<old_src>.*` get
-            # the prefix swapped to `_derived/<new_src>.*` so the
-            # convert / bake cache stays warm. Candidate set must
-            # include old_src — it was just removed from live_keys by
-            # the source rename above, but the derived blobs we're
-            # looking up still reference its name.
-            old_prefix = f"_derived/{old_src}"
-            new_prefix = f"_derived/{new_src}"
-            candidates = _source_keys() + [old_src]
-            sibling_pairs: list[tuple[str, str]] = []
-            for k in list(live_keys):
-                if not k.startswith(old_prefix):
-                    continue
-                # Pin each derived blob to its longest matching source
-                # key — without this, `wall.rmed.bak.glb` would be
-                # stolen as a sibling of `wall.rmed`.
-                if _owning_source(k, candidates) != old_src:
-                    continue
-                rest = k[len(old_prefix) :]
-                sibling_pairs.append((k, new_prefix + rest))
-
-            sibling_errors: list[str] = []
-            for sk_old, sk_new in sibling_pairs:
-                # overwrite=True for the same S3 reason as the source
-                # rename above. Sibling collisions are rare in practice
-                # because the destination derived prefix is always new
-                # (we just renamed the source to a new key).
-                try:
-                    await storage.rename(scope_obj, sk_old, sk_new, overwrite=True)
-                    live_keys.discard(sk_old)
-                    live_keys.add(sk_new)
-                except Exception as exc:
-                    logger.warning(
-                        "admin: sibling rename %s -> %s failed: %s",
-                        sk_old,
-                        sk_new,
-                        exc,
-                    )
-                    sibling_errors.append(f"{sk_old}: {exc}")
-
-            moved.append(
-                {
-                    "old": old_src,
-                    "new": new_src,
-                    "siblings_moved": len(sibling_pairs) - len(sibling_errors),
-                    "siblings_failed": sibling_errors,
-                }
-            )
+        keys, folder = await _parse_move_body(request)
+        result = await move_keys_to_folder(storage, scope_obj, keys, folder)
+        for entry in result["moved"]:
             await _audit(
                 request,
                 user,
                 scope_obj,
                 "move",
-                key=old_src,
+                key=entry["old"],
                 status="ok",
-                error="; ".join(sibling_errors) or None,
+                error="; ".join(entry["siblings_failed"]) or None,
             )
+        return JSONResponse(result)
 
-        return JSONResponse({"moved": moved, "failed": failed})
+    @admin.post("/scopes/{scope}/keys/rename")
+    async def admin_keys_rename(
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Rename a single source key (derived siblings cascade)."""
+        old_key, new_key = await _parse_rename_body(request)
+        result = await _rename_with_status(scope_obj, old_key, new_key)
+        await _audit(request, user, scope_obj, "rename", key=old_key, status="ok")
+        return JSONResponse(result)
 
     @admin.post("/scopes/{scope}/keys/copy-from")
     async def admin_keys_copy_from(

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -50,7 +50,12 @@ from .queue import JobQueue
 from .scope import Scope
 from .scope import can_access as scope_can_access
 from .storage import Storage
-from .storage_ops import delete_blob_cascade, derived_source_of, move_keys_to_folder, rename_key_cascade
+from .storage_ops import (
+    delete_blob_cascade,
+    derived_source_of,
+    move_keys_to_folder,
+    rename_key_cascade,
+)
 
 # Text-heavy CAD/FEM formats compress 5–10× with gzip; binary mesh
 # formats already pack their geometry tightly so we skip them. The

--- a/src/ada/comms/rest/storage_ops.py
+++ b/src/ada/comms/rest/storage_ops.py
@@ -1,0 +1,327 @@
+"""Shared storage mutation helpers with derived-blob cascade.
+
+Delete / rename / move-to-folder all have to drag the derived-blob zoo
+(`_derived/<src>.*` convert outputs, `.fea/` artefact trees, meta caches,
+profile dumps) along with their source so the bake cache survives and no
+orphans are left behind. The logic originated in the admin-only endpoints;
+it lives here so the user-level (personal-scope) endpoints share one
+implementation. Handlers own HTTP-body validation and audit logging —
+helpers take parsed inputs and return plain dicts, raising HTTPException
+only where the admin handlers historically did (empty key, source-delete
+failure).
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException
+
+from ada.config import logger
+
+from .converter import TARGET_FORMATS, is_derived_key
+from .scope import Scope
+from .storage import Storage
+
+
+def derived_source_of(derived_key: str) -> tuple[str, str] | None:
+    """Recover (source_key, target_label) from a derived key.
+
+    Handles the full derived-key zoo so storage listings attribute every
+    derived artefact to its real source instead of dropping it (silently)
+    or surfacing a fake source as an orphan:
+
+    * ``<src>.fea/<file>`` — streaming-viewer artefact tree
+      (mesh GLB, manifest, mesh-edges sidecar, per-field blobs).
+    * ``<src>.meta.json`` — legacy result-meta cache.
+    * ``<src>.<job_id>.prof`` — per-job cProfile dump.
+    * ``<src>.s<N>.<field>.<fmt>`` — legacy SIF step/field pick.
+    * ``<src>.<fmt>`` — plain legacy convert output.
+    """
+
+    if not is_derived_key(derived_key):
+        return None
+    stripped = derived_key[len("_derived/") :]
+
+    # Streaming-FEA artefact tree: `<src>.fea/<filename>`. The
+    # ".fea/" infix is anchored to the source's extension; finding
+    # it splits the key cleanly into source + artefact filename.
+    fea_idx = stripped.find(".fea/")
+    if fea_idx >= 0:
+        src_key = stripped[:fea_idx]
+        filename = stripped[fea_idx + len(".fea/") :]
+        return src_key, f"fea/{filename}"
+
+    # Legacy result-meta cache.
+    if stripped.endswith(".meta.json"):
+        return stripped[: -len(".meta.json")], "meta.json"
+
+    # Per-job profile blob: `<src>.<job_id>.prof`. job_id is
+    # uuid-hex (no dots) so the last dot before .prof bounds it.
+    if stripped.endswith(".prof"):
+        without_prof = stripped[: -len(".prof")]
+        last_dot = without_prof.rfind(".")
+        if last_dot > 0:
+            return without_prof[:last_dot], "prof"
+
+    # Legacy SIF step/field pick OR bare `<src>.<fmt>`. Try the
+    # step/field shape first when the candidate source ends in
+    # `.sif`; fall back to the bare match otherwise (avoids
+    # mis-attributing a non-SIF source whose name happens to
+    # contain `.s<digits>.`).
+    for tgt in TARGET_FORMATS:
+        suffix = "." + tgt
+        if stripped.endswith(suffix):
+            without_tgt = stripped[: -len(suffix)]
+            m = re.search(r"\.s\d+\.", without_tgt)
+            if m:
+                candidate_src = without_tgt[: m.start()]
+                if candidate_src.lower().endswith(".sif"):
+                    return candidate_src, tgt
+            return without_tgt, tgt
+
+    return None
+
+
+def owning_source(derived_key: str, candidates: list[str]) -> str | None:
+    """Return the longest source key whose derived prefix matches.
+
+    Derived blobs follow `_derived/<src>.<suffix>` (legacy GLB,
+    FEA artefacts, result-meta, etc.). When two source keys share
+    a string prefix (e.g. ``wall.rmed`` and ``wall.rmed.bak``),
+    naively matching the shorter prefix would steal the longer
+    source's derived blobs on rename. Pick the longest source-key
+    prefix followed by ``.`` or ``/`` and trust *that*.
+    """
+    if not derived_key.startswith("_derived/"):
+        return None
+    inner = derived_key[len("_derived/") :]
+    best: str | None = None
+    for src in candidates:
+        if inner.startswith(src + ".") or inner.startswith(src + "/"):
+            if best is None or len(src) > len(best):
+                best = src
+    return best
+
+
+async def delete_blob_cascade(storage: Storage, scope_obj: Scope, key: str) -> dict:
+    """Delete a blob; sources cascade to their derived siblings.
+
+    Returns ``{"deleted": [...], "errors": [...]}``. Pointing at a derived
+    blob deletes only that blob — except streaming-FEA artefacts, where the
+    whole ``<src>.fea/`` tree is reaped as a unit (the manifest references
+    every other file by name, so a partial delete leaves the picker
+    rendering against a stale manifest pointing at missing data).
+    """
+
+    clean = key.lstrip("/")
+    if not clean:
+        raise HTTPException(status_code=400, detail="empty key")
+
+    # If the caller pointed at a derived blob, only that blob goes;
+    # don't fan out and delete the source under their feet.
+    if is_derived_key(clean):
+        parsed = derived_source_of(clean)
+        if parsed is not None and parsed[1].startswith("fea/"):
+            prefix = f"_derived/{parsed[0]}.fea/"
+            scope_keys = [f.key for f in await storage.list(scope_obj)]
+            tree_keys = [k for k in scope_keys if k.startswith(prefix)]
+            deleted_tree: list[str] = []
+            tree_errors: list[str] = []
+            for k in tree_keys:
+                try:
+                    await storage.delete(scope_obj, k)
+                    deleted_tree.append(k)
+                except FileNotFoundError:
+                    continue
+                except Exception as exc:
+                    msg = str(exc).lower()
+                    if "not found" in msg or "no such" in msg:
+                        continue
+                    logger.warning(
+                        "storage-op: failed to delete %s in fea-tree reap: %s",
+                        k,
+                        exc,
+                    )
+                    tree_errors.append(f"{k}: {exc}")
+            return {"deleted": deleted_tree, "errors": tree_errors}
+
+        # Plain single-blob derived (legacy GLB, meta cache,
+        # profile, etc.) — drop just the one file.
+        try:
+            await storage.delete(scope_obj, clean)
+        except Exception as exc:
+            logger.exception("storage-op: delete failed for %s", clean)
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return {"deleted": [clean], "errors": []}
+
+    # Source delete: also reap every derived blob keyed off this
+    # source. List the scope and filter via derived_source_of so
+    # the full derived zoo (FEA artefact tree, result-meta cache,
+    # SIF step/field picks, profile blobs, plain converts) lands
+    # in the candidate set.
+    candidates = [clean]
+    scope_keys = [f.key for f in await storage.list(scope_obj)]
+    for k in scope_keys:
+        if not is_derived_key(k):
+            continue
+        parsed = derived_source_of(k)
+        if parsed is None:
+            continue
+        derived_src, _label = parsed
+        if derived_src == clean:
+            candidates.append(k)
+
+    deleted: list[str] = []
+    errors: list[str] = []
+    for k in candidates:
+        try:
+            await storage.delete(scope_obj, k)
+            deleted.append(k)
+        except FileNotFoundError:
+            # Derived blob just wasn't there — that's fine.
+            continue
+        except Exception as exc:
+            # Some backends raise a generic error for "not found";
+            # treat it as benign for derived siblings, but if the
+            # source itself can't be deleted, surface the failure.
+            msg = str(exc).lower()
+            if "not found" in msg or "no such" in msg:
+                continue
+            if k == clean:
+                logger.exception("storage-op: delete failed for source %s", clean)
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+            errors.append(f"{k}: {exc}")
+
+    return {"deleted": deleted, "errors": errors}
+
+
+async def rename_key_cascade(
+    storage: Storage,
+    scope_obj: Scope,
+    old_key: str,
+    new_key: str,
+    live_keys: set[str],
+) -> dict:
+    """Rename one source key, dragging its derived siblings along.
+
+    ``live_keys`` is the caller's snapshot of the scope's keyset; it is
+    mutated as renames happen so batch callers agree on what exists.
+    Returns a moved entry ``{"old", "new", "siblings_moved",
+    "siblings_failed"}`` on success or ``{"key", "reason"}`` on failure
+    (the caller distinguishes via the presence of ``"reason"``).
+    """
+
+    if is_derived_key(old_key):
+        return {"key": old_key, "reason": "cannot move derived blobs directly"}
+    if new_key == old_key:
+        return {"key": old_key, "reason": "destination matches source"}
+    if new_key in live_keys:
+        return {"key": old_key, "reason": f"target already exists: {new_key}"}
+    if old_key not in live_keys:
+        return {"key": old_key, "reason": "source not found"}
+
+    # The collision guard is the `new_key in live_keys` pre-check above —
+    # application layer. Pass overwrite=True because S3-compatible
+    # backends raise ``copy-if-not-exists not supported`` for the safer
+    # default. The narrow remaining race (two callers renaming into the
+    # same key concurrently) would clobber, but the audit log records
+    # every move.
+    try:
+        await storage.rename(scope_obj, old_key, new_key, overwrite=True)
+    except Exception as exc:
+        logger.exception("storage-op: rename failed for %s -> %s", old_key, new_key)
+        return {"key": old_key, "reason": str(exc)}
+
+    live_keys.discard(old_key)
+    live_keys.add(new_key)
+
+    # Derived siblings: keys under `_derived/<old_key>.*` get the prefix
+    # swapped to `_derived/<new_key>.*` so the convert / bake cache stays
+    # warm (re-baking a big SIF / RMED is expensive). Candidate set must
+    # include old_key — it was just removed from live_keys by the source
+    # rename above, but the derived blobs we're looking up still
+    # reference its name.
+    old_prefix = f"_derived/{old_key}"
+    new_prefix = f"_derived/{new_key}"
+    candidates = [k for k in live_keys if not is_derived_key(k)] + [old_key]
+    sibling_pairs: list[tuple[str, str]] = []
+    for k in list(live_keys):
+        if not k.startswith(old_prefix):
+            continue
+        # Pin each derived blob to its longest matching source key —
+        # without this, `wall.rmed.bak.glb` would be stolen as a
+        # sibling of `wall.rmed`.
+        if owning_source(k, candidates) != old_key:
+            continue
+        rest = k[len(old_prefix) :]
+        sibling_pairs.append((k, new_prefix + rest))
+
+    sibling_errors: list[str] = []
+    for sk_old, sk_new in sibling_pairs:
+        # overwrite=True for the same S3 reason as the source rename.
+        # Sibling collisions are rare in practice because the
+        # destination derived prefix is always new (we just renamed
+        # the source to a new key).
+        try:
+            await storage.rename(scope_obj, sk_old, sk_new, overwrite=True)
+            live_keys.discard(sk_old)
+            live_keys.add(sk_new)
+        except Exception as exc:
+            logger.warning(
+                "storage-op: sibling rename %s -> %s failed: %s",
+                sk_old,
+                sk_new,
+                exc,
+            )
+            sibling_errors.append(f"{sk_old}: {exc}")
+
+    return {
+        "old": old_key,
+        "new": new_key,
+        "siblings_moved": len(sibling_pairs) - len(sibling_errors),
+        "siblings_failed": sibling_errors,
+    }
+
+
+async def move_keys_to_folder(
+    storage: Storage,
+    scope_obj: Scope,
+    raw_keys: list[str],
+    folder: str,
+) -> dict:
+    """Batch-move source keys to a destination folder prefix.
+
+    Each source key is renamed to ``<folder>/<basename(src_key)>``
+    within the same scope. Per-key outcome reporting: failures (target
+    exists, rename backend error, etc.) don't abort the batch — the
+    caller gets ``{"moved", "failed"}`` and can re-attempt the failures.
+    """
+
+    # Dedup while preserving order.
+    seen: set[str] = set()
+    keys: list[str] = []
+    for raw in raw_keys:
+        cleaned = raw.strip().lstrip("/")
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            keys.append(cleaned)
+
+    # Snapshot the scope's keyset so we can detect target collisions
+    # and find derived siblings without re-listing per file. The set is
+    # mutated as renames happen so multiple moves into the same folder
+    # agree on what already exists.
+    live_keys = {f.key for f in await storage.list(scope_obj)}
+
+    moved: list[dict] = []
+    failed: list[dict] = []
+    for old_src in keys:
+        basename = old_src.rsplit("/", 1)[-1]
+        new_src = f"{folder}/{basename}"
+        result = await rename_key_cascade(storage, scope_obj, old_src, new_src, live_keys)
+        if "reason" in result:
+            failed.append(result)
+        else:
+            moved.append(result)
+
+    return {"moved": moved, "failed": failed}

--- a/src/frontend/src/components/InViewerPanelHost.tsx
+++ b/src/frontend/src/components/InViewerPanelHost.tsx
@@ -140,7 +140,7 @@ const InViewerPanelHost: React.FC = () => {
                 <Suspense fallback={
                     <div className="p-4 text-sm text-gray-400">Loading…</div>
                 }>
-                    {open === "admin" && <AdminPanel/>}
+                    {open === "admin" && <AdminPanel syncHash={false}/>}
                     {open === "convert" && <ConvertPage/>}
                 </Suspense>
             </div>

--- a/src/frontend/src/components/InViewerPanelHost.tsx
+++ b/src/frontend/src/components/InViewerPanelHost.tsx
@@ -140,7 +140,7 @@ const InViewerPanelHost: React.FC = () => {
                 <Suspense fallback={
                     <div className="p-4 text-sm text-gray-400">Loading…</div>
                 }>
-                    {open === "admin" && <AdminPanel syncHash={false}/>}
+                    {open === "admin" && <AdminPanel embedded/>}
                     {open === "convert" && <ConvertPage/>}
                 </Suspense>
             </div>

--- a/src/frontend/src/components/OptionsComponent.tsx
+++ b/src/frontend/src/components/OptionsComponent.tsx
@@ -162,7 +162,7 @@ function OptionsComponent() {
     // page; scroll inside instead.
     return (
         <div
-            className="bg-gray-400 bg-opacity-50 rounded-sm p-2 min-w-80 max-w-sm text-white text-sm space-y-3 max-h-[70vh] overflow-y-auto"
+            className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80 max-w-sm text-sm space-y-3 max-h-[70vh] overflow-y-auto"
         >
             <h2 className="font-bold">Options</h2>
             {versionInfo}

--- a/src/frontend/src/components/OptionsComponent.tsx
+++ b/src/frontend/src/components/OptionsComponent.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React, {Suspense, useEffect, useState} from "react";
 import {runtime} from "@/runtime/config";
 import {useOptionsStore} from "@/state/optionsStore";
@@ -6,6 +7,7 @@ import DisplayOptions from "./options/DisplayOptions";
 import ExperimentalOptions from "./options/ExperimentalOptions";
 import PerformanceOptions from "./options/PerformanceOptions";
 import ShortcutsModal from "./options/ShortcutsModal";
+import ThemeOptions from "./options/ThemeOptions";
 
 // REST-only controls (scope picker, signed-in row, admin button) live
 // here so they're reachable on phones and don't crowd the top bar.
@@ -102,6 +104,10 @@ function OptionsComponent() {
                 </div>
             </CollapsibleSection>
             <hr className="border-gray-600"/>
+            <CollapsibleSection title="Theme">
+                <ThemeOptions/>
+            </CollapsibleSection>
+            <hr className="border-gray-600"/>
             <CollapsibleSection title="Performance">
                 <PerformanceOptions/>
             </CollapsibleSection>
@@ -162,7 +168,7 @@ function OptionsComponent() {
     // page; scroll inside instead.
     return (
         <div
-            className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80 max-w-sm text-sm space-y-3 max-h-[70vh] overflow-y-auto"
+            className={`${PANEL_CHROME} min-w-80 max-w-sm text-sm space-y-3 max-h-[70vh] overflow-y-auto`}
         >
             <h2 className="font-bold">Options</h2>
             {versionInfo}

--- a/src/frontend/src/components/WebsocketStatusMenu.tsx
+++ b/src/frontend/src/components/WebsocketStatusMenu.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useWebsocketStatusStore} from '../state/websocketStatusStore';
 import {comms} from '../utils/comms';
@@ -100,7 +101,7 @@ export function WebsocketStatusBox() {
     }, [saveEdit, cancelEdit]);
 
     return (
-        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80">
+        <div className={`${PANEL_CHROME} min-w-80`}>
             <h2 className="font-bold">WebSocket Status</h2>
             <div className="text-xs text-gray-300 space-y-2 mb-2">
                 <div className="border-b border-gray-300 pb-2">

--- a/src/frontend/src/components/WebsocketStatusMenu.tsx
+++ b/src/frontend/src/components/WebsocketStatusMenu.tsx
@@ -100,9 +100,9 @@ export function WebsocketStatusBox() {
     }, [saveEdit, cancelEdit]);
 
     return (
-        <div className="bg-gray-400 bg-opacity-50 rounded-sm p-2 min-w-80">
+        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80">
             <h2 className="font-bold">WebSocket Status</h2>
-            <div className="text-xs text-gray-800 space-y-2 mb-2">
+            <div className="text-xs text-gray-300 space-y-2 mb-2">
                 <div className="border-b border-gray-300 pb-2">
                     <div className="font-medium mb-1">Frontend Instance</div>
                     <div className="flex items-center justify-between gap-2">
@@ -137,7 +137,7 @@ export function WebsocketStatusBox() {
                                     Save
                                 </button>
                                 <button
-                                    className="cursor-pointer text-gray-700 hover:text-gray-900 text-xs px-2 py-1 border border-gray-300 rounded-sm"
+                                    className="cursor-pointer text-gray-300 hover:text-gray-100 text-xs px-2 py-1 border border-gray-600 rounded-sm"
                                     onClick={cancelEdit}
                                     title="Cancel"
                                 >
@@ -160,7 +160,7 @@ export function WebsocketStatusBox() {
                         <div className="flex justify-between items-center mt-1">
                             <span className="font-medium">Connected Clients:</span>
                             <button
-                                className="cursor-pointer text-blue-700 hover:text-blue-900 font-medium"
+                                className="cursor-pointer text-blue-400 hover:text-blue-300 font-medium"
                                 onClick={() => setShowClientsList(!showClientsList)}
                                 title="Click to show/hide client list"
                             >
@@ -173,14 +173,14 @@ export function WebsocketStatusBox() {
                     )}
                     {showClientsList && connectedClients.length > 0 && (
                         <div className="mt-2 pl-2 border-l-2 border-blue-300">
-                            <div className="text-xs text-gray-700 mb-1">Client Instances:</div>
+                            <div className="text-xs text-gray-400 mb-1">Client Instances:</div>
                             {connectedClients.map((client) => (
                                 <div
                                     key={client.instanceId}
                                     className={`text-xs font-mono px-2 py-1 rounded mb-1 ${
                                         client.instanceId === comms.getInstanceId()
                                             ? 'bg-blue-200 text-blue-900 font-semibold'
-                                            : 'bg-gray-200 text-gray-800'
+                                            : 'bg-gray-700 text-gray-300'
                                     }`}
                                     title={String(client.instanceId)}
                                 >

--- a/src/frontend/src/components/admin/AdminPanel.tsx
+++ b/src/frontend/src/components/admin/AdminPanel.tsx
@@ -37,15 +37,16 @@ function readTabFromHash(): AdminTab {
 }
 
 interface AdminPanelProps {
-    /** Two-way bind the active tab to ``window.location.hash``. On by
-     * default for the full-page ``/admin`` route (refresh + deep links
-     * stay on the tab). The in-viewer floating panel passes false —
-     * scribbling ``#audit`` etc. onto the viewer URL from a draggable
-     * overlay is just noise. */
-    syncHash?: boolean;
+    /** Mounted inside the viewer's floating panel host rather than the
+     * full-page ``/admin`` route. Embedded mode keeps the URL alone
+     * (no ``#audit`` hash scribbling from a draggable overlay) and
+     * hides the "← viewer" link — the host's close button already
+     * covers leaving the panel. */
+    embedded?: boolean;
 }
 
-const AdminPanel: React.FC<AdminPanelProps> = ({syncHash = true}) => {
+const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false}) => {
+    const syncHash = !embedded;
     const isAdmin = useMeStore((s) => s.isAdmin);
     const [tab, setTab] = useState<AdminTab>(() => (syncHash ? readTabFromHash() : "audit"));
 
@@ -136,13 +137,15 @@ const AdminPanel: React.FC<AdminPanelProps> = ({syncHash = true}) => {
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                     <CliTokenButton/>
-                    <a
-                        href="/"
-                        className="text-sm text-blue-400 hover:text-blue-300 px-2 py-1"
-                        title="Back to viewer"
-                    >
-                        ← viewer
-                    </a>
+                    {!embedded && (
+                        <a
+                            href="/"
+                            className="text-sm text-blue-400 hover:text-blue-300 px-2 py-1"
+                            title="Back to viewer"
+                        >
+                            ← viewer
+                        </a>
+                    )}
                 </div>
             </header>
             <main className="flex-1 min-h-0 overflow-hidden">

--- a/src/frontend/src/components/admin/AdminPanel.tsx
+++ b/src/frontend/src/components/admin/AdminPanel.tsx
@@ -36,27 +36,38 @@ function readTabFromHash(): AdminTab {
     return VALID_TABS.has(raw) ? raw : "audit";
 }
 
-const AdminPanel: React.FC = () => {
+interface AdminPanelProps {
+    /** Two-way bind the active tab to ``window.location.hash``. On by
+     * default for the full-page ``/admin`` route (refresh + deep links
+     * stay on the tab). The in-viewer floating panel passes false —
+     * scribbling ``#audit`` etc. onto the viewer URL from a draggable
+     * overlay is just noise. */
+    syncHash?: boolean;
+}
+
+const AdminPanel: React.FC<AdminPanelProps> = ({syncHash = true}) => {
     const isAdmin = useMeStore((s) => s.isAdmin);
-    const [tab, setTab] = useState<AdminTab>(() => readTabFromHash());
+    const [tab, setTab] = useState<AdminTab>(() => (syncHash ? readTabFromHash() : "audit"));
 
     // Two-way bind ``tab`` to ``window.location.hash`` so reloads stay
     // on the selected tab AND back/forward navigation works inside
     // the page. setTab writes; popstate / hashchange reads back.
     useEffect(() => {
+        if (!syncHash) return;
         const onChange = () => setTab(readTabFromHash());
         window.addEventListener("hashchange", onChange);
         return () => window.removeEventListener("hashchange", onChange);
-    }, []);
+    }, [syncHash]);
 
     useEffect(() => {
+        if (!syncHash) return;
         const desired = `#${tab}`;
         if (window.location.hash !== desired) {
             // ``replaceState`` so each tab switch doesn't pollute the
             // back-button history with a long chain of admin tabs.
             window.history.replaceState(null, "", desired);
         }
-    }, [tab]);
+    }, [syncHash, tab]);
 
     if (!isAdmin) {
         // Non-admin landed on /admin directly (or auth dropped them

--- a/src/frontend/src/components/auth/AuthGate.tsx
+++ b/src/frontend/src/components/auth/AuthGate.tsx
@@ -98,6 +98,14 @@ const AuthGate: React.FC<{children: React.ReactNode}> = ({children}) => {
                 >
                     Sign in
                 </button>
+                <button
+                    className="text-xs text-gray-400 hover:text-gray-200 underline w-full"
+                    onClick={() => {
+                        void signIn(undefined, {forceLogin: true});
+                    }}
+                >
+                    Sign in with a different account
+                </button>
             </div>
         </div>
     );

--- a/src/frontend/src/components/common/PositionedMenu.tsx
+++ b/src/frontend/src/components/common/PositionedMenu.tsx
@@ -1,0 +1,173 @@
+// Portal-anchored popup menu — the positioning/dismiss core shared by
+// the per-row kebab menu (anchored to its button rect) and the storage
+// panel's right-click context menu (anchored to the cursor point).
+//
+// Why a portal instead of inline rendering: the menu has to clear
+// the row's overflow:hidden / z-index so it can spill out of
+// scrollable lists without being clipped. document.body is the only
+// stacking context that always works.
+//
+// Click-outside dismiss runs via a mousedown listener on document.
+// Rect anchors re-place on resize/scroll so the menu tracks the button
+// position without re-opening; point anchors instead close on scroll —
+// there's no element to track, and a context menu drifting away from
+// the row it was opened on reads as a bug.
+
+import React, {useLayoutEffect, useRef, useState} from "react";
+import {createPortal} from "react-dom";
+
+export interface KebabMenuItem {
+    /** Stable React key + identity. Disabled / hidden state is per
+     *  item, not folded into the key. */
+    key: string;
+    label: string;
+    /** Optional leading icon — a rendered SVG element, not a
+     *  component. Pass ``<KebabIcon class="h-3.5 w-3.5"/>`` etc.
+     *  Keeps the menu icon-shape decoupled from the icon-library
+     *  choice (adapy uses inline SVGs; shelf uses lucide-react). */
+    icon?: React.ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+    /** Renders the label in red. Use sparingly — Delete-like actions
+     *  only, so the destructive colour stays meaningful. */
+    destructive?: boolean;
+    /** When true, draws a horizontal divider above this item. Mirrors
+     *  shelf's pattern where the destructive section is visually
+     *  separated from the rest. */
+    separatorBefore?: boolean;
+    /** Optional tooltip on the menu item itself — useful for
+     *  surfacing why an action is disabled. */
+    title?: string;
+}
+
+export type MenuAnchor =
+    | {kind: "rect"; getRect: () => DOMRect | undefined}
+    | {kind: "point"; x: number; y: number};
+
+interface PositionedMenuProps {
+    items: KebabMenuItem[];
+    anchor: MenuAnchor;
+    onClose: () => void;
+    /** Optional non-interactive heading rendered at the top of the menu,
+     *  above the items (e.g. the row's full storage path). */
+    header?: React.ReactNode;
+    /** Elements whose clicks should NOT dismiss the menu (e.g. the
+     *  kebab button that toggles it — toggling handles its own close). */
+    ignoreOutsideRef?: React.RefObject<HTMLElement | null>;
+}
+
+export const PositionedMenu: React.FC<PositionedMenuProps> = ({
+    items,
+    anchor,
+    onClose,
+    header,
+    ignoreOutsideRef,
+}) => {
+    const menuRef = useRef<HTMLDivElement>(null);
+    const [style, setStyle] = useState<React.CSSProperties>(() =>
+        anchor.kind === "point"
+            ? {top: anchor.y, left: anchor.x, visibility: "hidden"}
+            : {visibility: "hidden"},
+    );
+
+    useLayoutEffect(() => {
+        const place = () => {
+            if (anchor.kind === "rect") {
+                const rect = anchor.getRect();
+                if (!rect) return;
+                setStyle({
+                    top: rect.bottom + 4,
+                    right: window.innerWidth - rect.right,
+                });
+                return;
+            }
+            // Point anchor: clamp to the viewport so a right-click near
+            // the bottom/right edge flips the menu inward instead of
+            // spilling off-screen.
+            const menu = menuRef.current;
+            const w = menu?.offsetWidth ?? 200;
+            const h = menu?.offsetHeight ?? 160;
+            const left = Math.min(anchor.x, window.innerWidth - w - 8);
+            const top = Math.min(anchor.y, window.innerHeight - h - 8);
+            setStyle({top: Math.max(8, top), left: Math.max(8, left)});
+        };
+        place();
+        const onClickOutside = (e: Event) => {
+            const target = e.target as Node | null;
+            if (!target) return;
+            if (menuRef.current?.contains(target)) return;
+            if (ignoreOutsideRef?.current?.contains(target)) return;
+            onClose();
+        };
+        const onScroll = anchor.kind === "rect" ? place : onClose;
+        // mousedown not click so the menu dismisses before any
+        // background click handler (e.g. the row's onClick) fires.
+        document.addEventListener("mousedown", onClickOutside);
+        // touchstart on iOS — Safari doesn't fire mousedown for taps
+        // outside the document hierarchy on portaled content.
+        document.addEventListener("touchstart", onClickOutside);
+        window.addEventListener("resize", place);
+        // capture:true so rect menus re-place (and point menus close)
+        // when a scrollable ancestor scrolls, not only the window.
+        window.addEventListener("scroll", onScroll, true);
+        return () => {
+            document.removeEventListener("mousedown", onClickOutside);
+            document.removeEventListener("touchstart", onClickOutside);
+            window.removeEventListener("resize", place);
+            window.removeEventListener("scroll", onScroll, true);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [anchor.kind, anchor.kind === "point" ? anchor.x : 0, anchor.kind === "point" ? anchor.y : 0]);
+
+    const run = (fn: () => void) => (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onClose();
+        fn();
+    };
+
+    return createPortal(
+        <div
+            ref={menuRef}
+            role="menu"
+            className="fixed z-50 min-w-[180px] rounded-sm border border-gray-700 bg-gray-800 shadow-lg text-gray-100"
+            style={style}
+            onClick={(e) => e.stopPropagation()}
+            onContextMenu={(e) => e.preventDefault()}
+        >
+            {header && (
+                <div className="px-3 py-1.5 text-[11px] text-gray-400 border-b border-gray-700 break-all">
+                    {header}
+                </div>
+            )}
+            {items.map((item) => (
+                <React.Fragment key={item.key}>
+                    {item.separatorBefore && (
+                        <div className="my-1 border-t border-gray-700"/>
+                    )}
+                    <button
+                        type="button"
+                        role="menuitem"
+                        disabled={item.disabled}
+                        onClick={run(item.onClick)}
+                        title={item.title}
+                        className={
+                            "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs " +
+                            "hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent " +
+                            (item.destructive ? "text-red-400 hover:text-red-300 " : "")
+                        }
+                    >
+                        {item.icon && (
+                            <span className="inline-flex h-3.5 w-3.5 items-center justify-center shrink-0">
+                                {item.icon}
+                            </span>
+                        )}
+                        <span className="truncate">{item.label}</span>
+                    </button>
+                </React.Fragment>
+            ))}
+        </div>,
+        document.body,
+    );
+};
+
+export default PositionedMenu;

--- a/src/frontend/src/components/common/RowKebabMenu.tsx
+++ b/src/frontend/src/components/common/RowKebabMenu.tsx
@@ -3,42 +3,14 @@
 // to adapy's inline-SVG icon convention (no lucide-react dep) and
 // dark theme (bg-gray-800 / border-gray-700).
 //
-// Why a portal instead of inline rendering: the menu has to clear
-// the row's overflow:hidden / z-index so it can spill out of
-// scrollable lists without being clipped. document.body is the only
-// stacking context that always works.
-//
-// Click-outside dismiss runs via a mousedown listener on document.
-// Resize + scroll re-place the menu so it tracks the button position
-// without re-opening — important when the row scrolls under a sticky
-// header.
+// The positioning/dismiss machinery lives in PositionedMenu (shared
+// with the storage panel's right-click context menu); this component
+// is just the toggle button + a rect anchor.
 
-import React, {useEffect, useRef, useState} from "react";
-import {createPortal} from "react-dom";
+import React, {useRef, useState} from "react";
+import PositionedMenu, {KebabMenuItem} from "./PositionedMenu";
 
-export interface KebabMenuItem {
-    /** Stable React key + identity. Disabled / hidden state is per
-     *  item, not folded into the key. */
-    key: string;
-    label: string;
-    /** Optional leading icon — a rendered SVG element, not a
-     *  component. Pass ``<KebabIcon class="h-3.5 w-3.5"/>`` etc.
-     *  Keeps the menu icon-shape decoupled from the icon-library
-     *  choice (adapy uses inline SVGs; shelf uses lucide-react). */
-    icon?: React.ReactNode;
-    onClick: () => void;
-    disabled?: boolean;
-    /** Renders the label in red. Use sparingly — Delete-like actions
-     *  only, so the destructive colour stays meaningful. */
-    destructive?: boolean;
-    /** When true, draws a horizontal divider above this item. Mirrors
-     *  shelf's pattern where the destructive section is visually
-     *  separated from the rest. */
-    separatorBefore?: boolean;
-    /** Optional tooltip on the menu item itself — useful for
-     *  surfacing why an action is disabled. */
-    title?: string;
-}
+export type {KebabMenuItem};
 
 interface RowKebabMenuProps {
     /** Accessible button label. Caller supplies context — "More
@@ -65,51 +37,7 @@ export const RowKebabMenu: React.FC<RowKebabMenuProps> = ({
     buttonClassName,
 }) => {
     const [open, setOpen] = useState(false);
-    const [pos, setPos] = useState<{top: number; right: number} | null>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const menuRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!open) return;
-        const place = () => {
-            const rect = buttonRef.current?.getBoundingClientRect();
-            if (!rect) return;
-            setPos({
-                top: rect.bottom + 4,
-                right: window.innerWidth - rect.right,
-            });
-        };
-        place();
-        const onClickOutside = (e: Event) => {
-            const target = e.target as Node | null;
-            if (!target) return;
-            if (buttonRef.current?.contains(target)) return;
-            if (menuRef.current?.contains(target)) return;
-            setOpen(false);
-        };
-        // mousedown not click so the menu dismisses before any
-        // background click handler (e.g. the row's onClick) fires.
-        document.addEventListener("mousedown", onClickOutside);
-        // touchstart on iOS — Safari doesn't fire mousedown for taps
-        // outside the document hierarchy on portaled content.
-        document.addEventListener("touchstart", onClickOutside);
-        window.addEventListener("resize", place);
-        // capture:true so the menu re-places when a scrollable
-        // ancestor scrolls, not only the window.
-        window.addEventListener("scroll", place, true);
-        return () => {
-            document.removeEventListener("mousedown", onClickOutside);
-            document.removeEventListener("touchstart", onClickOutside);
-            window.removeEventListener("resize", place);
-            window.removeEventListener("scroll", place, true);
-        };
-    }, [open]);
-
-    const run = (fn: () => void) => (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setOpen(false);
-        fn();
-    };
 
     return (
         <>
@@ -135,47 +63,17 @@ export const RowKebabMenu: React.FC<RowKebabMenuProps> = ({
             >
                 <KebabDotsIcon/>
             </button>
-            {open && pos && createPortal(
-                <div
-                    ref={menuRef}
-                    role="menu"
-                    className="fixed z-50 min-w-[180px] rounded-sm border border-gray-700 bg-gray-800 shadow-lg text-gray-100"
-                    style={{top: pos.top, right: pos.right}}
-                    onClick={(e) => e.stopPropagation()}
-                >
-                    {header && (
-                        <div className="px-3 py-1.5 text-[11px] text-gray-400 border-b border-gray-700 break-all">
-                            {header}
-                        </div>
-                    )}
-                    {items.map((item) => (
-                        <React.Fragment key={item.key}>
-                            {item.separatorBefore && (
-                                <div className="my-1 border-t border-gray-700"/>
-                            )}
-                            <button
-                                type="button"
-                                role="menuitem"
-                                disabled={item.disabled}
-                                onClick={run(item.onClick)}
-                                title={item.title}
-                                className={
-                                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs " +
-                                    "hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent " +
-                                    (item.destructive ? "text-red-400 hover:text-red-300 " : "")
-                                }
-                            >
-                                {item.icon && (
-                                    <span className="inline-flex h-3.5 w-3.5 items-center justify-center shrink-0">
-                                        {item.icon}
-                                    </span>
-                                )}
-                                <span className="truncate">{item.label}</span>
-                            </button>
-                        </React.Fragment>
-                    ))}
-                </div>,
-                document.body,
+            {open && (
+                <PositionedMenu
+                    items={items}
+                    header={header}
+                    onClose={() => setOpen(false)}
+                    ignoreOutsideRef={buttonRef}
+                    anchor={{
+                        kind: "rect",
+                        getRect: () => buttonRef.current?.getBoundingClientRect(),
+                    }}
+                />
             )}
         </>
     );

--- a/src/frontend/src/components/component_view/ComponentControls.tsx
+++ b/src/frontend/src/components/component_view/ComponentControls.tsx
@@ -173,7 +173,7 @@ const ComponentControls: React.FC = () => {
             <div className="flex items-center gap-2">
                 <span className="text-gray-300 shrink-0">Spec</span>
                 <select
-                    className="text-black bg-white rounded-sm px-1 py-0.5 min-w-0 flex-1 truncate"
+                    className="text-gray-100 bg-gray-700 border border-gray-600 rounded-sm px-1 py-0.5 min-w-0 flex-1 truncate"
                     value={selectedSpecName ?? ""}
                     onChange={(e) => handleSpecChange(e.target.value)}
                     disabled={specs === null}
@@ -250,7 +250,7 @@ const RoleRow: React.FC<{
                 <span className="text-gray-400 w-12 shrink-0">section</span>
                 <input
                     type="text"
-                    className="text-black bg-white rounded-sm px-1 py-0.5 flex-1 min-w-0"
+                    className="text-gray-100 bg-gray-700 border border-gray-600 rounded-sm px-1 py-0.5 flex-1 min-w-0"
                     value={(value.section as string) ?? ""}
                     placeholder={allowed}
                     onChange={(e) => onField("section", e.target.value)}
@@ -270,7 +270,7 @@ const RoleRow: React.FC<{
                     />
                     <input
                         type="number"
-                        className="text-black bg-white rounded-sm px-1 py-0.5 w-16"
+                        className="text-gray-100 bg-gray-700 border border-gray-600 rounded-sm px-1 py-0.5 w-16"
                         min={angleRange.min_deg}
                         max={angleRange.max_deg}
                         value={typeof value.angle_deg === "number" ? value.angle_deg : ""}

--- a/src/frontend/src/components/conversion/ConversionProgress.tsx
+++ b/src/frontend/src/components/conversion/ConversionProgress.tsx
@@ -4,6 +4,8 @@ import {useCompressionStore} from "@/state/compressionStore";
 import {useMeStore} from "@/state/meStore";
 import {useScopeStore, scopeUrlPart} from "@/state/scopeStore";
 import {viewerApi} from "@/services/viewerApi";
+import {useLoadQueueStore} from "@/state/loadQueueStore";
+import LoadQueueToast from "./LoadQueueToast";
 
 // Shared dismiss button. Hit area is 28×28 (Apple HIG min is 44 but
 // the toast is dense; 28 still beats the 24 we shipped with and stays
@@ -537,16 +539,22 @@ const ConversionProgress = () => {
     const clearJob = useConversionStore((s) => s.clearJob);
     const sweeps = useCompressionStore((s) => s.sweeps);
     const clearSweep = useCompressionStore((s) => s.clearSweep);
+    const loadCurrentName = useLoadQueueStore((s) => s.current?.name ?? null);
+    const loadQueueActive = useLoadQueueStore(
+        (s) => s.current !== null || s.queued.length > 0 || s.errors.length > 0,
+    );
 
-    const allVisible = Object.values(jobs).filter(
-        (j) => j.status === "queued" || j.status === "running" || j.status === "error"
-    );
     // In-progress jobs collapse into one toast; errors stay split so
-    // each one's traceback + copy button is reachable.
-    const inProgress = allVisible.filter(
-        (j) => j.status === "queued" || j.status === "running",
-    );
-    const errored = allVisible.filter((j) => j.status === "error");
+    // each one's traceback + copy button is reachable. The job driving
+    // the current scene load is hidden here — LoadQueueToast already
+    // shows its progress, and two bars for one model reads as two jobs.
+    const inProgress = Object.entries(jobs)
+        .filter(([k, j]) =>
+            (j.status === "queued" || j.status === "running") &&
+            !(loadCurrentName && k.startsWith(loadCurrentName + "::")))
+        .map(([, j]) => j);
+    const errored = Object.values(jobs).filter((j) => j.status === "error");
+    const allVisible = [...inProgress, ...errored];
     const visibleSweeps = Object.entries(sweeps);
 
     // We always render the outer slot so the admin-only
@@ -555,7 +563,7 @@ const ConversionProgress = () => {
     // so an empty container is invisible. The toast + sweeps only
     // render when there's actually something to show.
     const isAdmin = useMeStore.getState().isAdmin;
-    if (allVisible.length === 0 && visibleSweeps.length === 0 && !isAdmin) {
+    if (allVisible.length === 0 && visibleSweeps.length === 0 && !loadQueueActive && !isAdmin) {
         return null;
     }
 
@@ -572,6 +580,7 @@ const ConversionProgress = () => {
         // ``max-w-sm`` (24rem).
         <div className="absolute bottom-4 left-4 right-4 sm:left-auto sm:max-w-sm z-50 flex flex-col gap-2 pointer-events-auto">
             <AuditActivityBadge/>
+            <LoadQueueToast/>
             {visibleSweeps.map(([scopeLabel, state]) => (
                 <CompressionToast
                     key={`compress:${scopeLabel}`}

--- a/src/frontend/src/components/conversion/LoadQueueToast.tsx
+++ b/src/frontend/src/components/conversion/LoadQueueToast.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import {useLoadQueueStore} from "@/state/loadQueueStore";
+import {useConversionStore} from "@/state/conversionStore";
+
+// Scene-load progress toast — lives in the same bottom-right slot as
+// the conversion toast (mounted from ConversionProgress) so all
+// long-running feedback shares one visual language. Shows the model
+// currently loading (with the conversion job's progress/stage when
+// one is driving the load, else an indeterminate bar), the queued
+// models (each removable), and per-model load errors.
+
+const basename = (key: string) => key.split("/").pop() ?? key;
+
+const LoadQueueToast: React.FC = () => {
+    const current = useLoadQueueStore((s) => s.current);
+    const queued = useLoadQueueStore((s) => s.queued);
+    const errors = useLoadQueueStore((s) => s.errors);
+    const removeQueued = useLoadQueueStore((s) => s.removeQueued);
+    const clearError = useLoadQueueStore((s) => s.clearError);
+    const jobs = useConversionStore((s) => s.jobs);
+
+    if (!current && queued.length === 0 && errors.length === 0) return null;
+
+    // The load may be waiting on a conversion/bake job — surface that
+    // job's progress + stage. Keys are `${sourceKey}::<target>`.
+    const job = current
+        ? Object.entries(jobs).find(([k]) => k.startsWith(current.name + "::"))?.[1]
+        : undefined;
+    const pct = job ? Math.round((job.progress || 0) * 100) : null;
+
+    return (
+        <div className="bg-gray-800 text-gray-100 rounded-sm shadow-lg px-3 py-2 text-xs border border-gray-700 space-y-1">
+            {current && (
+                <div className="space-y-1 min-w-0">
+                    <div className="flex justify-between items-center gap-2 min-w-0">
+                        <span className="truncate min-w-0 flex-1" title={current.name}>
+                            {basename(current.name)}
+                        </span>
+                        <span className="ml-2 text-gray-400 shrink-0">
+                            Loading{pct !== null ? ` ${pct}%` : "…"}
+                        </span>
+                    </div>
+                    {job?.stage && (
+                        <div className="text-[11px] text-gray-400 truncate" title={job.stage}>
+                            {job.stage}
+                        </div>
+                    )}
+                    <div className="h-1 bg-gray-700 rounded-sm overflow-hidden">
+                        {pct !== null ? (
+                            <div
+                                className="h-full bg-blue-500 transition-all"
+                                style={{width: `${Math.max(pct, 4)}%`}}
+                            />
+                        ) : (
+                            <div className="h-full w-1/3 bg-blue-500 animate-[indeterminate_1.4s_ease-in-out_infinite]"/>
+                        )}
+                    </div>
+                </div>
+            )}
+            {queued.length > 0 && (
+                <div className={current ? "pt-1 border-t border-gray-700/60" : ""}>
+                    <div className="text-[11px] text-gray-400 mb-0.5">
+                        Queued ({queued.length})
+                    </div>
+                    <ul className="space-y-0.5 max-h-40 overflow-auto">
+                        {queued.map((t) => (
+                            <li key={t.name} className="flex items-center gap-2 min-w-0">
+                                <span className="truncate flex-1 min-w-0" title={t.name}>
+                                    {basename(t.name)}
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => removeQueued(t.name)}
+                                    className="shrink-0 px-1 rounded-sm text-gray-400 hover:text-red-300 hover:bg-gray-700 cursor-pointer"
+                                    title="Remove from load queue"
+                                    aria-label={`Remove ${basename(t.name)} from load queue`}
+                                >
+                                    ×
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+            {errors.map((e) => (
+                <div
+                    key={e.name}
+                    className="flex items-start justify-between gap-2 pt-1 border-t border-gray-700/60"
+                >
+                    <div className="min-w-0">
+                        <div className="truncate" title={e.name}>{basename(e.name)}</div>
+                        <div className="text-[11px] text-red-400 break-all">{e.message}</div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => clearError(e.name)}
+                        className="shrink-0 px-1 rounded-sm text-gray-400 hover:text-white hover:bg-gray-700 cursor-pointer"
+                        title="Dismiss"
+                        aria-label={`Dismiss error for ${basename(e.name)}`}
+                    >
+                        ×
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default LoadQueueToast;

--- a/src/frontend/src/components/icons/ExpandIcon.tsx
+++ b/src/frontend/src/components/icons/ExpandIcon.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+// Maximize / restore toggle for the storage panel. ``expanded``
+// switches between outward arrows (grow to modal) and inward arrows
+// (shrink back to the compact popover) so one button reads correctly
+// in both states.
+const ExpandIcon = ({expanded, ...props}: {expanded?: boolean} & React.SVGProps<SVGSVGElement>) => (
+    <svg
+        width="14px"
+        height="14px"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        {...props}
+    >
+        {expanded ? (
+            <>
+                <polyline points="10 3 10 10 3 10"/>
+                <polyline points="14 21 14 14 21 14"/>
+            </>
+        ) : (
+            <>
+                <polyline points="14 3 21 3 21 10"/>
+                <polyline points="10 21 3 21 3 14"/>
+                <line x1="21" y1="3" x2="14" y2="10"/>
+                <line x1="3" y1="21" x2="10" y2="14"/>
+            </>
+        )}
+    </svg>
+);
+
+export default ExpandIcon;

--- a/src/frontend/src/components/icons/FileTypeIcon.tsx
+++ b/src/frontend/src/components/icons/FileTypeIcon.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+// Small file-type glyph for storage rows: a document outline with a
+// colour-coded fold, keyed on extension family. One SVG shape, colour
+// carries the meaning — geometry (CAD sources), FEA models, FEA
+// results, GLB view artefacts, profiles, fallback grey.
+//
+// Colours are deliberately muted so a long list doesn't turn into a
+// fruit salad; the loaded-state blue tint on the filename stays the
+// strongest signal in the row.
+
+type Family = "geometry" | "fea-model" | "fea-result" | "view" | "profile" | "other";
+
+function familyOf(name: string): Family {
+    const lower = name.toLowerCase();
+    const ext = lower.slice(lower.lastIndexOf(".") + 1);
+    switch (ext) {
+        case "ifc":
+        case "step":
+        case "stp":
+        case "sat":
+            return "geometry";
+        case "inp":
+        case "fem":
+        case "sif":
+            return "fea-model";
+        case "sin":
+        case "rmed":
+        case "med":
+        case "frd":
+        case "odb":
+            return "fea-result";
+        case "glb":
+        case "gltf":
+            return "view";
+        case "prof":
+            return "profile";
+        default:
+            return "other";
+    }
+}
+
+const FAMILY_COLOR: Record<Family, string> = {
+    geometry: "text-sky-400",
+    "fea-model": "text-violet-400",
+    "fea-result": "text-emerald-400",
+    view: "text-amber-400",
+    profile: "text-rose-400",
+    other: "text-gray-400",
+};
+
+const FileTypeIcon: React.FC<{name: string; className?: string}> = ({name, className = ""}) => (
+    <svg
+        width="14px"
+        height="14px"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        className={`shrink-0 ${FAMILY_COLOR[familyOf(name)]} ${className}`}
+    >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+        <polyline points="14 2 14 8 20 8"/>
+    </svg>
+);
+
+export default FileTypeIcon;

--- a/src/frontend/src/components/icons/PlusIcon.tsx
+++ b/src/frontend/src/components/icons/PlusIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+// Plus sign for the storage panel's "add" menu (upload files / new
+// folder). ``currentColor`` so a parent text-* class colours it, same
+// convention as the other icons here.
+const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg
+        width="16px"
+        height="16px"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        {...props}
+    >
+        <line x1="12" y1="5" x2="12" y2="19"/>
+        <line x1="5" y1="12" x2="19" y2="12"/>
+    </svg>
+);
+
+export default PlusIcon;

--- a/src/frontend/src/components/icons/ReloadIcon.tsx
+++ b/src/frontend/src/components/icons/ReloadIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ReloadIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <svg width="24px" height="24px" viewBox="0 0 15 15" fill="none"
-         xmlns="http://www.w3.org/2000/svg">
+         xmlns="http://www.w3.org/2000/svg" {...props}>
         <path
             fillRule="evenodd"
             clipRule="evenodd"

--- a/src/frontend/src/components/icons/ViewIcon.tsx
+++ b/src/frontend/src/components/icons/ViewIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ViewIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <svg width="12px" height="12px" viewBox="0 0 24 24" fill="none"
-         xmlns="http://www.w3.org/2000/svg">
+         xmlns="http://www.w3.org/2000/svg" {...props}>
         <path
             d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z"
             stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/frontend/src/components/icons/ViewOffIcon.tsx
+++ b/src/frontend/src/components/icons/ViewOffIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+// Slashed-eye companion to ViewIcon — "hidden" state for the loaded-
+// models visibility toggle. Same outline so the two read as one
+// control flipping state.
+const ViewOffIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg width="12px" height="12px" viewBox="0 0 24 24" fill="none"
+         xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path
+            d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z"
+            stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        <line x1="4" y1="20" x2="20" y2="4"
+              stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+    </svg>
+);
+
+export default ViewOffIcon;

--- a/src/frontend/src/components/info_box_scene/FemConceptsPanel.tsx
+++ b/src/frontend/src/components/info_box_scene/FemConceptsPanel.tsx
@@ -73,7 +73,7 @@ const FemConceptsPanel = () => {
                         ‹
                     </button>
                     <select
-                        className="flex-1 text-sm rounded-sm px-1 py-0.5 bg-white text-black disabled:opacity-50"
+                        className="flex-1 text-sm rounded-sm px-1 py-0.5 bg-gray-700 text-gray-100 border border-gray-600 disabled:opacity-50"
                         disabled={nScen < 1}
                         value={selectedScenario}
                         onChange={(e) => setSelectedScenario(parseInt(e.target.value, 10))}

--- a/src/frontend/src/components/info_box_scene/GroupsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/GroupsSection.tsx
@@ -4,13 +4,46 @@ import {useVirtualizer} from "@tanstack/react-virtual";
 
 import type {GroupInfo} from '@/state/sceneInfoStore';
 import {useViewerStores, useViewerRefs} from '@/state/AdaViewerContext';
+import {useModelState, loadedSourceGroups} from '@/state/modelState';
 import {selectGroupMembers} from "@/utils/selectGroupMembers";
 import {CustomBatchedMesh} from "@/utils/mesh_select/CustomBatchedMesh";
 
+// Pull every group out of one model's ADA extension, tagged with the
+// storage key it came from.
+function groupsFromExtension(ext: any, source: string | undefined): GroupInfo[] {
+    const groups: GroupInfo[] = [];
+    for (const designObj of ext?.design_objects ?? []) {
+        for (const group of designObj.groups ?? []) {
+            groups.push({
+                name: group.name || 'Unnamed Group',
+                description: group.description,
+                members: group.members,
+                type: 'design' as const,
+                parent_name: designObj.name || 'Unnamed Object',
+                source,
+            });
+        }
+    }
+    for (const simObj of ext?.simulation_objects ?? []) {
+        for (const group of simObj.groups ?? []) {
+            groups.push({
+                name: group.name || 'Unnamed Group',
+                description: group.description,
+                members: group.members,
+                type: 'simulation' as const,
+                parent_name: simObj.name || 'Unnamed Object',
+                fe_object_type: group.fe_object_type,
+                source,
+            });
+        }
+    }
+    return groups;
+}
 
 const GroupsSection = () => {
     const {useSceneInfoStore, useObjectInfoStore} = useViewerStores();
     const {adaExtension: adaExtensionRef, scene: sceneRef} = useViewerRefs();
+    const loadedSourceNames = useModelState((s) => s.loadedSourceNames);
     const {
         selectedGroup,
         availableGroups,
@@ -18,62 +51,40 @@ const GroupsSection = () => {
         setAvailableGroups,
     } = useSceneInfoStore();
 
-    // Collect groups from ADA extension on component mount. Some
-    // fixtures (e.g. ship1t1.fem via the legacy convert path) bake
-    // thousands of element / node sets into ADA_EXT_data — building
-    // the array is cheap, but the previous render path expanded the
-    // whole list as <option> children of a native <select>, which
-    // froze the main thread on mount. The combobox below virtualizes
-    // the list so the render stays bounded.
+    // Collect groups from EVERY loaded model's ADA extension — each
+    // scene group keeps its own copy in userData.__adaExt, so multi-
+    // model overlays contribute one batch per source file (the old
+    // single adaExtensionRef only ever held the LAST loaded model).
+    // Subscribing to loadedSourceNames keeps the list live across
+    // load/unload instead of snapshotting on mount. Some fixtures
+    // (e.g. ship1t1.fem via the legacy convert path) bake thousands
+    // of element / node sets into ADA_EXT_data — building the array
+    // is cheap; the combobox below virtualizes the render.
     useEffect(() => {
-        const collectGroups = () => {
-            const groups: GroupInfo[] = [];
-            const adaExtension = adaExtensionRef.current;
+        const groups: GroupInfo[] = [];
+        for (const name of loadedSourceNames) {
+            const sceneGroup = loadedSourceGroups.get(name);
+            if (!sceneGroup) continue;
+            const ext = (sceneGroup.children?.[0] as any)?.userData?.__adaExt
+                ?? (sceneGroup as any)?.userData?.__adaExt;
+            if (ext) groups.push(...groupsFromExtension(ext, name));
+        }
+        // Fallback for the streaming/replace path (no per-source scene
+        // groups registered): the single active-extension ref.
+        if (groups.length === 0 && adaExtensionRef.current) {
+            groups.push(...groupsFromExtension(adaExtensionRef.current, undefined));
+        }
 
-            if (adaExtension) {
-                if (adaExtension.design_objects) {
-                    adaExtension.design_objects.forEach(designObj => {
-                        if (designObj.groups) {
-                            designObj.groups.forEach(group => {
-                                groups.push({
-                                    name: group.name || 'Unnamed Group',
-                                    description: group.description,
-                                    members: group.members,
-                                    type: 'design' as const,
-                                    parent_name: designObj.name || 'Unnamed Object'
-                                });
-                            });
-                        }
-                    });
-                }
-
-                if (adaExtension.simulation_objects) {
-                    adaExtension.simulation_objects.forEach(simObj => {
-                        if (simObj.groups) {
-                            simObj.groups.forEach(group => {
-                                groups.push({
-                                    name: group.name || 'Unnamed Group',
-                                    description: group.description,
-                                    members: group.members,
-                                    type: 'simulation' as const,
-                                    parent_name: simObj.name || 'Unnamed Object',
-                                    fe_object_type: group.fe_object_type
-                                });
-                            });
-                        }
-                    });
-                }
-            }
-
-            // Only overwrite when the ADA extension actually yielded groups. Streaming FEM/FEA
-            // models carry no ADA_EXT — their groups are pushed straight into this store by
-            // load_fea_streaming — so an empty collection here must NOT clobber them (the panel
-            // can mount after the model loads). Unload clears the store explicitly.
-            if (groups.length > 0) setAvailableGroups(groups);
-        };
-
-        collectGroups();
-    }, [setAvailableGroups]);
+        // Only overwrite when collection actually yielded groups.
+        // Streaming FEM/FEA models carry no ADA_EXT — their groups are
+        // pushed straight into this store by load_fea_streaming — so an
+        // empty collection must NOT clobber them. Exception: every
+        // model unloaded → clear, so stale groups don't outlive their
+        // model.
+        if (groups.length > 0 || loadedSourceNames.size === 0) {
+            setAvailableGroups(groups);
+        }
+    }, [setAvailableGroups, loadedSourceNames, adaExtensionRef]);
 
     const applyGroupSelection = async (group: GroupInfo | null) => {
         if (!group) {
@@ -88,8 +99,14 @@ const GroupsSection = () => {
         if (group.members && group.members.length > 0) {
             useObjectInfoStore.getState().setName(`Group: ${group.name}`);
 
+            // Resolve parent_name → mesh inside the owning model's scene
+            // group when we know the source; two loaded files with
+            // same-named objects would otherwise race on whichever the
+            // whole-scene traversal finds first.
+            const searchRoot = (group.source && loadedSourceGroups.get(group.source))
+                || sceneRef.current;
             const customBatchedMeshes: CustomBatchedMesh[] = [];
-            sceneRef.current?.traverse(obj => {
+            searchRoot?.traverse(obj => {
                 if (obj instanceof CustomBatchedMesh) {
                     customBatchedMeshes.push(obj);
                 }
@@ -125,6 +142,14 @@ const GroupsSection = () => {
 
             {selectedGroup && (
                 <>
+                    {selectedGroup.source && (
+                        <div className="table-row">
+                            <div className="table-cell w-24">Model:</div>
+                            <div className="table-cell w-48 truncate" title={selectedGroup.source}>
+                                {selectedGroup.source.split("/").pop()}
+                            </div>
+                        </div>
+                    )}
                     <div className="table-row">
                         <div className="table-cell w-24">Type:</div>
                         <div className="table-cell w-48 capitalize">
@@ -179,6 +204,10 @@ interface GroupComboboxProps {
 
 const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect}) => {
     const [open, setOpen] = useState(false);
+    const multiSource = useMemo(
+        () => new Set(groups.map((g) => g.source ?? "")).size > 1,
+        [groups],
+    );
     const [query, setQuery] = useState("");
     const triggerRef = useRef<HTMLButtonElement | null>(null);
     const popoverRef = useRef<HTMLDivElement | null>(null);
@@ -188,7 +217,9 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
     const filteredGroups = useMemo(() => {
         if (!query) return groups;
         const q = query.toLowerCase();
-        return groups.filter((g) => g.name.toLowerCase().includes(q));
+        return groups.filter((g) =>
+            g.name.toLowerCase().includes(q) ||
+            (g.source ?? "").toLowerCase().includes(q));
     }, [groups, query]);
 
     const rowVirtualizer = useVirtualizer({
@@ -321,7 +352,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                             >
                                 {rowVirtualizer.getVirtualItems().map((vRow) => {
                                     const g = filteredGroups[vRow.index];
-                                    const isSelected = selected?.name === g.name;
+                                    const isSelected = selected?.name === g.name && selected?.source === g.source;
                                     return (
                                         <button
                                             key={`${g.name}-${vRow.index}`}
@@ -342,10 +373,13 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                                                 height: vRow.size,
                                                 lineHeight: `${vRow.size}px`,
                                             }}
-                                            title={`${g.name} (${g.type})`}
+                                            title={g.source ? `${g.name} (${g.type}) — ${g.source}` : `${g.name} (${g.type})`}
                                         >
                                             {g.name}{" "}
                                             <span className="text-gray-400">({g.type})</span>
+                                            {multiSource && g.source && (
+                                                <span className="text-gray-400"> · {g.source.split("/").pop()}</span>
+                                            )}
                                         </button>
                                     );
                                 })}

--- a/src/frontend/src/components/info_box_scene/GroupsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/GroupsSection.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {createPortal} from "react-dom";
 import {useVirtualizer} from "@tanstack/react-virtual";
 
 import type {GroupInfo} from '@/state/sceneInfoStore';
@@ -223,6 +224,36 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
         if (open) searchRef.current?.focus();
     }, [open]);
 
+    // Portal placement: fixed, anchored under the trigger, floating
+    // over the 3D view. Rendering the popover inline made it part of
+    // the Scene panel's overflow-y-auto scroll area — opening it grew
+    // the panel and on mobile shifted the whole page. The list height
+    // clamps to the space below the trigger so it never runs off the
+    // bottom edge.
+    const [pos, setPos] = useState<{top: number; left: number; width: number; maxH: number} | null>(null);
+    useLayoutEffect(() => {
+        if (!open) {
+            setPos(null);
+            return;
+        }
+        const place = () => {
+            const rect = triggerRef.current?.getBoundingClientRect();
+            if (!rect) return;
+            const width = Math.max(rect.width, 220);
+            const left = Math.min(rect.left, window.innerWidth - width - 8);
+            const maxH = Math.max(120, Math.min(240, window.innerHeight - rect.bottom - 48));
+            setPos({top: rect.bottom + 4, left: Math.max(8, left), width, maxH});
+        };
+        place();
+        window.addEventListener("resize", place);
+        // capture:true so the popover tracks the panel scrolling under it.
+        window.addEventListener("scroll", place, true);
+        return () => {
+            window.removeEventListener("resize", place);
+            window.removeEventListener("scroll", place, true);
+        };
+    }, [open]);
+
     const triggerLabel = selected
         ? `${selected.name} (${selected.type})`
         : groups.length === 0
@@ -254,15 +285,19 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                     </button>
                 )}
             </div>
-            {open && (
+            {open && pos && createPortal(
                 <div
                     ref={popoverRef}
-                    className="absolute z-50 mt-1 w-full bg-gray-800 border border-gray-600 text-gray-100 rounded-sm shadow-lg"
+                    className="fixed z-50 bg-gray-800 border border-gray-600 text-gray-100 rounded-sm shadow-lg"
+                    style={{top: pos.top, left: pos.left, width: pos.width}}
                 >
                     <input
                         ref={searchRef}
                         type="text"
-                        className="w-full p-1 bg-gray-800 text-gray-100 placeholder-gray-400 border-b border-gray-600 text-xs"
+                        // text-base on touch: iOS zooms the page when a
+                        // focused input's font-size is under 16px, which
+                        // is the "whole page shifts" effect on mobile.
+                        className="w-full p-1 bg-gray-800 text-gray-100 placeholder-gray-400 border-b border-gray-600 text-base sm:text-xs"
                         placeholder={`Filter ${groups.length} group${groups.length === 1 ? "" : "s"}…`}
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
@@ -270,7 +305,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                     <div
                         ref={listRef}
                         className="overflow-auto"
-                        style={{maxHeight: 240}}
+                        style={{maxHeight: pos.maxH}}
                     >
                         {filteredGroups.length === 0 ? (
                             <div className="px-2 py-2 text-xs text-gray-400 italic">
@@ -317,7 +352,8 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                             </div>
                         )}
                     </div>
-                </div>
+                </div>,
+                document.body,
             )}
         </div>
     );

--- a/src/frontend/src/components/info_box_scene/GroupsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/GroupsSection.tsx
@@ -61,6 +61,15 @@ const GroupsSection = () => {
     // of element / node sets into ADA_EXT_data — building the array
     // is cheap; the combobox below virtualizes the render.
     useEffect(() => {
+        // Scene emptied → drop everything, selection included. The
+        // active-extension ref still holds the LAST model's data at
+        // this point, so it must not be consulted.
+        if (loadedSourceNames.size === 0) {
+            setAvailableGroups([]);
+            setSelectedGroup(null);
+            return;
+        }
+
         const groups: GroupInfo[] = [];
         for (const name of loadedSourceNames) {
             const sceneGroup = loadedSourceGroups.get(name);
@@ -78,13 +87,18 @@ const GroupsSection = () => {
         // Only overwrite when collection actually yielded groups.
         // Streaming FEM/FEA models carry no ADA_EXT — their groups are
         // pushed straight into this store by load_fea_streaming — so an
-        // empty collection must NOT clobber them. Exception: every
-        // model unloaded → clear, so stale groups don't outlive their
-        // model.
-        if (groups.length > 0 || loadedSourceNames.size === 0) {
-            setAvailableGroups(groups);
+        // empty collection must NOT clobber them.
+        if (groups.length > 0) setAvailableGroups(groups);
+
+        // A selected group whose model just unloaded is gone — clear it
+        // so the details table doesn't describe a ghost.
+        const sel = useSceneInfoStore.getState?.()
+            ? useSceneInfoStore.getState().selectedGroup
+            : null;
+        if (sel?.source && !loadedSourceNames.has(sel.source)) {
+            setSelectedGroup(null);
         }
-    }, [setAvailableGroups, loadedSourceNames, adaExtensionRef]);
+    }, [setAvailableGroups, setSelectedGroup, useSceneInfoStore, loadedSourceNames, adaExtensionRef]);
 
     const applyGroupSelection = async (group: GroupInfo | null) => {
         if (!group) {

--- a/src/frontend/src/components/info_box_scene/GroupsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/GroupsSection.tsx
@@ -236,7 +236,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                     ref={triggerRef}
                     type="button"
                     onClick={() => setOpen((v) => !v)}
-                    className="flex-1 p-1 rounded-sm bg-white border text-left text-xs truncate"
+                    className="flex-1 p-1 rounded-sm bg-gray-700 border border-gray-600 text-gray-100 text-left text-xs truncate"
                     disabled={groups.length === 0}
                     title={triggerLabel}
                 >
@@ -246,7 +246,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                     <button
                         type="button"
                         onClick={() => onSelect(null)}
-                        className="ml-1 px-1.5 bg-white border rounded-sm text-xs text-gray-700 hover:bg-gray-100"
+                        className="ml-1 px-1.5 bg-gray-700 border border-gray-600 rounded-sm text-xs text-gray-300 hover:bg-gray-600"
                         title="Clear selection"
                         aria-label="Clear selection"
                     >
@@ -257,12 +257,12 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
             {open && (
                 <div
                     ref={popoverRef}
-                    className="absolute z-50 mt-1 w-full bg-white border rounded-sm shadow-lg"
+                    className="absolute z-50 mt-1 w-full bg-gray-800 border border-gray-600 text-gray-100 rounded-sm shadow-lg"
                 >
                     <input
                         ref={searchRef}
                         type="text"
-                        className="w-full p-1 border-b text-xs"
+                        className="w-full p-1 bg-gray-800 text-gray-100 placeholder-gray-400 border-b border-gray-600 text-xs"
                         placeholder={`Filter ${groups.length} group${groups.length === 1 ? "" : "s"}…`}
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
@@ -273,7 +273,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                         style={{maxHeight: 240}}
                     >
                         {filteredGroups.length === 0 ? (
-                            <div className="px-2 py-2 text-xs text-gray-500 italic">
+                            <div className="px-2 py-2 text-xs text-gray-400 italic">
                                 No matches
                             </div>
                         ) : (
@@ -299,8 +299,8 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                                             className={
                                                 "absolute left-0 right-0 px-2 text-left text-xs truncate " +
                                                 (isSelected
-                                                    ? "bg-blue-100"
-                                                    : "hover:bg-gray-100")
+                                                    ? "bg-blue-900/60"
+                                                    : "hover:bg-gray-700")
                                             }
                                             style={{
                                                 top: vRow.start,
@@ -310,7 +310,7 @@ const GroupCombobox: React.FC<GroupComboboxProps> = ({groups, selected, onSelect
                                             title={`${g.name} (${g.type})`}
                                         >
                                             {g.name}{" "}
-                                            <span className="text-gray-500">({g.type})</span>
+                                            <span className="text-gray-400">({g.type})</span>
                                         </button>
                                     );
                                 })}

--- a/src/frontend/src/components/info_box_scene/LoadedModelsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/LoadedModelsSection.tsx
@@ -1,0 +1,106 @@
+import React, {useState} from "react";
+import {useModelState, loadedSourceGroups} from "@/state/modelState";
+import {unload_any_source} from "@/utils/scene/handlers/unload_any_source";
+import {requestRender} from "@/state/perfStore";
+import ViewIcon from "../icons/ViewIcon";
+import ViewOffIcon from "../icons/ViewOffIcon";
+
+// Flat list of every loaded model — the "layers panel" answer to
+// models living in deeply nested storage folders: whatever the prefix
+// depth, they're all toggleable/unloadable from one compact place.
+//
+// Eye button = scene visibility (group.visible flip; model stays in
+// GPU memory). × = full unload (frees the memory, clears tree-view).
+// Streaming-FEA models have no per-source group (replace_model owns
+// the whole scene), so they get no visibility toggle — only unload.
+
+const LoadedModelsSection: React.FC = () => {
+    const loadedSourceNames = useModelState((s) => s.loadedSourceNames);
+    // group.visible lives outside React — tick forces a re-render
+    // after a toggle so the icon state tracks it.
+    const [, setTick] = useState(0);
+    const [busyName, setBusyName] = useState<string | null>(null);
+
+    if (loadedSourceNames.size === 0) {
+        return <div className="text-xs italic text-gray-400">No models loaded.</div>;
+    }
+
+    const toggleVisibility = (name: string) => {
+        const group = loadedSourceGroups.get(name);
+        if (!group) return;
+        group.visible = !group.visible;
+        requestRender();
+        setTick((t) => t + 1);
+    };
+
+    const onUnload = async (name: string) => {
+        if (busyName) return;
+        setBusyName(name);
+        try {
+            await unload_any_source(name);
+        } catch (err) {
+            console.error("unload failed", name, err);
+        } finally {
+            setBusyName(null);
+        }
+    };
+
+    return (
+        <ul className="flex flex-col divide-y divide-gray-700/40 text-xs">
+            {Array.from(loadedSourceNames).map((name) => {
+                const group = loadedSourceGroups.get(name);
+                const visible = group ? group.visible : true;
+                const basename = name.split("/").pop() ?? name;
+                return (
+                    <li key={name} className="flex items-center gap-1.5 py-1">
+                        {group ? (
+                            <button
+                                type="button"
+                                onClick={() => toggleVisibility(name)}
+                                className={
+                                    "shrink-0 p-1 rounded-sm cursor-pointer hover:bg-gray-700 " +
+                                    (visible ? "text-blue-400" : "text-gray-500")
+                                }
+                                title={visible
+                                    ? "Hide in scene (stays loaded)"
+                                    : "Show in scene"}
+                                aria-label={visible ? `Hide ${basename}` : `Show ${basename}`}
+                            >
+                                {visible
+                                    ? <ViewIcon width="16px" height="16px"/>
+                                    : <ViewOffIcon width="16px" height="16px"/>}
+                            </button>
+                        ) : (
+                            // Streaming-FEA model — replace_model owns the
+                            // scene, no per-source group to hide.
+                            <span className="shrink-0 p-1 text-blue-400" title="Streaming FEA model">
+                                <ViewIcon width="16px" height="16px"/>
+                            </span>
+                        )}
+                        <span
+                            className={"flex-1 min-w-0 truncate " + (visible ? "" : "text-gray-500")}
+                            title={name}
+                        >
+                            {basename}
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => void onUnload(name)}
+                            disabled={busyName !== null}
+                            className={
+                                "shrink-0 px-1.5 py-0.5 rounded-sm cursor-pointer text-gray-400 " +
+                                "hover:text-red-300 hover:bg-gray-700 disabled:opacity-50"
+                            }
+                            title="Unload from scene (frees memory)"
+                            aria-label={`Unload ${basename}`}
+                        >
+                            {busyName === name ? "…" : "×"}
+                        </button>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+};
+
+export default LoadedModelsSection;

--- a/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
+++ b/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
@@ -2,6 +2,7 @@ import {PANEL_CHROME} from "@/state/themeStore";
 import React from "react";
 
 import CollapsibleSection from "@/components/common/CollapsibleSection";
+import LoadedModelsSection from "./LoadedModelsSection";
 import StatsSection from "./StatsSection";
 import GroupsSection from "./GroupsSection";
 import UtilitiesSection from "./UtilitiesSection";
@@ -33,6 +34,12 @@ const SceneInfoBox = () => {
                     <option value="fem">FEM</option>
                 </select>
             </div>
+            {/* Flat list of every loaded model, whatever storage folder
+                depth it came from — visible in every mode so toggling /
+                unloading never requires digging through prefix trees. */}
+            <CollapsibleSection title="Loaded models" defaultOpen>
+                <LoadedModelsSection/>
+            </CollapsibleSection>
             {mode === "info" ? (
                 <>
                     <CollapsibleSection title="Stats" defaultOpen>

--- a/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
+++ b/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React from "react";
 
 import CollapsibleSection from "@/components/common/CollapsibleSection";
@@ -17,7 +18,7 @@ const SceneInfoBox = () => {
     const mode = useSceneInfoStore((s) => s.mode);
     const setMode = useSceneInfoStore((s) => s.setMode);
     return (
-        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80 max-h-[80vh] overflow-y-auto">
+        <div className={`${PANEL_CHROME} min-w-80 max-h-[80vh] overflow-y-auto`}>
 
             <div className="flex items-center justify-between mb-1">
                 <h2 className="font-bold">Scene</h2>

--- a/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
+++ b/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
@@ -17,7 +17,7 @@ const SceneInfoBox = () => {
     const mode = useSceneInfoStore((s) => s.mode);
     const setMode = useSceneInfoStore((s) => s.setMode);
     return (
-        <div className="bg-gray-400 bg-opacity-50 rounded-sm p-2 min-w-80 max-h-[80vh] overflow-y-auto">
+        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80 max-h-[80vh] overflow-y-auto">
 
             <div className="flex items-center justify-between mb-1">
                 <h2 className="font-bold">Scene</h2>

--- a/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
+++ b/src/frontend/src/components/info_box_scene/SceneInfoBox.tsx
@@ -23,7 +23,7 @@ const SceneInfoBox = () => {
             <div className="flex items-center justify-between mb-1">
                 <h2 className="font-bold">Scene</h2>
                 <select
-                    className="text-sm rounded-sm px-1 py-0.5 bg-white text-black"
+                    className="text-sm rounded-sm px-1 py-0.5 bg-gray-700 text-gray-100 border border-gray-600"
                     value={mode}
                     onChange={(e) => setMode(e.target.value as "info" | "utilities" | "section" | "fem")}
                 >

--- a/src/frontend/src/components/info_box_scene/StatsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/StatsSection.tsx
@@ -94,7 +94,11 @@ const StatsSection = () => {
         const models = statsFromExtension(ext);
         if (models.length > 0) sources.push({source: name, models});
     }
-    if (sources.length === 0 && adaExtensionRef.current) {
+    // The single active-extension ref keeps the LAST model's data even
+    // after everything is unloaded — only consult it while something is
+    // actually loaded (the streaming/replace path), never for an empty
+    // scene.
+    if (sources.length === 0 && loadedSourceNames.size > 0 && adaExtensionRef.current) {
         const models = statsFromExtension(adaExtensionRef.current);
         if (models.length > 0) {
             sources.push({

--- a/src/frontend/src/components/info_box_scene/StatsSection.tsx
+++ b/src/frontend/src/components/info_box_scene/StatsSection.tsx
@@ -1,5 +1,6 @@
-import React, {useEffect, useState} from "react";
+import React from "react";
 import {useViewerRefs} from "@/state/AdaViewerContext";
+import {useModelState, loadedSourceGroups} from "@/state/modelState";
 
 // Per-model aggregate baked into ``DesignDataExtension.stats`` and
 // ``SimulationDataExtensionMetadata.stats`` at GLB time. The schema
@@ -24,63 +25,88 @@ interface ModelStats {
     counts: Record<string, number>;
 }
 
+interface SourceStats {
+    /** Storage key of the loaded file the stats came from. */
+    source: string;
+    models: ModelStats[];
+}
+
+function statsFromExtension(ext: any): ModelStats[] {
+    const items: ModelStats[] = [];
+
+    for (const sim of ext?.simulation_objects ?? []) {
+        const stats = sim.stats;
+        if (!stats) continue;
+        items.push({
+            key: `fea::${sim.name}`,
+            name: sim.name || "Unnamed",
+            kind: "FEA",
+            primaryCog: stats.cog ? {label: "COG", ...(stats.cog as Cog)} : undefined,
+            counts: (stats.element_counts ?? {}) as Record<string, number>,
+        });
+    }
+
+    for (const d of ext?.design_objects ?? []) {
+        const stats = d.stats;
+        if (!stats) continue;
+        // cog_mass is the honest aggregate when available; cog_volume
+        // is always present whenever any geometry contributes volume.
+        // Prefer mass as primary and show volume as secondary; fall
+        // back to volume-as-primary when mass isn't baked.
+        const m: ModelStats = {
+            key: `cad::${d.name}`,
+            name: d.name || "Unnamed",
+            kind: "CAD",
+            counts: (stats.object_counts ?? {}) as Record<string, number>,
+        };
+        if (stats.cog_mass) {
+            m.primaryCog = {label: "COG (mass)", ...(stats.cog_mass as Cog)};
+            if (stats.cog_volume) {
+                m.secondaryCog = {label: "COG (volume)", ...(stats.cog_volume as Cog)};
+            }
+        } else if (stats.cog_volume) {
+            m.primaryCog = {label: "COG (volume)", ...(stats.cog_volume as Cog)};
+        }
+        items.push(m);
+    }
+
+    return items;
+}
+
+// Per loaded source file. The loader stashes each model's ADA
+// extension on its scene group (userData.__adaExt), so multi-model
+// overlays keep one extension per source — the old single
+// adaExtensionRef only ever held the LAST loaded model. The ref
+// remains the fallback for the streaming/replace path, which doesn't
+// register per-source groups. Subscribing to loadedSourceNames keeps
+// the list live across load/unload (no more snapshot-on-mount).
 const StatsSection = () => {
     const {adaExtension: adaExtensionRef} = useViewerRefs();
-    const [models, setModels] = useState<ModelStats[]>([]);
+    const loadedSourceNames = useModelState((s) => s.loadedSourceNames);
 
-    // Snapshot on mount. Same trade-off as GroupsSection: the panel
-    // re-mounts when the user toggles it open, so opening after a model
-    // load picks up the fresh extension. Reloads while the panel is
-    // open won't refresh — fix that the day someone hits it.
-    useEffect(() => {
-        const ext = adaExtensionRef.current;
-        if (!ext) {
-            setModels([]);
-            return;
-        }
-
-        const items: ModelStats[] = [];
-
-        for (const sim of ext.simulation_objects ?? []) {
-            const stats = sim.stats;
-            if (!stats) continue;
-            items.push({
-                key: `fea::${sim.name}`,
-                name: sim.name || "Unnamed",
-                kind: "FEA",
-                primaryCog: stats.cog ? {label: "COG", ...(stats.cog as Cog)} : undefined,
-                counts: (stats.element_counts ?? {}) as Record<string, number>,
+    const sources: SourceStats[] = [];
+    for (const name of loadedSourceNames) {
+        const group = loadedSourceGroups.get(name);
+        if (!group) continue;
+        const ext = (group.children?.[0] as any)?.userData?.__adaExt
+            ?? (group as any)?.userData?.__adaExt;
+        if (!ext) continue;
+        const models = statsFromExtension(ext);
+        if (models.length > 0) sources.push({source: name, models});
+    }
+    if (sources.length === 0 && adaExtensionRef.current) {
+        const models = statsFromExtension(adaExtensionRef.current);
+        if (models.length > 0) {
+            sources.push({
+                source: loadedSourceNames.size === 1
+                    ? Array.from(loadedSourceNames)[0]
+                    : "",
+                models,
             });
         }
+    }
 
-        for (const d of ext.design_objects ?? []) {
-            const stats = d.stats;
-            if (!stats) continue;
-            // cog_mass is the honest aggregate when available; cog_volume
-            // is always present whenever any geometry contributes volume.
-            // Prefer mass as primary and show volume as secondary; fall
-            // back to volume-as-primary when mass isn't baked.
-            const m: ModelStats = {
-                key: `cad::${d.name}`,
-                name: d.name || "Unnamed",
-                kind: "CAD",
-                counts: (stats.object_counts ?? {}) as Record<string, number>,
-            };
-            if (stats.cog_mass) {
-                m.primaryCog = {label: "COG (mass)", ...(stats.cog_mass as Cog)};
-                if (stats.cog_volume) {
-                    m.secondaryCog = {label: "COG (volume)", ...(stats.cog_volume as Cog)};
-                }
-            } else if (stats.cog_volume) {
-                m.primaryCog = {label: "COG (volume)", ...(stats.cog_volume as Cog)};
-            }
-            items.push(m);
-        }
-
-        setModels(items);
-    }, [adaExtensionRef]);
-
-    if (models.length === 0) {
+    if (sources.length === 0) {
         return (
             <div className="text-xs italic opacity-70">
                 No stats baked into the loaded model(s).
@@ -88,10 +114,24 @@ const StatsSection = () => {
         );
     }
 
+    const showSourceHeaders = sources.length > 1;
+
     return (
-        <div className="space-y-2 text-xs">
-            {models.map((m) => (
-                <ModelStatsRow key={m.key} model={m}/>
+        <div className="space-y-3 text-xs">
+            {sources.map((s) => (
+                <div key={s.source || "::active"} className="space-y-2">
+                    {showSourceHeaders && (
+                        <div
+                            className="text-[10px] uppercase tracking-wide opacity-60 truncate"
+                            title={s.source}
+                        >
+                            {s.source.split("/").pop() ?? s.source}
+                        </div>
+                    )}
+                    {s.models.map((m) => (
+                        <ModelStatsRow key={`${s.source}::${m.key}`} model={m}/>
+                    ))}
+                </div>
             ))}
         </div>
     );
@@ -99,38 +139,59 @@ const StatsSection = () => {
 
 const fmt = (n: number) => (Math.abs(n) >= 1e4 || (n !== 0 && Math.abs(n) < 1e-3) ? n.toExponential(3) : n.toFixed(3));
 
-const formatCog = (c: Cog) => `(${fmt(c.x)}, ${fmt(c.y)}, ${fmt(c.z)})`;
+// One labeled key/value line — muted label left, mono value right.
+const StatRow: React.FC<{label: string; value: React.ReactNode; muted?: boolean}> = ({label, value, muted}) => (
+    <div className={"flex items-baseline justify-between gap-2 " + (muted ? "opacity-70" : "")}>
+        <span className="opacity-70 shrink-0">{label}</span>
+        <span className="font-mono tabular-nums text-right truncate">{value}</span>
+    </div>
+);
+
+const CogRows: React.FC<{cog: {label: string} & Cog; muted?: boolean}> = ({cog, muted}) => (
+    <>
+        <StatRow
+            label={cog.label}
+            value={`${fmt(cog.x)}, ${fmt(cog.y)}, ${fmt(cog.z)}`}
+            muted={muted}
+        />
+        {cog.total_mass != null && (
+            <StatRow label="Total mass" value={fmt(cog.total_mass)} muted={muted}/>
+        )}
+        {cog.total_volume != null && (
+            <StatRow label="Total volume" value={fmt(cog.total_volume)} muted={muted}/>
+        )}
+    </>
+);
 
 const ModelStatsRow: React.FC<{ model: ModelStats }> = ({model}) => {
     const countsList = Object.entries(model.counts).filter(([, v]) => v > 0);
     return (
-        <div>
-            <div className="font-semibold">
-                {model.name}{" "}
-                <span className="font-normal opacity-70">({model.kind})</span>
+        <div className="rounded-sm border border-gray-700/60 bg-gray-800/40 p-1.5 space-y-1">
+            <div className="flex items-center gap-1.5 min-w-0">
+                <span className="font-semibold truncate" title={model.name}>{model.name}</span>
+                <span
+                    className={
+                        "shrink-0 px-1 rounded-sm text-[9px] uppercase tracking-wide text-white " +
+                        (model.kind === "FEA" ? "bg-violet-700" : "bg-sky-700")
+                    }
+                >
+                    {model.kind}
+                </span>
             </div>
-            {model.primaryCog && (
-                <div>
-                    {model.primaryCog.label}: {formatCog(model.primaryCog)}
-                    {model.primaryCog.total_mass != null && (
-                        <> · mass {fmt(model.primaryCog.total_mass)}</>
-                    )}
-                    {model.primaryCog.total_volume != null && (
-                        <> · vol {fmt(model.primaryCog.total_volume)}</>
-                    )}
-                </div>
-            )}
-            {model.secondaryCog && (
-                <div className="opacity-70">
-                    {model.secondaryCog.label}: {formatCog(model.secondaryCog)}
-                    {model.secondaryCog.total_volume != null && (
-                        <> · vol {fmt(model.secondaryCog.total_volume)}</>
-                    )}
+            {(model.primaryCog || model.secondaryCog) && (
+                <div className="space-y-0.5">
+                    {model.primaryCog && <CogRows cog={model.primaryCog}/>}
+                    {model.secondaryCog && <CogRows cog={model.secondaryCog} muted/>}
                 </div>
             )}
             {countsList.length > 0 && (
-                <div>
-                    {countsList.map(([k, v]) => `${k}: ${v}`).join(" · ")}
+                <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 pt-0.5 border-t border-gray-700/50">
+                    {countsList.map(([k, v]) => (
+                        <div key={k} className="flex items-baseline justify-between gap-2 min-w-0">
+                            <span className="opacity-70 truncate" title={k}>{k}</span>
+                            <span className="font-mono tabular-nums">{v}</span>
+                        </div>
+                    ))}
                 </div>
             )}
         </div>

--- a/src/frontend/src/components/info_box_scene/UtilitiesSection.tsx
+++ b/src/frontend/src/components/info_box_scene/UtilitiesSection.tsx
@@ -86,7 +86,7 @@ function RefField({
     value: string | number | boolean | null;
     onChange: (v: string) => void;
 }) {
-    const common = "text-sm rounded-sm px-1 py-0.5 bg-white text-black w-full";
+    const common = "text-sm rounded-sm px-1 py-0.5 bg-gray-700 text-gray-100 border border-gray-600 w-full";
     const ownerOf = (key: string) => builds.find((b) => b.artefacts.some((a) => a.key === key));
     const [commit, setCommit] = React.useState<string>(
         () => ownerOf(String(value ?? ""))?.commit ?? builds[0]?.commit ?? "",
@@ -134,7 +134,7 @@ function KwargField({
     builds: VersionBuild[];
     loadedArtefact: string | null;
 }) {
-    const common = "text-sm rounded-sm px-1 py-0.5 bg-white text-black w-full";
+    const common = "text-sm rounded-sm px-1 py-0.5 bg-gray-700 text-gray-100 border border-gray-600 w-full";
     let input: React.ReactNode;
     if (kwarg.type === "ref") {
         input = <RefField builds={builds} loadedArtefact={loadedArtefact} value={value} onChange={onChange}/>;
@@ -322,7 +322,7 @@ const UtilitiesSection = () => {
             <label className="block mb-2">
                 <span className="text-xs font-medium">Utility</span>
                 <select
-                    className="text-sm rounded-sm px-1 py-0.5 bg-white text-black w-full"
+                    className="text-sm rounded-sm px-1 py-0.5 bg-gray-700 text-gray-100 border border-gray-600 w-full"
                     value={selectedUtility ?? ""}
                     onChange={(e) => onSelectUtility(e.target.value)}
                 >

--- a/src/frontend/src/components/info_box_selected_object/ObjectInfoBoxComponent.tsx
+++ b/src/frontend/src/components/info_box_selected_object/ObjectInfoBoxComponent.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React, {useState} from 'react';
 import {useViewerStores} from '@/state/AdaViewerContext';
 import {copySelectionNames, writeToClipboard} from '@/utils/clipboard/copySelectionNames';
@@ -86,7 +87,7 @@ const ObjectInfoBox = () => {
     };
 
     return (
-        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80">
+        <div className={`${PANEL_CHROME} min-w-80`}>
             <h2 className="font-bold">Selected Object Info</h2>
             {/* Name. Two layouts because mobile and desktop have very
                 different real-estate constraints:

--- a/src/frontend/src/components/info_box_selected_object/ObjectInfoBoxComponent.tsx
+++ b/src/frontend/src/components/info_box_selected_object/ObjectInfoBoxComponent.tsx
@@ -86,7 +86,7 @@ const ObjectInfoBox = () => {
     };
 
     return (
-        <div className="bg-gray-400 bg-opacity-50 rounded-sm p-2 min-w-80">
+        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 min-w-80">
             <h2 className="font-bold">Selected Object Info</h2>
             {/* Name. Two layouts because mobile and desktop have very
                 different real-estate constraints:

--- a/src/frontend/src/components/options/RestSection.tsx
+++ b/src/frontend/src/components/options/RestSection.tsx
@@ -72,10 +72,9 @@ const SignedInRow: React.FC = () => {
                 <div className="text-gray-400">Signed in as</div>
                 <div className="truncate" title={label}>{label}</div>
                 {sub && (
-                    // Lighter than the rest of the row so the ID stays legible on
-                    // the desktop panel's light (bg-gray-400/50) background, where
-                    // gray-400 text washes out. The ID itself is the copy control —
-                    // click it to copy the OIDC sub (no separate button).
+                    // Lighter than the rest of the row so the ID stays legible.
+                    // The ID itself is the copy control — click it to copy the
+                    // OIDC sub (no separate button).
                     <div className="flex items-center gap-1 mt-0.5 text-gray-200">
                         <span className="shrink-0">ID:</span>
                         <button

--- a/src/frontend/src/components/options/ThemeOptions.tsx
+++ b/src/frontend/src/components/options/ThemeOptions.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import {
+    effectivePanelTheme,
+    THEME_PRESETS,
+    ThemePresetId,
+    useThemeStore,
+} from "@/state/themeStore";
+
+// Theme picker for the menu-row panels. Four preset cards (each a
+// live mini-preview of its chrome) plus custom swatches for panel
+// background + text and an opacity slider, for landing anywhere
+// between "max legibility" and "don't distract from the 3D view".
+
+const ThemeOptions: React.FC = () => {
+    const preset = useThemeStore((s) => s.preset);
+    const customBg = useThemeStore((s) => s.customBg);
+    const customText = useThemeStore((s) => s.customText);
+    const bgOpacity = useThemeStore((s) => s.bgOpacity);
+    const setPreset = useThemeStore((s) => s.setPreset);
+    const setCustomBg = useThemeStore((s) => s.setCustomBg);
+    const setCustomText = useThemeStore((s) => s.setCustomText);
+    const setBgOpacity = useThemeStore((s) => s.setBgOpacity);
+    const resetCustom = useThemeStore((s) => s.resetCustom);
+
+    const hasCustom = customBg !== null || customText !== null;
+    const effective = effectivePanelTheme({preset, customBg, customText, bgOpacity});
+
+    return (
+        <div className="space-y-3 text-xs">
+            <div className="grid grid-cols-2 gap-2">
+                {(Object.keys(THEME_PRESETS) as ThemePresetId[]).map((id) => {
+                    const p = THEME_PRESETS[id];
+                    const active = preset === id && !hasCustom;
+                    return (
+                        <button
+                            key={id}
+                            type="button"
+                            onClick={() => setPreset(id)}
+                            title={p.hint}
+                            className={
+                                "rounded-md border px-2 py-1.5 text-left cursor-pointer " +
+                                (active
+                                    ? "border-blue-400 ring-1 ring-blue-400"
+                                    : "border-gray-600 hover:border-gray-400")
+                            }
+                            style={{background: p.theme.bg, color: p.theme.text}}
+                        >
+                            <div className="font-semibold">{p.name}</div>
+                            <div className="opacity-80">Aa panel text</div>
+                        </button>
+                    );
+                })}
+            </div>
+            <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                    <span>Panel color</span>
+                    <input
+                        type="color"
+                        // Color inputs need a hex; when no override is set show
+                        // a neutral derived from the active preset family.
+                        value={customBg ?? "#111827"}
+                        onChange={(e) => setCustomBg(e.target.value)}
+                        className="h-6 w-10 cursor-pointer rounded-sm border border-gray-600 bg-transparent"
+                        title="Custom panel background"
+                    />
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                    <span>Text color</span>
+                    <input
+                        type="color"
+                        value={customText ?? "#f3f4f6"}
+                        onChange={(e) => setCustomText(e.target.value)}
+                        className="h-6 w-10 cursor-pointer rounded-sm border border-gray-600 bg-transparent"
+                        title="Custom panel text color"
+                    />
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                    <span className={customBg ? "" : "opacity-50"}>
+                        Panel opacity
+                    </span>
+                    <input
+                        type="range"
+                        min={0.1}
+                        max={1}
+                        step={0.05}
+                        value={bgOpacity}
+                        onChange={(e) => setBgOpacity(Number(e.target.value))}
+                        disabled={!customBg}
+                        className="w-28 cursor-pointer disabled:cursor-default"
+                        title={customBg
+                            ? "Opacity of the custom panel color"
+                            : "Pick a custom panel color first — presets carry their own opacity"}
+                    />
+                </div>
+                {hasCustom && (
+                    <div className="flex items-center justify-between gap-2">
+                        <span
+                            className="rounded-sm border px-2 py-0.5"
+                            style={{
+                                background: effective.bg,
+                                color: effective.text,
+                                borderColor: effective.border,
+                            }}
+                        >
+                            custom preview
+                        </span>
+                        <button
+                            type="button"
+                            onClick={resetCustom}
+                            className="text-blue-400 hover:text-blue-300 cursor-pointer"
+                        >
+                            Reset to preset
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ThemeOptions;

--- a/src/frontend/src/components/server_info/ServerInfoBox.tsx
+++ b/src/frontend/src/components/server_info/ServerInfoBox.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React from 'react';
 import {useServerInfoStore} from "@/state/serverInfoStore";
 import ReloadIcon from "../icons/ReloadIcon";
@@ -6,7 +7,7 @@ import {request_list_of_files_from_server} from "@/utils/server_info/handlers/re
 const ServerInfoBox = () => {
     const {} = useServerInfoStore();
     return (
-        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md">
+        <div className={`${PANEL_CHROME} w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md`}>
             <h2 className="font-bold">Server Info</h2>
             <div className={"flex flex-row"}>
                 <div className={"pr-1 "}>Files:</div>

--- a/src/frontend/src/components/server_info/ServerInfoBox.tsx
+++ b/src/frontend/src/components/server_info/ServerInfoBox.tsx
@@ -6,7 +6,7 @@ import {request_list_of_files_from_server} from "@/utils/server_info/handlers/re
 const ServerInfoBox = () => {
     const {} = useServerInfoStore();
     return (
-        <div className="bg-gray-400 bg-opacity-50 rounded-sm p-2 w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md">
+        <div className="bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md">
             <h2 className="font-bold">Server Info</h2>
             <div className={"flex flex-row"}>
                 <div className={"pr-1 "}>Files:</div>

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -1252,6 +1252,7 @@ const StorageBrowser: React.FC = () => {
                                                 conversionJobs={conversionJobs}
                                                 expandedName={expandedName}
                                                 setExpandedName={setExpandedName}
+                                                onToggle={onToggle}
                                                 setPickerName={setPickerName}
                                                 selectionMode={inSelectionMode}
                                                 isSelected={selection.has(node.file.name)}
@@ -1341,6 +1342,7 @@ const StorageBrowser: React.FC = () => {
                                     conversionJobs={conversionJobs}
                                     expandedName={expandedName}
                                     setExpandedName={setExpandedName}
+                                    onToggle={onToggle}
                                     setPickerName={setPickerName}
                                     onOpenGitHistory={() => setGitHistoryOpen(true)}
                                     selectionMode={inSelectionMode}
@@ -1547,6 +1549,7 @@ interface FileRowProps {
     conversionJobs: Record<string, {progress: number; status?: string}>;
     expandedName: string | null;
     setExpandedName: (n: string | null) => void;
+    onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
     selectionMode: boolean;
     isSelected: boolean;
@@ -1580,6 +1583,7 @@ const FileRow: React.FC<FileRowProps> = ({
     conversionJobs,
     expandedName,
     setExpandedName,
+    onToggle,
     setPickerName,
     selectionMode,
     isSelected,
@@ -1681,22 +1685,56 @@ const FileRow: React.FC<FileRowProps> = ({
                 }
                 if (selectionMode) {
                     onSelectToggle(f.name);
+                    return;
                 }
+                // Tap/click anywhere on the row (outside the toggle and
+                // row buttons) opens the same menu as right-click — the
+                // primary mobile path to rename/move/delete/download.
+                onOpenContextMenu?.(e);
             }}
         >
             <div className="flex items-center justify-between gap-2">
-                {/* Selection checkbox — feeds the bulk-action toolbar
-                    under the header. Loading into the scene is an
-                    explicit action (toolbar Load / row menu), never a
-                    checkbox side effect. */}
-                <input
-                    type="checkbox"
-                    className="h-5 w-5 shrink-0 cursor-pointer"
-                    checked={isSelected}
-                    onChange={() => onSelectToggle(f.name)}
-                    onClick={(e) => e.stopPropagation()}
-                    title="Select for bulk actions (load / move / delete)"
-                />
+                {/* Normal mode: the checkbox IS the load toggle —
+                    checked (+ the eye marker) while the model is in the
+                    scene; clicking it loads/unloads directly. Long-press
+                    swaps the rows into selection mode, where the amber
+                    circle marks bulk-toolbar membership instead. */}
+                {selectionMode ? (
+                    <span
+                        className={
+                            "h-5 w-5 shrink-0 rounded-full border-2 inline-flex items-center justify-center " +
+                            (isSelected
+                                ? "bg-amber-600 border-amber-400"
+                                : "border-gray-400")
+                        }
+                        aria-checked={isSelected}
+                        role="checkbox"
+                    >
+                        {isSelected && (
+                            <svg viewBox="0 0 16 16" className="w-3 h-3 fill-white" aria-hidden>
+                                <path d="M6 11.2 2.4 7.6l1.4-1.4L6 8.4l6.2-6.2 1.4 1.4z"/>
+                            </svg>
+                        )}
+                    </span>
+                ) : (
+                    <input
+                        type="checkbox"
+                        className="h-5 w-5 shrink-0 cursor-pointer disabled:cursor-not-allowed"
+                        checked={isLoaded}
+                        onChange={() => void onToggle(f, !isLoaded)}
+                        onClick={(e) => e.stopPropagation()}
+                        disabled={
+                            isViewing || otherViewing ||
+                            (!isStreamingFEAResult(f.name) && !canLoadIntoSceneLegacy(f.name))
+                        }
+                        aria-busy={isViewing || undefined}
+                        title={isLoaded
+                            ? "Unload from scene"
+                            : isStreamingFEAResult(f.name)
+                                ? "Open in streaming FEA viewer"
+                                : "Load into scene"}
+                    />
+                )}
                 <FileTypeIcon name={f.name}/>
                 {renaming && onRenameCommit && onRenameCancel ? (
                     <InlineNameInput
@@ -1709,15 +1747,15 @@ const FileRow: React.FC<FileRowProps> = ({
                     <button
                         type="button"
                         onClick={(e) => {
+                            e.stopPropagation();
                             if (selectionMode) {
-                                // Selection mode: row click already handles
-                                // it; the inner button is just here for
-                                // truncation toggling normally. Bail.
-                                e.stopPropagation();
                                 onSelectToggle(f.name);
                                 return;
                             }
-                            setExpandedName(expandedName === f.name ? null : f.name);
+                            // Same menu as right-click — full path shows
+                            // in the menu header, so no separate
+                            // truncation toggle is needed.
+                            onOpenContextMenu?.(e);
                         }}
                         className={`flex-1 min-w-0 text-left ${expandedName === f.name ? 'whitespace-normal break-all' : 'truncate'} ${isLoaded ? 'text-blue-200 font-medium' : ''}`}
                         title={f.name}
@@ -1829,6 +1867,7 @@ interface VersionsTreeProps {
     conversionJobs: Record<string, {progress: number; status?: string}>;
     expandedName: string | null;
     setExpandedName: (n: string | null) => void;
+    onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
     onOpenGitHistory: () => void;
     selectionMode: boolean;
@@ -1987,6 +2026,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                                     conversionJobs={props.conversionJobs}
                                                                     expandedName={props.expandedName}
                                                                     setExpandedName={props.setExpandedName}
+                                                                    onToggle={props.onToggle}
                                                                     setPickerName={props.setPickerName}
                                                                     selectionMode={props.selectionMode}
                                                                     isSelected={props.selection.has(leaf.file.name)}

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useRef, useState} from "react";
+import {createPortal} from "react-dom";
 import {useServerInfoStore, ServerFileEntry} from "@/state/serverInfoStore";
 import {useConversionStore} from "@/state/conversionStore";
 import {useModelState} from "@/state/modelState";
@@ -11,7 +12,9 @@ import {unload_source_from_scene} from "@/utils/scene/handlers/unload_source_fro
 import {clear_loaded_model} from "@/utils/scene/handlers/clear_loaded_model";
 import {uploadAcceptAttr, uploadFile} from "@/utils/scene/handlers/upload_source_file";
 import ReloadIcon from "../icons/ReloadIcon";
-import UploadIcon from "../icons/UploadIcon";
+import PlusIcon from "../icons/PlusIcon";
+import ExpandIcon from "../icons/ExpandIcon";
+import FileTypeIcon from "../icons/FileTypeIcon";
 import FolderClosedIcon from "../icons/FolderClosedIcon";
 import FolderOpenIcon from "../icons/FolderOpenIcon";
 import ChevronRightIcon from "../icons/ChevronRightIcon";
@@ -24,12 +27,21 @@ import {
     FileTreeNode,
     FolderNode,
     loadExpandedFolders,
+    loadPendingFolders,
     saveExpandedFolders,
+    savePendingFolders,
 } from "@/utils/storage/fileTree";
 import {RowKebabMenu} from "@/components/common/RowKebabMenu";
+import PositionedMenu, {KebabMenuItem} from "@/components/common/PositionedMenu";
 import FolderPickerModal from "@/components/common/FolderPickerModal";
 import {viewerApi} from "@/services/viewerApi";
-import {useMeStore} from "@/state/meStore";
+import {useStorageMutations} from "./useStorageMutations";
+import {buildFileMenuItems, buildFolderMenuItems} from "./storageMenuItems";
+
+// Custom drag MIME for in-panel file moves. OS-file drops arrive as
+// ``dataTransfer.files`` instead; checking for this type tells the two
+// apart (types are readable during dragover, the payload only on drop).
+const KEYS_MIME = "application/x-adapy-keys";
 
 // Files that carry per-(step, field) result data and benefit from the
 // picker UI. .sif (Sesam text) and .sin (Sesam Norsam binary) both
@@ -92,6 +104,15 @@ function formatBytes(n: number): string {
     if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
     if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
     return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function dirnameOf(key: string): string {
+    const i = key.lastIndexOf("/");
+    return i >= 0 ? key.slice(0, i) : "";
+}
+
+function basenameOf(key: string): string {
+    return key.split("/").pop() ?? key;
 }
 
 // CI uploads land at ``versions/<branch>/<commit>/<filename>``; the
@@ -229,6 +250,54 @@ function formatRelative(iso: string): string {
     return new Date(t).toISOString().slice(0, 10);
 }
 
+// Inline name editor used for file/folder rename and new-folder
+// creation. Enter commits, Escape (or blur) cancels. ``selectStem``
+// pre-selects the basename-without-extension so a quick type replaces
+// the name but keeps the extension.
+const InlineNameInput: React.FC<{
+    initial: string;
+    placeholder?: string;
+    selectStem?: boolean;
+    onCommit: (value: string) => void;
+    onCancel: () => void;
+}> = ({initial, placeholder, selectStem, onCommit, onCancel}) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+        const el = inputRef.current;
+        if (!el) return;
+        el.focus();
+        if (selectStem) {
+            const dot = initial.lastIndexOf(".");
+            el.setSelectionRange(0, dot > 0 ? dot : initial.length);
+        } else {
+            el.select();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return (
+        <input
+            ref={inputRef}
+            type="text"
+            defaultValue={initial}
+            placeholder={placeholder}
+            className={
+                "flex-1 min-w-0 bg-gray-800 border border-blue-500 rounded-sm " +
+                "px-1 py-0.5 text-xs text-gray-100 focus:outline-hidden"
+            }
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                    onCommit((e.target as HTMLInputElement).value);
+                } else if (e.key === "Escape") {
+                    onCancel();
+                }
+            }}
+            onBlur={onCancel}
+        />
+    );
+};
+
 const StorageBrowser: React.FC = () => {
     const files = useServerInfoStore((s) => s.serverFileObjects);
     const {sidecars} = useBuildSidecars(files);
@@ -318,14 +387,70 @@ const StorageBrowser: React.FC = () => {
             return next;
         });
     };
-    // Admin-only organize actions — the underlying move endpoint is
-    // gated server-side. Non-admin users see no kebab on rows so the
-    // menu can't open into items that would 403 on click. Errors are
-    // surfaced via window.alert: this panel has no inline error
-    // banner today and the operations are explicit user actions, so a
-    // modal alert is acceptable rather than building a toast affordance
-    // for the rare failure case.
-    const isAdmin = useMeStore((s) => s.isAdmin);
+
+    // Client-side "pending" empty folders — storage is prefix-based so
+    // they have no server representation until a file lands in them.
+    // Persisted per-scope; pruned once a real key appears underneath.
+    const [pendingFolders, setPendingFolders] = useState<string[]>(
+        () => loadPendingFolders("storage", scopeKey),
+    );
+    useEffect(() => {
+        setPendingFolders(loadPendingFolders("storage", scopeKey));
+    }, [scopeKey]);
+    useEffect(() => {
+        savePendingFolders("storage", scopeKey, pendingFolders);
+    }, [scopeKey, pendingFolders]);
+    useEffect(() => {
+        setPendingFolders((prev) => {
+            const next = prev.filter(
+                (p) => !files.some((f) => f.name.replace(/^\/+/, "").startsWith(p + "/")),
+            );
+            return next.length === prev.length ? prev : next;
+        });
+    }, [files]);
+    const removePendingFoldersUnder = (path: string) => {
+        setPendingFolders((prev) =>
+            prev.filter((p) => p !== path && !p.startsWith(path + "/")),
+        );
+    };
+
+    // Where the "new folder" inline input is showing: "" = top level,
+    // a folder path = subfolder of it, null = hidden.
+    const [newFolderAt, setNewFolderAt] = useState<string | null>(null);
+    // Inline rename target (replaces the old window.prompt flow).
+    const [renaming, setRenaming] = useState<{kind: "file" | "folder"; path: string} | null>(null);
+    // Right-click context menu: items are computed at open time by the
+    // same builders that feed the kebab, so the two stay in lockstep.
+    const [ctxMenu, setCtxMenu] = useState<{x: number; y: number; items: KebabMenuItem[]} | null>(null);
+    const openCtxMenu = (e: React.MouseEvent, items: KebabMenuItem[]) => {
+        if (items.length === 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+        setCtxMenu({x: e.clientX, y: e.clientY, items});
+    };
+    // In-panel drag state: keys being dragged (for row dimming + the
+    // move-to-root strip). Cleared on dragend/drop.
+    const [draggingKeys, setDraggingKeys] = useState<string[] | null>(null);
+    // Maximize: same component, restyled as a centered fixed overlay
+    // with a backdrop. Styling-only so every bit of panel state
+    // (selection, expansion, menus) survives the toggle.
+    const [maximized, setMaximized] = useState(false);
+    useEffect(() => {
+        if (!maximized) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setMaximized(false);
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [maximized]);
+
+    // Mutating actions (delete / rename / move): personal scope for
+    // everyone via the user endpoints, admins elsewhere via the admin
+    // endpoints. The backend enforces the same split; canMutate just
+    // keeps dead-end affordances out of the UI.
+    const mutations = useStorageMutations();
+    const canMutate = mutations.canMutate;
+
     // The picker modal drives both move flows; ``onPick`` is the
     // closure that knows what to do once a destination is chosen.
     const [picker, setPicker] = useState<{
@@ -335,7 +460,11 @@ const StorageBrowser: React.FC = () => {
     // Download a stored blob with auth (REST mode). The suggested filename is the
     // key's basename so nested keys don't save as "a/b/c.ifc".
     const onDownloadFile = (key: string) => {
-        void viewerApi.downloadBlob(scopeKey, key, key.split("/").pop() ?? key);
+        void viewerApi.downloadBlob(scopeKey, key, basenameOf(key));
+    };
+
+    const alertError = (e: unknown) => {
+        window.alert(e instanceof Error ? e.message : String(e));
     };
 
     const onMoveSingleToFolder = (key: string) => {
@@ -343,76 +472,178 @@ const StorageBrowser: React.FC = () => {
             title: `Move "${key}" to folder`,
             onPick: async (folder) => {
                 try {
-                    const r = await viewerApi.adminMoveKeysToFolder(scopeKey, [key], folder);
+                    const r = await mutations.moveKeys([key], folder);
                     if (r.failed.length > 0) {
                         window.alert(r.failed.map((f) => `${f.key}: ${f.reason}`).join("\n"));
                     }
                     void request_list_of_files_from_server();
                 } catch (e) {
-                    window.alert(e instanceof Error ? e.message : String(e));
+                    alertError(e);
                 }
             },
         });
     };
-    const onFolderRenameOrMove = (
-        folderPath: string,
-        mode: "rename" | "moveInto",
-    ) => {
-        const runMove = async (newPath: string) => {
-            if (newPath === folderPath) return;
-            try {
-                const allKeys = files.map((f) => f.name);
-                const r = await viewerApi.adminRenameOrMoveFolder(
-                    scopeKey, folderPath, newPath, allKeys,
-                );
-                if (r.failed.length > 0) {
-                    window.alert(r.failed.map((f) => `${f.key}: ${f.reason}`).join("\n"));
-                }
-                setExpandedFolders((prev) => {
-                    const next = new Set(prev);
-                    next.delete(folderPath);
-                    next.add(newPath);
-                    return next;
-                });
-                void request_list_of_files_from_server();
-            } catch (e) {
-                window.alert(e instanceof Error ? e.message : String(e));
+
+    const runFolderMove = async (folderPath: string, newPath: string) => {
+        if (newPath === folderPath) return;
+        try {
+            const allKeys = files.map((f) => f.name);
+            const r = await mutations.renameOrMoveFolder(folderPath, newPath, allKeys);
+            if (r.failed.length > 0) {
+                window.alert(r.failed.map((f) => `${f.key}: ${f.reason}`).join("\n"));
             }
-        };
-        if (mode === "rename") {
-            const input = window.prompt(
-                `Rename folder "${folderPath}" to (sibling name, no slashes):`,
-                "",
-            );
-            if (input === null) return;
-            const trimmedInput = input.trim().replace(/^\/+|\/+$/g, "");
-            if (!trimmedInput) {
-                window.alert("Destination required");
-                return;
-            }
-            if (trimmedInput.includes("/")) {
-                window.alert("Rename must be a single name; use Move folder into… for nested moves");
-                return;
-            }
-            const lastSlash = folderPath.lastIndexOf("/");
-            const parent = lastSlash >= 0 ? folderPath.slice(0, lastSlash) : "";
-            void runMove(parent ? `${parent}/${trimmedInput}` : trimmedInput);
-            return;
+            setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                next.delete(folderPath);
+                next.add(newPath);
+                return next;
+            });
+            removePendingFoldersUnder(folderPath);
+            void request_list_of_files_from_server();
+        } catch (e) {
+            alertError(e);
         }
-        const basename = folderPath.split("/").pop() ?? folderPath;
+    };
+
+    const onMoveFolderInto = (folderPath: string) => {
+        const basename = basenameOf(folderPath);
         setPicker({
             title: `Move folder "${folderPath}" into`,
             onPick: async (dest) => {
-                await runMove(`${dest}/${basename}`);
+                await runFolderMove(folderPath, `${dest}/${basename}`);
             },
         });
     };
+
+    const onRenameFolderCommit = (folderPath: string, rawName: string, isPending: boolean) => {
+        setRenaming(null);
+        const name = rawName.trim().replace(/^\/+|\/+$/g, "");
+        if (!name || name === basenameOf(folderPath)) return;
+        if (name.includes("/")) {
+            window.alert("Rename must be a single name; use Move folder into… for nested moves");
+            return;
+        }
+        const parent = dirnameOf(folderPath);
+        const newPath = parent ? `${parent}/${name}` : name;
+        if (isPending) {
+            // No server keys yet — rename is pure client state.
+            setPendingFolders((prev) => prev.map((p) => (p === folderPath ? newPath : p)));
+            setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                next.delete(folderPath);
+                next.add(newPath);
+                return next;
+            });
+            return;
+        }
+        void runFolderMove(folderPath, newPath);
+    };
+
+    const onRenameFileCommit = async (f: ServerFileEntry, rawName: string) => {
+        setRenaming(null);
+        const name = rawName.trim();
+        if (!name || name === basenameOf(f.name)) return;
+        if (name.includes("/")) {
+            window.alert("Name must not contain '/' — use Move to folder… instead");
+            return;
+        }
+        const dir = dirnameOf(f.name);
+        const newKey = dir ? `${dir}/${name}` : name;
+        try {
+            // Unload first — the scene's source registry is keyed by
+            // name, and a renamed source would leave a stale entry.
+            if (loadedSourceNames.has(f.name)) {
+                if (isStreamingFEAResult(f.name)) await clear_loaded_model();
+                else unload_source_from_scene(f.name);
+            }
+            await mutations.renameKey(f.name, newKey);
+            void request_list_of_files_from_server();
+        } catch (e) {
+            alertError(e);
+        }
+    };
+
+    const unloadIfLoaded = async (name: string) => {
+        if (!loadedSourceNames.has(name)) return;
+        if (isStreamingFEAResult(name)) await clear_loaded_model();
+        else unload_source_from_scene(name);
+    };
+
+    const onDeleteFile = async (f: ServerFileEntry) => {
+        if (!window.confirm(`Delete "${f.name}"?\nConverted view caches are removed too.`)) return;
+        try {
+            await unloadIfLoaded(f.name);
+            await mutations.deleteKey(f.name);
+            void request_list_of_files_from_server();
+        } catch (e) {
+            alertError(e);
+        }
+    };
+
+    const onDeleteFolder = async (path: string, fileCount: number, isPending: boolean) => {
+        if (isPending && fileCount === 0) {
+            removePendingFoldersUnder(path);
+            return;
+        }
+        if (!window.confirm(
+            `Delete folder "${path}" and its ${fileCount} file${fileCount === 1 ? "" : "s"}?\n` +
+            "Converted view caches are removed too.",
+        )) return;
+        const prefix = path + "/";
+        const targets = files.filter((x) => x.name.replace(/^\/+/, "").startsWith(prefix));
+        try {
+            // Sequential: each delete cascades derived blobs server-side
+            // and parallel calls would race on the storage listing.
+            for (const t of targets) {
+                await unloadIfLoaded(t.name);
+                await mutations.deleteKey(t.name);
+            }
+            removePendingFoldersUnder(path);
+            setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                next.delete(path);
+                return next;
+            });
+            void request_list_of_files_from_server();
+        } catch (e) {
+            alertError(e);
+        }
+    };
+
+    const onCreateFolder = (parent: string, rawName: string) => {
+        setNewFolderAt(null);
+        const name = rawName.trim().replace(/^\/+|\/+$/g, "");
+        if (!name) return;
+        if (name.includes("/")) {
+            window.alert("Folder name must not contain '/'");
+            return;
+        }
+        const path = parent ? `${parent}/${name}` : name;
+        if (!parent && (name === "versions" || name === "_derived")) {
+            window.alert(`"${name}" is a reserved name`);
+            return;
+        }
+        setPendingFolders((prev) => (prev.includes(path) ? prev : [...prev, path]));
+        setExpandedFolders((prev) => {
+            const next = new Set(prev);
+            if (parent) next.add(parent);
+            next.add(path);
+            return next;
+        });
+    };
+
     // Owned input — clicking it must happen synchronously inside the
     // button's onClick to preserve the user-activation gesture (iOS Safari
     // refuses the file picker otherwise). The previous implementation
     // dispatched a CustomEvent that UploadContextMenu listened for, which
     // broke the gesture chain on mobile.
     const fileInputRef = useRef<HTMLInputElement>(null);
+    // Folder destination for the next picker-initiated upload
+    // ("Upload here…" on a folder). Consumed once by onFilePicked.
+    const uploadTargetRef = useRef<string | null>(null);
+    // "+" menu (upload files / new folder).
+    const [plusOpen, setPlusOpen] = useState(false);
+    const plusBtnRef = useRef<HTMLButtonElement>(null);
 
     // Toggle a file in/out of the scene. All adds go through the
     // overlay path so multiple models can coexist; ``Clear`` in
@@ -538,21 +769,22 @@ const StorageBrowser: React.FC = () => {
         }
     };
 
-    const onFilePicked = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const files = Array.from(e.target.files ?? []);
-        e.target.value = "";
-        if (files.length === 0) return;
+    // Upload a batch sequentially (presigned PUT is per-file); a failed
+    // file is collected and reported at the end rather than aborting
+    // the batch. ``folder`` prefixes every file's key — used by
+    // "Upload here…" and OS-file drops onto a folder row.
+    const uploadFilesTo = async (list: File[], folder?: string) => {
+        if (list.length === 0) return;
         setUploading(true);
-        // Upload sequentially (presigned PUT is per-file); a failed file is
-        // collected and reported at the end rather than aborting the batch.
         const failures: string[] = [];
-        for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-            setUploadName(files.length > 1 ? `${file.name} (${i + 1}/${files.length})` : file.name);
+        for (let i = 0; i < list.length; i++) {
+            const file = list[i];
+            setUploadName(list.length > 1 ? `${file.name} (${i + 1}/${list.length})` : file.name);
             setUploadLoaded(0);
             setUploadTotal(file.size);
             try {
                 await uploadFile(file, {
+                    folder,
                     onProgress: (loaded, total) => {
                         setUploadLoaded(loaded);
                         if (total) setUploadTotal(total);
@@ -570,17 +802,148 @@ const StorageBrowser: React.FC = () => {
         if (failures.length) window.alert(`Upload failed for: ${failures.join(", ")}`);
     };
 
+    const onFilePicked = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const picked = Array.from(e.target.files ?? []);
+        e.target.value = "";
+        const folder = uploadTargetRef.current ?? undefined;
+        uploadTargetRef.current = null;
+        void uploadFilesTo(picked, folder);
+    };
+
+    // ── Drag & drop ─────────────────────────────────────────────────
+    const onDragStartFile = (f: ServerFileEntry) => (e: React.DragEvent) => {
+        // Dragging a selected row drags the whole selection; dragging
+        // an unselected row drags just that file.
+        const keys = selection.has(f.name) ? Array.from(selection) : [f.name];
+        e.dataTransfer.setData(KEYS_MIME, JSON.stringify(keys));
+        e.dataTransfer.effectAllowed = "move";
+        setDraggingKeys(keys);
+    };
+    const onDragEndFile = () => setDraggingKeys(null);
+
+    // Drop onto a folder path ("" = root). Internal drags move keys;
+    // OS-file drops upload into the folder.
+    const handleDropOnFolder = async (target: string, e: React.DragEvent) => {
+        setDraggingKeys(null);
+        const txt = e.dataTransfer.getData(KEYS_MIME);
+        if (txt) {
+            if (!canMutate) return;
+            let keys: string[] = [];
+            try {
+                keys = JSON.parse(txt);
+            } catch {
+                return;
+            }
+            keys = keys.filter((k) => typeof k === "string" && dirnameOf(k) !== target);
+            if (keys.length === 0) return;
+            try {
+                if (target === "") {
+                    // Move-to-root: the move endpoint requires a non-empty
+                    // folder, so root moves are per-key renames to the
+                    // basename.
+                    for (const k of keys) {
+                        await mutations.renameKey(k, basenameOf(k));
+                    }
+                } else {
+                    const r = await mutations.moveKeys(keys, target);
+                    if (r.failed.length > 0) {
+                        window.alert(r.failed.map((f) => `${f.key}: ${f.reason}`).join("\n"));
+                    }
+                }
+                clearSelection();
+                void request_list_of_files_from_server();
+            } catch (err) {
+                alertError(err);
+            }
+            return;
+        }
+        if (e.dataTransfer.files?.length) {
+            void uploadFilesTo(Array.from(e.dataTransfer.files), target || undefined);
+        }
+    };
+
+    // ── Menu item builders (kebab + context menu share these) ───────
+    const fileMenuItems = (f: ServerFileEntry, displayName: string): KebabMenuItem[] => {
+        const busy = viewingName !== null;
+        return buildFileMenuItems(f, {
+            isLoaded: loadedSourceNames.has(f.name),
+            busy,
+            canMutate,
+            onToggle: (next) => void onToggle(f, next),
+            onLoadStreamer:
+                runtime.isRestMode() && runtime.convertEnabled()
+                    ? () => void onLoadStreamer(f.name)
+                    : undefined,
+            onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
+            onRename: () => setRenaming({kind: "file", path: f.name}),
+            onMoveToFolder: () => onMoveSingleToFolder(f.name),
+            onDelete: () => void onDeleteFile(f),
+        });
+    };
+    // CI version blobs stay read-only: load/streamer/download only.
+    const versionFileMenuItems = (f: ServerFileEntry): KebabMenuItem[] => {
+        const busy = viewingName !== null;
+        return buildFileMenuItems(f, {
+            isLoaded: loadedSourceNames.has(f.name),
+            busy,
+            canMutate: false,
+            onToggle: (next) => void onToggle(f, next),
+            onLoadStreamer:
+                runtime.isRestMode() && runtime.convertEnabled()
+                    ? () => void onLoadStreamer(f.name)
+                    : undefined,
+            onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
+        });
+    };
+    const folderMenuItems = (path: string, fileCount: number, isPending: boolean): KebabMenuItem[] =>
+        buildFolderMenuItems(path, {
+            canMutate,
+            fileCount,
+            onUploadHere: () => {
+                uploadTargetRef.current = path;
+                fileInputRef.current?.click();
+            },
+            onNewSubfolder: () => {
+                setNewFolderAt(path);
+                setExpandedFolders((prev) => new Set(prev).add(path));
+            },
+            onRename: () => setRenaming({kind: "folder", path}),
+            onMoveInto: () => onMoveFolderInto(path),
+            onDelete: () => void onDeleteFolder(path, fileCount, isPending),
+        });
+
+    const existingFolderPaths = Array.from(
+        new Set([...collectFolderPaths(files, (f) => f.name), ...pendingFolders]),
+    ).sort((a, b) => a.localeCompare(b));
+
+    const showRootDropStrip =
+        draggingKeys !== null && draggingKeys.some((k) => dirnameOf(k) !== "");
+
     return (
         <div
             data-no-upload-menu
-            // Match ObjectInfoBox styling. The viewport-clamped max-width
-            // makes the panel self-contain regardless of what the panel-row
-            // does — on mobile it stays inside the viewport even if the
-            // parent's width hasn't resolved. min-w-0 lets it actually
-            // shrink below intrinsic content width so the header buttons
-            // don't push past the right edge.
-            className="bg-gray-400 bg-opacity-50 rounded-sm p-2 w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md"
+            // Compact: match ObjectInfoBox footprint (viewport-clamped
+            // max-width so the panel self-contains on mobile).
+            // Maximized: same element restyled as a centered fixed
+            // overlay — styling-only so panel state survives the
+            // toggle. The host column has no transform ancestors, so
+            // position:fixed escapes it cleanly.
+            className={
+                "bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 " +
+                (maximized
+                    ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[61] " +
+                      "w-[min(56rem,calc(100vw-2rem))] max-h-[85vh] flex flex-col"
+                    : "w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md")
+            }
         >
+            {maximized && createPortal(
+                <div
+                    className="fixed inset-0 z-[60] bg-black/70"
+                    onClick={() => setMaximized(false)}
+                    aria-hidden="true"
+                />,
+                document.body,
+            )}
             <div className="flex justify-between items-center gap-2 mb-2">
                 <div className="min-w-0 flex-1">
                     <h2 className="font-bold truncate">Storage</h2>
@@ -589,7 +952,7 @@ const StorageBrowser: React.FC = () => {
                         scope are invisible to a list query under another
                         — surfacing the name avoids the "I uploaded but
                         nothing shows" confusion when scope drifts. */}
-                    <div className="text-[10px] uppercase tracking-wide text-gray-200/80 truncate"
+                    <div className="text-[10px] uppercase tracking-wide text-gray-400 truncate"
                          title={currentScope?.kind ? `${currentScope.kind}${currentScope.id ? ":" + currentScope.id : ""}` : "shared"}>
                         scope: {currentScope?.name ?? "Shared"}
                     </div>
@@ -604,14 +967,45 @@ const StorageBrowser: React.FC = () => {
                         onChange={onFilePicked}
                     />
                     <button
-                        className="bg-blue-700 hover:bg-blue-600 text-white p-1 rounded-sm disabled:opacity-60 flex items-center justify-center"
-                        onClick={() => fileInputRef.current?.click()}
+                        ref={plusBtnRef}
+                        type="button"
+                        className={
+                            "bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded-sm " +
+                            "flex items-center justify-center disabled:opacity-60 " +
+                            "p-2 sm:p-1 min-h-[40px] min-w-[40px] sm:min-h-0 sm:min-w-0 " +
+                            "focus:outline-hidden focus:ring-2 focus:ring-blue-400"
+                        }
+                        onClick={() => setPlusOpen((v) => !v)}
                         disabled={uploading}
-                        title="Upload a file to this scope"
-                        aria-label="Upload file"
+                        title="Add — upload files or create a folder"
+                        aria-label="Add"
+                        aria-haspopup="menu"
+                        aria-expanded={plusOpen}
                     >
-                        {uploading ? <Spinner/> : <UploadIcon/>}
+                        {uploading ? <Spinner/> : <PlusIcon/>}
                     </button>
+                    {plusOpen && (
+                        <PositionedMenu
+                            items={[
+                                {
+                                    key: "upload",
+                                    label: "Upload files…",
+                                    onClick: () => fileInputRef.current?.click(),
+                                },
+                                {
+                                    key: "new-folder",
+                                    label: "New folder…",
+                                    onClick: () => setNewFolderAt(""),
+                                },
+                            ]}
+                            onClose={() => setPlusOpen(false)}
+                            ignoreOutsideRef={plusBtnRef}
+                            anchor={{
+                                kind: "rect",
+                                getRect: () => plusBtnRef.current?.getBoundingClientRect(),
+                            }}
+                        />
+                    )}
                     <button
                         type="button"
                         className={
@@ -656,6 +1050,20 @@ const StorageBrowser: React.FC = () => {
                             {bulkBusy === "clear" ? "Clearing…" : "Clear"}
                         </button>
                     )}
+                    <button
+                        type="button"
+                        className={
+                            "bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-white rounded-sm " +
+                            "flex items-center justify-center " +
+                            "p-2 sm:p-1 min-h-[40px] min-w-[40px] sm:min-h-0 sm:min-w-0 " +
+                            "focus:outline-hidden focus:ring-2 focus:ring-blue-400"
+                        }
+                        onClick={() => setMaximized((v) => !v)}
+                        title={maximized ? "Restore compact panel" : "Maximize"}
+                        aria-label={maximized ? "Restore compact panel" : "Maximize"}
+                    >
+                        <ExpandIcon expanded={maximized}/>
+                    </button>
                 </div>
             </div>
             {uploadName && (
@@ -670,7 +1078,7 @@ const StorageBrowser: React.FC = () => {
                                 : formatBytes(uploadLoaded)}
                         </span>
                     </div>
-                    <div className="mt-1 h-1 w-full bg-gray-300/50 rounded-sm overflow-hidden">
+                    <div className="mt-1 h-1 w-full bg-gray-700 rounded-sm overflow-hidden">
                         {uploadTotal > 0 ? (
                             <div
                                 className="h-full bg-blue-600 transition-[width] duration-200"
@@ -687,22 +1095,75 @@ const StorageBrowser: React.FC = () => {
                     </div>
                 </div>
             )}
-            {files.length === 0 ? (
-                <div className="text-xs italic">
-                    No files yet. Use the Upload button to add one.
+            {files.length === 0 && pendingFolders.length === 0 && newFolderAt === null ? (
+                <div
+                    className="text-xs italic text-gray-300 rounded-sm border border-dashed border-gray-600 p-3"
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={(e) => {
+                        e.preventDefault();
+                        void handleDropOnFolder("", e);
+                    }}
+                >
+                    No files yet. Use + to upload, or drop files here.
                 </div>
             ) : (
                 (() => {
                     const {regular, branches} = classifyFiles(files, sidecars);
                     return (
-                        <div className="flex flex-col max-h-80 overflow-auto">
-                            {regular.length > 0 && (() => {
-                                const tree = buildFileTree(regular, (f) => f.name);
+                        <div
+                            className={
+                                "flex flex-col overflow-auto " +
+                                (maximized ? "flex-1 min-h-0" : "max-h-80")
+                            }
+                            // Background (non-row) drops land at root:
+                            // internal drags move to root, OS files
+                            // upload at top level. Rows stopPropagation
+                            // when they handle a drop themselves.
+                            onDragOver={(e) => e.preventDefault()}
+                            onDrop={(e) => {
+                                e.preventDefault();
+                                void handleDropOnFolder("", e);
+                            }}
+                        >
+                            {showRootDropStrip && (
+                                <div
+                                    className={
+                                        "mb-1 px-2 py-1 text-[11px] text-gray-300 rounded-sm " +
+                                        "border border-dashed border-blue-500/60 bg-blue-900/20"
+                                    }
+                                    onDragOver={(e) => {
+                                        e.preventDefault();
+                                        e.dataTransfer.dropEffect = "move";
+                                    }}
+                                    onDrop={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        void handleDropOnFolder("", e);
+                                    }}
+                                >
+                                    Drop here to move to root /
+                                </div>
+                            )}
+                            {newFolderAt === "" && (
+                                <div className="flex items-center gap-1.5 px-2 py-1">
+                                    <FolderClosedIcon className="shrink-0 text-blue-400"/>
+                                    <InlineNameInput
+                                        initial=""
+                                        placeholder="New folder name"
+                                        onCommit={(v) => onCreateFolder("", v)}
+                                        onCancel={() => setNewFolderAt(null)}
+                                    />
+                                </div>
+                            )}
+                            {(regular.length > 0 || pendingFolders.length > 0) && (() => {
+                                const tree = buildFileTree(regular, (f) => f.name, pendingFolders);
                                 const renderNode = (
                                     node: ServerFileTreeNode,
                                     depth: number,
                                 ): React.ReactNode => {
                                     if (node.kind === "file") {
+                                        const items = fileMenuItems(node.file, node.displayName);
+                                        const fileDir = dirnameOf(node.file.name);
                                         return (
                                             <FileRow
                                                 key={node.file.name}
@@ -720,14 +1181,35 @@ const StorageBrowser: React.FC = () => {
                                                 isSelected={selection.has(node.file.name)}
                                                 onLongPress={toggleSelection}
                                                 onSelectToggle={toggleSelection}
-                                                onMoveToFolder={isAdmin ? onMoveSingleToFolder : undefined}
-                                                onDownload={runtime.isRestMode() ? onDownloadFile : undefined}
-                                                onLoadStreamer={runtime.isRestMode() && runtime.convertEnabled() ? onLoadStreamer : undefined}
+                                                menuItems={items}
+                                                onOpenContextMenu={(e) => openCtxMenu(e, items)}
+                                                draggable={canMutate}
+                                                onDragStartRow={onDragStartFile(node.file)}
+                                                onDragEndRow={onDragEndFile}
+                                                onDropAt={(e) => {
+                                                    // OS files dropped on a file row land in
+                                                    // that row's folder; internal drags are a
+                                                    // no-op here (folders are the targets).
+                                                    if (e.dataTransfer.getData(KEYS_MIME)) return;
+                                                    if (e.dataTransfer.files?.length) {
+                                                        void uploadFilesTo(
+                                                            Array.from(e.dataTransfer.files),
+                                                            fileDir || undefined,
+                                                        );
+                                                    }
+                                                }}
+                                                dimmed={draggingKeys?.includes(node.file.name) ?? false}
+                                                renaming={renaming?.kind === "file" && renaming.path === node.file.name}
+                                                onRenameCommit={(v) => void onRenameFileCommit(node.file, v)}
+                                                onRenameCancel={() => setRenaming(null)}
+                                                showModified={maximized}
                                             />
                                         );
                                     }
                                     const expanded = expandedFolders.has(node.path);
                                     const total = countFiles(node);
+                                    const isPending = total === 0;
+                                    const items = folderMenuItems(node.path, total, isPending);
                                     return (
                                         <React.Fragment key={`folder:${node.path}`}>
                                             <FolderRow
@@ -735,14 +1217,29 @@ const StorageBrowser: React.FC = () => {
                                                 depth={depth}
                                                 expanded={expanded}
                                                 fileCount={total}
+                                                isPending={isPending}
                                                 onToggle={() => toggleFolder(node.path)}
-                                                onRename={isAdmin
-                                                    ? () => onFolderRenameOrMove(node.path, "rename")
-                                                    : undefined}
-                                                onMoveInto={isAdmin
-                                                    ? () => onFolderRenameOrMove(node.path, "moveInto")
-                                                    : undefined}
+                                                menuItems={items}
+                                                onOpenContextMenu={(e) => openCtxMenu(e, items)}
+                                                onDropInto={(e) => void handleDropOnFolder(node.path, e)}
+                                                renaming={renaming?.kind === "folder" && renaming.path === node.path}
+                                                onRenameCommit={(v) => onRenameFolderCommit(node.path, v, isPending)}
+                                                onRenameCancel={() => setRenaming(null)}
                                             />
+                                            {expanded && newFolderAt === node.path && (
+                                                <li
+                                                    className="flex items-center gap-1.5 px-2 py-1"
+                                                    style={{paddingLeft: 8 + (depth + 1) * 12}}
+                                                >
+                                                    <FolderClosedIcon className="shrink-0 text-blue-400"/>
+                                                    <InlineNameInput
+                                                        initial=""
+                                                        placeholder="New folder name"
+                                                        onCommit={(v) => onCreateFolder(node.path, v)}
+                                                        onCancel={() => setNewFolderAt(null)}
+                                                    />
+                                                </li>
+                                            )}
                                             {expanded &&
                                                 node.children.map((c) =>
                                                     renderNode(c, depth + 1),
@@ -751,7 +1248,7 @@ const StorageBrowser: React.FC = () => {
                                     );
                                 };
                                 return (
-                                    <ul className="flex flex-col divide-y divide-gray-500/40">
+                                    <ul className="flex flex-col divide-y divide-gray-700/60">
                                         {tree.map((n) => renderNode(n, 0))}
                                     </ul>
                                 );
@@ -772,13 +1269,21 @@ const StorageBrowser: React.FC = () => {
                                     selection={selection}
                                     onLongPress={toggleSelection}
                                     onSelectToggle={toggleSelection}
-                                    onDownload={runtime.isRestMode() ? onDownloadFile : undefined}
-                                    onLoadStreamer={runtime.isRestMode() && runtime.convertEnabled() ? onLoadStreamer : undefined}
+                                    fileMenuItemsFor={versionFileMenuItems}
+                                    onOpenContextMenu={openCtxMenu}
+                                    showModified={maximized}
                                 />
                             )}
                         </div>
                     );
                 })()
+            )}
+            {ctxMenu && (
+                <PositionedMenu
+                    items={ctxMenu.items}
+                    onClose={() => setCtxMenu(null)}
+                    anchor={{kind: "point", x: ctxMenu.x, y: ctxMenu.y}}
+                />
             )}
             {pickerName && (
                 <FieldPickerModal
@@ -801,7 +1306,7 @@ const StorageBrowser: React.FC = () => {
             <FolderPickerModal
                 open={picker !== null}
                 title={picker?.title ?? ""}
-                existingFolders={collectFolderPaths(files, (f) => f.name)}
+                existingFolders={existingFolderPaths}
                 onCancel={() => setPicker(null)}
                 onPick={(folder) => {
                     const action = picker?.onPick;
@@ -817,7 +1322,7 @@ const StorageBrowser: React.FC = () => {
                         // storage panel's footprint on desktop while
                         // still pinning to the bottom on mobile where
                         // the panel takes the full screen anyway.
-                        "mt-2 -mx-2 -mb-2 px-2 py-2 border-t border-gray-500/40 bg-gray-700/95 " +
+                        "mt-2 -mx-2 -mb-2 px-2 py-2 border-t border-gray-700 bg-gray-800/95 " +
                         "rounded-b flex items-center gap-2 sticky bottom-0"
                     }
                 >
@@ -873,11 +1378,20 @@ interface FolderRowProps {
     depth: number;
     expanded: boolean;
     fileCount: number;
+    /** Client-side pending folder (no server keys under it yet). */
+    isPending?: boolean;
     onToggle: () => void;
-    /** Admin-only: when present, a kebab appears with rename + move-
-     * into. Non-admins get a plain folder row without the menu. */
-    onRename?: () => void;
-    onMoveInto?: () => void;
+    /** Shared with the right-click context menu — built once by the
+     * parent so kebab and context menu never diverge. Empty array
+     * hides the kebab. */
+    menuItems: KebabMenuItem[];
+    onOpenContextMenu?: (e: React.MouseEvent) => void;
+    /** Drop handler for in-panel moves + OS-file uploads into this
+     * folder. Hover highlight is local state. */
+    onDropInto?: (e: React.DragEvent) => void;
+    renaming?: boolean;
+    onRenameCommit?: (newName: string) => void;
+    onRenameCancel?: () => void;
 }
 
 const FolderRow: React.FC<FolderRowProps> = ({
@@ -885,27 +1399,57 @@ const FolderRow: React.FC<FolderRowProps> = ({
     depth,
     expanded,
     fileCount,
+    isPending,
     onToggle,
-    onRename,
-    onMoveInto,
+    menuItems,
+    onOpenContextMenu,
+    onDropInto,
+    renaming,
+    onRenameCommit,
+    onRenameCancel,
 }) => {
     const indentPx = depth * 12;
+    // dragenter/dragleave fire per child element; a counter survives
+    // the churn where a plain boolean would flicker.
+    const [dragHover, setDragHover] = useState(0);
+    const acceptsDrop = (e: React.DragEvent) =>
+        e.dataTransfer.types.includes(KEYS_MIME) || e.dataTransfer.types.includes("Files");
     return (
         <li
-            className="flex items-center gap-1.5 px-2 py-1 cursor-pointer hover:bg-gray-300/10 select-none"
+            className={
+                "flex items-center gap-1.5 px-2 py-1 rounded cursor-pointer select-none " +
+                "hover:bg-gray-800/80 " +
+                (dragHover > 0 ? "ring-1 ring-blue-400 bg-blue-900/30 " : "") +
+                (isPending ? "opacity-80 " : "")
+            }
             style={{paddingLeft: 8 + indentPx}}
             onClick={onToggle}
+            onContextMenu={onOpenContextMenu}
             role="button"
             aria-expanded={expanded}
             aria-label={`${expanded ? "Collapse" : "Expand"} folder ${folder.name}`}
+            onDragEnter={onDropInto ? (e) => {
+                if (acceptsDrop(e)) setDragHover((c) => c + 1);
+            } : undefined}
+            onDragLeave={onDropInto ? () => setDragHover((c) => Math.max(0, c - 1)) : undefined}
+            onDragOver={onDropInto ? (e) => {
+                if (!acceptsDrop(e)) return;
+                e.preventDefault();
+                e.stopPropagation();
+                e.dataTransfer.dropEffect = "move";
+            } : undefined}
+            onDrop={onDropInto ? (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDragHover(0);
+                onDropInto(e);
+            } : undefined}
         >
             {/* Chevron — single right-pointing icon rotated 90° on
-                expand. text-blue-600 matches the progress bar accent
-                AND stays legible on the panel's light (bg-gray-400/50)
-                background, where the lighter blue-300 washed out. */}
+                expand. */}
             <ChevronRightIcon
                 className={
-                    "shrink-0 text-blue-600 transition-transform duration-150 " +
+                    "shrink-0 text-blue-400 transition-transform duration-150 " +
                     (expanded ? "rotate-90" : "")
                 }
             />
@@ -913,38 +1457,34 @@ const FolderRow: React.FC<FolderRowProps> = ({
                 Same blue tone so eye + chevron read as one
                 composite control. */}
             {expanded ? (
-                <FolderOpenIcon className="shrink-0 text-blue-600"/>
+                <FolderOpenIcon className="shrink-0 text-blue-400"/>
             ) : (
-                <FolderClosedIcon className="shrink-0 text-blue-600"/>
+                <FolderClosedIcon className="shrink-0 text-blue-400"/>
             )}
-            <span className="text-xs flex-1 min-w-0 truncate font-semibold">
-                {folder.name}/
-            </span>
+            {renaming && onRenameCommit && onRenameCancel ? (
+                <InlineNameInput
+                    initial={folder.name}
+                    onCommit={onRenameCommit}
+                    onCancel={onRenameCancel}
+                />
+            ) : (
+                <span className="text-xs flex-1 min-w-0 truncate font-semibold">
+                    {folder.name}/
+                </span>
+            )}
             <span className="text-[10px] text-gray-400 shrink-0">
-                {fileCount}
+                {isPending ? "empty" : fileCount}
             </span>
-            {onRename && onMoveInto && (
+            {menuItems.length > 0 && (
                 <span
                     className="shrink-0"
                     onClick={(e) => e.stopPropagation()}
                 >
                     <RowKebabMenu
                         ariaLabel={`Organize folder ${folder.path}`}
-                        buttonClassName="h-6 w-6 text-gray-300 hover:bg-gray-500/30"
-                        items={[
-                            {
-                                key: "rename",
-                                label: "Rename folder…",
-                                title: "Sibling-name rename. Subfolders preserved.",
-                                onClick: onRename,
-                            },
-                            {
-                                key: "move-into",
-                                label: "Move folder into…",
-                                title: "Move under a destination prefix. Subfolders preserved.",
-                                onClick: onMoveInto,
-                            },
-                        ]}
+                        buttonClassName="h-6 w-6 text-gray-300 hover:bg-gray-700"
+                        header={<span className="font-mono">{folder.path}/</span>}
+                        items={menuItems}
                     />
                 </span>
             )}
@@ -967,15 +1507,23 @@ interface FileRowProps {
     isSelected: boolean;
     onLongPress: (name: string) => void;
     onSelectToggle: (name: string) => void;
-    /** Admin-only: when present, the kebab on this row offers a
-     * "Move to folder…" item. */
-    onMoveToFolder?: (key: string) => void;
-    /** When present (REST mode), the kebab offers a "Download" item that
-     * fetches the stored blob with auth and saves it. Available to any user. */
-    onDownload?: (key: string) => void;
-    /** When present (REST + convert), STEP rows get a "Load using streamer" item
-     * that converts via the memory-bounded streaming reader (large-file OOM path). */
-    onLoadStreamer?: (key: string) => void;
+    /** Row actions — shared between the kebab and the right-click
+     * context menu (parent builds both from one list). */
+    menuItems: KebabMenuItem[];
+    onOpenContextMenu?: (e: React.MouseEvent) => void;
+    /** In-panel drag source (move to folder). */
+    draggable?: boolean;
+    onDragStartRow?: (e: React.DragEvent) => void;
+    onDragEndRow?: () => void;
+    /** OS-file drops on this row (upload into the row's folder). */
+    onDropAt?: (e: React.DragEvent) => void;
+    /** Row is part of the in-flight drag payload. */
+    dimmed?: boolean;
+    renaming?: boolean;
+    onRenameCommit?: (newBasename: string) => void;
+    onRenameCancel?: () => void;
+    /** Maximized view: show the last-modified column. */
+    showModified?: boolean;
 }
 
 const FileRow: React.FC<FileRowProps> = ({
@@ -993,9 +1541,17 @@ const FileRow: React.FC<FileRowProps> = ({
     isSelected,
     onLongPress,
     onSelectToggle,
-    onMoveToFolder,
-    onDownload,
-    onLoadStreamer,
+    menuItems,
+    onOpenContextMenu,
+    draggable,
+    onDragStartRow,
+    onDragEndRow,
+    onDropAt,
+    dimmed,
+    renaming,
+    onRenameCommit,
+    onRenameCancel,
+    showModified,
 }) => {
     const isViewing = viewingName === f.name;
     const otherViewing = viewingName !== null && !isViewing;
@@ -1044,12 +1600,26 @@ const FileRow: React.FC<FileRowProps> = ({
     return (
         <li
             className={
-                "flex flex-col px-1 py-1 text-xs " +
+                "flex flex-col px-1 py-1 text-xs rounded " +
+                (dimmed ? "opacity-40 " : "") +
                 (selectionMode
                     ? "cursor-pointer " + (isSelected ? "bg-amber-700/30" : "hover:bg-amber-700/10")
-                    : "")
+                    : "hover:bg-gray-800/60")
             }
             style={indentPx ? {paddingLeft: `${4 + indentPx}px`} : undefined}
+            draggable={draggable || undefined}
+            onDragStart={draggable && onDragStartRow ? (e) => {
+                cancelLongPress();
+                onDragStartRow(e);
+            } : undefined}
+            onDragEnd={onDragEndRow}
+            onDragOver={onDropAt ? (e) => e.preventDefault() : undefined}
+            onDrop={onDropAt ? (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onDropAt(e);
+            } : undefined}
+            onContextMenu={onOpenContextMenu}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}
@@ -1122,25 +1692,43 @@ const FileRow: React.FC<FileRowProps> = ({
                         />
                     </label>
                 )}
-                <button
-                    type="button"
-                    onClick={(e) => {
-                        if (selectionMode) {
-                            // Selection mode: row click already handles
-                            // it; the inner button is just here for
-                            // truncation toggling normally. Bail.
-                            e.stopPropagation();
-                            onSelectToggle(f.name);
-                            return;
-                        }
-                        setExpandedName(expandedName === f.name ? null : f.name);
-                    }}
-                    className={`flex-1 min-w-0 text-left ${expandedName === f.name ? 'whitespace-normal break-all' : 'truncate'} ${isLoaded ? 'text-blue-200 font-medium' : ''}`}
-                    title={f.name}
-                >
-                    {displayName}
-                </button>
+                <FileTypeIcon name={f.name}/>
+                {renaming && onRenameCommit && onRenameCancel ? (
+                    <InlineNameInput
+                        initial={displayName}
+                        selectStem
+                        onCommit={onRenameCommit}
+                        onCancel={onRenameCancel}
+                    />
+                ) : (
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            if (selectionMode) {
+                                // Selection mode: row click already handles
+                                // it; the inner button is just here for
+                                // truncation toggling normally. Bail.
+                                e.stopPropagation();
+                                onSelectToggle(f.name);
+                                return;
+                            }
+                            setExpandedName(expandedName === f.name ? null : f.name);
+                        }}
+                        className={`flex-1 min-w-0 text-left ${expandedName === f.name ? 'whitespace-normal break-all' : 'truncate'} ${isLoaded ? 'text-blue-200 font-medium' : ''}`}
+                        title={f.name}
+                    >
+                        {displayName}
+                    </button>
+                )}
                 <div className="flex items-center gap-1 shrink-0">
+                    {showModified && (
+                        <span
+                            className="text-[10px] text-gray-400 tabular-nums whitespace-nowrap"
+                            title={f.lastModified}
+                        >
+                            {formatRelative(f.lastModified)}
+                        </span>
+                    )}
                     {isViewing && <Spinner/>}
                     {/* Legacy single-shot (step, field) picker — kept
                         only for hypothetical future non-streaming FEA
@@ -1155,7 +1743,7 @@ const FileRow: React.FC<FileRowProps> = ({
                         re-appears for it without code changes here. */}
                     {!selectionMode && isFEAResult(f.name) && !isStreamingFEAResult(f.name) && runtime.isRestMode() && runtime.convertEnabled() && (
                         <button
-                            className="p-1 rounded-sm text-white hover:bg-gray-300/40 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="p-1 rounded-sm text-white hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 setPickerName(f.name);
@@ -1167,42 +1755,20 @@ const FileRow: React.FC<FileRowProps> = ({
                             <span className="leading-none text-sm font-mono">⇅</span>
                         </button>
                     )}
-                    {/* Streaming-FEA picker button removed — the
-                        toggle checkbox now opens the streaming session
-                        with defaults, and field / reduction / step
-                        live in SimulationControls. */}
-                    {!selectionMode && (onMoveToFolder || onDownload || onLoadStreamer) && (
+                    {!selectionMode && menuItems.length > 0 && (
                         <span onClick={(e) => e.stopPropagation()}>
                             <RowKebabMenu
                                 ariaLabel={`Actions for ${displayName}`}
-                                buttonClassName="h-7 w-7 text-gray-200 hover:bg-gray-300/30"
+                                buttonClassName="h-7 w-7 text-gray-200 hover:bg-gray-700"
                                 header={<span className="font-mono" title={f.name}>{f.name}</span>}
-                                items={[
-                                    ...(onLoadStreamer && /\.(step|stp)$/i.test(f.name) ? [{
-                                        key: "load-streamer",
-                                        label: "Load using streamer",
-                                        title: "Memory-bounded streaming STEP→GLB — for large assemblies that fail the normal load.",
-                                        disabled: otherViewing || isViewing,
-                                        onClick: () => onLoadStreamer(f.name),
-                                    }] : []),
-                                    ...(onDownload ? [{
-                                        key: "download",
-                                        label: "Download",
-                                        onClick: () => onDownload(f.name),
-                                    }] : []),
-                                    ...(onMoveToFolder ? [{
-                                        key: "move-to-folder",
-                                        label: "Move to folder…",
-                                        onClick: () => onMoveToFolder(f.name),
-                                    }] : []),
-                                ]}
+                                items={menuItems}
                             />
                         </span>
                     )}
                 </div>
             </div>
             {isViewing && (
-                <div className="mt-1 h-1 w-full bg-gray-300/50 rounded-sm overflow-hidden">
+                <div className="mt-1 h-1 w-full bg-gray-700 rounded-sm overflow-hidden">
                     {viewJob && viewJob.status !== 'queued' ? (
                         <div
                             className="h-full bg-blue-600 transition-[width] duration-200"
@@ -1232,6 +1798,10 @@ const FileRow: React.FC<FileRowProps> = ({
 // All branches collapse-by-default except the most recently active
 // one, whose latest commit is also auto-expanded. State is local to
 // the panel; refresh resets it.
+//
+// Version blobs are CI build outputs — read-only by design. Their
+// rows get load/download menus only: no rename/move/delete, no drag,
+// no drop targets.
 // ──────────────────────────────────────────────────────────────────
 
 interface VersionsTreeProps {
@@ -1249,8 +1819,10 @@ interface VersionsTreeProps {
     selection: Set<string>;
     onLongPress: (name: string) => void;
     onSelectToggle: (name: string) => void;
-    onDownload?: (key: string) => void;
-    onLoadStreamer?: (key: string) => void;
+    /** Read-only menu builder from the parent (load/streamer/download). */
+    fileMenuItemsFor: (file: ServerFileEntry) => KebabMenuItem[];
+    onOpenContextMenu: (e: React.MouseEvent, items: KebabMenuItem[]) => void;
+    showModified?: boolean;
 }
 
 const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
@@ -1307,9 +1879,9 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
     };
 
     return (
-        <div className="border-t border-gray-500/40 pt-1 mt-1">
+        <div className="border-t border-gray-700/60 pt-1 mt-1">
             <div className="flex items-center justify-between px-1 pb-1">
-                <div className="text-[10px] uppercase tracking-wide text-gray-200/70">
+                <div className="text-[10px] uppercase tracking-wide text-gray-400">
                     Versions
                 </div>
                 <button
@@ -1321,7 +1893,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                     Git history
                 </button>
             </div>
-            <ul className="flex flex-col divide-y divide-gray-500/30">
+            <ul className="flex flex-col divide-y divide-gray-700/40">
                 {branches.map((b, bIdx) => {
                     const branchOpen = openBranches.has(b.encodedBranch);
                     return (
@@ -1329,7 +1901,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                             <button
                                 type="button"
                                 onClick={() => toggleBranch(b.encodedBranch)}
-                                className="flex items-center gap-1 px-1 py-1 text-xs text-left w-full hover:bg-gray-300/10"
+                                className="flex items-center gap-1 px-1 py-1 text-xs text-left w-full hover:bg-gray-800/80"
                                 aria-expanded={branchOpen}
                                 title={b.displayBranch}
                             >
@@ -1339,7 +1911,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                 <span className="font-mono text-[11px] truncate flex-1 min-w-0">
                                     {b.displayBranch}
                                 </span>
-                                <span className="text-[10px] text-gray-300/80 shrink-0">
+                                <span className="text-[10px] text-gray-400 shrink-0">
                                     {b.commits.length} commit{b.commits.length === 1 ? "" : "s"}
                                 </span>
                             </button>
@@ -1354,7 +1926,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                 <button
                                                     type="button"
                                                     onClick={() => toggleCommit(commitKey)}
-                                                    className="flex items-center gap-1 px-1 py-1 text-xs text-left w-full hover:bg-gray-300/10"
+                                                    className="flex items-center gap-1 px-1 py-1 text-xs text-left w-full hover:bg-gray-800/80"
                                                     style={{paddingLeft: "16px"}}
                                                     aria-expanded={commitOpen}
                                                 >
@@ -1372,7 +1944,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                             latest
                                                         </span>
                                                     )}
-                                                    <span className="ml-auto text-[10px] text-gray-300/80 shrink-0">
+                                                    <span className="ml-auto text-[10px] text-gray-400 shrink-0">
                                                         {formatRelative(
                                                             // Prefer git timestamp from the sidecar
                                                             // (commit time); fall back to the blob
@@ -1385,28 +1957,32 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                     </span>
                                                 </button>
                                                 {commitOpen && (
-                                                    <ul className="flex flex-col divide-y divide-gray-500/20">
-                                                        {c.leaves.map((leaf) => (
-                                                            <FileRow
-                                                                key={leaf.file.name}
-                                                                file={leaf.file}
-                                                                displayName={leaf.artefactName}
-                                                                indentLevel={2}
-                                                                viewingName={props.viewingName}
-                                                                loadedSourceNames={props.loadedSourceNames}
-                                                                conversionJobs={props.conversionJobs}
-                                                                expandedName={props.expandedName}
-                                                                setExpandedName={props.setExpandedName}
-                                                                onToggle={props.onToggle}
-                                                                setPickerName={props.setPickerName}
-                                                                selectionMode={props.selectionMode}
-                                                                isSelected={props.selection.has(leaf.file.name)}
-                                                                onLongPress={props.onLongPress}
-                                                                onSelectToggle={props.onSelectToggle}
-                                                                onDownload={props.onDownload}
-                                                                onLoadStreamer={props.onLoadStreamer}
-                                                            />
-                                                        ))}
+                                                    <ul className="flex flex-col divide-y divide-gray-700/30">
+                                                        {c.leaves.map((leaf) => {
+                                                            const items = props.fileMenuItemsFor(leaf.file);
+                                                            return (
+                                                                <FileRow
+                                                                    key={leaf.file.name}
+                                                                    file={leaf.file}
+                                                                    displayName={leaf.artefactName}
+                                                                    indentLevel={2}
+                                                                    viewingName={props.viewingName}
+                                                                    loadedSourceNames={props.loadedSourceNames}
+                                                                    conversionJobs={props.conversionJobs}
+                                                                    expandedName={props.expandedName}
+                                                                    setExpandedName={props.setExpandedName}
+                                                                    onToggle={props.onToggle}
+                                                                    setPickerName={props.setPickerName}
+                                                                    selectionMode={props.selectionMode}
+                                                                    isSelected={props.selection.has(leaf.file.name)}
+                                                                    onLongPress={props.onLongPress}
+                                                                    onSelectToggle={props.onSelectToggle}
+                                                                    menuItems={items}
+                                                                    onOpenContextMenu={(e) => props.onOpenContextMenu(e, items)}
+                                                                    showModified={props.showModified}
+                                                                />
+                                                            );
+                                                        })}
                                                     </ul>
                                                 )}
                                             </li>

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -937,8 +937,11 @@ const StorageBrowser: React.FC = () => {
             }
         >
             {maximized && createPortal(
+                // Light scrim — just enough to signal modality and give
+                // the panel edge contrast without blacking out the 3D
+                // scene behind it.
                 <div
-                    className="fixed inset-0 z-[60] bg-black/70"
+                    className="fixed inset-0 z-[60] bg-black/25"
                     onClick={() => setMaximized(false)}
                     aria-hidden="true"
                 />,
@@ -982,7 +985,12 @@ const StorageBrowser: React.FC = () => {
                         aria-haspopup="menu"
                         aria-expanded={plusOpen}
                     >
-                        {uploading ? <Spinner/> : <PlusIcon/>}
+                        {/* Fixed 24px icon slot — keeps this button the
+                            same size as Refresh/Maximize whether it
+                            shows the plus or the busy spinner. */}
+                        <span className="inline-flex h-6 w-6 items-center justify-center">
+                            {uploading ? <Spinner/> : <PlusIcon width="24px" height="24px"/>}
+                        </span>
                     </button>
                     {plusOpen && (
                         <PositionedMenu
@@ -1021,7 +1029,7 @@ const StorageBrowser: React.FC = () => {
                         aria-label="Refresh list"
                         aria-busy={refreshing}
                     >
-                        <span className={refreshing ? "animate-spin" : ""}>
+                        <span className={"inline-flex h-6 w-6 items-center justify-center " + (refreshing ? "animate-spin" : "")}>
                             <ReloadIcon/>
                         </span>
                     </button>
@@ -1062,7 +1070,9 @@ const StorageBrowser: React.FC = () => {
                         title={maximized ? "Restore compact panel" : "Maximize"}
                         aria-label={maximized ? "Restore compact panel" : "Maximize"}
                     >
-                        <ExpandIcon expanded={maximized}/>
+                        <span className="inline-flex h-6 w-6 items-center justify-center">
+                            <ExpandIcon expanded={maximized} width="24px" height="24px"/>
+                        </span>
                     </button>
                 </div>
             </div>

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -15,6 +15,7 @@ import ReloadIcon from "../icons/ReloadIcon";
 import PlusIcon from "../icons/PlusIcon";
 import ExpandIcon from "../icons/ExpandIcon";
 import FileTypeIcon from "../icons/FileTypeIcon";
+import ViewIcon from "../icons/ViewIcon";
 import FolderClosedIcon from "../icons/FolderClosedIcon";
 import FolderOpenIcon from "../icons/FolderOpenIcon";
 import ChevronRightIcon from "../icons/ChevronRightIcon";
@@ -1761,6 +1762,18 @@ const FileRow: React.FC<FileRowProps> = ({
                         >
                             {formatRelative(f.lastModified)}
                         </span>
+                    )}
+                    {/* Explicit "in scene" marker. The checkbox is a
+                        selection control (bulk actions), so loaded
+                        state needs its own signal — the blue filename
+                        tint alone is easy to miss on mobile. */}
+                    {isLoaded && !isViewing && (
+                        <ViewIcon
+                            width="16px"
+                            height="16px"
+                            className="text-blue-400"
+                            aria-label="Loaded in scene"
+                        />
                     )}
                     {isViewing && <Spinner/>}
                     {/* Legacy single-shot (step, field) picker — kept

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -309,13 +309,13 @@ const StorageBrowser: React.FC = () => {
     // Active "Show all" run — disables the per-row toggles while we're
     // overlaying every file in sequence, so the user can't kick off a
     // second batch on top of the first.
-    const [bulkBusy, setBulkBusy] = useState<"load" | "unload" | "clear" | null>(null);
+    const [bulkBusy, setBulkBusy] = useState<"load" | "unload" | "clear" | "delete" | null>(null);
     const [gitHistoryOpen, setGitHistoryOpen] = useState(false);
-    // Multi-select mode: a Set of file names. Empty set = mode off.
-    // Entered by long-press on any FileRow (or via the "Select" button
-    // in the header on desktop where long-press is unergonomic). Tap
-    // toggles set membership while in mode; the existing per-row
-    // checkbox is hidden so the row itself is the tap target.
+    // Selection: a Set of file names driving the bulk-action toolbar
+    // under the header (load / unload / move / delete). The per-row
+    // checkbox toggles membership — loading into the scene is an
+    // explicit action (toolbar or row menu), never a checkbox side
+    // effect. Long-press still selects (mobile ergonomics).
     const [selection, setSelection] = useState<Set<string>>(() => new Set());
     const inSelectionMode = selection.size > 0;
     const toggleSelection = (name: string) => {
@@ -713,7 +713,9 @@ const StorageBrowser: React.FC = () => {
     // regardless of the per-row state mix.
     const onLoadSelected = async () => {
         if (bulkBusy !== null) return;
-        const targets = files.filter((f) => selection.has(f.name) && !loadedSourceNames.has(f.name));
+        const targets = files.filter((f) =>
+            selection.has(f.name) && !loadedSourceNames.has(f.name) &&
+            (isStreamingFEAResult(f.name) || canLoadIntoSceneLegacy(f.name)));
         if (targets.length === 0) {
             clearSelection();
             return;
@@ -750,6 +752,53 @@ const StorageBrowser: React.FC = () => {
             setBulkBusy(null);
             clearSelection();
         }
+    };
+
+    // Bulk delete / move over the selection set. Version blobs are
+    // server-protected (400), so the toolbar disables these when the
+    // selection includes any — no silent skipping.
+    const onDeleteSelected = async () => {
+        if (bulkBusy !== null) return;
+        const keys = Array.from(selection);
+        if (keys.length === 0) return;
+        if (!window.confirm(
+            `Delete ${keys.length} file${keys.length === 1 ? "" : "s"}?\n` +
+            "Converted view caches are removed too.",
+        )) return;
+        setBulkBusy("delete");
+        try {
+            // Sequential: deletes cascade derived blobs server-side and
+            // parallel calls would race on the storage listing.
+            for (const k of keys) {
+                await unloadIfLoaded(k);
+                await mutations.deleteKey(k);
+            }
+            void request_list_of_files_from_server();
+        } catch (e) {
+            alertError(e);
+        } finally {
+            setBulkBusy(null);
+            clearSelection();
+        }
+    };
+    const onMoveSelected = () => {
+        const keys = Array.from(selection);
+        if (keys.length === 0) return;
+        setPicker({
+            title: `Move ${keys.length} file${keys.length === 1 ? "" : "s"} to folder`,
+            onPick: async (folder) => {
+                try {
+                    const r = await mutations.moveKeys(keys, folder);
+                    if (r.failed.length > 0) {
+                        window.alert(r.failed.map((f) => `${f.key}: ${f.reason}`).join("\n"));
+                    }
+                    clearSelection();
+                    void request_list_of_files_from_server();
+                } catch (e) {
+                    alertError(e);
+                }
+            },
+        });
     };
 
     // Drop every loaded source via the canonical teardown.
@@ -868,6 +917,7 @@ const StorageBrowser: React.FC = () => {
         return buildFileMenuItems(f, {
             isLoaded: loadedSourceNames.has(f.name),
             busy,
+            loadDisabled: !isStreamingFEAResult(f.name) && !canLoadIntoSceneLegacy(f.name),
             canMutate,
             onToggle: (next) => void onToggle(f, next),
             onLoadStreamer:
@@ -886,6 +936,7 @@ const StorageBrowser: React.FC = () => {
         return buildFileMenuItems(f, {
             isLoaded: loadedSourceNames.has(f.name),
             busy,
+            loadDisabled: !isStreamingFEAResult(f.name) && !canLoadIntoSceneLegacy(f.name),
             canMutate: false,
             onToggle: (next) => void onToggle(f, next),
             onLoadStreamer:
@@ -932,7 +983,7 @@ const StorageBrowser: React.FC = () => {
                 "bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 " +
                 (maximized
                     ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[61] " +
-                      "w-[min(56rem,calc(100vw-2rem))] max-h-[85vh] flex flex-col"
+                      "w-[calc(100vw-3rem)] h-[calc(100vh-3rem)] flex flex-col"
                     : "w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md")
             }
         >
@@ -973,7 +1024,7 @@ const StorageBrowser: React.FC = () => {
                         ref={plusBtnRef}
                         type="button"
                         className={
-                            "bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded-sm " +
+                            "bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded-sm cursor-pointer " +
                             "flex items-center justify-center disabled:opacity-60 " +
                             "p-2 sm:p-1 min-h-[40px] min-w-[40px] sm:min-h-0 sm:min-w-0 " +
                             "focus:outline-hidden focus:ring-2 focus:ring-blue-400"
@@ -1017,7 +1068,7 @@ const StorageBrowser: React.FC = () => {
                     <button
                         type="button"
                         className={
-                            "bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded-sm " +
+                            "bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded-sm cursor-pointer " +
                             "flex items-center justify-center " +
                             // 40px+ tap target on mobile per WCAG; tighter
                             // on desktop where the cursor is precise.
@@ -1045,7 +1096,7 @@ const StorageBrowser: React.FC = () => {
                         <button
                             type="button"
                             className={
-                                "bg-gray-700 hover:bg-gray-600 active:bg-gray-800 disabled:opacity-60 " +
+                                "bg-gray-700 hover:bg-gray-600 active:bg-gray-800 disabled:opacity-60 cursor-pointer " +
                                 "text-white rounded-sm text-xs whitespace-nowrap " +
                                 "px-2 sm:px-2 py-1 min-h-[40px] sm:min-h-0"
                             }
@@ -1061,7 +1112,7 @@ const StorageBrowser: React.FC = () => {
                     <button
                         type="button"
                         className={
-                            "bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-white rounded-sm " +
+                            "bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-white rounded-sm cursor-pointer " +
                             "flex items-center justify-center " +
                             "p-2 sm:p-1 min-h-[40px] min-w-[40px] sm:min-h-0 sm:min-w-0 " +
                             "focus:outline-hidden focus:ring-2 focus:ring-blue-400"
@@ -1076,6 +1127,65 @@ const StorageBrowser: React.FC = () => {
                     </button>
                 </div>
             </div>
+            {inSelectionMode && (() => {
+                const selectionHasVersions = Array.from(selection).some((k) =>
+                    k.replace(/^\/+/, "").startsWith("versions/"),
+                );
+                const btn = "text-white text-xs px-2 py-1 rounded-sm min-h-[36px] sm:min-h-0 cursor-pointer disabled:opacity-60 disabled:cursor-default";
+                return (
+                    <div className="mb-2 px-2 py-1.5 rounded-sm border border-gray-700 bg-gray-800/95 flex items-center gap-2 flex-wrap">
+                        <span className="text-xs text-white whitespace-nowrap">
+                            {selection.size} selected
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => void onLoadSelected()}
+                            disabled={bulkBusy !== null}
+                            className={`bg-blue-700 hover:bg-blue-600 active:bg-blue-800 ${btn}`}
+                        >
+                            {bulkBusy === "load" ? "Loading…" : "Load"}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onUnloadSelected}
+                            disabled={bulkBusy !== null}
+                            className={`bg-gray-700 hover:bg-gray-600 active:bg-gray-800 ${btn}`}
+                        >
+                            {bulkBusy === "unload" ? "Unloading…" : "Unload"}
+                        </button>
+                        {canMutate && (
+                            <button
+                                type="button"
+                                onClick={onMoveSelected}
+                                disabled={bulkBusy !== null || selectionHasVersions}
+                                title={selectionHasVersions ? "CI version files can't be moved" : "Move selected files to a folder"}
+                                className={`bg-gray-700 hover:bg-gray-600 active:bg-gray-800 ${btn}`}
+                            >
+                                Move…
+                            </button>
+                        )}
+                        {canMutate && (
+                            <button
+                                type="button"
+                                onClick={() => void onDeleteSelected()}
+                                disabled={bulkBusy !== null || selectionHasVersions}
+                                title={selectionHasVersions ? "CI version files can't be deleted" : "Delete selected files (incl. converted caches)"}
+                                className={`bg-red-800 hover:bg-red-700 active:bg-red-900 ${btn}`}
+                            >
+                                {bulkBusy === "delete" ? "Deleting…" : "Delete"}
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            onClick={clearSelection}
+                            disabled={bulkBusy !== null}
+                            className={`ml-auto bg-gray-600 hover:bg-gray-500 ${btn}`}
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                );
+            })()}
             {uploadName && (
                 <div className="mb-2 text-xs">
                     <div className="flex items-center justify-between gap-2">
@@ -1185,7 +1295,6 @@ const StorageBrowser: React.FC = () => {
                                                 conversionJobs={conversionJobs}
                                                 expandedName={expandedName}
                                                 setExpandedName={setExpandedName}
-                                                onToggle={onToggle}
                                                 setPickerName={setPickerName}
                                                 selectionMode={inSelectionMode}
                                                 isSelected={selection.has(node.file.name)}
@@ -1272,7 +1381,6 @@ const StorageBrowser: React.FC = () => {
                                     conversionJobs={conversionJobs}
                                     expandedName={expandedName}
                                     setExpandedName={setExpandedName}
-                                    onToggle={onToggle}
                                     setPickerName={setPickerName}
                                     onOpenGitHistory={() => setGitHistoryOpen(true)}
                                     selectionMode={inSelectionMode}
@@ -1324,54 +1432,6 @@ const StorageBrowser: React.FC = () => {
                     if (action) void action(folder);
                 }}
             />
-            {inSelectionMode && (
-                <div
-                    className={
-                        // Sticky inside the panel rather than fixed to
-                        // viewport — keeps the action bar bound to the
-                        // storage panel's footprint on desktop while
-                        // still pinning to the bottom on mobile where
-                        // the panel takes the full screen anyway.
-                        "mt-2 -mx-2 -mb-2 px-2 py-2 border-t border-gray-700 bg-gray-800/95 " +
-                        "rounded-b flex items-center gap-2 sticky bottom-0"
-                    }
-                >
-                    <span className="text-xs text-white whitespace-nowrap">
-                        {selection.size} selected
-                    </span>
-                    {/* Load is the primary action in this bar
-                        (affirmative — adds models to the scene), so
-                        it gets the same blue as Upload / Refresh.
-                        Unload + Cancel are neutral gray; the
-                        amber row highlight already conveys "these
-                        rows are armed for an action", no need for
-                        red to scream "destructive". */}
-                    <button
-                        type="button"
-                        onClick={() => void onLoadSelected()}
-                        disabled={bulkBusy !== null}
-                        className="bg-blue-700 hover:bg-blue-600 active:bg-blue-800 disabled:opacity-60 text-white text-xs px-2 py-1 rounded-sm min-h-[36px]"
-                    >
-                        {bulkBusy === "load" ? "Loading…" : "Load"}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={onUnloadSelected}
-                        disabled={bulkBusy !== null}
-                        className="bg-gray-700 hover:bg-gray-600 active:bg-gray-800 disabled:opacity-60 text-white text-xs px-2 py-1 rounded-sm min-h-[36px]"
-                    >
-                        {bulkBusy === "unload" ? "Unloading…" : "Unload"}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={clearSelection}
-                        disabled={bulkBusy !== null}
-                        className="ml-auto bg-gray-600 hover:bg-gray-500 disabled:opacity-60 text-white text-xs px-2 py-1 rounded-sm min-h-[36px]"
-                    >
-                        Cancel
-                    </button>
-                </div>
-            )}
         </div>
     );
 };
@@ -1511,7 +1571,6 @@ interface FileRowProps {
     conversionJobs: Record<string, {progress: number; status?: string}>;
     expandedName: string | null;
     setExpandedName: (n: string | null) => void;
-    onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
     selectionMode: boolean;
     isSelected: boolean;
@@ -1545,7 +1604,6 @@ const FileRow: React.FC<FileRowProps> = ({
     conversionJobs,
     expandedName,
     setExpandedName,
-    onToggle,
     setPickerName,
     selectionMode,
     isSelected,
@@ -1610,13 +1668,12 @@ const FileRow: React.FC<FileRowProps> = ({
     return (
         <li
             className={
-                "flex flex-col px-1 py-1 text-xs rounded " +
+                "flex flex-col pr-1 py-1 text-xs rounded " +
                 (dimmed ? "opacity-40 " : "") +
-                (selectionMode
-                    ? "cursor-pointer " + (isSelected ? "bg-amber-700/30" : "hover:bg-amber-700/10")
-                    : "hover:bg-gray-800/60")
+                (isSelected ? "bg-amber-700/30 " : "hover:bg-gray-800/60 ") +
+                (selectionMode ? "cursor-pointer" : "")
             }
-            style={indentPx ? {paddingLeft: `${4 + indentPx}px`} : undefined}
+            style={{paddingLeft: `${8 + indentPx}px`}}
             draggable={draggable || undefined}
             onDragStart={draggable && onDragStartRow ? (e) => {
                 cancelLongPress();
@@ -1652,56 +1709,18 @@ const FileRow: React.FC<FileRowProps> = ({
             }}
         >
             <div className="flex items-center justify-between gap-2">
-                {selectionMode ? (
-                    <span
-                        className={
-                            "h-5 w-5 shrink-0 rounded-full border-2 inline-flex items-center justify-center " +
-                            (isSelected
-                                ? "bg-amber-600 border-amber-400"
-                                : "border-gray-400")
-                        }
-                        aria-checked={isSelected}
-                        role="checkbox"
-                    >
-                        {isSelected && (
-                            <svg viewBox="0 0 16 16" className="w-3 h-3 fill-white" aria-hidden>
-                                <path d="M6 11.2 2.4 7.6l1.4-1.4L6 8.4l6.2-6.2 1.4 1.4z"/>
-                            </svg>
-                        )}
-                    </span>
-                ) : (
-                    <label
-                        className={
-                            "flex items-center gap-2 cursor-pointer select-none px-1 py-1 -mx-1 -my-1 " +
-                            (isLoaded ? "text-blue-200 font-medium" : "")
-                        }
-                        title={
-                            isViewing
-                                ? "Loading…"
-                                : otherViewing
-                                    ? "Another file is loading"
-                                    : isLoaded
-                                        ? "Loaded in scene — uncheck to remove"
-                                        : isStreamingFEAResult(f.name)
-                                            ? "Open in streaming FEA viewer (default field, configure in Simulation controls)"
-                                            : "Add to scene (overlays alongside any other loaded files)"
-                        }
-                    >
-                        <input
-                            type="checkbox"
-                            className="h-5 w-5 shrink-0 cursor-pointer disabled:cursor-not-allowed"
-                            checked={isLoaded}
-                            onChange={(e) => onToggle(f, e.target.checked)}
-                            disabled={
-                                isViewing || otherViewing ||
-                                // The legacy GLB toggle still gates non-streaming
-                                // sources without a usable convert target.
-                                (!isStreamingFEAResult(f.name) && !canLoadIntoSceneLegacy(f.name))
-                            }
-                            aria-busy={isViewing || undefined}
-                        />
-                    </label>
-                )}
+                {/* Selection checkbox — feeds the bulk-action toolbar
+                    under the header. Loading into the scene is an
+                    explicit action (toolbar Load / row menu), never a
+                    checkbox side effect. */}
+                <input
+                    type="checkbox"
+                    className="h-5 w-5 shrink-0 cursor-pointer"
+                    checked={isSelected}
+                    onChange={() => onSelectToggle(f.name)}
+                    onClick={(e) => e.stopPropagation()}
+                    title="Select for bulk actions (load / move / delete)"
+                />
                 <FileTypeIcon name={f.name}/>
                 {renaming && onRenameCommit && onRenameCancel ? (
                     <InlineNameInput
@@ -1751,7 +1770,7 @@ const FileRow: React.FC<FileRowProps> = ({
                         the moment a new isFEAResult format that is
                         NOT in the streaming set ships, the picker
                         re-appears for it without code changes here. */}
-                    {!selectionMode && isFEAResult(f.name) && !isStreamingFEAResult(f.name) && runtime.isRestMode() && runtime.convertEnabled() && (
+                    {isFEAResult(f.name) && !isStreamingFEAResult(f.name) && runtime.isRestMode() && runtime.convertEnabled() && (
                         <button
                             className="p-1 rounded-sm text-white hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
                             onClick={(e) => {
@@ -1765,7 +1784,7 @@ const FileRow: React.FC<FileRowProps> = ({
                             <span className="leading-none text-sm font-mono">⇅</span>
                         </button>
                     )}
-                    {!selectionMode && menuItems.length > 0 && (
+                    {menuItems.length > 0 && (
                         <span onClick={(e) => e.stopPropagation()}>
                             <RowKebabMenu
                                 ariaLabel={`Actions for ${displayName}`}
@@ -1822,7 +1841,6 @@ interface VersionsTreeProps {
     conversionJobs: Record<string, {progress: number; status?: string}>;
     expandedName: string | null;
     setExpandedName: (n: string | null) => void;
-    onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
     onOpenGitHistory: () => void;
     selectionMode: boolean;
@@ -1981,7 +1999,6 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                                     conversionJobs={props.conversionJobs}
                                                                     expandedName={props.expandedName}
                                                                     setExpandedName={props.setExpandedName}
-                                                                    onToggle={props.onToggle}
                                                                     setPickerName={props.setPickerName}
                                                                     selectionMode={props.selectionMode}
                                                                     isSelected={props.selection.has(leaf.file.name)}

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -39,58 +39,13 @@ import FolderPickerModal from "@/components/common/FolderPickerModal";
 import {viewerApi} from "@/services/viewerApi";
 import {useStorageMutations} from "./useStorageMutations";
 import {buildFileMenuItems, buildFolderMenuItems} from "./storageMenuItems";
+import {canLoadIntoSceneLegacy, isFEAResult, isStreamingFEAResult} from "@/utils/scene/fileKinds";
+import {unload_any_source} from "@/utils/scene/handlers/unload_any_source";
 
 // Custom drag MIME for in-panel file moves. OS-file drops arrive as
 // ``dataTransfer.files`` instead; checking for this type tells the two
 // apart (types are readable during dragover, the payload only on drop).
 const KEYS_MIME = "application/x-adapy-keys";
-
-// Files that carry per-(step, field) result data and benefit from the
-// picker UI. .sif (Sesam text) and .sin (Sesam Norsam binary) both
-// carry the same record schema and converter; new formats land
-// here when their converter learns to honor (step, field).
-function isFEAResult(name: string): boolean {
-    const lower = name.toLowerCase();
-    return lower.endsWith(".sif") || lower.endsWith(".sin");
-}
-
-// Files that flow through the streaming-viewer artefact bake (mesh
-// GLB + per-field blobs + manifest). Static set: .sif, .sin, and
-// .rmed are adapy-native streaming sources. Capability workers (e.g.
-// abaqus .odb / .sqlite) advertise additional extensions through
-// /api/config → window.STREAMING_ONLY_EXTS; honoring that here is
-// what keeps a plug-in's stream-readable formats from accidentally
-// hitting the legacy /convert pipeline (415) on click.
-function isStreamingFEAResult(name: string): boolean {
-    const lower = name.toLowerCase();
-    if (lower.endsWith(".sif") || lower.endsWith(".sin") || lower.endsWith(".rmed")) return true;
-    // Design-model FEM meshes now load through the same streaming bake (mesh + beam-solids,
-    // clickable + tree), so FE-mesh viewing is one path. They stay legacy-convertible on the
-    // /convert page (like .sif).
-    if (lower.endsWith(".inp") || lower.endsWith(".fem") || lower.endsWith(".med")) return true;
-    for (const e of runtime.streamingOnlyExts()) {
-        const norm = e.startsWith(".") ? e.toLowerCase() : `.${e.toLowerCase()}`;
-        if (lower.endsWith(norm)) return true;
-    }
-    return false;
-}
-
-// Files the legacy "load into scene" checkbox can handle — those
-// that have a usable GLB target via the legacy convert pipeline.
-// Mirror of ada.comms.rest.converter.supported_targets_for: anything
-// in _STREAMING_FEA_EXTS (or a worker-advertised streaming-only
-// extension) has no legacy GLB target, only the streaming bake. The
-// toggle path routes those through ``load_fea_with_defaults``
-// instead of disabling the checkbox.
-function canLoadIntoSceneLegacy(name: string): boolean {
-    const lower = name.toLowerCase();
-    if (lower.endsWith(".rmed")) return false;
-    for (const e of runtime.streamingOnlyExts()) {
-        const norm = e.startsWith(".") ? e.toLowerCase() : `.${e.toLowerCase()}`;
-        if (lower.endsWith(norm)) return false;
-    }
-    return true;
-}
 
 // Small inline CSS spinner. Uses border tricks rather than an SVG so
 // it scales with text size and stays crisp at 16px tall icons.
@@ -554,10 +509,7 @@ const StorageBrowser: React.FC = () => {
         try {
             // Unload first — the scene's source registry is keyed by
             // name, and a renamed source would leave a stale entry.
-            if (loadedSourceNames.has(f.name)) {
-                if (isStreamingFEAResult(f.name)) await clear_loaded_model();
-                else unload_source_from_scene(f.name);
-            }
+            if (loadedSourceNames.has(f.name)) await unload_any_source(f.name);
             await mutations.renameKey(f.name, newKey);
             void request_list_of_files_from_server();
         } catch (e) {
@@ -567,8 +519,7 @@ const StorageBrowser: React.FC = () => {
 
     const unloadIfLoaded = async (name: string) => {
         if (!loadedSourceNames.has(name)) return;
-        if (isStreamingFEAResult(name)) await clear_loaded_model();
-        else unload_source_from_scene(name);
+        await unload_any_source(name);
     };
 
     const onDeleteFile = async (f: ServerFileEntry) => {
@@ -1335,6 +1286,8 @@ const StorageBrowser: React.FC = () => {
                                     const total = countFiles(node);
                                     const isPending = total === 0;
                                     const items = folderMenuItems(node.path, total, isPending);
+                                    const loadedCount = Array.from(loadedSourceNames)
+                                        .filter((n) => n.startsWith(node.path + "/")).length;
                                     return (
                                         <React.Fragment key={`folder:${node.path}`}>
                                             <FolderRow
@@ -1343,6 +1296,7 @@ const StorageBrowser: React.FC = () => {
                                                 expanded={expanded}
                                                 fileCount={total}
                                                 isPending={isPending}
+                                                loadedCount={loadedCount}
                                                 onToggle={() => toggleFolder(node.path)}
                                                 menuItems={items}
                                                 onOpenContextMenu={(e) => openCtxMenu(e, items)}
@@ -1456,6 +1410,10 @@ interface FolderRowProps {
     fileCount: number;
     /** Client-side pending folder (no server keys under it yet). */
     isPending?: boolean;
+    /** Loaded-in-scene models anywhere under this folder — propagates
+     * the row-level eye marker up the tree so collapsed folders still
+     * show where the loaded models live. */
+    loadedCount?: number;
     onToggle: () => void;
     /** Shared with the right-click context menu — built once by the
      * parent so kebab and context menu never diverge. Empty array
@@ -1476,6 +1434,7 @@ const FolderRow: React.FC<FolderRowProps> = ({
     expanded,
     fileCount,
     isPending,
+    loadedCount,
     onToggle,
     menuItems,
     onOpenContextMenu,
@@ -1546,6 +1505,17 @@ const FolderRow: React.FC<FolderRowProps> = ({
             ) : (
                 <span className="text-xs flex-1 min-w-0 truncate font-semibold">
                     {folder.name}/
+                </span>
+            )}
+            {(loadedCount ?? 0) > 0 && (
+                <span
+                    className="shrink-0 inline-flex items-center gap-0.5 text-blue-400"
+                    title={`${loadedCount} loaded model${loadedCount === 1 ? "" : "s"} inside`}
+                >
+                    <ViewIcon width="14px" height="14px"/>
+                    {(loadedCount ?? 0) > 1 && (
+                        <span className="text-[10px] tabular-nums">{loadedCount}</span>
+                    )}
                 </span>
             )}
             <span className="text-[10px] text-gray-400 shrink-0">

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -903,8 +903,11 @@ const StorageBrowser: React.FC = () => {
             className={
                 PANEL_CHROME + " " +
                 (maximized
-                    ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[61] " +
-                      "w-[calc(100vw-3rem)] h-[calc(100vh-3rem)] flex flex-col"
+                    ? "fixed left-1/2 top-6 -translate-x-1/2 z-[61] " +
+                      // dvh not vh: on mobile 100vh includes the area
+                      // behind the browser chrome, so a vh-sized panel
+                      // ran past the visible viewport bottom.
+                      "w-[calc(100vw-3rem)] h-[calc(100dvh-3rem)] flex flex-col"
                     : "w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md")
             }
         >

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -387,15 +387,30 @@ const StorageBrowser: React.FC = () => {
     // Right-click context menu: items are computed at open time by the
     // same builders that feed the kebab, so the two stay in lockstep.
     const [ctxMenu, setCtxMenu] = useState<{x: number; y: number; items: KebabMenuItem[]} | null>(null);
-    const openCtxMenu = (e: React.MouseEvent, items: KebabMenuItem[]) => {
+    const openCtxMenu = (
+        e: {clientX: number; clientY: number; preventDefault?: () => void; stopPropagation?: () => void},
+        items: KebabMenuItem[],
+    ) => {
         if (items.length === 0) return;
-        e.preventDefault();
-        e.stopPropagation();
+        e.preventDefault?.();
+        e.stopPropagation?.();
         setCtxMenu({x: e.clientX, y: e.clientY, items});
     };
     // In-panel drag state: keys being dragged (for row dimming + the
     // move-to-root strip). Cleared on dragend/drop.
     const [draggingKeys, setDraggingKeys] = useState<string[] | null>(null);
+    // Keyboard-navigation focus, keyed `folder:<path>` / `file:<name>`.
+    // Pointer interactions move it too, so arrows continue from the
+    // last clicked row.
+    const [focusedKey, setFocusedKey] = useState<string | null>(null);
+    const listScrollRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (!focusedKey) return;
+        const el = listScrollRef.current?.querySelector(
+            `[data-rowkey="${CSS.escape(focusedKey)}"]`,
+        ) as HTMLElement | null;
+        el?.scrollIntoView({block: "nearest"});
+    }, [focusedKey]);
     // Maximize: same component, restyled as a centered fixed overlay
     // with a backdrop. Styling-only so every bit of panel state
     // (selection, expansion, menus) survives the toggle.
@@ -888,6 +903,79 @@ const StorageBrowser: React.FC = () => {
         new Set([...collectFolderPaths(files, (f) => f.name), ...pendingFolders]),
     ).sort((a, b) => a.localeCompare(b));
 
+    // ── Keyboard navigation over the visible (regular) tree ────────
+    // Flattened render order of the rows currently on screen; versions
+    // subtree is excluded (its own collapsing structure).
+    const {regular: regularFiles, branches: versionBranches} = classifyFiles(files, sidecars);
+    const visibleTree = buildFileTree(regularFiles, (f) => f.name, pendingFolders);
+    type FlatRow =
+        | {kind: "folder"; path: string; depth: number; parent: string}
+        | {kind: "file"; name: string; file: ServerFileEntry; depth: number; parent: string};
+    const flatRows: FlatRow[] = [];
+    {
+        const walk = (nodes: ServerFileTreeNode[], depth: number, parent: string) => {
+            for (const n of nodes) {
+                if (n.kind === "folder") {
+                    flatRows.push({kind: "folder", path: n.path, depth, parent});
+                    if (expandedFolders.has(n.path)) walk(n.children, depth + 1, n.path);
+                } else {
+                    flatRows.push({kind: "file", name: n.file.name, file: n.file, depth, parent});
+                }
+            }
+        };
+        walk(visibleTree, 0, "");
+    }
+    const rowKeyOf = (r: FlatRow) => (r.kind === "folder" ? `folder:${r.path}` : `file:${r.name}`);
+
+    const onListKeyDown = (e: React.KeyboardEvent) => {
+        if (flatRows.length === 0) return;
+        if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter", " "].includes(e.key)) return;
+        // Don't steal keys from the inline rename/new-folder inputs.
+        if ((e.target as HTMLElement).tagName === "INPUT") return;
+        e.preventDefault();
+        e.stopPropagation();
+        const idx = focusedKey ? flatRows.findIndex((r) => rowKeyOf(r) === focusedKey) : -1;
+        const row = idx >= 0 ? flatRows[idx] : null;
+        const focusAt = (i: number) => {
+            const clamped = Math.max(0, Math.min(flatRows.length - 1, i));
+            setFocusedKey(rowKeyOf(flatRows[clamped]));
+        };
+        switch (e.key) {
+            case "ArrowDown":
+                focusAt(idx < 0 ? 0 : idx + 1);
+                break;
+            case "ArrowUp":
+                focusAt(idx < 0 ? flatRows.length - 1 : idx - 1);
+                break;
+            case "ArrowRight":
+                if (!row) {
+                    focusAt(0);
+                } else if (row.kind === "folder") {
+                    if (!expandedFolders.has(row.path)) toggleFolder(row.path);
+                    else if (idx + 1 < flatRows.length && flatRows[idx + 1].parent === row.path) focusAt(idx + 1);
+                }
+                break;
+            case "ArrowLeft":
+                if (!row) {
+                    focusAt(0);
+                } else if (row.kind === "folder" && expandedFolders.has(row.path)) {
+                    toggleFolder(row.path);
+                } else if (row.parent) {
+                    const pIdx = flatRows.findIndex((r) => r.kind === "folder" && r.path === row.parent);
+                    if (pIdx >= 0) focusAt(pIdx);
+                }
+                break;
+            case "Enter":
+                if (!row) break;
+                if (row.kind === "folder") toggleFolder(row.path);
+                else void onToggle(row.file, !(loadedSourceNames.has(row.name) || queuedLoadNames.has(row.name)));
+                break;
+            case " ":
+                if (row?.kind === "file") toggleSelection(row.name);
+                break;
+        }
+    };
+
     const showRootDropStrip =
         draggingKeys !== null && draggingKeys.some((k) => dirnameOf(k) !== "");
 
@@ -1158,11 +1246,16 @@ const StorageBrowser: React.FC = () => {
                 </div>
             ) : (
                 (() => {
-                    const {regular, branches} = classifyFiles(files, sidecars);
+                    const regular = regularFiles;
+                    const branches = versionBranches;
                     return (
                         <div
+                            ref={listScrollRef}
+                            tabIndex={0}
+                            onKeyDown={onListKeyDown}
                             className={
-                                "flex flex-col overflow-auto " +
+                                "flex flex-col overflow-auto focus:outline-hidden " +
+                                "focus-visible:ring-1 focus-visible:ring-blue-500/40 rounded-sm " +
                                 (maximized ? "flex-1 min-h-0" : "max-h-80")
                             }
                             // Background (non-row) drops land at root:
@@ -1206,7 +1299,7 @@ const StorageBrowser: React.FC = () => {
                                 </div>
                             )}
                             {(regular.length > 0 || pendingFolders.length > 0) && (() => {
-                                const tree = buildFileTree(regular, (f) => f.name, pendingFolders);
+                                const tree = visibleTree;
                                 const renderNode = (
                                     node: ServerFileTreeNode,
                                     depth: number,
@@ -1227,11 +1320,14 @@ const StorageBrowser: React.FC = () => {
                                                 setExpandedName={setExpandedName}
                                                 onToggle={onToggle}
                                                 setPickerName={setPickerName}
-                                                selectionMode={inSelectionMode}
                                                 isSelected={selection.has(node.file.name)}
                                                 isQueued={queuedLoadNames.has(node.file.name)}
-                                                onLongPress={toggleSelection}
-                                                onSelectToggle={toggleSelection}
+                                                onSelectToggle={(name) => {
+                                                    setFocusedKey(`file:${name}`);
+                                                    toggleSelection(name);
+                                                }}
+                                                rowKey={`file:${node.file.name}`}
+                                                focused={focusedKey === `file:${node.file.name}`}
                                                 menuItems={items}
                                                 onOpenContextMenu={(e) => openCtxMenu(e, items)}
                                                 draggable={canMutate}
@@ -1272,7 +1368,12 @@ const StorageBrowser: React.FC = () => {
                                                 fileCount={total}
                                                 isPending={isPending}
                                                 loadedCount={loadedCount}
-                                                onToggle={() => toggleFolder(node.path)}
+                                                onToggle={() => {
+                                                    setFocusedKey(`folder:${node.path}`);
+                                                    toggleFolder(node.path);
+                                                }}
+                                                rowKey={`folder:${node.path}`}
+                                                focused={focusedKey === `folder:${node.path}`}
                                                 menuItems={items}
                                                 onOpenContextMenu={(e) => openCtxMenu(e, items)}
                                                 onDropInto={(e) => void handleDropOnFolder(node.path, e)}
@@ -1319,9 +1420,7 @@ const StorageBrowser: React.FC = () => {
                                     onToggle={onToggle}
                                     setPickerName={setPickerName}
                                     onOpenGitHistory={() => setGitHistoryOpen(true)}
-                                    selectionMode={inSelectionMode}
                                     selection={selection}
-                                    onLongPress={toggleSelection}
                                     onSelectToggle={toggleSelection}
                                     fileMenuItemsFor={versionFileMenuItems}
                                     onOpenContextMenu={openCtxMenu}
@@ -1402,6 +1501,9 @@ interface FolderRowProps {
     renaming?: boolean;
     onRenameCommit?: (newName: string) => void;
     onRenameCancel?: () => void;
+    /** Keyboard-navigation identity + highlight. */
+    rowKey?: string;
+    focused?: boolean;
 }
 
 const FolderRow: React.FC<FolderRowProps> = ({
@@ -1418,6 +1520,8 @@ const FolderRow: React.FC<FolderRowProps> = ({
     renaming,
     onRenameCommit,
     onRenameCancel,
+    rowKey,
+    focused,
 }) => {
     const indentPx = depth * 12;
     // dragenter/dragleave fire per child element; a counter survives
@@ -1427,10 +1531,12 @@ const FolderRow: React.FC<FolderRowProps> = ({
         e.dataTransfer.types.includes(KEYS_MIME) || e.dataTransfer.types.includes("Files");
     return (
         <li
+            data-rowkey={rowKey}
             className={
                 "flex items-center gap-1.5 px-2 py-1 rounded cursor-pointer select-none " +
                 "hover:bg-gray-800/80 " +
                 (dragHover > 0 ? "ring-1 ring-blue-400 bg-blue-900/30 " : "") +
+                (focused && dragHover === 0 ? "ring-1 ring-blue-400/70 " : "") +
                 (isPending ? "opacity-80 " : "")
             }
             style={{paddingLeft: 8 + indentPx}}
@@ -1525,16 +1631,18 @@ interface FileRowProps {
     setExpandedName: (n: string | null) => void;
     onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
-    selectionMode: boolean;
     isSelected: boolean;
     /** Waiting in the scene-load queue (untick to remove). */
     isQueued?: boolean;
-    onLongPress: (name: string) => void;
     onSelectToggle: (name: string) => void;
     /** Row actions — shared between the kebab and the right-click
      * context menu (parent builds both from one list). */
     menuItems: KebabMenuItem[];
-    onOpenContextMenu?: (e: React.MouseEvent) => void;
+    /** Desktop right-click AND touch long-press both land here. */
+    onOpenContextMenu?: (e: {clientX: number; clientY: number; preventDefault?: () => void; stopPropagation?: () => void}) => void;
+    /** Keyboard-navigation identity + highlight. */
+    rowKey?: string;
+    focused?: boolean;
     /** In-panel drag source (move to folder). */
     draggable?: boolean;
     onDragStartRow?: (e: React.DragEvent) => void;
@@ -1561,13 +1669,13 @@ const FileRow: React.FC<FileRowProps> = ({
     setExpandedName,
     onToggle,
     setPickerName,
-    selectionMode,
     isSelected,
     isQueued,
-    onLongPress,
     onSelectToggle,
     menuItems,
     onOpenContextMenu,
+    rowKey,
+    focused,
     draggable,
     onDragStartRow,
     onDragEndRow,
@@ -1587,10 +1695,9 @@ const FileRow: React.FC<FileRowProps> = ({
         : 0;
     const indentPx = indentLevel * 12;
 
-    // Long-press to enter selection mode. 500 ms hold, cancelled by
-    // pointer move > 8 px (treats it as a scroll, not a hold). Once
-    // we're in selection mode, taps toggle membership instead — see
-    // the row's onClick below.
+    // Long-press = the touch path to the context menu (desktop has
+    // right-click). 500 ms hold, cancelled by pointer move > 8 px
+    // (treats it as a scroll, not a hold) or by a drag starting.
     const longPressTimer = useRef<number | null>(null);
     const longPressStart = useRef<{x: number; y: number} | null>(null);
     const longPressFired = useRef(false);
@@ -1601,13 +1708,13 @@ const FileRow: React.FC<FileRowProps> = ({
         }
     };
     const onPointerDown: React.PointerEventHandler = (e) => {
-        if (selectionMode) return; // already in mode; rely on click
-        longPressStart.current = {x: e.clientX, y: e.clientY};
+        const {clientX, clientY} = e;
+        longPressStart.current = {x: clientX, y: clientY};
         longPressFired.current = false;
         cancelLongPress();
         longPressTimer.current = window.setTimeout(() => {
             longPressFired.current = true;
-            onLongPress(f.name);
+            onOpenContextMenu?.({clientX, clientY});
         }, 500);
     };
     const onPointerMove: React.PointerEventHandler = (e) => {
@@ -1624,11 +1731,12 @@ const FileRow: React.FC<FileRowProps> = ({
 
     return (
         <li
+            data-rowkey={rowKey}
             className={
-                "flex flex-col pr-1 py-1 text-xs rounded " +
+                "flex flex-col pr-1 py-1 text-xs rounded cursor-pointer select-none " +
                 (dimmed ? "opacity-40 " : "") +
-                (isSelected ? "bg-amber-700/30 " : "hover:bg-gray-800/60 ") +
-                (selectionMode ? "cursor-pointer" : "")
+                (focused ? "ring-1 ring-blue-400/70 " : "") +
+                (isSelected ? "bg-amber-700/30 " : "hover:bg-gray-800/60 ")
             }
             style={{paddingLeft: `${8 + indentPx}px`}}
             draggable={draggable || undefined}
@@ -1653,47 +1761,24 @@ const FileRow: React.FC<FileRowProps> = ({
             }}
             onClick={(e) => {
                 if (longPressFired.current) {
-                    // The long-press already toggled selection on; the
-                    // synthetic click fires after pointerup and would
-                    // double-toggle if we let it through.
+                    // The long-press already opened the context menu;
+                    // the synthetic click fires after pointerup and
+                    // would also toggle selection if let through.
                     longPressFired.current = false;
                     e.stopPropagation();
                     return;
                 }
-                if (selectionMode) {
-                    onSelectToggle(f.name);
-                    return;
-                }
-                // Tap/click anywhere on the row (outside the toggle and
-                // row buttons) opens the same menu as right-click — the
-                // primary mobile path to rename/move/delete/download.
-                onOpenContextMenu?.(e);
+                // Single click/tap = selection toggle (feeds the bulk
+                // toolbar). Context menu is right-click / long-press.
+                onSelectToggle(f.name);
             }}
         >
             <div className="flex items-center justify-between gap-2">
-                {/* Normal mode: the checkbox IS the load toggle —
-                    checked (+ the eye marker) while the model is in the
-                    scene; clicking it loads/unloads directly. Long-press
-                    swaps the rows into selection mode, where the amber
-                    circle marks bulk-toolbar membership instead. */}
-                {selectionMode ? (
-                    <span
-                        className={
-                            "h-5 w-5 shrink-0 rounded-full border-2 inline-flex items-center justify-center " +
-                            (isSelected
-                                ? "bg-amber-600 border-amber-400"
-                                : "border-gray-400")
-                        }
-                        aria-checked={isSelected}
-                        role="checkbox"
-                    >
-                        {isSelected && (
-                            <svg viewBox="0 0 16 16" className="w-3 h-3 fill-white" aria-hidden>
-                                <path d="M6 11.2 2.4 7.6l1.4-1.4L6 8.4l6.2-6.2 1.4 1.4z"/>
-                            </svg>
-                        )}
-                    </span>
-                ) : (
+                {/* The checkbox IS the load toggle — checked (+ the
+                    eye marker) while the model is in the scene; clicking
+                    it loads/unloads directly. Row click = selection
+                    (amber highlight feeds the bulk toolbar). */}
+                {(
                     <input
                         type="checkbox"
                         className="h-5 w-5 shrink-0 cursor-pointer disabled:cursor-not-allowed"
@@ -1727,14 +1812,7 @@ const FileRow: React.FC<FileRowProps> = ({
                         type="button"
                         onClick={(e) => {
                             e.stopPropagation();
-                            if (selectionMode) {
-                                onSelectToggle(f.name);
-                                return;
-                            }
-                            // Same menu as right-click — full path shows
-                            // in the menu header, so no separate
-                            // truncation toggle is needed.
-                            onOpenContextMenu?.(e);
+                            onSelectToggle(f.name);
                         }}
                         className={`flex-1 min-w-0 text-left ${expandedName === f.name ? 'whitespace-normal break-all' : 'truncate'} ${isLoaded ? 'text-blue-200 font-medium' : ''}`}
                         title={f.name}
@@ -1854,13 +1932,14 @@ interface VersionsTreeProps {
     onToggle: (entry: ServerFileEntry, nextChecked: boolean) => Promise<void>;
     setPickerName: (n: string | null) => void;
     onOpenGitHistory: () => void;
-    selectionMode: boolean;
     selection: Set<string>;
-    onLongPress: (name: string) => void;
     onSelectToggle: (name: string) => void;
     /** Read-only menu builder from the parent (load/streamer/download). */
     fileMenuItemsFor: (file: ServerFileEntry) => KebabMenuItem[];
-    onOpenContextMenu: (e: React.MouseEvent, items: KebabMenuItem[]) => void;
+    onOpenContextMenu: (
+        e: {clientX: number; clientY: number; preventDefault?: () => void; stopPropagation?: () => void},
+        items: KebabMenuItem[],
+    ) => void;
     showModified?: boolean;
 }
 
@@ -2012,9 +2091,7 @@ const VersionsTree: React.FC<VersionsTreeProps> = (props) => {
                                                                     setExpandedName={props.setExpandedName}
                                                                     onToggle={props.onToggle}
                                                                     setPickerName={props.setPickerName}
-                                                                    selectionMode={props.selectionMode}
                                                                     isSelected={props.selection.has(leaf.file.name)}
-                                                                    onLongPress={props.onLongPress}
                                                                     onSelectToggle={props.onSelectToggle}
                                                                     menuItems={items}
                                                                     onOpenContextMenu={(e) => props.onOpenContextMenu(e, items)}

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -903,11 +903,13 @@ const StorageBrowser: React.FC = () => {
             className={
                 PANEL_CHROME + " " +
                 (maximized
-                    ? "fixed left-1/2 top-6 -translate-x-1/2 z-[61] " +
-                      // dvh not vh: on mobile 100vh includes the area
-                      // behind the browser chrome, so a vh-sized panel
-                      // ran past the visible viewport bottom.
-                      "w-[calc(100vw-3rem)] h-[calc(100dvh-3rem)] flex flex-col"
+                    ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[61] " +
+                      // Same footprint as the floating admin panel
+                      // (InViewerPanelHost Rnd: 1100×720 capped to the
+                      // viewport). dvh not vh: on mobile 100vh includes
+                      // the area behind the browser chrome, so a
+                      // vh-sized panel ran past the visible bottom.
+                      "w-[min(1100px,calc(100vw-2rem))] h-[min(720px,calc(100dvh-5rem))] flex flex-col"
                     : "w-full min-w-0 max-w-[calc(100vw-1rem)] md:max-w-md")
             }
         >

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -988,11 +988,15 @@ const StorageBrowser: React.FC = () => {
             }
         >
             {maximized && createPortal(
-                // Light scrim — just enough to signal modality and give
-                // the panel edge contrast without blacking out the 3D
-                // scene behind it.
+                // Light scrim — just enough to signal modality without
+                // blacking out the 3D scene. z-[5]: the panel lives in
+                // the menu overlay's `z-10` stacking context, so its
+                // own z-index can never exceed 10 at the root level —
+                // a body-portaled scrim above 10 paints OVER the panel
+                // and darkens it too (visibly so on mobile). Below 10
+                // it dims only the canvas underneath.
                 <div
-                    className="fixed inset-0 z-[60] bg-black/25"
+                    className="fixed inset-0 z-[5] bg-black/25"
                     onClick={() => setMaximized(false)}
                     aria-hidden="true"
                 />,

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -1,3 +1,4 @@
+import {PANEL_CHROME} from "@/state/themeStore";
 import React, {useEffect, useRef, useState} from "react";
 import {createPortal} from "react-dom";
 import {useServerInfoStore, ServerFileEntry} from "@/state/serverInfoStore";
@@ -981,7 +982,7 @@ const StorageBrowser: React.FC = () => {
             // toggle. The host column has no transform ancestors, so
             // position:fixed escapes it cleanly.
             className={
-                "bg-gray-900/95 border border-gray-700 text-gray-100 shadow-lg rounded-md p-2 " +
+                PANEL_CHROME + " " +
                 (maximized
                     ? "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[61] " +
                       "w-[calc(100vw-3rem)] h-[calc(100vh-3rem)] flex flex-col"

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -38,6 +38,7 @@ import PositionedMenu, {KebabMenuItem} from "@/components/common/PositionedMenu"
 import FolderPickerModal from "@/components/common/FolderPickerModal";
 import {viewerApi} from "@/services/viewerApi";
 import {useStorageMutations} from "./useStorageMutations";
+import {useLoadQueueStore} from "@/state/loadQueueStore";
 import {buildFileMenuItems, buildFolderMenuItems} from "./storageMenuItems";
 import {canLoadIntoSceneLegacy, isFEAResult, isStreamingFEAResult} from "@/utils/scene/fileKinds";
 import {unload_any_source} from "@/utils/scene/handlers/unload_any_source";
@@ -291,7 +292,14 @@ const StorageBrowser: React.FC = () => {
     const [uploadLoaded, setUploadLoaded] = useState(0);
     const [uploadTotal, setUploadTotal] = useState(0);
     const [expandedName, setExpandedName] = useState<string | null>(null);
-    const [viewingName, setViewingName] = useState<string | null>(null);
+    // Scene loads run through the sequential load queue; the row
+    // spinner tracks whichever model the queue is currently loading.
+    const loadCurrent = useLoadQueueStore((s) => s.current);
+    const loadQueued = useLoadQueueStore((s) => s.queued);
+    const enqueueLoad = useLoadQueueStore((s) => s.enqueue);
+    const removeQueuedLoad = useLoadQueueStore((s) => s.removeQueued);
+    const viewingName = loadCurrent?.name ?? null;
+    const queuedLoadNames = new Set(loadQueued.map((t) => t.name));
     // Sticky 600ms spin window for the Refresh button so a tap is
     // visually acknowledged even though the underlying list-files
     // request is fire-and-forget over websocket. Without this the
@@ -606,52 +614,30 @@ const StorageBrowser: React.FC = () => {
     // bbox); subsequent files reuse that translation so they
     // overlay correctly.
     const onToggle = async (entry: ServerFileEntry, nextChecked: boolean) => {
-        if (viewingName) return; // already busy with another file
-        setViewingName(entry.name);
+        if (nextChecked) {
+            // Queue the load — more can be queued while one is in
+            // flight; the queue drains sequentially (shared loader
+            // state can't take concurrent loads).
+            enqueueLoad({name: entry.name});
+            return;
+        }
+        if (queuedLoadNames.has(entry.name)) {
+            removeQueuedLoad(entry.name);
+            return;
+        }
+        if (viewingName === entry.name) return; // mid-load; can't cancel
         try {
-            if (nextChecked) {
-                if (isStreamingFEAResult(entry.name)) {
-                    // Streaming-FEA toggle: fetch manifest, load with
-                    // defaults (first field, default reduction, step 0),
-                    // and let SimulationControls take it from there.
-                    // No more picker modal in the way.
-                    await load_fea_with_defaults(entry.name);
-                } else {
-                    await overlay_file_in_scene(entry.name);
-                }
-            } else {
-                if (isStreamingFEAResult(entry.name)) {
-                    // FEA streaming meshes were loaded via replace_model
-                    // (scene-wide replace, no per-source group registered).
-                    // unload_source_from_scene would no-op because there's
-                    // no group ref to look up. Clear the whole scene
-                    // instead — that also tears down the FEA session
-                    // store + animation driver.
-                    await clear_loaded_model();
-                } else {
-                    unload_source_from_scene(entry.name);
-                }
-            }
+            await unload_any_source(entry.name);
         } catch (err) {
             console.error("storage toggle failed", err);
-        } finally {
-            setViewingName(null);
         }
     };
 
     // Load a STEP file via the memory-bounded streaming converter (one solid at a
     // time) — for large assemblies whose normal OCC->GLB conversion OOM-kills the
     // worker. Same overlay flow as onToggle, with the streamer flag set.
-    const onLoadStreamer = async (name: string) => {
-        if (viewingName) return;
-        setViewingName(name);
-        try {
-            await overlay_file_in_scene(name, undefined, {streamer: true});
-        } catch (err) {
-            console.error("streamer load failed", err);
-        } finally {
-            setViewingName(null);
-        }
+    const onLoadStreamer = (name: string) => {
+        enqueueLoad({name, streamer: true});
     };
 
     // Bulk "show all" — overlay every file currently absent from the
@@ -664,30 +650,12 @@ const StorageBrowser: React.FC = () => {
     // already-loaded items (no-op overlay) and unload already-hidden
     // items (no-op unload) so the user gets a predictable result
     // regardless of the per-row state mix.
-    const onLoadSelected = async () => {
-        if (bulkBusy !== null) return;
+    const onLoadSelected = () => {
         const targets = files.filter((f) =>
             selection.has(f.name) && !loadedSourceNames.has(f.name) &&
             (isStreamingFEAResult(f.name) || canLoadIntoSceneLegacy(f.name)));
-        if (targets.length === 0) {
-            clearSelection();
-            return;
-        }
-        setBulkBusy("load");
-        try {
-            for (const f of targets) {
-                setViewingName(f.name);
-                try {
-                    await overlay_file_in_scene(f.name);
-                } catch (err) {
-                    console.error("load-selected overlay failed", f.name, err);
-                }
-            }
-        } finally {
-            setViewingName(null);
-            setBulkBusy(null);
-            clearSelection();
-        }
+        for (const f of targets) enqueueLoad({name: f.name});
+        clearSelection();
     };
     const onUnloadSelected = () => {
         if (bulkBusy !== null) return;
@@ -866,7 +834,7 @@ const StorageBrowser: React.FC = () => {
 
     // ── Menu item builders (kebab + context menu share these) ───────
     const fileMenuItems = (f: ServerFileEntry, displayName: string): KebabMenuItem[] => {
-        const busy = viewingName !== null;
+        const busy = viewingName === f.name;
         return buildFileMenuItems(f, {
             isLoaded: loadedSourceNames.has(f.name),
             busy,
@@ -875,7 +843,7 @@ const StorageBrowser: React.FC = () => {
             onToggle: (next) => void onToggle(f, next),
             onLoadStreamer:
                 runtime.isRestMode() && runtime.convertEnabled()
-                    ? () => void onLoadStreamer(f.name)
+                    ? () => onLoadStreamer(f.name)
                     : undefined,
             onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
             onRename: () => setRenaming({kind: "file", path: f.name}),
@@ -885,7 +853,7 @@ const StorageBrowser: React.FC = () => {
     };
     // CI version blobs stay read-only: load/streamer/download only.
     const versionFileMenuItems = (f: ServerFileEntry): KebabMenuItem[] => {
-        const busy = viewingName !== null;
+        const busy = viewingName === f.name;
         return buildFileMenuItems(f, {
             isLoaded: loadedSourceNames.has(f.name),
             busy,
@@ -894,7 +862,7 @@ const StorageBrowser: React.FC = () => {
             onToggle: (next) => void onToggle(f, next),
             onLoadStreamer:
                 runtime.isRestMode() && runtime.convertEnabled()
-                    ? () => void onLoadStreamer(f.name)
+                    ? () => onLoadStreamer(f.name)
                     : undefined,
             onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
         });
@@ -1096,11 +1064,11 @@ const StorageBrowser: React.FC = () => {
                         </span>
                         <button
                             type="button"
-                            onClick={() => void onLoadSelected()}
+                            onClick={onLoadSelected}
                             disabled={bulkBusy !== null}
                             className={`bg-blue-700 hover:bg-blue-600 active:bg-blue-800 ${btn}`}
                         >
-                            {bulkBusy === "load" ? "Loading…" : "Load"}
+                            Load
                         </button>
                         <button
                             type="button"
@@ -1256,6 +1224,7 @@ const StorageBrowser: React.FC = () => {
                                                 setPickerName={setPickerName}
                                                 selectionMode={inSelectionMode}
                                                 isSelected={selection.has(node.file.name)}
+                                                isQueued={queuedLoadNames.has(node.file.name)}
                                                 onLongPress={toggleSelection}
                                                 onSelectToggle={toggleSelection}
                                                 menuItems={items}
@@ -1553,6 +1522,8 @@ interface FileRowProps {
     setPickerName: (n: string | null) => void;
     selectionMode: boolean;
     isSelected: boolean;
+    /** Waiting in the scene-load queue (untick to remove). */
+    isQueued?: boolean;
     onLongPress: (name: string) => void;
     onSelectToggle: (name: string) => void;
     /** Row actions — shared between the kebab and the right-click
@@ -1587,6 +1558,7 @@ const FileRow: React.FC<FileRowProps> = ({
     setPickerName,
     selectionMode,
     isSelected,
+    isQueued,
     onLongPress,
     onSelectToggle,
     menuItems,
@@ -1720,19 +1692,21 @@ const FileRow: React.FC<FileRowProps> = ({
                     <input
                         type="checkbox"
                         className="h-5 w-5 shrink-0 cursor-pointer disabled:cursor-not-allowed"
-                        checked={isLoaded}
-                        onChange={() => void onToggle(f, !isLoaded)}
+                        checked={isLoaded || isQueued || isViewing}
+                        onChange={() => void onToggle(f, !(isLoaded || isQueued))}
                         onClick={(e) => e.stopPropagation()}
                         disabled={
-                            isViewing || otherViewing ||
+                            isViewing ||
                             (!isStreamingFEAResult(f.name) && !canLoadIntoSceneLegacy(f.name))
                         }
                         aria-busy={isViewing || undefined}
                         title={isLoaded
                             ? "Unload from scene"
-                            : isStreamingFEAResult(f.name)
-                                ? "Open in streaming FEA viewer"
-                                : "Load into scene"}
+                            : isQueued
+                                ? "Queued to load — untick to remove from the queue"
+                                : isStreamingFEAResult(f.name)
+                                    ? "Open in streaming FEA viewer (queues if another model is loading)"
+                                    : "Load into scene (queues if another model is loading)"}
                     />
                 )}
                 <FileTypeIcon name={f.name}/>
@@ -1776,6 +1750,11 @@ const FileRow: React.FC<FileRowProps> = ({
                         selection control (bulk actions), so loaded
                         state needs its own signal — the blue filename
                         tint alone is easy to miss on mobile. */}
+                    {isQueued && (
+                        <span className="text-[10px] text-amber-400 uppercase tracking-wide shrink-0">
+                            queued
+                        </span>
+                    )}
                     {isLoaded && !isViewing && (
                         <ViewIcon
                             width="16px"

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -47,6 +47,9 @@ import {unload_any_source} from "@/utils/scene/handlers/unload_any_source";
 // ``dataTransfer.files`` instead; checking for this type tells the two
 // apart (types are readable during dragover, the payload only on drop).
 const KEYS_MIME = "application/x-adapy-keys";
+// Folder drags carry the folder path instead — the drop handler moves
+// the whole prefix (subfolders preserved via the grouped-move helper).
+const FOLDER_MIME = "application/x-adapy-folder";
 
 // Small inline CSS spinner. Uses border tricks rather than an SVG so
 // it scales with text size and stays crisp at 16px tall icons.
@@ -285,6 +288,8 @@ const StorageBrowser: React.FC = () => {
         });
     };
     const clearSelection = () => setSelection(new Set());
+    // Anchor for shift-click range selection (the last row toggled).
+    const lastSelectedRef = useRef<string | null>(null);
     // Upload progress: name = current file (or null), loaded/total in
     // bytes. Total may stay 0 if the browser can't determine it (rare
     // for File uploads); we treat that as indeterminate.
@@ -399,6 +404,7 @@ const StorageBrowser: React.FC = () => {
     // In-panel drag state: keys being dragged (for row dimming + the
     // move-to-root strip). Cleared on dragend/drop.
     const [draggingKeys, setDraggingKeys] = useState<string[] | null>(null);
+    const [draggingFolder, setDraggingFolder] = useState<string | null>(null);
     // Keyboard-navigation focus, keyed `folder:<path>` / `file:<name>`.
     // Pointer interactions move it too, so arrows continue from the
     // last clicked row.
@@ -810,6 +816,18 @@ const StorageBrowser: React.FC = () => {
     // OS-file drops upload into the folder.
     const handleDropOnFolder = async (target: string, e: React.DragEvent) => {
         setDraggingKeys(null);
+        setDraggingFolder(null);
+        const folderPath = e.dataTransfer.getData(FOLDER_MIME);
+        if (folderPath) {
+            if (!canMutate) return;
+            // No-ops: into itself, into its own subtree, or where it
+            // already lives.
+            if (target === folderPath || target.startsWith(folderPath + "/")) return;
+            if (dirnameOf(folderPath) === target) return;
+            const base = basenameOf(folderPath);
+            await runFolderMove(folderPath, target ? `${target}/${base}` : base);
+            return;
+        }
         const txt = e.dataTransfer.getData(KEYS_MIME);
         if (txt) {
             if (!canMutate) return;
@@ -977,7 +995,8 @@ const StorageBrowser: React.FC = () => {
     };
 
     const showRootDropStrip =
-        draggingKeys !== null && draggingKeys.some((k) => dirnameOf(k) !== "");
+        (draggingKeys !== null && draggingKeys.some((k) => dirnameOf(k) !== "")) ||
+        (draggingFolder !== null && dirnameOf(draggingFolder) !== "");
 
     return (
         <div
@@ -1322,8 +1341,28 @@ const StorageBrowser: React.FC = () => {
                                                 setPickerName={setPickerName}
                                                 isSelected={selection.has(node.file.name)}
                                                 isQueued={queuedLoadNames.has(node.file.name)}
-                                                onSelectToggle={(name) => {
+                                                onSelectToggle={(name, shiftKey) => {
                                                     setFocusedKey(`file:${name}`);
+                                                    if (shiftKey && lastSelectedRef.current && lastSelectedRef.current !== name) {
+                                                        // Range-select between the anchor and this
+                                                        // row, in visible order.
+                                                        const fileNames = flatRows
+                                                            .filter((r) => r.kind === "file")
+                                                            .map((r) => (r as {name: string}).name);
+                                                        const a = fileNames.indexOf(lastSelectedRef.current);
+                                                        const b = fileNames.indexOf(name);
+                                                        if (a >= 0 && b >= 0) {
+                                                            const [lo, hi] = a < b ? [a, b] : [b, a];
+                                                            setSelection((prev) => {
+                                                                const next = new Set(prev);
+                                                                for (let i = lo; i <= hi; i++) next.add(fileNames[i]);
+                                                                return next;
+                                                            });
+                                                            lastSelectedRef.current = name;
+                                                            return;
+                                                        }
+                                                    }
+                                                    lastSelectedRef.current = name;
                                                     toggleSelection(name);
                                                 }}
                                                 rowKey={`file:${node.file.name}`}
@@ -1377,6 +1416,13 @@ const StorageBrowser: React.FC = () => {
                                                 menuItems={items}
                                                 onOpenContextMenu={(e) => openCtxMenu(e, items)}
                                                 onDropInto={(e) => void handleDropOnFolder(node.path, e)}
+                                                draggable={canMutate && !isPending}
+                                                onDragStartRow={(e) => {
+                                                    e.dataTransfer.setData(FOLDER_MIME, node.path);
+                                                    e.dataTransfer.effectAllowed = "move";
+                                                    setDraggingFolder(node.path);
+                                                }}
+                                                onDragEndRow={() => setDraggingFolder(null)}
                                                 renaming={renaming?.kind === "folder" && renaming.path === node.path}
                                                 onRenameCommit={(v) => onRenameFolderCommit(node.path, v, isPending)}
                                                 onRenameCancel={() => setRenaming(null)}
@@ -1498,6 +1544,10 @@ interface FolderRowProps {
     /** Drop handler for in-panel moves + OS-file uploads into this
      * folder. Hover highlight is local state. */
     onDropInto?: (e: React.DragEvent) => void;
+    /** In-panel drag source (move the whole folder). */
+    draggable?: boolean;
+    onDragStartRow?: (e: React.DragEvent) => void;
+    onDragEndRow?: () => void;
     renaming?: boolean;
     onRenameCommit?: (newName: string) => void;
     onRenameCancel?: () => void;
@@ -1517,6 +1567,9 @@ const FolderRow: React.FC<FolderRowProps> = ({
     menuItems,
     onOpenContextMenu,
     onDropInto,
+    draggable,
+    onDragStartRow,
+    onDragEndRow,
     renaming,
     onRenameCommit,
     onRenameCancel,
@@ -1528,7 +1581,9 @@ const FolderRow: React.FC<FolderRowProps> = ({
     // the churn where a plain boolean would flicker.
     const [dragHover, setDragHover] = useState(0);
     const acceptsDrop = (e: React.DragEvent) =>
-        e.dataTransfer.types.includes(KEYS_MIME) || e.dataTransfer.types.includes("Files");
+        e.dataTransfer.types.includes(KEYS_MIME) ||
+        e.dataTransfer.types.includes(FOLDER_MIME) ||
+        e.dataTransfer.types.includes("Files");
     return (
         <li
             data-rowkey={rowKey}
@@ -1540,6 +1595,9 @@ const FolderRow: React.FC<FolderRowProps> = ({
                 (isPending ? "opacity-80 " : "")
             }
             style={{paddingLeft: 8 + indentPx}}
+            draggable={draggable || undefined}
+            onDragStart={draggable && onDragStartRow ? onDragStartRow : undefined}
+            onDragEnd={onDragEndRow}
             onClick={onToggle}
             onContextMenu={onOpenContextMenu}
             role="button"
@@ -1634,7 +1692,7 @@ interface FileRowProps {
     isSelected: boolean;
     /** Waiting in the scene-load queue (untick to remove). */
     isQueued?: boolean;
-    onSelectToggle: (name: string) => void;
+    onSelectToggle: (name: string, shiftKey?: boolean) => void;
     /** Row actions — shared between the kebab and the right-click
      * context menu (parent builds both from one list). */
     menuItems: KebabMenuItem[];
@@ -1708,6 +1766,10 @@ const FileRow: React.FC<FileRowProps> = ({
         }
     };
     const onPointerDown: React.PointerEventHandler = (e) => {
+        // Touch only — on mouse/pen the menu lives on right-click, and a
+        // held left button must stay free to start an HTML5 drag (which
+        // begins on movement; a timer firing mid-hold stole the gesture).
+        if (e.pointerType !== "touch") return;
         const {clientX, clientY} = e;
         longPressStart.current = {x: clientX, y: clientY};
         longPressFired.current = false;
@@ -1769,8 +1831,10 @@ const FileRow: React.FC<FileRowProps> = ({
                     return;
                 }
                 // Single click/tap = selection toggle (feeds the bulk
-                // toolbar). Context menu is right-click / long-press.
-                onSelectToggle(f.name);
+                // toolbar); shift-click selects the visible range from
+                // the last toggled row. Context menu is right-click /
+                // long-press.
+                onSelectToggle(f.name, e.shiftKey);
             }}
         >
             <div className="flex items-center justify-between gap-2">
@@ -1812,7 +1876,7 @@ const FileRow: React.FC<FileRowProps> = ({
                         type="button"
                         onClick={(e) => {
                             e.stopPropagation();
-                            onSelectToggle(f.name);
+                            onSelectToggle(f.name, e.shiftKey);
                         }}
                         className={`flex-1 min-w-0 text-left ${expandedName === f.name ? 'whitespace-normal break-all' : 'truncate'} ${isLoaded ? 'text-blue-200 font-medium' : ''}`}
                         title={f.name}

--- a/src/frontend/src/components/storage/storageMenuItems.tsx
+++ b/src/frontend/src/components/storage/storageMenuItems.tsx
@@ -15,6 +15,9 @@ export interface FileMenuContext {
     isLoaded: boolean;
     /** This row (or another) is busy loading into the scene. */
     busy: boolean;
+    /** No usable view target (legacy convert can't produce a GLB and
+     * the format isn't a streaming source) — Load is disabled. */
+    loadDisabled?: boolean;
     canMutate: boolean;
     onToggle: (nextChecked: boolean) => void;
     /** REST + convert mode only: streaming STEP load for big assemblies. */
@@ -34,7 +37,10 @@ export function buildFileMenuItems(
     items.push({
         key: "toggle-load",
         label: ctx.isLoaded ? "Unload from scene" : "Load into scene",
-        disabled: ctx.busy,
+        disabled: ctx.busy || (!ctx.isLoaded && ctx.loadDisabled),
+        title: !ctx.isLoaded && ctx.loadDisabled
+            ? "No viewable target for this format"
+            : undefined,
         onClick: () => ctx.onToggle(!ctx.isLoaded),
     });
     if (ctx.onLoadStreamer && /\.(step|stp)$/i.test(file.name)) {

--- a/src/frontend/src/components/storage/storageMenuItems.tsx
+++ b/src/frontend/src/components/storage/storageMenuItems.tsx
@@ -1,0 +1,142 @@
+// Single source of truth for the storage panel's file/folder action
+// menus. Both entry points — the per-row kebab (touch/mobile) and the
+// right-click context menu (desktop) — render the same items, so an
+// action added here shows up in both without divergence.
+//
+// Mutating items (rename / move / delete / new subfolder) are included
+// only when ``ctx.canMutate`` is set: personal scope for everyone,
+// admin elsewhere (see useStorageMutations). VersionsTree rows pass
+// ``canMutate: false`` regardless — CI version blobs stay read-only.
+
+import {KebabMenuItem} from "@/components/common/PositionedMenu";
+import {ServerFileEntry} from "@/state/serverInfoStore";
+
+export interface FileMenuContext {
+    isLoaded: boolean;
+    /** This row (or another) is busy loading into the scene. */
+    busy: boolean;
+    canMutate: boolean;
+    onToggle: (nextChecked: boolean) => void;
+    /** REST + convert mode only: streaming STEP load for big assemblies. */
+    onLoadStreamer?: () => void;
+    /** REST mode only. */
+    onDownload?: () => void;
+    onRename?: () => void;
+    onMoveToFolder?: () => void;
+    onDelete?: () => void;
+}
+
+export function buildFileMenuItems(
+    file: ServerFileEntry,
+    ctx: FileMenuContext,
+): KebabMenuItem[] {
+    const items: KebabMenuItem[] = [];
+    items.push({
+        key: "toggle-load",
+        label: ctx.isLoaded ? "Unload from scene" : "Load into scene",
+        disabled: ctx.busy,
+        onClick: () => ctx.onToggle(!ctx.isLoaded),
+    });
+    if (ctx.onLoadStreamer && /\.(step|stp)$/i.test(file.name)) {
+        items.push({
+            key: "load-streamer",
+            label: "Load using streamer",
+            title: "Memory-bounded streaming STEP→GLB — for large assemblies that fail the normal load.",
+            disabled: ctx.busy,
+            onClick: ctx.onLoadStreamer,
+        });
+    }
+    if (ctx.onDownload) {
+        items.push({
+            key: "download",
+            label: "Download",
+            onClick: ctx.onDownload,
+        });
+    }
+    if (ctx.canMutate && ctx.onRename) {
+        items.push({
+            key: "rename",
+            label: "Rename…",
+            onClick: ctx.onRename,
+        });
+    }
+    if (ctx.canMutate && ctx.onMoveToFolder) {
+        items.push({
+            key: "move-to-folder",
+            label: "Move to folder…",
+            onClick: ctx.onMoveToFolder,
+        });
+    }
+    if (ctx.canMutate && ctx.onDelete) {
+        items.push({
+            key: "delete",
+            label: "Delete",
+            destructive: true,
+            separatorBefore: true,
+            title: "Deletes the file and its converted view caches.",
+            onClick: ctx.onDelete,
+        });
+    }
+    return items;
+}
+
+export interface FolderMenuContext {
+    canMutate: boolean;
+    fileCount: number;
+    onRename?: () => void;
+    onMoveInto?: () => void;
+    onNewSubfolder?: () => void;
+    onUploadHere?: () => void;
+    onDelete?: () => void;
+}
+
+export function buildFolderMenuItems(
+    folderPath: string,
+    ctx: FolderMenuContext,
+): KebabMenuItem[] {
+    const items: KebabMenuItem[] = [];
+    // Uploading is allowed in every scope the user can read, so
+    // "Upload here…" stays available even when canMutate is off.
+    if (ctx.onUploadHere) {
+        items.push({
+            key: "upload-here",
+            label: "Upload here…",
+            onClick: ctx.onUploadHere,
+        });
+    }
+    if (!ctx.canMutate) return items;
+    if (ctx.onNewSubfolder) {
+        items.push({
+            key: "new-subfolder",
+            label: "New subfolder…",
+            onClick: ctx.onNewSubfolder,
+        });
+    }
+    if (ctx.onRename) {
+        items.push({
+            key: "rename",
+            label: "Rename folder…",
+            title: "Sibling-name rename. Subfolders preserved.",
+            onClick: ctx.onRename,
+        });
+    }
+    if (ctx.onMoveInto) {
+        items.push({
+            key: "move-into",
+            label: "Move folder into…",
+            title: "Move under a destination prefix. Subfolders preserved.",
+            onClick: ctx.onMoveInto,
+        });
+    }
+    if (ctx.onDelete) {
+        items.push({
+            key: "delete",
+            label: `Delete folder (${ctx.fileCount} file${ctx.fileCount === 1 ? "" : "s"})`,
+            destructive: true,
+            separatorBefore: true,
+            title: "Deletes every file under this folder, including their converted view caches.",
+            onClick: ctx.onDelete,
+        });
+    }
+    return items;
+}

--- a/src/frontend/src/components/storage/useStorageMutations.ts
+++ b/src/frontend/src/components/storage/useStorageMutations.ts
@@ -1,0 +1,51 @@
+import {useMemo} from "react";
+import {viewerApi, MoveKeysResult, MovedKeyEntry} from "@/services/viewerApi";
+import {useScopeStore, scopeUrlPart} from "@/state/scopeStore";
+import {useMeStore} from "@/state/meStore";
+
+// Single predicate + dispatch point for every mutating storage action
+// in the user-facing panel. Personal scope → everyone, via the
+// user-level endpoints; any other scope → admins only, via the admin
+// endpoints (the backend enforces the same split). When canMutate is
+// false the UI hides rename/move/delete affordances entirely.
+export interface StorageMutations {
+    canMutate: boolean;
+    deleteKey: (key: string) => Promise<{deleted: string[]; errors?: string[]}>;
+    moveKeys: (keys: string[], folder: string) => Promise<MoveKeysResult>;
+    renameKey: (oldKey: string, newKey: string) => Promise<MovedKeyEntry>;
+    renameOrMoveFolder: (
+        oldFolder: string,
+        newFolder: string,
+        allKeys: string[],
+    ) => Promise<MoveKeysResult>;
+}
+
+export function useStorageMutations(): StorageMutations {
+    const scope = useScopeStore((s) => s.current);
+    const isAdmin = useMeStore((s) => s.isAdmin);
+
+    return useMemo(() => {
+        const scopeUrl = scopeUrlPart(scope);
+        const personal = scope?.kind === "user";
+        const canMutate = personal || isAdmin;
+
+        if (personal) {
+            return {
+                canMutate,
+                deleteKey: (key) => viewerApi.deleteBlob(scopeUrl, key),
+                moveKeys: (keys, folder) => viewerApi.moveKeysToFolder(scopeUrl, keys, folder),
+                renameKey: (oldKey, newKey) => viewerApi.renameKey(scopeUrl, oldKey, newKey),
+                renameOrMoveFolder: (oldFolder, newFolder, allKeys) =>
+                    viewerApi.renameOrMoveFolder(scopeUrl, oldFolder, newFolder, allKeys),
+            };
+        }
+        return {
+            canMutate,
+            deleteKey: (key) => viewerApi.adminDeleteBlob(scopeUrl, key),
+            moveKeys: (keys, folder) => viewerApi.adminMoveKeysToFolder(scopeUrl, keys, folder),
+            renameKey: (oldKey, newKey) => viewerApi.adminRenameKey(scopeUrl, oldKey, newKey),
+            renameOrMoveFolder: (oldFolder, newFolder, allKeys) =>
+                viewerApi.adminRenameOrMoveFolder(scopeUrl, oldFolder, newFolder, allKeys),
+        };
+    }, [scope, isAdmin]);
+}

--- a/src/frontend/src/components/viewer/FemConceptsController.tsx
+++ b/src/frontend/src/components/viewer/FemConceptsController.tsx
@@ -4,7 +4,7 @@ import * as THREE from "three";
 import {sceneRef, cameraRef, rendererRef, adaExtensionRef} from "@/state/refs";
 import {requestRender} from "@/state/perfStore";
 import {useFemConceptsStore} from "@/state/femConceptsStore";
-import {useModelState} from "@/state/modelState";
+import {useModelState, loadedSourceGroups} from "@/state/modelState";
 import type {MassGlyph, BcGlyph, LoadScenario} from "@/extensions/design_and_analysis_extension";
 
 // Headless: reconciles the FEM-concepts store with three.js, drawing a glyph
@@ -37,14 +37,19 @@ const FemConceptsController: React.FC = () => {
     return null;
 };
 
-// Merge the fem_concepts blocks across every design + simulation object in the
-// loaded model's ADA_EXT extension into flat masses/bcs/scenarios arrays.
+// Merge the fem_concepts blocks across every design + simulation object of
+// every LOADED model into flat masses/bcs/scenarios arrays. Each loaded
+// scene group keeps its own ADA extension (userData.__adaExt); the single
+// adaExtensionRef is only consulted while something is loaded (the
+// streaming/replace path) — it still holds the LAST model's data after an
+// unload, which used to leave dead masses/BCs/loads in the overlay.
 function parseExtension(): {masses: MassGlyph[]; bcs: BcGlyph[]; scenarios: LoadScenario[]} {
-    const ext = adaExtensionRef.current as any;
     const masses: MassGlyph[] = [];
     const bcs: BcGlyph[] = [];
     const scenarios: LoadScenario[] = [];
-    if (ext) {
+
+    const ingest = (ext: any) => {
+        if (!ext) return;
         const objs = [...(ext.design_objects ?? []), ...(ext.simulation_objects ?? [])];
         for (const o of objs) {
             const fc = o?.fem_concepts;
@@ -53,6 +58,22 @@ function parseExtension(): {masses: MassGlyph[]; bcs: BcGlyph[]; scenarios: Load
             if (fc.bcs) bcs.push(...fc.bcs);
             if (fc.scenarios) scenarios.push(...fc.scenarios);
         }
+    };
+
+    const loadedNames = useModelState.getState().loadedSourceNames;
+    let foundPerSource = false;
+    for (const name of loadedNames) {
+        const group = loadedSourceGroups.get(name);
+        if (!group) continue;
+        const ext = (group.children?.[0] as any)?.userData?.__adaExt
+            ?? (group as any)?.userData?.__adaExt;
+        if (ext) {
+            ingest(ext);
+            foundPerSource = true;
+        }
+    }
+    if (!foundPerSource && loadedNames.size > 0) {
+        ingest(adaExtensionRef.current as any);
     }
     return {masses, bcs, scenarios};
 }

--- a/src/frontend/src/components/viewer/sceneHelpers/setupPointerHandler.ts
+++ b/src/frontend/src/components/viewer/sceneHelpers/setupPointerHandler.ts
@@ -170,24 +170,46 @@ export function setupPointerHandler(
     };
 }
 
-/** Raycast at screen coords and return the nearest world-space hit on
- *  any mesh (points hits also count). Returns null on a clean miss. */
+/** World-space surface point under the cursor, for the double-tap
+ *  "set rotation pivot" gesture. Returns null on a clean miss.
+ *
+ *  GPU mesh pick first: depth-buffer accurate and the same picker the
+ *  selection path trusts. The CPU raycast fallback must NOT use the
+ *  Raycaster defaults — ``Points.threshold`` / ``Line.threshold``
+ *  default to 1 *world unit*, so on FEM models (node points + edge
+ *  lines everywhere) the "nearest" hit was often a vertex passing
+ *  within a unit of the ray right next to the camera. The pivot then
+ *  landed essentially at the camera position and rotation degenerated
+ *  into spinning in place — easiest to trigger on mobile, where you
+ *  pinch in close before double-tapping. */
 function pickWorldPoint(
     e: MouseEvent,
     camera: THREE.PerspectiveCamera,
     scene: THREE.Scene,
     renderer: THREE.WebGLRenderer,
 ): THREE.Vector3 | null {
+    try {
+        const meshPick = gpuMeshPicker.pickAt(e.clientX, e.clientY);
+        if (meshPick) return meshPick.worldPosition.clone();
+    } catch {
+        // GPU pick unavailable — CPU raycast below still works.
+    }
     const rect = renderer.domElement.getBoundingClientRect();
     const nx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     const ny = -((e.clientY - rect.top) / rect.height) * 2 + 1;
     const pointer = new THREE.Vector2(nx, ny);
     const ray = new THREE.Raycaster();
+    ray.params.Points = {...ray.params.Points, threshold: 0.02};
+    ray.params.Line = {...ray.params.Line, threshold: 0.02};
     ray.layers.set(0);
     ray.layers.disable(1);
     ray.setFromCamera(pointer, camera);
+    // Never pivot onto something hugging the near plane — a hit that
+    // close is a threshold artifact, not a tapped surface.
+    const minDist = camera.near * 2;
     const hits = ray.intersectObjects(scene.children, true);
-    return hits.length > 0 ? hits[0].point.clone() : null;
+    const hit = hits.find((h) => h.distance > minDist);
+    return hit ? hit.point.clone() : null;
 }
 
 /** Set the camera's rotation pivot without moving the camera. */

--- a/src/frontend/src/services/auth/oidc.ts
+++ b/src/frontend/src/services/auth/oidc.ts
@@ -145,7 +145,10 @@ export function getUser(): {sub?: string; email?: string; name?: string} {
 }
 
 /** Kick off the authorize redirect. Caller is the AuthGate UI. */
-export async function signIn(returnUrl?: string): Promise<void> {
+export async function signIn(
+    returnUrl?: string,
+    opts?: {forceLogin?: boolean},
+): Promise<void> {
     const d = await loadDiscovery();
     const verifier = randomUrl(32);
     const challenge = base64url(await sha256Bytes(verifier));
@@ -174,6 +177,13 @@ export async function signIn(returnUrl?: string): Promise<void> {
         code_challenge_method: "S256",
         state,
     });
+    if (opts?.forceLogin) {
+        // Standard OIDC prompt param — both Authentik and Azure AD honor
+        // it by re-showing the login form even when an IdP session
+        // exists, letting the user pick a different account. Only sent
+        // on explicit request so the normal silent-SSO path is unchanged.
+        params.set("prompt", "login");
+    }
     const aud = runtime.authAudience();
     if (aud && aud !== runtime.authClientId()) {
         // Auth0 / some Azure AD configurations need this so the issued

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -22,6 +22,45 @@ export type ConvertStatus = "queued" | "running" | "done" | "error" | "cancelled
  *  sub so URLs are user-agnostic. */
 export type ScopeUrl = string;
 
+/** One successfully renamed/moved source key with its derived-sibling tally. */
+export interface MovedKeyEntry {
+    old: string;
+    new: string;
+    siblings_moved: number;
+    siblings_failed: string[];
+}
+
+export interface MoveKeysResult {
+    moved: MovedKeyEntry[];
+    failed: Array<{key: string; reason: string}>;
+}
+
+/** Group keys under ``oldFolder`` by their parent path relative to it,
+ * mapping each group to its ``<newFolder>/<relative_parent>`` move
+ * destination. Shared by the user and admin folder rename/move flows —
+ * the move endpoint flattens inputs into one target folder, so a single
+ * batch call would lose the folder's internal structure. */
+function groupKeysByRelativeParent(
+    oldFolder: string,
+    newFolder: string,
+    allKeys: string[],
+): Map<string, string[]> {
+    const oldTrimmed = oldFolder.replace(/^\/+|\/+$/g, "");
+    const newTrimmed = newFolder.replace(/^\/+|\/+$/g, "");
+    const prefix = oldTrimmed + "/";
+    const groups = new Map<string, string[]>();
+    for (const k of allKeys) {
+        if (!k.startsWith(prefix)) continue;
+        const rest = k.slice(prefix.length);
+        const lastSlash = rest.lastIndexOf("/");
+        const relParent = lastSlash >= 0 ? rest.slice(0, lastSlash) : "";
+        const dest = relParent ? `${newTrimmed}/${relParent}` : newTrimmed;
+        if (!groups.has(dest)) groups.set(dest, []);
+        groups.get(dest)!.push(k);
+    }
+    return groups;
+}
+
 export interface MeResponse {
     sub: string;
     email: string;
@@ -861,6 +900,76 @@ export const viewerApi = {
         } finally {
             URL.revokeObjectURL(url);
         }
+    },
+
+    /** Delete an own file (derived blobs cascade server-side).
+     * Personal scope only — shared/project scopes return 403; admins
+     * use adminDeleteBlob there. */
+    async deleteBlob(
+        scope: ScopeUrl,
+        key: string,
+    ): Promise<{deleted: string[]; errors?: string[]}> {
+        const r = await authedFetch(this.blobUrl(scope, key), {method: "DELETE"});
+        return jsonOrThrow(r, "deleteBlob");
+    },
+
+    /** Batch-move own source keys into a destination folder. Personal
+     * scope only; mirrors adminMoveKeysToFolder. */
+    async moveKeysToFolder(
+        scope: ScopeUrl,
+        keys: string[],
+        folder: string,
+    ): Promise<MoveKeysResult> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/scopes/${encodeURIComponent(scope)}/keys/move-to-folder`,
+            {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({keys, folder}),
+            },
+        );
+        return jsonOrThrow(r, "moveKeysToFolder");
+    },
+
+    /** Rename a single own source key (derived blobs follow). Personal
+     * scope only. 409 → target exists, 404 → source missing. */
+    async renameKey(
+        scope: ScopeUrl,
+        oldKey: string,
+        newKey: string,
+    ): Promise<MovedKeyEntry> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/scopes/${encodeURIComponent(scope)}/keys/rename`,
+            {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({old_key: oldKey, new_key: newKey}),
+            },
+        );
+        return jsonOrThrow(r, "renameKey");
+    },
+
+    /** Rename or relocate a folder prefix in the personal scope —
+     * user-level twin of adminRenameOrMoveFolder (same grouped-move
+     * strategy, see that method's docstring). */
+    async renameOrMoveFolder(
+        scope: ScopeUrl,
+        oldFolder: string,
+        newFolder: string,
+        allKeys: string[],
+    ): Promise<MoveKeysResult> {
+        const groups = groupKeysByRelativeParent(oldFolder, newFolder, allKeys);
+        const movedAll: MovedKeyEntry[] = [];
+        const failedAll: Array<{key: string; reason: string}> = [];
+        // Sequential not parallel: each call mutates the scope's keyset
+        // on the server; concurrent calls would race on collision
+        // detection.
+        for (const [dest, keys] of groups) {
+            const r = await this.moveKeysToFolder(scope, keys, dest);
+            movedAll.push(...r.moved);
+            failedAll.push(...r.failed);
+        }
+        return {moved: movedAll, failed: failedAll};
     },
 
     /** Fetch raw bytes for a key. Used by the in-browser Pyodide
@@ -1893,15 +2002,7 @@ export const viewerApi = {
         scope: ScopeUrl,
         keys: string[],
         folder: string,
-    ): Promise<{
-        moved: Array<{
-            old: string;
-            new: string;
-            siblings_moved: number;
-            siblings_failed: string[];
-        }>;
-        failed: Array<{key: string; reason: string}>;
-    }> {
+    ): Promise<MoveKeysResult> {
         const r = await authedFetch(
             `${runtime.apiBase()}/admin/scopes/${encodeURIComponent(scope)}/keys/move-to-folder`,
             {
@@ -1911,6 +2012,24 @@ export const viewerApi = {
             },
         );
         return jsonOrThrow(r, "adminMoveKeysToFolder");
+    },
+
+    /** Admin: rename a single source key in any scope (derived blobs
+     * follow). Twin of the user-level renameKey. */
+    async adminRenameKey(
+        scope: ScopeUrl,
+        oldKey: string,
+        newKey: string,
+    ): Promise<MovedKeyEntry> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/admin/scopes/${encodeURIComponent(scope)}/keys/rename`,
+            {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({old_key: oldKey, new_key: newKey}),
+            },
+        );
+        return jsonOrThrow(r, "adminRenameKey");
     },
 
     /** Server-side copy keys from another scope into ``dstScope`` (e.g. pulling
@@ -1953,30 +2072,9 @@ export const viewerApi = {
         oldFolder: string,
         newFolder: string,
         allKeys: string[],
-    ): Promise<{
-        moved: Array<{
-            old: string;
-            new: string;
-            siblings_moved: number;
-            siblings_failed: string[];
-        }>;
-        failed: Array<{key: string; reason: string}>;
-    }> {
-        const oldTrimmed = oldFolder.replace(/^\/+|\/+$/g, "");
-        const newTrimmed = newFolder.replace(/^\/+|\/+$/g, "");
-        const prefix = oldTrimmed + "/";
-        // dest folder → keys to send.
-        const groups = new Map<string, string[]>();
-        for (const k of allKeys) {
-            if (!k.startsWith(prefix)) continue;
-            const rest = k.slice(prefix.length);
-            const lastSlash = rest.lastIndexOf("/");
-            const relParent = lastSlash >= 0 ? rest.slice(0, lastSlash) : "";
-            const dest = relParent ? `${newTrimmed}/${relParent}` : newTrimmed;
-            if (!groups.has(dest)) groups.set(dest, []);
-            groups.get(dest)!.push(k);
-        }
-        const movedAll: Array<{old: string; new: string; siblings_moved: number; siblings_failed: string[]}> = [];
+    ): Promise<MoveKeysResult> {
+        const groups = groupKeysByRelativeParent(oldFolder, newFolder, allKeys);
+        const movedAll: MovedKeyEntry[] = [];
         const failedAll: Array<{key: string; reason: string}> = [];
         // Sequential not parallel: each call mutates the scope's keyset
         // on the server; concurrent calls would race on collision

--- a/src/frontend/src/state/loadQueueStore.ts
+++ b/src/frontend/src/state/loadQueueStore.ts
@@ -1,0 +1,79 @@
+import {create} from "zustand";
+import {overlay_file_in_scene} from "@/utils/scene/handlers/overlay_file_in_scene";
+import {load_fea_with_defaults} from "@/utils/scene/handlers/load_fea_streaming";
+import {isStreamingFEAResult} from "@/utils/scene/fileKinds";
+
+// Sequential scene-load queue. overlay_file_in_scene shares loader
+// state, so concurrent loads corrupt the scene — but that's an
+// implementation constraint, not a UX one: the user can keep ticking
+// checkboxes and the queue drains one model at a time. The toast
+// (LoadQueueToast) renders current + queued + errors from this store;
+// the storage rows mark queued entries and let an un-tick remove them
+// before their turn comes.
+
+export interface LoadTask {
+    name: string;
+    /** Memory-bounded streaming STEP→GLB path (row menu action). */
+    streamer?: boolean;
+}
+
+interface LoadQueueState {
+    current: LoadTask | null;
+    queued: LoadTask[];
+    errors: Array<{name: string; message: string}>;
+    enqueue: (task: LoadTask) => void;
+    removeQueued: (name: string) => void;
+    clearError: (name: string) => void;
+}
+
+export const useLoadQueueStore = create<LoadQueueState>((set, get) => ({
+    current: null,
+    queued: [],
+    errors: [],
+    enqueue: (task) => {
+        const s = get();
+        if (s.current?.name === task.name) return;
+        if (s.queued.some((t) => t.name === task.name)) return;
+        set({
+            queued: [...s.queued, task],
+            // Re-queuing a previously failed load clears its stale error.
+            errors: s.errors.filter((e) => e.name !== task.name),
+        });
+        void runNext();
+    },
+    removeQueued: (name) =>
+        set((s) => ({queued: s.queued.filter((t) => t.name !== name)})),
+    clearError: (name) =>
+        set((s) => ({errors: s.errors.filter((e) => e.name !== name)})),
+}));
+
+async function runNext(): Promise<void> {
+    const store = useLoadQueueStore;
+    if (store.getState().current) return;
+    const next = store.getState().queued[0];
+    if (!next) return;
+    store.setState((s) => ({current: next, queued: s.queued.slice(1)}));
+    try {
+        if (next.streamer) {
+            await overlay_file_in_scene(next.name, undefined, {streamer: true});
+        } else if (isStreamingFEAResult(next.name)) {
+            // Streaming-FEA replaces the whole scene (replace_model) —
+            // documented behavior of loading such a file; queued
+            // overlays after it land on the fresh scene.
+            await load_fea_with_defaults(next.name);
+        } else {
+            await overlay_file_in_scene(next.name);
+        }
+    } catch (err) {
+        console.error("queued load failed", next.name, err);
+        store.setState((s) => ({
+            errors: [
+                ...s.errors,
+                {name: next.name, message: err instanceof Error ? err.message : String(err)},
+            ],
+        }));
+    } finally {
+        store.setState({current: null});
+        void runNext();
+    }
+}

--- a/src/frontend/src/state/sceneInfoStore.ts
+++ b/src/frontend/src/state/sceneInfoStore.ts
@@ -11,6 +11,12 @@ export interface GroupInfo {
   type: 'design' | 'simulation';
   fe_object_type?: 'node' | 'element';
   parent_name: string;
+  /** Storage key of the loaded file this group came from. Disambiguates
+   * groups across multi-model overlays (shown in the picker, and scopes
+   * the member-mesh lookup to the owning model's scene group). Absent
+   * for streaming-FEA groups pushed by load_fea_streaming — there's
+   * only ever one streaming model in the scene. */
+  source?: string;
 }
 
 // One kwarg in a utility's input form (mirrors the worker @utility spec).

--- a/src/frontend/src/state/themeStore.ts
+++ b/src/frontend/src/state/themeStore.ts
@@ -1,0 +1,115 @@
+import {create} from "zustand";
+import {persist} from "zustand/middleware";
+
+// Panel theming for the menu-row info boxes (Options / Storage /
+// Selected Object / Scene / Server / WS status). The panels read
+// their chrome from CSS custom properties (--ada-panel-*) via the
+// shared PANEL_CHROME class string; this store owns the values and
+// writes them onto <html> whenever they change, so switching theme
+// re-paints every panel without prop drilling.
+//
+// Why themable at all: panel chrome is a trade-off between text
+// legibility and how much attention the box steals from the 3D view.
+// The dark default reads best; the pale glass distracts least. The
+// two middle presets split the difference, and the custom swatches
+// let the user land anywhere.
+
+export interface PanelTheme {
+    /** Any CSS color — presets use rgba() so the alpha rides along. */
+    bg: string;
+    border: string;
+    text: string;
+}
+
+export const THEME_PRESETS: Record<string, {name: string; hint: string; theme: PanelTheme}> = {
+    dark: {
+        name: "Dark",
+        hint: "High contrast, easiest to read",
+        theme: {bg: "rgba(17, 24, 39, 0.95)", border: "rgba(55, 65, 81, 1)", text: "#f3f4f6"},
+    },
+    slate: {
+        name: "Slate glass",
+        hint: "Dark but translucent — the scene shows through",
+        theme: {bg: "rgba(30, 41, 59, 0.62)", border: "rgba(148, 163, 184, 0.35)", text: "#f1f5f9"},
+    },
+    mist: {
+        name: "Mist",
+        hint: "Light glass with dark text",
+        theme: {bg: "rgba(226, 232, 240, 0.55)", border: "rgba(71, 85, 105, 0.4)", text: "#111827"},
+    },
+    pale: {
+        name: "Pale glass",
+        hint: "The classic unobtrusive gray",
+        theme: {bg: "rgba(156, 163, 175, 0.5)", border: "rgba(156, 163, 175, 0)", text: "#ffffff"},
+    },
+};
+
+export type ThemePresetId = keyof typeof THEME_PRESETS;
+
+/** Shared chrome class for every menu-row panel. Color comes from the
+ *  CSS vars this store maintains; shape/elevation stay constant. */
+export const PANEL_CHROME =
+    "bg-[var(--ada-panel-bg)] border border-[var(--ada-panel-border)] " +
+    "text-[var(--ada-panel-text)] shadow-lg rounded-md p-2";
+
+interface ThemeState {
+    preset: ThemePresetId;
+    /** Hex overrides from the custom swatches; null = use the preset. */
+    customBg: string | null;
+    customText: string | null;
+    /** Alpha applied to customBg (presets carry their own alpha). */
+    bgOpacity: number;
+    setPreset: (p: ThemePresetId) => void;
+    setCustomBg: (hex: string) => void;
+    setCustomText: (hex: string) => void;
+    setBgOpacity: (a: number) => void;
+    resetCustom: () => void;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) return hex;
+    const n = parseInt(m[1], 16);
+    return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}
+
+export function effectivePanelTheme(s: Pick<ThemeState, "preset" | "customBg" | "customText" | "bgOpacity">): PanelTheme {
+    const base = (THEME_PRESETS[s.preset] ?? THEME_PRESETS.dark).theme;
+    return {
+        bg: s.customBg ? hexToRgba(s.customBg, s.bgOpacity) : base.bg,
+        border: base.border,
+        text: s.customText ?? base.text,
+    };
+}
+
+function applyPanelThemeVars(theme: PanelTheme): void {
+    const root = document.documentElement.style;
+    root.setProperty("--ada-panel-bg", theme.bg);
+    root.setProperty("--ada-panel-border", theme.border);
+    root.setProperty("--ada-panel-text", theme.text);
+}
+
+export const useThemeStore = create<ThemeState>()(
+    persist(
+        (set) => ({
+            preset: "dark",
+            customBg: null,
+            customText: null,
+            bgOpacity: 0.9,
+            // Picking a preset clears the custom swatches — the preset
+            // IS the chosen look; stale overrides shadowing it would
+            // make the preset buttons feel broken.
+            setPreset: (p) => set({preset: p, customBg: null, customText: null}),
+            setCustomBg: (hex) => set({customBg: hex}),
+            setCustomText: (hex) => set({customText: hex}),
+            setBgOpacity: (a) => set({bgOpacity: Math.min(1, Math.max(0.1, a))}),
+            resetCustom: () => set({customBg: null, customText: null}),
+        }),
+        {name: "ada-panel-theme"},
+    ),
+);
+
+// Paint on import (default or persisted snapshot) and on every change —
+// including the async persist rehydration, which fires subscribers.
+applyPanelThemeVars(effectivePanelTheme(useThemeStore.getState()));
+useThemeStore.subscribe((s) => applyPanelThemeVars(effectivePanelTheme(s)));

--- a/src/frontend/src/state/themeStore.ts
+++ b/src/frontend/src/state/themeStore.ts
@@ -22,15 +22,15 @@ export interface PanelTheme {
 }
 
 export const THEME_PRESETS: Record<string, {name: string; hint: string; theme: PanelTheme}> = {
-    dark: {
-        name: "Dark",
-        hint: "High contrast, easiest to read",
-        theme: {bg: "rgba(17, 24, 39, 0.95)", border: "rgba(55, 65, 81, 1)", text: "#f3f4f6"},
-    },
     slate: {
         name: "Slate glass",
         hint: "Dark but translucent — the scene shows through",
         theme: {bg: "rgba(30, 41, 59, 0.62)", border: "rgba(148, 163, 184, 0.35)", text: "#f1f5f9"},
+    },
+    dark: {
+        name: "Dark",
+        hint: "High contrast, easiest to read",
+        theme: {bg: "rgba(17, 24, 39, 0.95)", border: "rgba(55, 65, 81, 1)", text: "#f3f4f6"},
     },
     mist: {
         name: "Mist",
@@ -74,7 +74,7 @@ function hexToRgba(hex: string, alpha: number): string {
 }
 
 export function effectivePanelTheme(s: Pick<ThemeState, "preset" | "customBg" | "customText" | "bgOpacity">): PanelTheme {
-    const base = (THEME_PRESETS[s.preset] ?? THEME_PRESETS.dark).theme;
+    const base = (THEME_PRESETS[s.preset] ?? THEME_PRESETS.slate).theme;
     return {
         bg: s.customBg ? hexToRgba(s.customBg, s.bgOpacity) : base.bg,
         border: base.border,
@@ -92,7 +92,7 @@ function applyPanelThemeVars(theme: PanelTheme): void {
 export const useThemeStore = create<ThemeState>()(
     persist(
         (set) => ({
-            preset: "dark",
+            preset: "slate",
             customBg: null,
             customText: null,
             bgOpacity: 0.9,

--- a/src/frontend/src/utils/scene/fileKinds.ts
+++ b/src/frontend/src/utils/scene/fileKinds.ts
@@ -1,0 +1,52 @@
+import {runtime} from "@/runtime/config";
+
+// File-kind predicates shared by the storage browser and the scene
+// panel's loaded-models list. Extracted from StorageBrowser so the
+// unload/visibility code paths agree on which files are streaming-FEA
+// (loaded via replace_model, torn down via clear_loaded_model) vs
+// regular overlays (per-source groups).
+
+// Files that carry per-(step, field) result data and benefit from the
+// picker UI. .sif (Sesam text) and .sin (Sesam Norsam binary) both
+// carry the same record schema and converter; new formats land
+// here when their converter learns to honor (step, field).
+export function isFEAResult(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower.endsWith(".sif") || lower.endsWith(".sin");
+}
+
+// Files that flow through the streaming-viewer artefact bake (mesh
+// GLB + per-field blobs + manifest). Static set: .sif, .sin, and
+// .rmed are adapy-native streaming sources. Capability workers (e.g.
+// abaqus .odb / .sqlite) advertise additional extensions through
+// /api/config → window.STREAMING_ONLY_EXTS; honoring that here is
+// what keeps a plug-in's stream-readable formats from accidentally
+// hitting the legacy /convert pipeline (415) on click.
+export function isStreamingFEAResult(name: string): boolean {
+    const lower = name.toLowerCase();
+    if (lower.endsWith(".sif") || lower.endsWith(".sin") || lower.endsWith(".rmed")) return true;
+    // Design-model FEM meshes now load through the same streaming bake (mesh + beam-solids,
+    // clickable + tree), so FE-mesh viewing is one path. They stay legacy-convertible on the
+    // /convert page (like .sif).
+    if (lower.endsWith(".inp") || lower.endsWith(".fem") || lower.endsWith(".med")) return true;
+    for (const e of runtime.streamingOnlyExts()) {
+        const norm = e.startsWith(".") ? e.toLowerCase() : `.${e.toLowerCase()}`;
+        if (lower.endsWith(norm)) return true;
+    }
+    return false;
+}
+
+// Files the legacy "load into scene" path can handle — those that
+// have a usable GLB target via the legacy convert pipeline. Mirror of
+// ada.comms.rest.converter.supported_targets_for: anything in
+// _STREAMING_FEA_EXTS (or a worker-advertised streaming-only
+// extension) has no legacy GLB target, only the streaming bake.
+export function canLoadIntoSceneLegacy(name: string): boolean {
+    const lower = name.toLowerCase();
+    if (lower.endsWith(".rmed")) return false;
+    for (const e of runtime.streamingOnlyExts()) {
+        const norm = e.startsWith(".") ? e.toLowerCase() : `.${e.toLowerCase()}`;
+        if (lower.endsWith(norm)) return false;
+    }
+    return true;
+}

--- a/src/frontend/src/utils/scene/handlers/unload_any_source.ts
+++ b/src/frontend/src/utils/scene/handlers/unload_any_source.ts
@@ -1,0 +1,14 @@
+// Unload a loaded source by name, routing to the right teardown:
+// streaming-FEA models were loaded via replace_model (scene-wide, no
+// per-source group registered), so only clear_loaded_model tears them
+// down properly (FEA session store + animation driver included);
+// regular overlays unload per-source.
+
+import {isStreamingFEAResult} from "@/utils/scene/fileKinds";
+import {clear_loaded_model} from "@/utils/scene/handlers/clear_loaded_model";
+import {unload_source_from_scene} from "@/utils/scene/handlers/unload_source_from_scene";
+
+export async function unload_any_source(name: string): Promise<void> {
+    if (isStreamingFEAResult(name)) await clear_loaded_model();
+    else unload_source_from_scene(name);
+}

--- a/src/frontend/src/utils/scene/handlers/unload_source_from_scene.ts
+++ b/src/frontend/src/utils/scene/handlers/unload_source_from_scene.ts
@@ -5,13 +5,41 @@
 import {Object3D} from "three";
 import {useModelState} from "@/state/modelState";
 import {useSelectedObjectStore} from "@/state/useSelectedObjectStore";
-import {sceneRef} from "@/state/refs";
+import {useTreeViewStore} from "@/state/treeViewStore";
+import {modelKeyMapRef, sceneRef} from "@/state/refs";
 import {CustomBatchedMesh} from "@/utils/mesh_select/CustomBatchedMesh";
 import {requestRender} from "@/state/perfStore";
 
 export function unload_source_from_scene(sourceName: string): void {
     const group = useModelState.getState().unregisterLoadedSource(sourceName);
     if (!group) return;
+
+    // Drop this model's root from the tree view + the model-key map.
+    // Each load registers one tree root under the synthetic container
+    // (cacheAndBuildTree) keyed by model_key = the modelKeyMapRef key
+    // for this group; without this the hierarchy panel keeps showing
+    // the unloaded model and selection-sync walks dead refs.
+    let modelKey: string | null = null;
+    modelKeyMapRef.current?.forEach((g, key) => {
+        if (g === group) modelKey = key;
+    });
+    if (modelKey !== null) {
+        modelKeyMapRef.current?.delete(modelKey);
+        const ts = useTreeViewStore.getState();
+        const td = ts.treeData;
+        if (td) {
+            if (td.model_key === modelKey) {
+                // Single un-containered root (first/only model).
+                ts.clearTreeData();
+            } else if (Array.isArray(td.children)) {
+                const remaining = td.children.filter((c) => c.model_key !== modelKey);
+                if (remaining.length !== td.children.length) {
+                    if (remaining.length === 0) ts.clearTreeData();
+                    else ts.setTreeData({...td, children: remaining});
+                }
+            }
+        }
+    }
 
     // Drop selection entries that point at meshes we're about to
     // detach, BEFORE we tear the group down. Without this, the

--- a/src/frontend/src/utils/scene/handlers/upload_source_file.ts
+++ b/src/frontend/src/utils/scene/handlers/upload_source_file.ts
@@ -168,9 +168,13 @@ export async function uploadFile(
         /** Override the scope for this upload. Defaults to whatever
          * the user has selected in the scope picker. */
         scope?: ScopeUrl;
+        /** Destination folder prefix within the scope; the file lands
+         * at `<folder>/<file.name>`. */
+        folder?: string;
     },
 ): Promise<void> {
-    const key = file.name;
+    const folder = opts?.folder?.replace(/^\/+|\/+$/g, "");
+    const key = folder ? `${folder}/${file.name}` : file.name;
     const ext = extOf(key);
     if (!acceptedSourceExts().includes(ext)) {
         throw new Error(`unsupported file type: ${ext || "(no extension)"}`);

--- a/src/frontend/src/utils/selectGroupMembers.ts
+++ b/src/frontend/src/utils/selectGroupMembers.ts
@@ -122,12 +122,39 @@ export async function selectGroupMembers(
             return;
         }
 
-        // Default: element/mesh selection path
+        // Default: element/mesh selection path. Resolve the actual
+        // CustomBatchedMesh instances under the model root — the store
+        // keys (and everything downstream: highlight repaint, the
+        // "Go to object" bounding-box walk) need real meshes with
+        // geometry + drawRanges. The previous force-cast of the model
+        // GROUP to a mesh put a geometry-less object in the store, so
+        // centerViewOnSelection skipped every entry and framing a
+        // selected set silently did nothing.
+        const meshesByName = new Map<string, CustomBatchedMesh[]>();
+        const allMeshes: CustomBatchedMesh[] = [];
+        root.traverse((obj: THREE.Object3D) => {
+            if (obj instanceof CustomBatchedMesh) {
+                allMeshes.push(obj);
+                const arr = meshesByName.get(obj.name) ?? [];
+                arr.push(obj);
+                meshesByName.set(obj.name, arr);
+            }
+        });
+        if (allMeshes.length === 0 && root instanceof CustomBatchedMesh) {
+            // Some load paths register the mesh itself as the model root.
+            allMeshes.push(root);
+        }
+
         const batchData: Array<[CustomBatchedMesh, string]> = [];
-        // We currently select the entire model_key's CustomBatchedMesh (as in original code)
-        const mesh = root as unknown as CustomBatchedMesh;
-        for (const [, rangeId] of meshRangePairs) {
-            batchData.push([mesh, rangeId]);
+        for (const [meshName, rangeId] of meshRangePairs) {
+            const named = meshesByName.get(meshName);
+            // Prefer the mesh that actually owns the range — GLB node
+            // names can repeat across primitive splits.
+            const target =
+                named?.find((m) => m.drawRanges?.has(rangeId)) ??
+                named?.[0] ??
+                allMeshes.find((m) => m.drawRanges?.has(rangeId));
+            if (target) batchData.push([target, rangeId]);
         }
 
         // Clear current selection and add batch of meshes
@@ -135,6 +162,8 @@ export async function selectGroupMembers(
         if (batchData.length > 0) {
             selectedObjectStore.addBatchofMeshes(batchData);
             console.log(`Selected ${batchData.length} mesh ranges for group members`);
+        } else {
+            console.warn('No meshes resolved for group member ranges:', meshRangePairs.length);
         }
 
     } catch (error) {

--- a/src/frontend/src/utils/storage/fileTree.ts
+++ b/src/frontend/src/utils/storage/fileTree.ts
@@ -30,6 +30,11 @@ export type FileTreeNode<T> = FolderNode<T> | FileNode<T>;
 export function buildFileTree<T>(
     files: T[],
     getPath: (file: T) => string,
+    /** Folder paths to materialise even when no file lives under them.
+     * Used for client-side "pending" folders — storage is prefix-based
+     * so an empty folder has no server representation until a file
+     * lands in it. */
+    extraFolders?: Iterable<string>,
 ): FileTreeNode<T>[] {
     const root: FolderNode<T> = {
         kind: "folder",
@@ -41,10 +46,7 @@ export function buildFileTree<T>(
     const folderIndex = new Map<string, FolderNode<T>>();
     folderIndex.set("", root);
 
-    for (const f of files) {
-        const trimmed = getPath(f).replace(/^\/+/, "");
-        const parts = trimmed.split("/");
-        const filename = parts.pop() ?? trimmed;
+    const ensureFolder = (parts: string[]): FolderNode<T> => {
         let parent = root;
         let acc = "";
         for (const seg of parts) {
@@ -57,11 +59,24 @@ export function buildFileTree<T>(
             }
             parent = next;
         }
+        return parent;
+    };
+
+    for (const f of files) {
+        const trimmed = getPath(f).replace(/^\/+/, "");
+        const parts = trimmed.split("/");
+        const filename = parts.pop() ?? trimmed;
+        const parent = ensureFolder(parts);
         parent.children.push({
             kind: "file",
             file: f,
             displayName: filename,
         });
+    }
+
+    for (const folder of extraFolders ?? []) {
+        const trimmed = folder.replace(/^\/+|\/+$/g, "");
+        if (trimmed) ensureFolder(trimmed.split("/"));
     }
 
     // Folders first (alpha), then files (alpha by display name). Stable
@@ -144,6 +159,46 @@ export function saveExpandedFolders(
         window.localStorage.setItem(
             expandedFoldersKey(namespace, scope),
             JSON.stringify(Array.from(expanded)),
+        );
+    } catch {
+        // localStorage full / disabled — silently lose the state.
+    }
+}
+
+// Client-side "pending" empty folders, persisted per-scope like the
+// expand state. Folders are pure key prefixes on the server, so a
+// just-created empty folder only exists here until a file lands in it
+// (the caller prunes entries that have become real). Device-local by
+// design — an empty folder only matters as an upload/move target on
+// the device that created it.
+
+function pendingFoldersKey(namespace: string, scope: string): string {
+    return `ada.${namespace}.pendingFolders.${scope}`;
+}
+
+export function loadPendingFolders(namespace: string, scope: string): string[] {
+    try {
+        const raw = window.localStorage.getItem(pendingFoldersKey(namespace, scope));
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+            return parsed.filter((x) => typeof x === "string");
+        }
+    } catch {
+        // corrupt entry — no pending folders.
+    }
+    return [];
+}
+
+export function savePendingFolders(
+    namespace: string,
+    scope: string,
+    folders: readonly string[],
+): void {
+    try {
+        window.localStorage.setItem(
+            pendingFoldersKey(namespace, scope),
+            JSON.stringify(folders),
         );
     } catch {
         // localStorage full / disabled — silently lose the state.

--- a/tests/comms/rest/test_user_storage_ops.py
+++ b/tests/comms/rest/test_user_storage_ops.py
@@ -1,0 +1,290 @@
+"""Integration tests for user-level (personal-scope) file management.
+
+Regular users can delete / rename / move files in their own personal
+scope only; shared and project scopes stay admin-managed, and CI
+``versions/`` blobs plus the ``_derived/`` bake cache are protected
+even inside the personal scope. Same env shim + LocalStore staging as
+test_admin_move_to_folder.py; non-admin principal via the
+User.local_dev monkeypatch from test_admin.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import auth as auth_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+from ada.comms.rest.scope import Scope  # noqa: E402
+
+USER_SUB = "demo-user"
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+@pytest.fixture
+def app_client(tmp_path: pathlib.Path, monkeypatch):
+    """API client whose principal is a NON-admin user with a fixed sub."""
+    monkeypatch.setattr(
+        auth_module.User,
+        "local_dev",
+        classmethod(
+            lambda cls: cls(
+                sub=USER_SUB,
+                email="demo@x.invalid",
+                display_name="Demo",
+                groups=frozenset(),
+                is_admin=False,
+            )
+        ),
+    )
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        yield client
+
+
+def _storage(client: TestClient):
+    storage = client.app.state.__dict__.get("_test_storage")
+    if storage is None:
+        for route in client.app.routes:
+            ep = getattr(route, "endpoint", None)
+            if ep is None:
+                continue
+            cells = getattr(ep, "__closure__", None)
+            if not cells:
+                continue
+            for c in cells:
+                v = c.cell_contents
+                if v.__class__.__name__ == "Storage":
+                    storage = v
+                    break
+            if storage is not None:
+                break
+        client.app.state._test_storage = storage
+    return storage
+
+
+def _put(client: TestClient, key: str, data: bytes, scope: Scope | None = None) -> None:
+    """Stage a blob directly in storage (bypasses upload validation so
+    we can lay out _derived/ and versions/ fixtures)."""
+    scope = scope or Scope.user(USER_SUB)
+    asyncio.run(_storage(client).put_bytes(scope, key, data))
+
+
+def _keys(client: TestClient, scope: Scope | None = None) -> set[str]:
+    scope = scope or Scope.user(USER_SUB)
+    files = asyncio.run(_storage(client).list(scope))
+    return {f.key for f in files}
+
+
+def test_user_delete_cascades_derived(app_client: TestClient):
+    """Deleting an own personal-scope source reaps its derived blobs."""
+    _put(app_client, "models/wall.rmed", b"rmed")
+    _put(app_client, "_derived/models/wall.rmed.glb", b"glb")
+    _put(app_client, "_derived/models/wall.rmed.fea/fea.manifest.json", b"{}")
+    _put(app_client, "_derived/models/wall.rmed.fea/fea.DEPL.bin", b"\x00")
+    _put(app_client, "models/other.ifc", b"keep-me")
+
+    r = app_client.delete("/api/scopes/user:me/blobs/models/wall.rmed")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "models/wall.rmed" in body["deleted"]
+    assert body["errors"] == []
+
+    keys = _keys(app_client)
+    assert "models/wall.rmed" not in keys
+    assert not any(k.startswith("_derived/models/wall.rmed") for k in keys)
+    assert "models/other.ifc" in keys
+
+
+def test_user_move_to_folder_cascades_and_reports_collisions(app_client: TestClient):
+    _put(app_client, "a.rmed", b"a")
+    _put(app_client, "_derived/a.rmed.glb", b"derived-a")
+    _put(app_client, "b.ifc", b"b")
+    _put(app_client, "dest/b.ifc", b"already-there")
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/move-to-folder",
+        json={"keys": ["a.rmed", "b.ifc"], "folder": "dest"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["moved"]) == 1
+    assert body["moved"][0]["new"] == "dest/a.rmed"
+    assert body["moved"][0]["siblings_moved"] == 1
+    assert len(body["failed"]) == 1
+    assert "already exists" in body["failed"][0]["reason"]
+
+    keys = _keys(app_client)
+    assert "dest/a.rmed" in keys
+    assert "_derived/dest/a.rmed.glb" in keys
+    assert "b.ifc" in keys  # collision left in place
+
+
+def test_user_rename_cascades_derived(app_client: TestClient):
+    _put(app_client, "old.ifc", b"x")
+    _put(app_client, "_derived/old.ifc.glb", b"derived")
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/rename",
+        json={"old_key": "old.ifc", "new_key": "new-name.ifc"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["old"] == "old.ifc"
+    assert body["new"] == "new-name.ifc"
+    assert body["siblings_moved"] == 1
+
+    keys = _keys(app_client)
+    assert "old.ifc" not in keys
+    assert "new-name.ifc" in keys
+    assert "_derived/new-name.ifc.glb" in keys
+
+
+def test_user_rename_conflict_and_missing(app_client: TestClient):
+    _put(app_client, "a.ifc", b"a")
+    _put(app_client, "b.ifc", b"b")
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/rename",
+        json={"old_key": "a.ifc", "new_key": "b.ifc"},
+    )
+    assert r.status_code == 409, r.text
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/rename",
+        json={"old_key": "ghost.ifc", "new_key": "real.ifc"},
+    )
+    assert r.status_code == 404, r.text
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/rename",
+        json={"old_key": "a.ifc", "new_key": "a.ifc"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_user_mutations_personal_scope_only(app_client: TestClient):
+    """Shared scope (and any non-personal scope) → 403 even though the
+    user could read/upload there."""
+    _put(app_client, "shared.ifc", b"s", scope=Scope.shared())
+
+    r = app_client.delete("/api/scopes/shared/blobs/shared.ifc")
+    assert r.status_code == 403, r.text
+
+    r = app_client.post(
+        "/api/scopes/shared/keys/move-to-folder",
+        json={"keys": ["shared.ifc"], "folder": "x"},
+    )
+    assert r.status_code == 403, r.text
+
+    r = app_client.post(
+        "/api/scopes/shared/keys/rename",
+        json={"old_key": "shared.ifc", "new_key": "y.ifc"},
+    )
+    assert r.status_code == 403, r.text
+
+    # Untouched.
+    assert "shared.ifc" in _keys(app_client, Scope.shared())
+
+
+def test_user_cannot_reach_other_users_scope(app_client: TestClient):
+    """Explicit user:<other-sub> is rejected outright."""
+    _put(app_client, "theirs.ifc", b"t", scope=Scope.user("someone-else"))
+
+    r = app_client.delete("/api/scopes/user:someone-else/blobs/theirs.ifc")
+    assert r.status_code in (400, 403), r.text
+    assert "theirs.ifc" in _keys(app_client, Scope.user("someone-else"))
+
+
+def test_user_protected_keys_rejected(app_client: TestClient):
+    """versions/ and _derived/ are admin-managed even in personal scope."""
+    _put(app_client, "versions/main/abc123/model.glb", b"ci")
+    _put(app_client, "_derived/some.ifc.glb", b"derived")
+    _put(app_client, "mine.ifc", b"m")
+
+    r = app_client.delete("/api/scopes/user:me/blobs/versions/main/abc123/model.glb")
+    assert r.status_code == 400, r.text
+
+    r = app_client.delete("/api/scopes/user:me/blobs/_derived/some.ifc.glb")
+    assert r.status_code == 400, r.text
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/move-to-folder",
+        json={"keys": ["versions/main/abc123/model.glb"], "folder": "x"},
+    )
+    assert r.status_code == 400, r.text
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/move-to-folder",
+        json={"keys": ["mine.ifc"], "folder": "versions/main"},
+    )
+    assert r.status_code == 400, r.text
+
+    r = app_client.post(
+        "/api/scopes/user:me/keys/rename",
+        json={"old_key": "mine.ifc", "new_key": "_derived/mine.ifc"},
+    )
+    assert r.status_code == 400, r.text
+
+    keys = _keys(app_client)
+    assert "versions/main/abc123/model.glb" in keys
+    assert "_derived/some.ifc.glb" in keys
+    assert "mine.ifc" in keys
+
+
+def test_admin_rename_endpoint_exists_for_admins(tmp_path: pathlib.Path):
+    """The admin rename variant works in any scope (default local_dev
+    principal is admin)."""
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        _put(client, "x.ifc", b"x", scope=Scope.shared())
+        _put(client, "_derived/x.ifc.glb", b"d", scope=Scope.shared())
+        r = client.post(
+            "/api/admin/scopes/shared/keys/rename",
+            json={"old_key": "x.ifc", "new_key": "renamed.ifc"},
+        )
+        assert r.status_code == 200, r.text
+        keys = _keys(client, Scope.shared())
+        assert "renamed.ifc" in keys
+        assert "_derived/renamed.ifc.glb" in keys


### PR DESCRIPTION
## Summary

User-facing file management and a broad UX pass over the hosted viewer's panels, plus targeted 3D-interaction fixes.

### Auth
- "Sign in with a different account" on the auth gate — opt-in `prompt=login` on the authorize redirect (Authentik and Azure AD both honor it; the default silent-SSO path is unchanged).

### Backend: user-level file management (personal scope only)
- The admin delete/move cascade logic (derived blobs, `.fea/` artefact trees, longest-prefix source pinning) moved into shared `storage_ops.py` helpers; admin handlers are thin wrappers.
- New user endpoints: `DELETE /api/scopes/{scope}/blobs/{key}`, `POST .../keys/move-to-folder`, `POST .../keys/rename` (+ admin rename twin). Guards: `scope.kind == "user"` only, `versions/` and `_derived/` keys rejected, all audited.
- 8 new integration tests; full REST suite green (135 passed).

### Storage panel revamp
- Checkbox = direct load/unload toggle; tapping the row anywhere else opens the context menu (also via right-click); long-press enters multi-select with a bulk toolbar (Load / Unload / Move / Delete).
- "+" menu replaces the upload button (upload files / new folder); client-side pending folders persisted per scope until a file lands in them.
- Drag & drop: move files (incl. multi-selection) between folders, move-to-root strip, OS-file drops upload into the hovered folder.
- Inline rename (replaces `window.prompt`), maximize toggle (near-fullscreen overlay, state-preserving), file-type icons, loaded-eye markers that propagate to parent folders, per-row sequential load queue with a progress toast (current + queued + errors).
- CI `versions/` tree stays read-only; project scopes deferred to a later phase.

### Panels & theming
- Menu-row panels share one chrome driven by CSS variables; a new collapsible Theme section in Options offers four presets (dark default, two translucent middle grounds, the classic pale gray) plus custom bg/text swatches and an opacity slider.
- Scene panel: "Loaded models" layers list (visibility toggle + unload per model), per-model stats cards from each model's own ADA extension, groups dropdown covering all loaded models with source tagging/filtering and scoped member resolution.
- Fixes: groups popover portals out of the panel scroll container (page-shift on mobile), white-on-white dropdowns after the theme change, admin panel hash/`← viewer` link in floating mode.

### 3D interaction fixes
- Double-tap orbit pivot landed at the camera on FEM models (raycaster default 1-unit Points/Line thresholds); now GPU-pick first with tight CPU fallback.
- Tree-view roots are removed on per-model unload/delete (previously only Clear did).
- "Go to object" after selecting an element set framed nothing — the selection store held the model group instead of the actual meshes.

## Test plan
- `pytest tests/comms/rest/` (135 passed) — incl. new `test_user_storage_ops.py` authz/cascade coverage.
- Frontend `tsc --noEmit`, `npm test` (33 passed), production build.
- Manual pass on a deployed instance, desktop + mobile: upload/new-folder/DnD/rename/delete as a non-admin in personal scope, 403s outside it, load queue with multiple models, theme switching, maximize on mobile, double-tap pivot, element-set framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)