### PR TITLE
feat: IFC geometry-primitive coverage (#47) — Tiers 1–3

### DIFF
--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -44,7 +44,9 @@ ENV PYTHONUNBUFFERED=1 \
     HOME=/home/app \
     XDG_CACHE_HOME=/home/app/.cache \
     NUMBA_CACHE_DIR=/home/app/.cache \
-    MPLCONFIGDIR=/home/app/.cache/matplotlib
+    MPLCONFIGDIR=/home/app/.cache/matplotlib \
+    USER=app \
+    LOGNAME=app
 
 # `pixi run` activates the env and exec's the task. Python's asyncio
 # signal handlers in the worker handle SIGTERM/SIGINT cleanly as PID 1.

--- a/pixi.lock
+++ b/pixi.lock
@@ -7546,7 +7546,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.7.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.8.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8175,7 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.7.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.8.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -8573,7 +8573,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.7.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.8.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10602,25 +10602,25 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.7.0-py312h29cc896_0.conda
-  sha256: 0e83449b8a75804515fcd96cc861e6a1f5f7e5556499d95a4173269001a5fd72
-  md5: aad178df651f64a84011079e1f9ad0cc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.8.0-py312h29cc896_0.conda
+  sha256: 52a03cae1c879ad9f711cb5632a59ec28e400700f42e08173655108b3e2c709a
+  md5: 769e3e1bb3e7942b8a52d7e872255359
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.2,<2.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
   - occt >=7.9.3,<7.9.4.0a0
-  - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python_abi 3.12.* *_cp312
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=hash-mapping
-  size: 11569686
-  timestamp: 1780943501965
+  - pkg:pypi/ada-cpp?source=compressed-mapping
+  size: 11566904
+  timestamp: 1781445607714
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -19812,9 +19812,9 @@ packages:
   purls: []
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.7.0-py312h9b4feea_0.conda
-  sha256: 11181a89b64424e21ff52d29b2f03eeaa87f80d7421ccd0b022ec1accea01092
-  md5: 9eaa030a8c9c6bfefd0ab066cbb1fd2b
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.8.0-py312h9b4feea_0.conda
+  sha256: 54857f5a2ab62dc8e3b7a4bdc1bfe5c35a564a8f7e0ba10cee99ef0ff57832ee
+  md5: 0fa4b590fca6ced510905d96d59c05f2
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
@@ -19822,14 +19822,14 @@ packages:
   - __osx >=11.0
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
-  size: 9778900
-  timestamp: 1780943545670
+  size: 9780513
+  timestamp: 1781445644474
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -23561,25 +23561,25 @@ packages:
   purls: []
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.7.0-py312h710a262_0.conda
-  sha256: afa69afd9dab78de5b5b1fd68ad3bdaf94a8faaa1b606b33a59da37cfd7bd4e8
-  md5: 6925e8ffb0652467955a97e36bc95e95
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.8.0-py312h710a262_0.conda
+  sha256: 007050249904527087f421463909fb57a57710c6a170e3ae25f8de245a68f4d4
+  md5: 9a3d24dc0af83c6848fe792026c30450
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libzlib >=1.3.2,<2.0a0
   - occt >=7.9.3,<7.9.4.0a0
-  - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python_abi 3.12.* *_cp312
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=hash-mapping
-  size: 4975250
-  timestamp: 1780943531443
+  - pkg:pypi/ada-cpp?source=compressed-mapping
+  size: 4980557
+  timestamp: 1781445632194
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.toml
+++ b/pixi.toml
@@ -131,7 +131,8 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # `adacpp` and without `pyocc` exercises adacpp as the sole CAD backend
 # (no pythonocc fallback by design).
 [feature.adacpp.dependencies]
-ada-cpp = "0.7.0.*"
+# 0.8.0 carries build_swept_disk_solid (IfcSweptDiskSolid parity); see adapy AdacppBackend.
+ada-cpp = "0.8.0.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/src/ada/cad/__init__.py
+++ b/src/ada/cad/__init__.py
@@ -462,6 +462,46 @@ class AdacppBackend:
                     shape = self._cad.build_advanced_face_bspline(*surf_args, bounds)
                 else:
                     shape = self._cad.build_bspline_surface_face(*surf_args)
+        elif isinstance(g, su.Face) and not isinstance(g, su.FaceSurface):
+            # Plain polygonal face (faceted-brep / PolyLoop bound) — a single planar polygon.
+            import ada.geom.curves as cu
+
+            bound = g.bounds[0].bound
+            if not isinstance(bound, cu.PolyLoop):
+                raise NotImplementedError(
+                    f"AdacppBackend.build: Face bound {type(bound).__name__!r} not yet ported to adacpp."
+                )
+            shape = self._cad.polygon_face([self._xyz(p) for p in bound.polygon])
+        elif isinstance(g, su.PolygonalFaceSet):
+            # n-gon mesh: a planar face per (1-based) index loop, sewn into a shell.
+            faces = [
+                self._cad.polygon_face([self._xyz(g.coordinates[i - 1]) for i in face_idx]) for face_idx in g.faces
+            ]
+            shape = self._cad.sew_faces(faces)
+        elif isinstance(g, so.RectangularPyramid):
+            # Rectangular base + 4 triangular sides (apex centred above), placed at the frame.
+            x, y, z = g.x_length, g.y_length, g.z_length
+            base = [(0, 0, 0), (x, 0, 0), (x, y, 0), (0, y, 0)]
+            apex = (x / 2.0, y / 2.0, z)
+            world = [self._to_world(g.position, p) for p in base] + [self._to_world(g.position, apex)]
+            faces = [self._cad.polygon_face(world[:4])]
+            for i in range(4):
+                faces.append(self._cad.polygon_face([world[i], world[(i + 1) % 4], world[4]]))
+            shape = self._cad.sew_faces(faces)
+        elif isinstance(g, so.FacetedBrep):
+            from ada.geom import Geometry as _Geometry
+            from ada.geom.booleans import BoolOpEnum
+
+            shape = self.build(_Geometry(geometry.id, g.outer))
+            for void in g.voids:
+                shape = self.boolean(BoolOpEnum.DIFFERENCE, shape, self.build(_Geometry(geometry.id, void)))
+        elif isinstance(g, so.SweptDiskSolid):
+            # Disk swept along the directrix; the native verb extracts the start frame and
+            # builds the circular profile in C++ (robust for any directrix kind).
+            directrix = self._encode_curve(g.directrix)
+            shape = self._cad.build_swept_disk_solid(
+                directrix, float(g.radius), float(g.inner_radius) if g.inner_radius else 0.0
+            )
         elif isinstance(g, su.WireFilledFace):
             # Interpolate a smooth surface through the boundary edges
             # (BRepOffsetAPI_MakeFilling) — the SAT exppc fallback face.
@@ -491,6 +531,48 @@ class AdacppBackend:
         c = list(p)
         return [float(c[0]), float(c[1]), float(c[2]) if len(c) > 2 else 0.0]
 
+    @staticmethod
+    def _to_world(position, local) -> list[float]:
+        """Transform a point in an Axis2Placement3D's local frame to world coordinates."""
+        import numpy as np
+
+        loc = np.asarray(list(position.location), dtype=float)
+        z = np.asarray(list(position.axis) if position.axis is not None else (0, 0, 1), dtype=float)
+        x = np.asarray(list(position.ref_direction) if position.ref_direction is not None else (1, 0, 0), dtype=float)
+        z = z / (np.linalg.norm(z) or 1.0)
+        x = x / (np.linalg.norm(x) or 1.0)
+        y = np.cross(z, x)
+        lx, ly, lz = local
+        w = loc + lx * x + ly * y + lz * z
+        return [float(v) for v in w]
+
+    @staticmethod
+    def _arc_midpoint(circle, p_start, p_end, sense: bool = True) -> list[float]:
+        """A point on ``circle`` at the angle bisecting start→end (along ``sense``) — the
+        midpoint an arc edge record (kind 1) needs."""
+        import numpy as np
+
+        c = np.asarray(list(circle.position.location), dtype=float)
+        z = np.asarray(list(circle.position.axis), dtype=float)
+        x = np.asarray(list(circle.position.ref_direction), dtype=float)
+        z = z / (np.linalg.norm(z) or 1.0)
+        x = x / (np.linalg.norm(x) or 1.0)
+        y = np.cross(z, x)
+        r = float(circle.radius)
+
+        def ang(p):
+            d = np.asarray(list(p), dtype=float) - c
+            return np.arctan2(float(d @ y), float(d @ x))
+
+        a0, a1 = ang(p_start), ang(p_end)
+        if sense and a1 <= a0:
+            a1 += 2.0 * np.pi
+        elif not sense and a1 >= a0:
+            a1 -= 2.0 * np.pi
+        am = 0.5 * (a0 + a1)
+        m = c + r * (np.cos(am) * x + np.sin(am) * y)
+        return [float(v) for v in m]
+
     def _encode_curve(self, curve) -> list[list[float]]:
         # Encode an ada.geom profile curve as adacpp edge records:
         #   line=[0, p1, p2], arc=[1, start, mid, end], circle=[2, centre, axis, r].
@@ -507,6 +589,26 @@ class AdacppBackend:
         if isinstance(curve, cu.Circle):
             axis = self._xyz(curve.position.axis) if curve.position.axis is not None else [0.0, 0.0, 1.0]
             return [[2.0, *self._xyz(curve.position.location), *axis, float(curve.radius)]]
+        if isinstance(curve, cu.PolyLine):
+            pts = curve.points
+            return [[0.0, *self._xyz(a), *self._xyz(b)] for a, b in zip(pts[:-1], pts[1:])]
+        if isinstance(curve, cu.TrimmedCurve):
+            from ada.geom.points import Point as _Point
+
+            b, t1, t2 = curve.basis_curve, curve.trim1, curve.trim2
+            if isinstance(b, cu.Line) and isinstance(t1, _Point) and isinstance(t2, _Point):
+                return [[0.0, *self._xyz(t1), *self._xyz(t2)]]
+            if isinstance(b, cu.Circle) and isinstance(t1, _Point) and isinstance(t2, _Point):
+                mid = self._arc_midpoint(b, t1, t2, curve.sense_agreement)
+                return [[1.0, *self._xyz(t1), *mid, *self._xyz(t2)]]
+            raise NotImplementedError(
+                f"AdacppBackend.build: TrimmedCurve basis {type(b).__name__!r} not yet ported to adacpp."
+            )
+        if isinstance(curve, cu.CompositeCurve):
+            edges = []
+            for seg in curve.segments:
+                edges.extend(self._encode_curve(seg.parent_curve))
+            return edges
         raise NotImplementedError(
             f"AdacppBackend.build: profile curve {type(curve).__name__!r} not yet ported to adacpp."
         )

--- a/src/ada/cadit/ifc/read/geom/curves.py
+++ b/src/ada/cadit/ifc/read/geom/curves.py
@@ -1,6 +1,7 @@
 import ifcopenshell
 
 from ada.geom import curves as geo_cu
+from ada.geom.direction import Direction
 from ada.geom.points import Point
 
 
@@ -13,12 +14,59 @@ def get_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.CURVE_GEOM_TYP
         return rational_b_spline_curve_with_knots(ifc_entity)
     elif ifc_entity.is_a("IfcBSplineCurveWithKnots"):
         return b_spline_curve_with_knots(ifc_entity)
+    elif ifc_entity.is_a("IfcTrimmedCurve"):
+        return trimmed_curve(ifc_entity)
+    elif ifc_entity.is_a("IfcLine"):
+        return line(ifc_entity)
+    elif ifc_entity.is_a("IfcCircle"):
+        return circle(ifc_entity)
+    elif ifc_entity.is_a("IfcEllipse"):
+        return ellipse(ifc_entity)
     elif ifc_entity.is_a("IfcSurfaceCurve"):
         # The 3D curve is the geometric master; the attached p-curve is recovered
         # separately by oriented_edge() onto the OrientedEdge.
         return get_curve(ifc_entity.Curve3D)
     else:
         raise NotImplementedError(f"Geometry type {ifc_entity.is_a()} not implemented")
+
+
+def line(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.Line:
+    return geo_cu.Line(pnt=Point(ifc_entity.Pnt.Coordinates), dir=Direction(ifc_entity.Dir.Orientation.DirectionRatios))
+
+
+def circle(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.Circle:
+    from .placement import axis3d
+
+    return geo_cu.Circle(position=axis3d(ifc_entity.Position), radius=ifc_entity.Radius)
+
+
+def ellipse(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.Ellipse:
+    from .placement import axis3d
+
+    return geo_cu.Ellipse(
+        position=axis3d(ifc_entity.Position),
+        semi_axis1=ifc_entity.SemiAxis1,
+        semi_axis2=ifc_entity.SemiAxis2,
+    )
+
+
+def _trim_select(trim) -> "Point | float":
+    """One IfcTrimmingSelect entry: a Cartesian point or a parameter value. IFC allows up to
+    two (point AND parameter) — we keep the Cartesian point when present, else the parameter."""
+    for item in trim:
+        if hasattr(item, "is_a") and item.is_a("IfcCartesianPoint"):
+            return Point(item.Coordinates)
+    return float(trim[0].wrappedValue if hasattr(trim[0], "wrappedValue") else trim[0])
+
+
+def trimmed_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.TrimmedCurve:
+    return geo_cu.TrimmedCurve(
+        basis_curve=get_curve(ifc_entity.BasisCurve),
+        trim1=_trim_select(ifc_entity.Trim1),
+        trim2=_trim_select(ifc_entity.Trim2),
+        sense_agreement=ifc_entity.SenseAgreement,
+        master_representation=ifc_entity.MasterRepresentation,
+    )
 
 
 def pcurve_2d_from_surface_curve(surface_curve: ifcopenshell.entity_instance) -> geo_cu.Pcurve2dBSpline | None:

--- a/src/ada/cadit/ifc/read/geom/curves.py
+++ b/src/ada/cadit/ifc/read/geom/curves.py
@@ -16,6 +16,8 @@ def get_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.CURVE_GEOM_TYP
         return b_spline_curve_with_knots(ifc_entity)
     elif ifc_entity.is_a("IfcTrimmedCurve"):
         return trimmed_curve(ifc_entity)
+    elif ifc_entity.is_a("IfcCompositeCurve"):
+        return composite_curve(ifc_entity)
     elif ifc_entity.is_a("IfcLine"):
         return line(ifc_entity)
     elif ifc_entity.is_a("IfcCircle"):
@@ -57,6 +59,18 @@ def _trim_select(trim) -> "Point | float":
         if hasattr(item, "is_a") and item.is_a("IfcCartesianPoint"):
             return Point(item.Coordinates)
     return float(trim[0].wrappedValue if hasattr(trim[0], "wrappedValue") else trim[0])
+
+
+def composite_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.CompositeCurve:
+    segments = [
+        geo_cu.CompositeCurveSegment(
+            parent_curve=get_curve(seg.ParentCurve),
+            same_sense=seg.SameSense,
+            transition=seg.Transition,
+        )
+        for seg in ifc_entity.Segments
+    ]
+    return geo_cu.CompositeCurve(segments=segments, self_intersect=bool(ifc_entity.SelfIntersect))
 
 
 def trimmed_curve(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.TrimmedCurve:

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -16,6 +16,7 @@ from .solids import (
     ifc_cylinder,
     ifc_sphere,
     revolved_solid_area,
+    swept_disk_solid,
 )
 from .surfaces import (
     advanced_face,
@@ -44,6 +45,9 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return extruded_solid_area(geom_repr)
     elif geom_repr.is_a("IfcRevolvedAreaSolid"):
         return revolved_solid_area(geom_repr)
+    elif geom_repr.is_a("IfcSweptDiskSolid"):
+        # Covers the IfcSweptDiskSolidPolygonal subtype too.
+        return swept_disk_solid(geom_repr)
     elif geom_repr.is_a("IfcTriangulatedFaceSet"):
         return triangulated_face_set(geom_repr)
     elif geom_repr.is_a("IfcPolygonalFaceSet"):

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -24,6 +24,7 @@ from .solids import (
 )
 from .surfaces import (
     advanced_face,
+    curve_bounded_plane,
     half_space_solid,
     polygonal_face_set,
     shell_based_surface_model,
@@ -84,6 +85,8 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return read_face(geom_repr)
     elif geom_repr.is_a("IfcShellBasedSurfaceModel"):
         return shell_based_surface_model(geom_repr)
+    elif geom_repr.is_a("IfcCurveBoundedPlane"):
+        return curve_bounded_plane(geom_repr)
     elif geom_repr.is_a("IfcHalfSpaceSolid"):
         # Covers the IfcPolygonalBoundedHalfSpace subtype too.
         return half_space_solid(geom_repr)

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -90,6 +90,10 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
     elif geom_repr.is_a("IfcHalfSpaceSolid"):
         # Covers the IfcPolygonalBoundedHalfSpace subtype too.
         return half_space_solid(geom_repr)
+    elif geom_repr.is_a("IfcCsgSolid"):
+        # A CSG container — the solid is its tree-root expression (a CSG primitive or a
+        # boolean result). adapy has no distinct CsgSolid type; read through to the root.
+        return import_geometry_from_ifc_geom(geom_repr.TreeRootExpression)
     elif geom_repr.is_a("IfcBooleanResult"):
         # Covers IfcBooleanClippingResult (a subtype). Returns a wrapped Geometry carrying
         # the cut(s) as bool_operations, not a raw geom — callers handle both (read_shapes).

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
 
 from .solids import (
     extruded_solid_area,
+    extruded_solid_area_tapered,
     faceted_brep,
+    fixed_reference_swept_area_solid,
     ifc_block,
     ifc_cone,
     ifc_cylinder,
@@ -43,10 +45,15 @@ def get_product_definitions(prod_def: ifcopenshell.entity_instance) -> list[GEOM
 
 
 def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GEOM:
-    if geom_repr.is_a("IfcExtrudedAreaSolid"):
+    if geom_repr.is_a("IfcExtrudedAreaSolidTapered"):
+        # Must precede IfcExtrudedAreaSolid — Tapered is a subtype of it.
+        return extruded_solid_area_tapered(geom_repr)
+    elif geom_repr.is_a("IfcExtrudedAreaSolid"):
         return extruded_solid_area(geom_repr)
     elif geom_repr.is_a("IfcRevolvedAreaSolid"):
         return revolved_solid_area(geom_repr)
+    elif geom_repr.is_a("IfcFixedReferenceSweptAreaSolid"):
+        return fixed_reference_swept_area_solid(geom_repr)
     elif geom_repr.is_a("IfcSweptDiskSolid"):
         # Covers the IfcSweptDiskSolidPolygonal subtype too.
         return swept_disk_solid(geom_repr)

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from .solids import (
     extruded_solid_area,
+    faceted_brep,
     ifc_block,
     ifc_cone,
     ifc_cylinder,
@@ -25,6 +26,7 @@ from .surfaces import (
     shell_based_surface_model,
     triangulated_face_set,
 )
+from .surfaces import face as read_face
 
 GEOM = Union[geo_so.SOLID_GEOM_TYPES | geo_cu.CURVE_GEOM_TYPES | geo_su.SURFACE_GEOM_TYPES]
 
@@ -60,8 +62,16 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return ifc_cylinder(geom_repr)
     elif geom_repr.is_a("IfcRightCircularCone"):
         return ifc_cone(geom_repr)
+    elif geom_repr.is_a("IfcFacetedBrep") or geom_repr.is_a("IfcFacetedBrepWithVoids"):
+        # WithVoids is a sibling of FacetedBrep (both direct IfcManifoldSolidBrep subtypes),
+        # so it must be matched explicitly — is_a("IfcFacetedBrep") does not cover it.
+        return faceted_brep(geom_repr)
     elif geom_repr.is_a("IfcAdvancedFace"):
         return advanced_face(geom_repr)
+    elif geom_repr.is_a("IfcFace"):
+        # Plain polygonal face (after IfcAdvancedFace, which is a subtype) — used by
+        # faceted-brep closed shells.
+        return read_face(geom_repr)
     elif geom_repr.is_a("IfcShellBasedSurfaceModel"):
         return shell_based_surface_model(geom_repr)
     elif geom_repr.is_a("IfcHalfSpaceSolid"):

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -20,6 +20,7 @@ from .solids import (
 from .surfaces import (
     advanced_face,
     half_space_solid,
+    polygonal_face_set,
     shell_based_surface_model,
     triangulated_face_set,
 )
@@ -45,6 +46,8 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return revolved_solid_area(geom_repr)
     elif geom_repr.is_a("IfcTriangulatedFaceSet"):
         return triangulated_face_set(geom_repr)
+    elif geom_repr.is_a("IfcPolygonalFaceSet"):
+        return polygonal_face_set(geom_repr)
     elif geom_repr.is_a("IfcBlock"):
         return ifc_block(geom_repr)
     elif geom_repr.is_a("IfcSphere"):

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -17,6 +17,7 @@ from .solids import (
     ifc_block,
     ifc_cone,
     ifc_cylinder,
+    ifc_rectangular_pyramid,
     ifc_sphere,
     revolved_solid_area,
     swept_disk_solid,
@@ -63,6 +64,8 @@ def import_geometry_from_ifc_geom(geom_repr: ifcopenshell.entity_instance) -> GE
         return polygonal_face_set(geom_repr)
     elif geom_repr.is_a("IfcBlock"):
         return ifc_block(geom_repr)
+    elif geom_repr.is_a("IfcRectangularPyramid"):
+        return ifc_rectangular_pyramid(geom_repr)
     elif geom_repr.is_a("IfcSphere"):
         return ifc_sphere(geom_repr)
     elif geom_repr.is_a("IfcRightCircularCylinder"):

--- a/src/ada/cadit/ifc/read/geom/geom_reader.py
+++ b/src/ada/cadit/ifc/read/geom/geom_reader.py
@@ -22,15 +22,14 @@ from .solids import (
     revolved_solid_area,
     swept_disk_solid,
 )
+from .surfaces import advanced_face, curve_bounded_plane
+from .surfaces import face as read_face
 from .surfaces import (
-    advanced_face,
-    curve_bounded_plane,
     half_space_solid,
     polygonal_face_set,
     shell_based_surface_model,
     triangulated_face_set,
 )
-from .surfaces import face as read_face
 
 GEOM = Union[geo_so.SOLID_GEOM_TYPES | geo_cu.CURVE_GEOM_TYPES | geo_su.SURFACE_GEOM_TYPES]
 

--- a/src/ada/cadit/ifc/read/geom/solids.py
+++ b/src/ada/cadit/ifc/read/geom/solids.py
@@ -88,6 +88,16 @@ def ifc_cone(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Cone:
     return geo_so.Cone(position=position, bottom_radius=ifc_entity.BottomRadius, height=ifc_entity.Height)
 
 
+def ifc_rectangular_pyramid(ifc_entity: ifcopenshell.entity_instance) -> geo_so.RectangularPyramid:
+    position = axis2placement(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()
+    return geo_so.RectangularPyramid(
+        position=position,
+        x_length=ifc_entity.XLength,
+        y_length=ifc_entity.YLength,
+        z_length=ifc_entity.Height,
+    )
+
+
 def ifc_block(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Box:
     position = axis2placement(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()
     return geo_so.Box(

--- a/src/ada/cadit/ifc/read/geom/solids.py
+++ b/src/ada/cadit/ifc/read/geom/solids.py
@@ -4,8 +4,22 @@ from ada.geom import solids as geo_so
 from ada.geom.placement import Axis2Placement3D
 from ada.geom.points import Point
 
+from .curves import get_curve
 from .placement import axis1placement, axis2placement, axis3d, ifc_direction
 from .surfaces import get_surface
+
+
+def swept_disk_solid(ifc_entity: ifcopenshell.entity_instance) -> geo_so.SweptDiskSolid:
+    # Covers the IfcSweptDiskSolidPolygonal subtype (which adds a FilletRadius).
+    fillet_radius = getattr(ifc_entity, "FilletRadius", None)
+    return geo_so.SweptDiskSolid(
+        directrix=get_curve(ifc_entity.Directrix),
+        radius=ifc_entity.Radius,
+        inner_radius=ifc_entity.InnerRadius,
+        start_param=ifc_entity.StartParam,
+        end_param=ifc_entity.EndParam,
+        fillet_radius=fillet_radius,
+    )
 
 
 def ifc_sphere(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Sphere:

--- a/src/ada/cadit/ifc/read/geom/solids.py
+++ b/src/ada/cadit/ifc/read/geom/solids.py
@@ -6,7 +6,13 @@ from ada.geom.points import Point
 
 from .curves import get_curve
 from .placement import axis1placement, axis2placement, axis3d, ifc_direction
-from .surfaces import get_surface
+from .surfaces import closed_shell, get_surface
+
+
+def faceted_brep(ifc_entity: ifcopenshell.entity_instance) -> geo_so.FacetedBrep:
+    # Handles IfcFacetedBrep and the sibling IfcFacetedBrepWithVoids (adds inner void shells).
+    voids = [closed_shell(v) for v in ifc_entity.Voids] if ifc_entity.is_a("IfcFacetedBrepWithVoids") else []
+    return geo_so.FacetedBrep(outer=closed_shell(ifc_entity.Outer), voids=voids)
 
 
 def swept_disk_solid(ifc_entity: ifcopenshell.entity_instance) -> geo_so.SweptDiskSolid:

--- a/src/ada/cadit/ifc/read/geom/solids.py
+++ b/src/ada/cadit/ifc/read/geom/solids.py
@@ -42,6 +42,30 @@ def extruded_solid_area(ifc_entity: ifcopenshell.entity_instance) -> geo_so.Extr
     )
 
 
+def extruded_solid_area_tapered(ifc_entity: ifcopenshell.entity_instance) -> geo_so.ExtrudedAreaSolidTapered:
+    base = extruded_solid_area(ifc_entity)
+    return geo_so.ExtrudedAreaSolidTapered(
+        swept_area=base.swept_area,
+        position=base.position,
+        depth=base.depth,
+        extruded_direction=base.extruded_direction,
+        end_swept_area=get_surface(ifc_entity.EndSweptArea),
+    )
+
+
+def fixed_reference_swept_area_solid(
+    ifc_entity: ifcopenshell.entity_instance,
+) -> geo_so.FixedReferenceSweptAreaSolid:
+    # FixedReference / StartParam / EndParam are not part of adapy's geom model (the OCC build
+    # derives orientation from the directrix), so they are intentionally dropped on read.
+    position = axis3d(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()
+    return geo_so.FixedReferenceSweptAreaSolid(
+        swept_area=get_surface(ifc_entity.SweptArea),
+        position=position,
+        directrix=get_curve(ifc_entity.Directrix),
+    )
+
+
 def revolved_solid_area(ifc_entity: ifcopenshell.entity_instance) -> geo_so.RevolvedAreaSolid:
     revolve_axis = axis1placement(ifc_entity.Axis)
     position = axis3d(ifc_entity.Position) if ifc_entity.Position is not None else Axis2Placement3D()

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -143,8 +143,10 @@ def face(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Face:
     return geo_su.Face(bounds=[face_bound(b) for b in ifc_entity.Bounds])
 
 
-def bspline_surface_with_knots(ifc_entity: ifcopenshell.entity_instance) -> geo_su.BSplineSurfaceWithKnots:
-    return geo_su.BSplineSurfaceWithKnots(
+def bspline_surface_with_knots(
+    ifc_entity: ifcopenshell.entity_instance,
+) -> geo_su.BSplineSurfaceWithKnots | geo_su.RationalBSplineSurfaceWithKnots:
+    kwargs = dict(
         u_degree=ifc_entity.UDegree,
         v_degree=ifc_entity.VDegree,
         control_points_list=[[Point(*p) for p in x] for x in ifc_entity.ControlPointsList],
@@ -158,6 +160,13 @@ def bspline_surface_with_knots(ifc_entity: ifcopenshell.entity_instance) -> geo_
         v_knots=ifc_entity.VKnots,
         knot_spec=geo_cu.KnotType.from_str(ifc_entity.KnotSpec),
     )
+    # IfcRationalBSplineSurfaceWithKnots is a subtype of IfcBSplineSurfaceWithKnots — preserve
+    # its per-control-point weights instead of silently downcasting to a non-rational surface.
+    if ifc_entity.is_a("IfcRationalBSplineSurfaceWithKnots"):
+        return geo_su.RationalBSplineSurfaceWithKnots(
+            **kwargs, weights_data=[list(row) for row in ifc_entity.WeightsData]
+        )
+    return geo_su.BSplineSurfaceWithKnots(**kwargs)
 
 
 def advanced_face(ifc_entity: ifcopenshell.entity_instance) -> geo_su.AdvancedFace:

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -118,6 +118,17 @@ def rectangle_profile_def(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Re
     )
 
 
+def curve_bounded_plane(ifc_entity: ifcopenshell.entity_instance) -> geo_su.CurveBoundedPlane:
+    from .curves import get_curve
+
+    inner = [get_curve(c) for c in ifc_entity.InnerBoundaries] if ifc_entity.InnerBoundaries else []
+    return geo_su.CurveBoundedPlane(
+        basis_surface=plane(ifc_entity.BasisSurface),
+        outer_boundary=get_curve(ifc_entity.OuterBoundary),
+        inner_boundaries=inner,
+    )
+
+
 def poly_loop(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.PolyLoop:
     return geo_cu.PolyLoop(polygon=[Point(p.Coordinates) for p in ifc_entity.Polygon])
 

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -202,6 +202,20 @@ def toroidal_surface(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Toroida
     )
 
 
+def surface_of_revolution(ifc_entity: ifcopenshell.entity_instance) -> geo_su.SurfaceOfRevolution:
+    from .curves import get_curve
+    from .placement import axis1placement, axis3d
+
+    swept = ifc_entity.SweptCurve
+    # IFC SweptCurve is an IfcProfileDef; the generatrix is its wrapped Curve.
+    curve = get_curve(swept.Curve) if swept.is_a("IfcArbitraryOpenProfileDef") else get_curve(swept)
+    return geo_su.SurfaceOfRevolution(
+        swept_curve=curve,
+        axis_position=axis1placement(ifc_entity.AxisPosition),
+        position=axis3d(ifc_entity.Position) if ifc_entity.Position is not None else None,
+    )
+
+
 def face_surface_geom(ifc_surface: ifcopenshell.entity_instance) -> geo_su.SURFACE_GEOM_TYPES:
     """Read any supported IfcSurface used as an AdvancedFace.FaceSurface."""
     # IfcRationalBSplineSurfaceWithKnots is a subtype of IfcBSplineSurfaceWithKnots — the one
@@ -214,6 +228,8 @@ def face_surface_geom(ifc_surface: ifcopenshell.entity_instance) -> geo_su.SURFA
         return spherical_surface(ifc_surface)
     elif ifc_surface.is_a("IfcToroidalSurface"):
         return toroidal_surface(ifc_surface)
+    elif ifc_surface.is_a("IfcSurfaceOfRevolution"):
+        return surface_of_revolution(ifc_surface)
     elif ifc_surface.is_a("IfcPlane"):
         return plane(ifc_surface)
     raise NotImplementedError(f"Face surface type {ifc_surface.is_a()} is not implemented")

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -118,11 +118,17 @@ def rectangle_profile_def(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Re
     )
 
 
+def poly_loop(ifc_entity: ifcopenshell.entity_instance) -> geo_cu.PolyLoop:
+    return geo_cu.PolyLoop(polygon=[Point(p.Coordinates) for p in ifc_entity.Polygon])
+
+
 def face_bound(ifc_entity: ifcopenshell.entity_instance) -> geo_su.FaceBound:
 
     ifc_bound = ifc_entity.Bound
     if ifc_bound.is_a("IfcEdgeLoop"):
         bound = edge_loop(ifc_bound)
+    elif ifc_bound.is_a("IfcPolyLoop"):
+        bound = poly_loop(ifc_bound)
     else:
         raise NotImplementedError(f"{ifc_entity} is not yet implemented.")
 
@@ -130,6 +136,11 @@ def face_bound(ifc_entity: ifcopenshell.entity_instance) -> geo_su.FaceBound:
         bound=bound,
         orientation=ifc_entity.Orientation,
     )
+
+
+def face(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Face:
+    """IfcFace -> Face. IfcFaceBound and IfcFaceOuterBound both read as FaceBound."""
+    return geo_su.Face(bounds=[face_bound(b) for b in ifc_entity.Bounds])
 
 
 def bspline_surface_with_knots(ifc_entity: ifcopenshell.entity_instance) -> geo_su.BSplineSurfaceWithKnots:

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -169,17 +169,50 @@ def bspline_surface_with_knots(
     return geo_su.BSplineSurfaceWithKnots(**kwargs)
 
 
+def cylindrical_surface(ifc_entity: ifcopenshell.entity_instance) -> geo_su.CylindricalSurface:
+    from .placement import axis3d
+
+    return geo_su.CylindricalSurface(position=axis3d(ifc_entity.Position), radius=ifc_entity.Radius)
+
+
+def spherical_surface(ifc_entity: ifcopenshell.entity_instance) -> geo_su.SphericalSurface:
+    from .placement import axis3d
+
+    return geo_su.SphericalSurface(position=axis3d(ifc_entity.Position), radius=ifc_entity.Radius)
+
+
+def toroidal_surface(ifc_entity: ifcopenshell.entity_instance) -> geo_su.ToroidalSurface:
+    from .placement import axis3d
+
+    return geo_su.ToroidalSurface(
+        position=axis3d(ifc_entity.Position),
+        major_radius=ifc_entity.MajorRadius,
+        minor_radius=ifc_entity.MinorRadius,
+    )
+
+
+def face_surface_geom(ifc_surface: ifcopenshell.entity_instance) -> geo_su.SURFACE_GEOM_TYPES:
+    """Read any supported IfcSurface used as an AdvancedFace.FaceSurface."""
+    # IfcRationalBSplineSurfaceWithKnots is a subtype of IfcBSplineSurfaceWithKnots — the one
+    # reader handles both and preserves rationality.
+    if ifc_surface.is_a("IfcBSplineSurfaceWithKnots"):
+        return bspline_surface_with_knots(ifc_surface)
+    elif ifc_surface.is_a("IfcCylindricalSurface"):
+        return cylindrical_surface(ifc_surface)
+    elif ifc_surface.is_a("IfcSphericalSurface"):
+        return spherical_surface(ifc_surface)
+    elif ifc_surface.is_a("IfcToroidalSurface"):
+        return toroidal_surface(ifc_surface)
+    elif ifc_surface.is_a("IfcPlane"):
+        return plane(ifc_surface)
+    raise NotImplementedError(f"Face surface type {ifc_surface.is_a()} is not implemented")
+
+
 def advanced_face(ifc_entity: ifcopenshell.entity_instance) -> geo_su.AdvancedFace:
-    ifc_face_surface = ifc_entity.FaceSurface
-
-    face_surface = None
-    if ifc_face_surface.is_a("IfcBSplineSurfaceWithKnots"):
-        face_surface = bspline_surface_with_knots(ifc_face_surface)
-
-    if face_surface is None:
-        raise NotImplementedError(f"{ifc_entity} is not yet implemented.")
-
-    return geo_su.AdvancedFace(bounds=[face_bound(x) for x in ifc_entity.Bounds], face_surface=face_surface)
+    return geo_su.AdvancedFace(
+        bounds=[face_bound(x) for x in ifc_entity.Bounds],
+        face_surface=face_surface_geom(ifc_entity.FaceSurface),
+    )
 
 
 def closed_shell(ifc_entity: ifcopenshell.entity_instance) -> geo_su.ClosedShell:

--- a/src/ada/cadit/ifc/read/geom/surfaces.py
+++ b/src/ada/cadit/ifc/read/geom/surfaces.py
@@ -99,6 +99,17 @@ def triangulated_face_set(ifc_entity: ifcopenshell.entity_instance) -> geo_su.Tr
     )
 
 
+def polygonal_face_set(ifc_entity: ifcopenshell.entity_instance) -> geo_su.PolygonalFaceSet:
+    # Each IfcIndexedPolygonalFace carries 1-based CoordIndex into the shared point list.
+    # IfcIndexedPolygonalFaceWithVoids (a subtype) additionally has InnerCoordIndices — not
+    # yet represented; its outer loop still reads correctly here.
+    return geo_su.PolygonalFaceSet(
+        coordinates=[Point(*x) for x in ifc_entity.Coordinates.CoordList],
+        faces=[list(face.CoordIndex) for face in ifc_entity.Faces],
+        closed=bool(ifc_entity.Closed) if ifc_entity.Closed is not None else True,
+    )
+
+
 def rectangle_profile_def(ifc_entity: ifcopenshell.entity_instance) -> geo_su.RectangleProfileDef:
     return geo_su.RectangleProfileDef(
         profile_type=geo_su.ProfileType.from_str(ifc_entity.ProfileType),

--- a/src/ada/cadit/ifc/write/geom/curves.py
+++ b/src/ada/cadit/ifc/write/geom/curves.py
@@ -259,3 +259,8 @@ def edge_loop(
     """Converts an EdgeLoop to an IFC representation"""
     edges = [oriented_edge(e, f, basis_surface=basis_surface) for e in el.edge_list]
     return f.create_entity("IfcEdgeLoop", EdgeList=edges)
+
+
+def poly_loop(pl: geo_cu.PolyLoop, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a PolyLoop to an IfcPolyLoop (a closed polygon of Cartesian points)."""
+    return f.create_entity("IfcPolyLoop", Polygon=[cpt(f, p) for p in pl.polygon])

--- a/src/ada/cadit/ifc/write/geom/curves.py
+++ b/src/ada/cadit/ifc/write/geom/curves.py
@@ -191,6 +191,27 @@ def create_line(line: geo_cu.Line, f: ifcopenshell.file) -> ifcopenshell.entity_
     return f.create_entity("IfcLine", Pnt=cpt(f, line.pnt), Dir=vector(line.dir, f))
 
 
+def write_curve(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Write any supported curve to its matching IFC curve entity (IfcCurve)."""
+    if isinstance(curve, geo_cu.IndexedPolyCurve):
+        return indexed_poly_curve(curve, f)
+    elif isinstance(curve, geo_cu.PolyLine):
+        return poly_line(curve, f)
+    elif isinstance(curve, geo_cu.Line):
+        return create_line(curve, f)
+    elif isinstance(curve, geo_cu.Circle):
+        return circle_curve(curve, f)
+    elif isinstance(curve, geo_cu.Ellipse):
+        return create_ellipse(curve, f)
+    elif isinstance(curve, geo_cu.BSplineCurveWithKnots):
+        return b_spline_curve_with_knots(curve, f)
+    elif isinstance(curve, geo_cu.TrimmedCurve):
+        return create_trimmed_curve(curve, f)
+    elif isinstance(curve, geo_cu.CompositeCurve):
+        return composite_curve(curve, f)
+    raise NotImplementedError(f"Unsupported curve type for IFC write: {type(curve)}")
+
+
 def _basis_curve(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Write a TrimmedCurve basis curve to its matching IFC curve entity."""
     if isinstance(curve, geo_cu.Line):
@@ -202,6 +223,20 @@ def _basis_curve(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcope
     elif isinstance(curve, geo_cu.BSplineCurveWithKnots):
         return b_spline_curve_with_knots(curve, f)
     raise NotImplementedError(f"Unsupported trimmed-curve basis type: {type(curve)}")
+
+
+def composite_curve(cc: geo_cu.CompositeCurve, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a CompositeCurve to an IfcCompositeCurve."""
+    segments = [
+        f.create_entity(
+            "IfcCompositeCurveSegment",
+            Transition=seg.transition,
+            SameSense=seg.same_sense,
+            ParentCurve=write_curve(seg.parent_curve, f),
+        )
+        for seg in cc.segments
+    ]
+    return f.create_entity("IfcCompositeCurve", Segments=segments, SelfIntersect=cc.self_intersect)
 
 
 def _trim_select(trim, f: ifcopenshell.file) -> tuple:

--- a/src/ada/cadit/ifc/write/geom/curves.py
+++ b/src/ada/cadit/ifc/write/geom/curves.py
@@ -191,6 +191,40 @@ def create_line(line: geo_cu.Line, f: ifcopenshell.file) -> ifcopenshell.entity_
     return f.create_entity("IfcLine", Pnt=cpt(f, line.pnt), Dir=vector(line.dir, f))
 
 
+def _basis_curve(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Write a TrimmedCurve basis curve to its matching IFC curve entity."""
+    if isinstance(curve, geo_cu.Line):
+        return create_line(curve, f)
+    elif isinstance(curve, geo_cu.Circle):
+        return circle_curve(curve, f)
+    elif isinstance(curve, geo_cu.Ellipse):
+        return create_ellipse(curve, f)
+    elif isinstance(curve, geo_cu.BSplineCurveWithKnots):
+        return b_spline_curve_with_knots(curve, f)
+    raise NotImplementedError(f"Unsupported trimmed-curve basis type: {type(curve)}")
+
+
+def _trim_select(trim, f: ifcopenshell.file) -> tuple:
+    """A single IfcTrimmingSelect entry: a Cartesian point or a parameter value."""
+    from ada.geom.points import Point
+
+    if isinstance(trim, Point):
+        return (cpt(f, trim),)
+    return (float(trim),)
+
+
+def create_trimmed_curve(tc: geo_cu.TrimmedCurve, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a TrimmedCurve to an IfcTrimmedCurve."""
+    return f.create_entity(
+        "IfcTrimmedCurve",
+        BasisCurve=_basis_curve(tc.basis_curve, f),
+        Trim1=_trim_select(tc.trim1, f),
+        Trim2=_trim_select(tc.trim2, f),
+        SenseAgreement=tc.sense_agreement,
+        MasterRepresentation=tc.master_representation,
+    )
+
+
 def oriented_edge(
     oe: geo_cu.OrientedEdge,
     f: ifcopenshell.file,

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -7,10 +7,35 @@ from ada.cadit.ifc.write.geom.placement import (
     ifc_placement_from_axis3d,
     point,
 )
+from ada.geom import curves as geo_cu
 from ada.geom import solids as geo_so
 from ada.geom import surfaces as geo_su
 
+from .curves import circle_curve, indexed_poly_curve, poly_line
 from .surfaces import arbitrary_profile_def
+
+
+def _directrix(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Write a sweep directrix curve to its matching IFC curve entity."""
+    if isinstance(curve, geo_cu.IndexedPolyCurve):
+        return indexed_poly_curve(curve, f)
+    elif isinstance(curve, geo_cu.PolyLine):
+        return poly_line(curve, f)
+    elif isinstance(curve, geo_cu.Circle):
+        return circle_curve(curve, f)
+    raise NotImplementedError(f"Unsupported directrix curve type: {type(curve)}")
+
+
+def swept_disk_solid(sds: geo_so.SweptDiskSolid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a SweptDiskSolid to an IfcSweptDiskSolid."""
+    kwargs = dict(Directrix=_directrix(sds.directrix, f), Radius=float(sds.radius))
+    if sds.inner_radius is not None:
+        kwargs["InnerRadius"] = float(sds.inner_radius)
+    if sds.start_param is not None:
+        kwargs["StartParam"] = float(sds.start_param)
+    if sds.end_param is not None:
+        kwargs["EndParam"] = float(sds.end_param)
+    return f.create_entity("IfcSweptDiskSolid", **kwargs)
 
 
 def extruded_area_solid(

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -12,7 +12,17 @@ from ada.geom import solids as geo_so
 from ada.geom import surfaces as geo_su
 
 from .curves import circle_curve, indexed_poly_curve, poly_line
-from .surfaces import arbitrary_profile_def
+from .surfaces import arbitrary_profile_def, create_closed_shell
+
+
+def faceted_brep(fb: geo_so.FacetedBrep, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a FacetedBrep to an IfcFacetedBrep, or IfcFacetedBrepWithVoids when it has
+    inner void shells."""
+    outer = create_closed_shell(fb.outer, f)
+    if not fb.voids:
+        return f.create_entity("IfcFacetedBrep", Outer=outer)
+    voids = [create_closed_shell(v, f) for v in fb.voids]
+    return f.create_entity("IfcFacetedBrepWithVoids", Outer=outer, Voids=voids)
 
 
 def _directrix(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -36,6 +36,26 @@ def _directrix(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopens
     raise NotImplementedError(f"Unsupported directrix curve type: {type(curve)}")
 
 
+def fixed_reference_swept_area_solid(
+    frs: geo_so.FixedReferenceSweptAreaSolid, f: ifcopenshell.file
+) -> ifcopenshell.entity_instance:
+    """Converts a FixedReferenceSweptAreaSolid to an IfcFixedReferenceSweptAreaSolid.
+
+    adapy's geom model doesn't track the fixed-reference direction (the OCC build derives
+    orientation from the directrix), so FixedReference is emitted from the position's
+    ref_direction to satisfy the (mandatory) IFC attribute."""
+    from ada.geom.direction import Direction
+
+    ref = frs.position.ref_direction if frs.position.ref_direction is not None else Direction(1, 0, 0)
+    return f.create_entity(
+        "IfcFixedReferenceSweptAreaSolid",
+        SweptArea=arbitrary_profile_def(frs.swept_area, f),
+        Position=ifc_placement_from_axis3d(frs.position, f),
+        Directrix=_directrix(frs.directrix, f),
+        FixedReference=direction(ref, f),
+    )
+
+
 def swept_disk_solid(sds: geo_so.SweptDiskSolid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Converts a SweptDiskSolid to an IfcSweptDiskSolid."""
     kwargs = dict(Directrix=_directrix(sds.directrix, f), Radius=float(sds.radius))

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -56,6 +56,17 @@ def fixed_reference_swept_area_solid(
     )
 
 
+def rectangular_pyramid(rp: geo_so.RectangularPyramid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a RectangularPyramid to an IfcRectangularPyramid."""
+    return f.create_entity(
+        "IfcRectangularPyramid",
+        Position=ifc_placement_from_axis3d(rp.position, f),
+        XLength=float(rp.x_length),
+        YLength=float(rp.y_length),
+        Height=float(rp.z_length),
+    )
+
+
 def swept_disk_solid(sds: geo_so.SweptDiskSolid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Converts a SweptDiskSolid to an IfcSweptDiskSolid."""
     kwargs = dict(Directrix=_directrix(sds.directrix, f), Radius=float(sds.radius))

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -6,7 +6,7 @@ from ada import BoolHalfSpace
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
-from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_loop
+from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_line, poly_loop
 from .placement import ifc_placement_from_axis3d
 from .points import cpt
 
@@ -266,25 +266,26 @@ def create_toroidal_surface(ts: geo_su.ToroidalSurface, f: ifcopenshell.file) ->
     )
 
 
+def _bounded_curve(curve: geo_cu.CURVE_GEOM_TYPES, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Write a boundary curve to an IfcCurve (IfcCurveBoundedPlane boundaries are IfcCurve, not
+    topological loops)."""
+    if isinstance(curve, geo_cu.IndexedPolyCurve):
+        return indexed_poly_curve(curve, f)
+    elif isinstance(curve, geo_cu.PolyLine):
+        return poly_line(curve, f)
+    elif isinstance(curve, geo_cu.Circle):
+        return circle_curve(curve, f)
+    raise NotImplementedError(f"Unsupported curve-bounded-plane boundary type: {type(curve)}")
+
+
 def curve_bounded_plane(cbp: geo_su.CurveBoundedPlane, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
-    """Converts a CurveBoundedPlane to an IFC representation"""
-    basis_surface = create_plane(cbp.basis_surface, f)
+    """Converts a CurveBoundedPlane to an IfcCurveBoundedPlane.
 
-    if isinstance(cbp.outer_boundary, geo_cu.EdgeLoop):
-        outer_boundary = edge_loop(cbp.outer_boundary, f)
-    else:
-        raise NotImplementedError(f"Unsupported outer boundary type: {type(cbp.outer_boundary)}")
-
-    if isinstance(cbp.inner_boundaries, list) and len(cbp.inner_boundaries) == 0:
-        inner_boundaries = cbp.inner_boundaries
-    elif isinstance(cbp.inner_boundaries, geo_cu.EdgeLoop):
-        inner_boundaries = edge_loop(cbp.inner_boundaries, f)
-    else:
-        raise NotImplementedError(f"Unsupported inner boundaries type: {type(cbp.inner_boundaries)}")
-
+    IfcCurveBoundedPlane.OuterBoundary / InnerBoundaries are IfcCurve (a planar bounded curve),
+    not topological edge loops — the geom ``outer_boundary`` is a CURVE_GEOM_TYPES accordingly."""
     return f.create_entity(
         "IfcCurveBoundedPlane",
-        BasisSurface=basis_surface,
-        OuterBoundary=outer_boundary,
-        InnerBoundaries=inner_boundaries,
+        BasisSurface=create_plane(cbp.basis_surface, f),
+        OuterBoundary=_bounded_curve(cbp.outer_boundary, f),
+        InnerBoundaries=[_bounded_curve(c, f) for c in cbp.inner_boundaries],
     )

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -6,7 +6,7 @@ from ada import BoolHalfSpace
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
-from .curves import circle_curve, edge_loop, indexed_poly_curve
+from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_loop
 from .placement import ifc_placement_from_axis3d
 from .points import cpt
 
@@ -89,6 +89,8 @@ def face_bound(fb: geo_su.FaceBound, f: ifcopenshell.file, basis_surface=None) -
     """Converts a FaceBound to an IFC representation"""
     if isinstance(fb.bound, geo_cu.EdgeLoop):
         bound = edge_loop(fb.bound, f, basis_surface=basis_surface)
+    elif isinstance(fb.bound, geo_cu.PolyLoop):
+        bound = poly_loop(fb.bound, f)
     else:
         raise NotImplementedError(f"Unsupported bound type: {type(fb.bound)}")
 

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -152,6 +152,24 @@ def create_face_surface(fs: geo_su.FaceSurface, f: ifcopenshell.file) -> ifcopen
     )
 
 
+def polygonal_face_set(pfs: geo_su.PolygonalFaceSet, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a PolygonalFaceSet to an IfcPolygonalFaceSet.
+
+    Faces reference the shared IfcCartesianPointList3D by 1-based index via
+    IfcIndexedPolygonalFace (the sibling of the triangulated face set's CoordIndex)."""
+    coordinates = f.create_entity(
+        "IfcCartesianPointList3D",
+        CoordList=[(float(p.x), float(p.y), float(p.z)) for p in pfs.coordinates],
+    )
+    faces = [f.create_entity("IfcIndexedPolygonalFace", CoordIndex=[int(i) for i in face]) for face in pfs.faces]
+    return f.create_entity(
+        "IfcPolygonalFaceSet",
+        Coordinates=coordinates,
+        Closed=pfs.closed,
+        Faces=faces,
+    )
+
+
 def create_closed_shell(cs: geo_su.ClosedShell, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Converts a ClosedShell to an IFC representation.
 

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -6,8 +6,8 @@ from ada import BoolHalfSpace
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
-from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_line, poly_loop
-from .placement import ifc_placement_from_axis3d
+from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_line, poly_loop, write_curve
+from .placement import direction, ifc_placement_from_axis3d, point
 from .points import cpt
 
 
@@ -239,6 +239,24 @@ def create_plane(plane: geo_su.Plane, f: ifcopenshell.file) -> ifcopenshell.enti
     return f.create_entity(
         "IfcPlane",
         Position=ifc_placement_from_axis3d(plane.position, f),
+    )
+
+
+def create_surface_of_revolution(
+    sor: geo_su.SurfaceOfRevolution, f: ifcopenshell.file
+) -> ifcopenshell.entity_instance:
+    """Converts a SurfaceOfRevolution to an IfcSurfaceOfRevolution.
+
+    The generatrix curve is wrapped in an IfcArbitraryOpenProfileDef (the IFC SweptCurve type)."""
+    profile = f.create_entity(
+        "IfcArbitraryOpenProfileDef", ProfileType="CURVE", Curve=write_curve(sor.swept_curve, f)
+    )
+    axis_position = f.create_entity(
+        "IfcAxis1Placement", point(sor.axis_position.location, f), direction(sor.axis_position.axis, f)
+    )
+    position = ifc_placement_from_axis3d(sor.position, f) if sor.position is not None else None
+    return f.create_entity(
+        "IfcSurfaceOfRevolution", SweptCurve=profile, Position=position, AxisPosition=axis_position
     )
 
 

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -6,7 +6,14 @@ from ada import BoolHalfSpace
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
-from .curves import circle_curve, edge_loop, indexed_poly_curve, poly_line, poly_loop, write_curve
+from .curves import (
+    circle_curve,
+    edge_loop,
+    indexed_poly_curve,
+    poly_line,
+    poly_loop,
+    write_curve,
+)
 from .placement import direction, ifc_placement_from_axis3d, point
 from .points import cpt
 
@@ -242,22 +249,16 @@ def create_plane(plane: geo_su.Plane, f: ifcopenshell.file) -> ifcopenshell.enti
     )
 
 
-def create_surface_of_revolution(
-    sor: geo_su.SurfaceOfRevolution, f: ifcopenshell.file
-) -> ifcopenshell.entity_instance:
+def create_surface_of_revolution(sor: geo_su.SurfaceOfRevolution, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Converts a SurfaceOfRevolution to an IfcSurfaceOfRevolution.
 
     The generatrix curve is wrapped in an IfcArbitraryOpenProfileDef (the IFC SweptCurve type)."""
-    profile = f.create_entity(
-        "IfcArbitraryOpenProfileDef", ProfileType="CURVE", Curve=write_curve(sor.swept_curve, f)
-    )
+    profile = f.create_entity("IfcArbitraryOpenProfileDef", ProfileType="CURVE", Curve=write_curve(sor.swept_curve, f))
     axis_position = f.create_entity(
         "IfcAxis1Placement", point(sor.axis_position.location, f), direction(sor.axis_position.axis, f)
     )
     position = ifc_placement_from_axis3d(sor.position, f) if sor.position is not None else None
-    return f.create_entity(
-        "IfcSurfaceOfRevolution", SweptCurve=profile, Position=position, AxisPosition=axis_position
-    )
+    return f.create_entity("IfcSurfaceOfRevolution", SweptCurve=profile, Position=position, AxisPosition=axis_position)
 
 
 def create_cylindrical_surface(cs: geo_su.CylindricalSurface, f: ifcopenshell.file) -> ifcopenshell.entity_instance:

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -242,6 +242,30 @@ def create_plane(plane: geo_su.Plane, f: ifcopenshell.file) -> ifcopenshell.enti
     )
 
 
+def create_cylindrical_surface(cs: geo_su.CylindricalSurface, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a CylindricalSurface to an IfcCylindricalSurface."""
+    return f.create_entity(
+        "IfcCylindricalSurface", Position=ifc_placement_from_axis3d(cs.position, f), Radius=float(cs.radius)
+    )
+
+
+def create_spherical_surface(ss: geo_su.SphericalSurface, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a SphericalSurface to an IfcSphericalSurface."""
+    return f.create_entity(
+        "IfcSphericalSurface", Position=ifc_placement_from_axis3d(ss.position, f), Radius=float(ss.radius)
+    )
+
+
+def create_toroidal_surface(ts: geo_su.ToroidalSurface, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+    """Converts a ToroidalSurface to an IfcToroidalSurface."""
+    return f.create_entity(
+        "IfcToroidalSurface",
+        Position=ifc_placement_from_axis3d(ts.position, f),
+        MajorRadius=float(ts.major_radius),
+        MinorRadius=float(ts.minor_radius),
+    )
+
+
 def curve_bounded_plane(cbp: geo_su.CurveBoundedPlane, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
     """Converts a CurveBoundedPlane to an IFC representation"""
     basis_surface = create_plane(cbp.basis_surface, f)

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -2837,15 +2837,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 continue
             ext = pathlib.PurePosixPath(f.key).suffix.lower()
             targets = ConverterRegistry.targets_for(ext)
-            # validate_only runs skip the conversion grid and emit only parity cells.
-            if not validate_only:
+            if validate_only:
+                # A validation run does cross-format visual-parity only (no conversion
+                # grid), and only when the source can produce a structure-preserving
+                # format to compare against. Parity is a validation concern — full
+                # conversion runs do not emit parity cells.
+                if any(t in ("ifc", "xml", "step") for t in targets):
+                    cells.append((f.key, "parity"))
+            else:
                 for target_format in targets:
                     cells.append((f.key, target_format))
-            # Cross-format visual-parity validation cell — only when the source
-            # can produce a structure-preserving format to compare against.
-            # Appended before set_audit_run_total so the run total accounts for it.
-            if any(t in ("ifc", "xml", "step") for t in targets):
-                cells.append((f.key, "parity"))
 
         await db_module.set_audit_run_total(pool, run_id, len(cells))
         if not cells:
@@ -2863,6 +2864,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         scope_id=scope_obj.id,
                         target_capability=worker_pool,
                         force_rebuild=force_rebuild,
+                        # Parity produces no derived blob — pass an explicit derived_key so
+                        # enqueue doesn't route through derived_key_for(), which rejects the
+                        # "parity" pseudo-format (not in TARGET_FORMATS). Same pattern the
+                        # fea_artefacts flow uses for its manifest key.
+                        derived_key=f"_derived/{source_key}.parity",
                     )
                 except Exception as exc:
                     logger.exception("audit run %s: parity enqueue failed for %s", run_id, source_key)

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -53,6 +53,8 @@ def _scope_of(job: Job) -> Scope:
         return Scope.project(job.scope_id)
     if job.scope_kind == "user" and job.scope_id:
         return Scope.user(job.scope_id)
+    if job.scope_kind == "corpus" and job.scope_id:
+        return Scope.corpus(job.scope_id)
     return Scope.shared()
 
 

--- a/src/ada/core/utils.py
+++ b/src/ada/core/utils.py
@@ -65,11 +65,21 @@ def roundoff(x: float, precision=Config().general_precision) -> float:
     return xout if abs(xout) != 0.0 else 0.0
 
 
-def get_current_user():
-    """Return the username of currently logged in user"""
-    import getpass
+def get_current_user() -> str:
+    """Return the username of the current user.
 
-    return getpass.getuser()
+    ``getpass.getuser()`` falls back to ``pwd.getpwuid(os.getuid())`` when no
+    USER/LOGNAME/LNAME/USERNAME env var is set, which raises in a non-root
+    container whose runtime uid has no ``/etc/passwd`` entry (e.g. the worker
+    image running as uid 10001). Degrade gracefully to a sensible default so
+    FEM deck writers never crash on the username stamp."""
+    import getpass
+    import os
+
+    try:
+        return getpass.getuser()
+    except (KeyError, OSError):
+        return os.environ.get("USER") or os.environ.get("LOGNAME") or "unknown"
 
 
 def thread_this(list_in, function, cpus=4):

--- a/src/ada/geom/curves.py
+++ b/src/ada/geom/curves.py
@@ -25,6 +25,7 @@ CURVE_GEOM_TYPES = Union[
     "IndexedPolyCurve",
     "PolyLine",
     "TrimmedCurve",
+    "CompositeCurve",
     "GeometricCurveSet",
 ]
 
@@ -99,6 +100,32 @@ class TrimmedCurve:
     trim2: "Point | float"
     sense_agreement: bool = True
     master_representation: str = "PARAMETER"
+
+
+@dataclass
+class CompositeCurveSegment:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCompositeCurveSegment.htm)
+
+    One segment of a CompositeCurve, wrapping a bounded parent curve.
+    """
+
+    parent_curve: "CURVE_GEOM_TYPES"
+    same_sense: bool = True
+    transition: str = "CONTINUOUS"
+
+
+@dataclass
+class CompositeCurve:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcCompositeCurve.htm)
+    STEP AP242 (https://www.steptools.com/stds/stp_aim/html/t_composite_curve.html)
+
+    A curve assembled from an ordered list of bounded parent-curve segments.
+    """
+
+    segments: list[CompositeCurveSegment]
+    self_intersect: bool = False
 
 
 @dataclass

--- a/src/ada/geom/curves.py
+++ b/src/ada/geom/curves.py
@@ -24,6 +24,7 @@ CURVE_GEOM_TYPES = Union[
     "BSplineCurveWithKnots",
     "IndexedPolyCurve",
     "PolyLine",
+    "TrimmedCurve",
     "GeometricCurveSet",
 ]
 
@@ -79,6 +80,25 @@ class ArcLine:
 @dataclass
 class PolyLine:
     points: list[Point]
+
+
+@dataclass
+class TrimmedCurve:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcTrimmedCurve.htm)
+    STEP AP242 (https://www.steptools.com/stds/stp_aim/html/t_trimmed_curve.html)
+
+    A bounded segment of an (unbounded) basis curve — line / circle / ellipse. Each trim is
+    either a Cartesian ``Point`` lying on the curve or a parameter value (float);
+    ``master_representation`` records which the producer considered authoritative
+    ("PARAMETER", "CARTESIAN" or "UNSPECIFIED").
+    """
+
+    basis_curve: "Line | Circle | Ellipse | BSplineCurveWithKnots"
+    trim1: "Point | float"
+    trim2: "Point | float"
+    sense_agreement: bool = True
+    master_representation: str = "PARAMETER"
 
 
 @dataclass

--- a/src/ada/geom/solids.py
+++ b/src/ada/geom/solids.py
@@ -64,6 +64,25 @@ class FixedReferenceSweptAreaSolid:
 
 
 @dataclass
+class SweptDiskSolid:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSweptDiskSolid.htm)
+    STEP AP242 (https://www.steptools.com/stds/stp_aim/html/t_swept_disk_solid.html)
+
+    A circular — or annular, when ``inner_radius`` is set — disk swept along the ``directrix``
+    curve. The canonical representation for pipes/rods. ``IfcSweptDiskSolidPolygonal`` (a
+    polyline directrix with a fillet radius) maps here too, with ``fillet_radius`` set.
+    """
+
+    directrix: CURVE_GEOM_TYPES
+    radius: float
+    inner_radius: float | None = None
+    start_param: float | None = None
+    end_param: float | None = None
+    fillet_radius: float | None = None
+
+
+@dataclass
 class Box:
     """
     IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcBlock.htm)
@@ -179,4 +198,5 @@ SOLID_GEOM_TYPES = Union[
     FixedReferenceSweptAreaSolid,
     AdvancedBrep,
     ExtrudedAreaSolidTapered,
+    SweptDiskSolid,
 ]

--- a/src/ada/geom/solids.py
+++ b/src/ada/geom/solids.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Union
 
 from ada.core.vector_utils import create_right_hand_vectors_xv_yv_from_zv
@@ -11,6 +11,7 @@ from ada.geom.points import Point
 from ada.geom.surfaces import (
     SURFACE_GEOM_TYPES,
     ArbitraryProfileDef,
+    ClosedShell,
     ConnectedFaceSet,
     ProfileDef,
 )
@@ -187,6 +188,19 @@ class AdvancedBrep:
     outer: ConnectedFaceSet
 
 
+@dataclass
+class FacetedBrep:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcFacetedBrep.htm)
+
+    A manifold solid bounded by planar polygonal faces — the most common B-rep encoding. Maps to
+    ``IfcFacetedBrepWithVoids`` when ``voids`` (inner closed shells) are present.
+    """
+
+    outer: ClosedShell
+    voids: list[ClosedShell] = field(default_factory=list)
+
+
 SOLID_GEOM_TYPES = Union[
     ExtrudedAreaSolid,
     RevolvedAreaSolid,
@@ -197,6 +211,7 @@ SOLID_GEOM_TYPES = Union[
     Sphere,
     FixedReferenceSweptAreaSolid,
     AdvancedBrep,
+    FacetedBrep,
     ExtrudedAreaSolidTapered,
     SweptDiskSolid,
 ]

--- a/src/ada/geom/surfaces.py
+++ b/src/ada/geom/surfaces.py
@@ -7,7 +7,7 @@ from typing import Union
 import ada.geom.curves as geo_cu
 from ada.geom.curves import EdgeLoop, PolyLoop
 from ada.geom.direction import Direction
-from ada.geom.placement import Axis2Placement3D
+from ada.geom.placement import Axis1Placement, Axis2Placement3D
 from ada.geom.points import Point
 
 
@@ -173,6 +173,22 @@ class SurfaceOfLinearExtrusion:
     position: Axis2Placement3D
     extrusion_direction: Direction
     depth: float
+
+
+@dataclass
+class SurfaceOfRevolution:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSurfaceOfRevolution.htm)
+    STEP AP242 (https://www.steptools.com/stds/stp_aim/html/t_surface_of_revolution.html)
+
+    A surface formed by revolving a generatrix curve about an axis. Note: the IFC entity types
+    ``SweptCurve`` as an ``IfcProfileDef`` (the generatrix wrapped in an open profile) — adapy
+    models the generatrix directly as a curve and wraps/unwraps the profile on write/read.
+    """
+
+    swept_curve: geo_cu.CURVE_GEOM_TYPES
+    axis_position: Axis1Placement
+    position: Axis2Placement3D = None
 
 
 @dataclass
@@ -414,5 +430,6 @@ SURFACE_GEOM_TYPES = Union[
     BSplineSurfaceWithKnots,
     RationalBSplineSurfaceWithKnots,
     SurfaceOfLinearExtrusion,
+    SurfaceOfRevolution,
     ClosedShell,
 ]

--- a/src/ada/geom/surfaces.py
+++ b/src/ada/geom/surfaces.py
@@ -222,6 +222,21 @@ class TriangulatedFaceSet:
 
 
 @dataclass
+class PolygonalFaceSet:
+    """
+    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcPolygonalFaceSet.htm)
+
+    The compact sibling of :class:`TriangulatedFaceSet`: an indexed mesh whose faces are
+    arbitrary planar polygons (n-gons) rather than triangles. Each face is a list of 1-based
+    indices into the shared ``coordinates`` list (matching IFC's ``IfcIndexedPolygonalFace``).
+    """
+
+    coordinates: list[Point]
+    faces: list[list[int]]
+    closed: bool = True
+
+
+@dataclass
 class RectangleProfileDef(ProfileDef):
     """
     IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcRectangleProfileDef.htm)
@@ -386,6 +401,7 @@ SURFACE_GEOM_TYPES = Union[
     IShapeProfileDef,
     TShapeProfileDef,
     TriangulatedFaceSet,
+    PolygonalFaceSet,
     CircleProfileDef,
     RectangleProfileDef,
     AdvancedFace,

--- a/src/ada/geom/surfaces.py
+++ b/src/ada/geom/surfaces.py
@@ -31,8 +31,14 @@ class CylindricalSurface:
 @dataclass
 class ConicalSurface:
     """
-    IFC4x3 (https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSurface.htm)
     STEP AP242 (https://www.steptools.com/stds/stp_aim/html/t_conical_surface.html)
+
+    NOTE: there is **no** ``IfcConicalSurface`` in IFC4 / IFC4x3 — the conical surface only
+    exists in STEP AP242 and ACIS SAT. This class is used for STEP/SAT round-trip and OCC build
+    (``Geom_ConicalSurface``); it has no direct IFC entity. To express it in IFC it must be
+    written as an ``IfcSurfaceOfRevolution`` (a line generatrix revolved about the axis), which
+    is not yet implemented — the IFC face-surface writers raise rather than emit a non-existent
+    ``IfcConicalSurface``.
     """
 
     position: Axis2Placement3D

--- a/src/ada/occ/geom/__init__.py
+++ b/src/ada/occ/geom/__init__.py
@@ -30,6 +30,8 @@ def geom_to_occ_geom(geom: Geometry) -> TopoDS_Shape | TopoDS_Solid:
         occ_geom = geo_so.make_cylinder_from_geom(geometry)
     elif isinstance(geometry, so.Sphere):
         occ_geom = geo_so.make_sphere_from_geom(geometry)
+    elif isinstance(geometry, so.RectangularPyramid):
+        occ_geom = geo_so.make_rectangular_pyramid_from_geom(geometry)
     elif isinstance(geometry, so.ExtrudedAreaSolidTapered):
         occ_geom = geo_so.make_extruded_area_shape_tapered_from_geom(geometry)
     elif isinstance(geometry, so.ExtrudedAreaSolid):

--- a/src/ada/occ/geom/__init__.py
+++ b/src/ada/occ/geom/__init__.py
@@ -40,6 +40,8 @@ def geom_to_occ_geom(geom: Geometry) -> TopoDS_Shape | TopoDS_Solid:
         occ_geom = geo_so.make_fixed_reference_swept_area_shape_from_geom(geometry)
     elif isinstance(geometry, so.SweptDiskSolid):
         occ_geom = geo_so.make_swept_disk_solid_from_geom(geometry)
+    elif isinstance(geometry, so.FacetedBrep):
+        occ_geom = geo_so.make_faceted_brep_from_geom(geometry)
 
     # Surface models
     elif isinstance(geometry, su.FaceBasedSurfaceModel):

--- a/src/ada/occ/geom/__init__.py
+++ b/src/ada/occ/geom/__init__.py
@@ -54,6 +54,8 @@ def geom_to_occ_geom(geom: Geometry) -> TopoDS_Shape | TopoDS_Solid:
         occ_geom = geo_su.make_open_shell_from_geom(geometry)
     elif isinstance(geometry, su.ShellBasedSurfaceModel):
         occ_geom = geo_su.make_shell_from_shell_based_surface_geom(geometry)
+    elif isinstance(geometry, su.PolygonalFaceSet):
+        occ_geom = geo_su.make_shell_from_polygonal_face_set_geom(geometry)
     else:
         raise NotImplementedError(f"Geometry to OCC conversion for type {type(geometry)} not implemented")
 

--- a/src/ada/occ/geom/__init__.py
+++ b/src/ada/occ/geom/__init__.py
@@ -38,6 +38,8 @@ def geom_to_occ_geom(geom: Geometry) -> TopoDS_Shape | TopoDS_Solid:
         occ_geom = geo_so.make_revolved_area_shape_from_geom(geometry)
     elif isinstance(geometry, so.FixedReferenceSweptAreaSolid):
         occ_geom = geo_so.make_fixed_reference_swept_area_shape_from_geom(geometry)
+    elif isinstance(geometry, so.SweptDiskSolid):
+        occ_geom = geo_so.make_swept_disk_solid_from_geom(geometry)
 
     # Surface models
     elif isinstance(geometry, su.FaceBasedSurfaceModel):

--- a/src/ada/occ/geom/curves.py
+++ b/src/ada/occ/geom/curves.py
@@ -390,6 +390,14 @@ def make_wire_from_trimmed_curve(tc: geo_cu.TrimmedCurve) -> TopoDS_Wire:
     return wire.Wire()
 
 
+def make_wire_from_composite_curve(cc: geo_cu.CompositeCurve) -> TopoDS_Wire:
+    """Concatenate each segment's parent-curve wire into a single wire."""
+    wire_builder = BRepBuilderAPI_MakeWire()
+    for seg in cc.segments:
+        wire_builder.Add(make_wire_from_curve(seg.parent_curve))
+    return wire_builder.Wire()
+
+
 def make_wire_from_edge_loop(edge_loop: geo_cu.EdgeLoop) -> TopoDS_Wire:
     from ada.config import logger
 
@@ -476,6 +484,8 @@ def make_wire_from_curve(outer_curve: geo_cu.CURVE_GEOM_TYPES):
         return segments_to_wire([outer_curve])
     elif isinstance(outer_curve, geo_cu.TrimmedCurve):
         return make_wire_from_trimmed_curve(outer_curve)
+    elif isinstance(outer_curve, geo_cu.CompositeCurve):
+        return make_wire_from_composite_curve(outer_curve)
     else:
         raise NotImplementedError(f"Unsupported curve type {type(outer_curve)}")
 

--- a/src/ada/occ/geom/curves.py
+++ b/src/ada/occ/geom/curves.py
@@ -362,6 +362,34 @@ def make_wire_from_ellipse(ellipse: geo_cu.Ellipse) -> TopoDS_Wire:
     return wire.Wire()
 
 
+def make_wire_from_trimmed_curve(tc: geo_cu.TrimmedCurve) -> TopoDS_Wire:
+    """Build a bounded wire from a TrimmedCurve.
+
+    Supports the two common geometric cases with Cartesian-point trims: a Line basis (straight
+    segment between the trims) and a Circle basis (arc between the trims). Parameter-only trims
+    and other bases are not yet built into OCC geometry."""
+    from ada.geom.points import Point
+
+    basis = tc.basis_curve
+    p1, p2 = tc.trim1, tc.trim2
+    if not (isinstance(p1, Point) and isinstance(p2, Point)):
+        raise NotImplementedError("TrimmedCurve OCC build currently requires Cartesian-point trims")
+
+    if isinstance(basis, geo_cu.Line):
+        edge = BRepBuilderAPI_MakeEdge(point3d(p1), point3d(p2)).Edge()
+    elif isinstance(basis, geo_cu.Circle):
+        circ = gp_Circ(gp_Ax2(gp_Pnt(*basis.position.location), gp_Dir(*basis.position.axis)), float(basis.radius))
+        arc = GC_MakeArcOfCircle(circ, point3d(p1), point3d(p2), bool(tc.sense_agreement)).Value()
+        edge = BRepBuilderAPI_MakeEdge(arc).Edge()
+    else:
+        raise NotImplementedError(f"TrimmedCurve OCC build not implemented for basis {type(basis)}")
+
+    wire = BRepBuilderAPI_MakeWire()
+    wire.Add(edge)
+    wire.Build()
+    return wire.Wire()
+
+
 def make_wire_from_edge_loop(edge_loop: geo_cu.EdgeLoop) -> TopoDS_Wire:
     from ada.config import logger
 
@@ -446,6 +474,8 @@ def make_wire_from_curve(outer_curve: geo_cu.CURVE_GEOM_TYPES):
         return make_wire_from_circle(outer_curve)
     elif isinstance(outer_curve, geo_cu.Edge):
         return segments_to_wire([outer_curve])
+    elif isinstance(outer_curve, geo_cu.TrimmedCurve):
+        return make_wire_from_trimmed_curve(outer_curve)
     else:
         raise NotImplementedError(f"Unsupported curve type {type(outer_curve)}")
 

--- a/src/ada/occ/geom/solids.py
+++ b/src/ada/occ/geom/solids.py
@@ -100,6 +100,47 @@ def make_revolved_area_shape_from_geom(ras: geo_so.RevolvedAreaSolid) -> TopoDS_
     return ras_shape
 
 
+def make_swept_disk_solid_from_geom(sds: geo_so.SweptDiskSolid) -> TopoDS_Shape | TopoDS_Solid:
+    """Sweep a circular (or annular) disk along the directrix — the pipe/rod primitive.
+
+    The disk profile is placed at the spine start, normal to the start tangent; PipeShell
+    keeps it perpendicular along the spine. An inner radius is swept the same way and cut out
+    to leave a tube."""
+    from OCC.Core.BRep import BRep_Tool
+    from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
+    from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire
+    from OCC.Core.BRepTools import BRepTools_WireExplorer
+    from OCC.Core.gp import gp_Ax2, gp_Circ, gp_Dir, gp_Pnt, gp_Vec
+
+    spine = make_wire_from_curve(sds.directrix)
+
+    # Start point + tangent of the spine (a circle is rotationally symmetric, so the
+    # tangent's sign is irrelevant — only the plane it defines matters).
+    first_edge = BRepTools_WireExplorer(spine).Current()
+    curve, f0, _ = BRep_Tool.Curve(first_edge)
+    p0 = gp_Pnt()
+    d0 = gp_Vec()
+    curve.D1(f0, p0, d0)
+    disk_axis = gp_Ax2(p0, gp_Dir(d0))
+
+    def _disk_wire(r: float):
+        edge = BRepBuilderAPI_MakeEdge(gp_Circ(disk_axis, r)).Edge()
+        return BRepBuilderAPI_MakeWire(edge).Wire()
+
+    def _sweep(profile_wire):
+        pipe_builder = BRepOffsetAPI_MakePipeShell(spine)
+        pipe_builder.SetTransitionMode(BRepBuilderAPI_RoundCorner)
+        pipe_builder.Add(profile_wire, True, False)
+        pipe_builder.Build()
+        pipe_builder.MakeSolid()
+        return pipe_builder.Shape()
+
+    solid = _sweep(_disk_wire(sds.radius))
+    if sds.inner_radius:
+        solid = BRepAlgoAPI_Cut(solid, _sweep(_disk_wire(sds.inner_radius))).Shape()
+    return solid
+
+
 def make_fixed_reference_swept_area_shape_from_geom(frs: geo_so.FixedReferenceSweptAreaSolid) -> TopoDS_Solid:
     spine = make_wire_from_curve(frs.directrix)
 

--- a/src/ada/occ/geom/solids.py
+++ b/src/ada/occ/geom/solids.py
@@ -100,6 +100,21 @@ def make_revolved_area_shape_from_geom(ras: geo_so.RevolvedAreaSolid) -> TopoDS_
     return ras_shape
 
 
+def make_faceted_brep_from_geom(brep: geo_so.FacetedBrep) -> TopoDS_Shape | TopoDS_Solid:
+    """Build a faceted B-rep: the outer closed shell becomes a solid, and each inner void shell
+    is made solid and cut out."""
+    from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
+    from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeSolid
+
+    from ada.occ.geom.surfaces import make_closed_shell_from_geom
+
+    solid = BRepBuilderAPI_MakeSolid(make_closed_shell_from_geom(brep.outer)).Solid()
+    for void in brep.voids:
+        void_solid = BRepBuilderAPI_MakeSolid(make_closed_shell_from_geom(void)).Solid()
+        solid = BRepAlgoAPI_Cut(solid, void_solid).Shape()
+    return solid
+
+
 def make_swept_disk_solid_from_geom(sds: geo_so.SweptDiskSolid) -> TopoDS_Shape | TopoDS_Solid:
     """Sweep a circular (or annular) disk along the directrix — the pipe/rod primitive.
 

--- a/src/ada/occ/geom/solids.py
+++ b/src/ada/occ/geom/solids.py
@@ -41,6 +41,33 @@ def make_sphere_from_geom(sphere: geo_so.Sphere) -> TopoDS_Shape:
     return occBrep.BRepPrimAPI_MakeSphere(gp_Pnt(*sphere.center), sphere.radius).Shape()
 
 
+def make_rectangular_pyramid_from_geom(rp: geo_so.RectangularPyramid) -> TopoDS_Shape:
+    """Build an IfcRectangularPyramid: a rectangular base in the local XY plane with the apex
+    centred above it at the given height. Built from its 4 triangular sides + base, sewn into a
+    solid, then placed."""
+    from OCC.Core.BRepBuilderAPI import (
+        BRepBuilderAPI_MakeFace,
+        BRepBuilderAPI_MakePolygon,
+        BRepBuilderAPI_MakeSolid,
+        BRepBuilderAPI_Sewing,
+    )
+
+    x, y, z = rp.x_length, rp.y_length, rp.z_length
+    base = [gp_Pnt(0, 0, 0), gp_Pnt(x, 0, 0), gp_Pnt(x, y, 0), gp_Pnt(0, y, 0)]
+    apex = gp_Pnt(x / 2.0, y / 2.0, z)
+
+    sewing = BRepBuilderAPI_Sewing(1e-7)
+    base_poly = BRepBuilderAPI_MakePolygon(base[0], base[1], base[2], base[3], True)
+    sewing.Add(BRepBuilderAPI_MakeFace(base_poly.Wire(), True).Face())
+    for i in range(4):
+        tri = BRepBuilderAPI_MakePolygon(base[i], base[(i + 1) % 4], apex, True)
+        sewing.Add(BRepBuilderAPI_MakeFace(tri.Wire(), True).Face())
+    sewing.Perform()
+
+    solid = BRepBuilderAPI_MakeSolid(sewing.SewedShape()).Solid()
+    return transform_shape_to_pos(solid, rp.position.location, rp.position.axis, rp.position.ref_direction)
+
+
 def make_cylinder_from_geom(cylinder: geo_so.Cylinder) -> TopoDS_Shape:
     axis = cylinder.position.axis
     vec = gp_Dir(0, 0, 1) if axis is None else gp_Dir(*axis)

--- a/src/ada/occ/geom/surfaces.py
+++ b/src/ada/occ/geom/surfaces.py
@@ -1360,6 +1360,21 @@ def make_conical_surface_from_geom(cone: geo_su.ConicalSurface) -> Geom_ConicalS
     return Geom_ConicalSurface(gp_Cone(ax3, cone.semi_angle, cone.radius))
 
 
+def make_surface_of_revolution_from_geom(sor: geo_su.SurfaceOfRevolution):
+    """Build a Geom_SurfaceOfRevolution by revolving the generatrix curve about the axis.
+    Currently supports a Line generatrix (the common cone/cylinder-from-revolution case)."""
+    from OCC.Core.Geom import Geom_Line, Geom_SurfaceOfRevolution
+    from OCC.Core.gp import gp_Ax1
+
+    gen = sor.swept_curve
+    if isinstance(gen, geo_cu.Line):
+        generatrix = Geom_Line(gp_Pnt(*gen.pnt), gp_Dir(*gen.dir))
+    else:
+        raise NotImplementedError(f"SurfaceOfRevolution generatrix {type(gen)} not implemented")
+    axis = gp_Ax1(gp_Pnt(*sor.axis_position.location), gp_Dir(*sor.axis_position.axis))
+    return Geom_SurfaceOfRevolution(generatrix, axis)
+
+
 def make_spherical_surface_from_geom(sphere: geo_su.SphericalSurface) -> Geom_SphericalSurface:
     location = sphere.position.location
     axis = sphere.position.axis
@@ -1422,6 +1437,8 @@ def make_surface_from_geom(face_surface):
         return make_spherical_surface_from_geom(face_surface)
     elif type(face_surface) is geo_su.ToroidalSurface:
         return make_toroidal_surface_from_geom(face_surface)
+    elif type(face_surface) is geo_su.SurfaceOfRevolution:
+        return make_surface_of_revolution_from_geom(face_surface)
     elif type(face_surface) in (geo_su.BSplineSurfaceWithKnots, geo_su.RationalBSplineSurfaceWithKnots):
         return make_bspline_surface_with_knots(face_surface)
     else:

--- a/src/ada/occ/geom/surfaces.py
+++ b/src/ada/occ/geom/surfaces.py
@@ -1485,6 +1485,21 @@ def _add_cfs_faces_to_shell(builder: BRep_Builder, occ_shell: TopoDS_Shell, cfs_
                 logger.warning("Skipping AdvancedFace (%s surface): %s", type(cfs_face.face_surface).__name__, ex)
                 continue
 
+        # Handle plain Face with PolyLoop bounds (faceted-brep polygons)
+        elif type(cfs_face) is geo_su.Face:
+            n_faces += 1
+            try:
+                outer = cfs_face.bounds[0].bound
+                if not isinstance(outer, PolyLoop):
+                    raise NotImplementedError(f"Only PolyLoop bounds supported for Face, not {type(outer)}")
+                face = make_face_from_poly_loop(outer)
+                builder.UpdateFace(face, 1e-6)
+                builder.Add(occ_shell, face)
+            except Exception as ex:
+                n_dropped += 1
+                logger.warning("Skipping Face (PolyLoop): %s", ex)
+                continue
+
         # Handle FaceSurface (legacy support)
         elif type(cfs_face) is geo_su.FaceSurface:
             n_faces += 1

--- a/src/ada/occ/geom/surfaces.py
+++ b/src/ada/occ/geom/surfaces.py
@@ -8,7 +8,9 @@ from OCC.Core.BRepBndLib import brepbndlib
 from OCC.Core.BRepBuilderAPI import (
     BRepBuilderAPI_MakeEdge,
     BRepBuilderAPI_MakeFace,
+    BRepBuilderAPI_MakePolygon,
     BRepBuilderAPI_MakeWire,
+    BRepBuilderAPI_Sewing,
 )
 from OCC.Core.BRepTools import BRepTools_WireExplorer, breptools
 from OCC.Core.Geom import (
@@ -1540,6 +1542,36 @@ def make_open_shell_from_geom(shell: geo_su.OpenShell) -> TopoDS_Shell:
     builder.MakeShell(occ_shell)
     _add_cfs_faces_to_shell(builder, occ_shell, shell.cfs_faces)
     return occ_shell
+
+
+def make_shell_from_polygonal_face_set_geom(pfs: geo_su.PolygonalFaceSet) -> TopoDS_Shape:
+    """Build an IfcPolygonalFaceSet — a shared point list plus n-gon faces — into a sewn
+    OCC shell. Each face is a planar polygon wire (1-based indices into the point list);
+    sewing stitches the per-face shells along shared edges so a closed set becomes a solidable
+    watertight shell."""
+    coords = pfs.coordinates
+    sewing = BRepBuilderAPI_Sewing(1e-6)
+    n_faces = 0
+    for face_idx in pfs.faces:
+        poly = BRepBuilderAPI_MakePolygon()
+        for i in face_idx:
+            poly.Add(point3d(coords[i - 1]))
+        poly.Close()
+        if not poly.IsDone():
+            logger.warning("PolygonalFaceSet: skipping face %s (could not build polygon wire)", face_idx)
+            continue
+        face_maker = BRepBuilderAPI_MakeFace(poly.Wire(), True)
+        if not face_maker.IsDone():
+            logger.warning("PolygonalFaceSet: skipping non-planar/degenerate face %s", face_idx)
+            continue
+        sewing.Add(face_maker.Face())
+        n_faces += 1
+
+    if n_faces == 0:
+        raise UnableToCreateTesselationFromSolidOCCGeom("PolygonalFaceSet produced no usable faces")
+
+    sewing.Perform()
+    return sewing.SewedShape()
 
 
 def make_shell_from_shell_based_surface_geom(sbsm: geo_su.ShellBasedSurfaceModel) -> TopoDS_Shape:

--- a/tests/comms/rest/test_worker_scope.py
+++ b/tests/comms/rest/test_worker_scope.py
@@ -1,0 +1,48 @@
+"""Regression tests for worker._scope_of — the job→Scope reconstruction.
+
+A corpus job previously fell through to Scope.shared(), so the worker fetched
+the source from shared/<key> and every corpus-scope conversion 404'd.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.comms.rest.queue import Job
+from ada.comms.rest.worker import _scope_of
+
+
+def _job(scope_kind: str, scope_id: str | None) -> Job:
+    return Job(
+        job_id="j",
+        source_key="src.ifc",
+        derived_key="d",
+        status="queued",
+        target_format="glb",
+        progress=0.0,
+        stage="queued",
+        created_at=0.0,
+        updated_at=0.0,
+        scope_kind=scope_kind,
+        scope_id=scope_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,sid,exp_kind,exp_prefix",
+    [
+        ("corpus", "basic", "corpus", "corpus/basic"),
+        ("user", "sub-7", "user", "users/sub-7"),
+        ("project", "p1", "project", "projects/p1"),
+        ("shared", None, "shared", "shared"),
+    ],
+)
+def test_scope_of_maps_each_kind(kind, sid, exp_kind, exp_prefix):
+    s = _scope_of(_job(kind, sid))
+    assert s.kind == exp_kind
+    assert s.prefix() == exp_prefix
+
+
+def test_scope_of_corpus_is_not_shared():
+    # The specific regression: corpus must not silently degrade to shared.
+    assert _scope_of(_job("corpus", "basic")).prefix() == "corpus/basic"

--- a/tests/core/geom/solids/test_csg_solid.py
+++ b/tests/core/geom/solids/test_csg_solid.py
@@ -1,0 +1,34 @@
+import ifcopenshell
+
+from ada.cadit.ifc.read.geom.geom_reader import import_geometry_from_ifc_geom
+from ada.geom import Geometry
+from ada.geom import solids as geo_so
+
+
+def _block(f, axis, x, y, z):
+    return f.create_entity("IfcBlock", axis, x, y, z)
+
+
+def _axis(f):
+    return f.create_entity("IfcAxis2Placement3D", f.create_entity("IfcCartesianPoint", (0.0, 0.0, 0.0)))
+
+
+def test_csg_solid_wrapping_primitive():
+    f = ifcopenshell.file(schema="IFC4")
+    csg = f.create_entity("IfcCsgSolid", _block(f, _axis(f), 1.0, 2.0, 3.0))
+
+    geom = import_geometry_from_ifc_geom(csg)
+    assert isinstance(geom, geo_so.Box)
+    assert (geom.x_length, geom.y_length, geom.z_length) == (1.0, 2.0, 3.0)
+
+
+def test_csg_solid_wrapping_boolean_result():
+    f = ifcopenshell.file(schema="IFC4")
+    axis = _axis(f)
+    cut = f.create_entity("IfcBooleanResult", "DIFFERENCE", _block(f, axis, 2.0, 2.0, 2.0), _block(f, axis, 1.0, 1.0, 1.0))
+    csg = f.create_entity("IfcCsgSolid", cut)
+
+    geom = import_geometry_from_ifc_geom(csg)
+    # A boolean tree reads back as a base Geometry carrying the cut as a bool operation.
+    assert isinstance(geom, Geometry)
+    assert len(geom.bool_operations) == 1

--- a/tests/core/geom/solids/test_csg_solid.py
+++ b/tests/core/geom/solids/test_csg_solid.py
@@ -25,7 +25,9 @@ def test_csg_solid_wrapping_primitive():
 def test_csg_solid_wrapping_boolean_result():
     f = ifcopenshell.file(schema="IFC4")
     axis = _axis(f)
-    cut = f.create_entity("IfcBooleanResult", "DIFFERENCE", _block(f, axis, 2.0, 2.0, 2.0), _block(f, axis, 1.0, 1.0, 1.0))
+    cut = f.create_entity(
+        "IfcBooleanResult", "DIFFERENCE", _block(f, axis, 2.0, 2.0, 2.0), _block(f, axis, 1.0, 1.0, 1.0)
+    )
     csg = f.create_entity("IfcCsgSolid", cut)
 
     geom = import_geometry_from_ifc_geom(csg)

--- a/tests/core/geom/solids/test_faceted_brep.py
+++ b/tests/core/geom/solids/test_faceted_brep.py
@@ -1,0 +1,91 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.solids import faceted_brep as read_faceted_brep
+from ada.cadit.ifc.write.geom.solids import faceted_brep as write_faceted_brep
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+from ada.geom.points import Point
+
+
+def _cube_shell(origin=(0.0, 0.0, 0.0), size=1.0) -> geo_su.ClosedShell:
+    ox, oy, oz = origin
+    s = size
+    p = [
+        Point(ox, oy, oz),
+        Point(ox + s, oy, oz),
+        Point(ox + s, oy + s, oz),
+        Point(ox, oy + s, oz),
+        Point(ox, oy, oz + s),
+        Point(ox + s, oy, oz + s),
+        Point(ox + s, oy + s, oz + s),
+        Point(ox, oy + s, oz + s),
+    ]
+    quads = [
+        [0, 1, 2, 3],  # bottom
+        [4, 5, 6, 7],  # top
+        [0, 1, 5, 4],  # front
+        [1, 2, 6, 5],  # right
+        [2, 3, 7, 6],  # back
+        [3, 0, 4, 7],  # left
+    ]
+    faces = [
+        geo_su.Face(bounds=[geo_su.FaceBound(bound=geo_cu.PolyLoop(polygon=[p[i] for i in quad]), orientation=True)])
+        for quad in quads
+    ]
+    return geo_su.ClosedShell(cfs_faces=faces)
+
+
+def test_faceted_brep_occ_build():
+    from ada.geom import solids as geo_so
+
+    fb = geo_so.FacetedBrep(outer=_cube_shell())
+    occ_shape = active_backend().build(Geometry("fb", fb))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")
+
+
+def test_faceted_brep_ifc_roundtrip():
+    from ada.geom import solids as geo_so
+
+    fb = geo_so.FacetedBrep(outer=_cube_shell())
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_fb = write_faceted_brep(fb, f)
+
+    assert ifc_fb.is_a("IfcFacetedBrep")
+    assert ifc_fb.Outer.is_a("IfcClosedShell")
+    assert len(ifc_fb.Outer.CfsFaces) == 6
+    # Each face is a plain IfcFace with an IfcPolyLoop bound of 4 points.
+    first_face = ifc_fb.Outer.CfsFaces[0]
+    assert first_face.is_a("IfcFace")
+    assert first_face.Bounds[0].Bound.is_a("IfcPolyLoop")
+    assert len(first_face.Bounds[0].Bound.Polygon) == 4
+
+    read_back = read_faceted_brep(ifc_fb)
+    assert isinstance(read_back, geo_so.FacetedBrep)
+    assert len(read_back.outer.cfs_faces) == 6
+    assert isinstance(read_back.outer.cfs_faces[0].bounds[0].bound, geo_cu.PolyLoop)
+    assert read_back.voids == []
+
+
+def test_faceted_brep_with_voids_roundtrip():
+    from ada.geom import solids as geo_so
+
+    # Outer 2.0 cube with an inner 1.0 void -> IfcFacetedBrepWithVoids (a hollow block).
+    fb = geo_so.FacetedBrep(
+        outer=_cube_shell(size=2.0),
+        voids=[_cube_shell(origin=(0.5, 0.5, 0.5), size=1.0)],
+    )
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_fb = write_faceted_brep(fb, f)
+    assert ifc_fb.is_a("IfcFacetedBrepWithVoids")
+    assert len(ifc_fb.Voids) == 1
+
+    read_back = read_faceted_brep(ifc_fb)
+    assert len(read_back.voids) == 1
+    assert len(read_back.voids[0].cfs_faces) == 6
+
+    occ_shape = active_backend().build(Geometry("hollow", fb))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")

--- a/tests/core/geom/solids/test_rectangular_pyramid.py
+++ b/tests/core/geom/solids/test_rectangular_pyramid.py
@@ -1,0 +1,35 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.solids import ifc_rectangular_pyramid
+from ada.cadit.ifc.write.geom.solids import rectangular_pyramid as write_rectangular_pyramid
+from ada.geom import Geometry
+from ada.geom import solids as geo_so
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+
+
+def _pyramid() -> geo_so.RectangularPyramid:
+    pos = Axis2Placement3D(Point(0, 0, 0), Direction(0, 0, 1), Direction(1, 0, 0))
+    return geo_so.RectangularPyramid(position=pos, x_length=2.0, y_length=3.0, z_length=4.0)
+
+
+def test_rectangular_pyramid_occ_build():
+    occ_shape = active_backend().build(Geometry("pyr", _pyramid()))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")
+
+
+def test_rectangular_pyramid_ifc_roundtrip():
+    rp = _pyramid()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_rp = write_rectangular_pyramid(rp, f)
+
+    assert ifc_rp.is_a("IfcRectangularPyramid")
+    assert ifc_rp.XLength == 2.0
+    assert ifc_rp.YLength == 3.0
+    assert ifc_rp.Height == 4.0
+
+    back = ifc_rectangular_pyramid(ifc_rp)
+    assert isinstance(back, geo_so.RectangularPyramid)
+    assert (back.x_length, back.y_length, back.z_length) == (2.0, 3.0, 4.0)

--- a/tests/core/geom/solids/test_rectangular_pyramid.py
+++ b/tests/core/geom/solids/test_rectangular_pyramid.py
@@ -2,7 +2,9 @@ import ifcopenshell
 
 from ada.cad import active_backend
 from ada.cadit.ifc.read.geom.solids import ifc_rectangular_pyramid
-from ada.cadit.ifc.write.geom.solids import rectangular_pyramid as write_rectangular_pyramid
+from ada.cadit.ifc.write.geom.solids import (
+    rectangular_pyramid as write_rectangular_pyramid,
+)
 from ada.geom import Geometry
 from ada.geom import solids as geo_so
 from ada.geom.direction import Direction

--- a/tests/core/geom/solids/test_sweep_read_roundtrip.py
+++ b/tests/core/geom/solids/test_sweep_read_roundtrip.py
@@ -1,0 +1,54 @@
+import ifcopenshell
+
+import ada
+from ada.cadit.ifc.read.geom.geom_reader import import_geometry_from_ifc_geom
+from ada.cadit.ifc.read.geom.solids import (
+    extruded_solid_area_tapered,
+    fixed_reference_swept_area_solid,
+)
+from ada.cadit.ifc.write.geom.solids import (
+    extruded_area_solid_tapered,
+    fixed_reference_swept_area_solid as write_frs,
+)
+from ada.geom import curves as geo_cu
+from ada.geom import solids as geo_so
+from ada.geom import surfaces as geo_su
+
+
+def test_extruded_area_solid_tapered_roundtrip():
+    bm = ada.BeamTapered("b", (0, 0, 0), (0, 0, 1), "IPE400", "IPE300")
+    geo = bm.solid_geom().geometry
+    assert isinstance(geo, geo_so.ExtrudedAreaSolidTapered)
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_tap = extruded_area_solid_tapered(geo, f)
+    assert ifc_tap.is_a("IfcExtrudedAreaSolidTapered")
+
+    back = extruded_solid_area_tapered(ifc_tap)
+    assert isinstance(back, geo_so.ExtrudedAreaSolidTapered)
+    assert isinstance(back.swept_area, geo_su.ArbitraryProfileDef)
+    assert isinstance(back.end_swept_area, geo_su.ArbitraryProfileDef)
+    assert back.depth == geo.depth
+
+    # The top-level dispatch must route Tapered to the tapered reader, not the base reader.
+    routed = import_geometry_from_ifc_geom(ifc_tap)
+    assert isinstance(routed, geo_so.ExtrudedAreaSolidTapered)
+
+
+def test_fixed_reference_swept_area_solid_roundtrip():
+    sweep = ada.PrimSweep("s", [(0, 0, 0), (0.5, 0, 0, 0.2), (0.8, 0.8, 1)], [(0, 0), (0.1, 0), (0.1, 0.1), (0, 0.1)])
+    geo = sweep.solid_geom().geometry
+    assert isinstance(geo, geo_so.FixedReferenceSweptAreaSolid)
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_frs = write_frs(geo, f)
+    assert ifc_frs.is_a("IfcFixedReferenceSweptAreaSolid")
+    assert ifc_frs.FixedReference is not None
+
+    back = fixed_reference_swept_area_solid(ifc_frs)
+    assert isinstance(back, geo_so.FixedReferenceSweptAreaSolid)
+    assert isinstance(back.swept_area, geo_su.ArbitraryProfileDef)
+    assert isinstance(back.directrix, geo_cu.IndexedPolyCurve)
+
+    routed = import_geometry_from_ifc_geom(ifc_frs)
+    assert isinstance(routed, geo_so.FixedReferenceSweptAreaSolid)

--- a/tests/core/geom/solids/test_sweep_read_roundtrip.py
+++ b/tests/core/geom/solids/test_sweep_read_roundtrip.py
@@ -6,8 +6,8 @@ from ada.cadit.ifc.read.geom.solids import (
     extruded_solid_area_tapered,
     fixed_reference_swept_area_solid,
 )
+from ada.cadit.ifc.write.geom.solids import extruded_area_solid_tapered
 from ada.cadit.ifc.write.geom.solids import (
-    extruded_area_solid_tapered,
     fixed_reference_swept_area_solid as write_frs,
 )
 from ada.geom import curves as geo_cu

--- a/tests/core/geom/solids/test_swept_disk_solid.py
+++ b/tests/core/geom/solids/test_swept_disk_solid.py
@@ -1,0 +1,49 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.solids import swept_disk_solid as read_swept_disk_solid
+from ada.cadit.ifc.write.geom.solids import swept_disk_solid as write_swept_disk_solid
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import solids as geo_so
+from ada.geom.points import Point
+
+
+def _directrix() -> geo_cu.IndexedPolyCurve:
+    # An L-shaped polyline directrix (exercises the bend transition handling).
+    return geo_cu.IndexedPolyCurve(
+        segments=[
+            geo_cu.Edge(Point(0, 0, 0), Point(0, 0, 1)),
+            geo_cu.Edge(Point(0, 0, 1), Point(0, 1, 1)),
+        ]
+    )
+
+
+def test_swept_disk_solid_occ_build():
+    sds = geo_so.SweptDiskSolid(directrix=_directrix(), radius=0.05)
+    occ_shape = active_backend().build(Geometry("sds", sds))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")
+
+
+def test_swept_disk_solid_annular_occ_build():
+    sds = geo_so.SweptDiskSolid(directrix=_directrix(), radius=0.05, inner_radius=0.03)
+    occ_shape = active_backend().build(Geometry("sds", sds))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")
+
+
+def test_swept_disk_solid_ifc_roundtrip():
+    sds = geo_so.SweptDiskSolid(directrix=_directrix(), radius=0.05, inner_radius=0.03)
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_sds = write_swept_disk_solid(sds, f)
+
+    assert ifc_sds.is_a("IfcSweptDiskSolid")
+    assert ifc_sds.Radius == 0.05
+    assert ifc_sds.InnerRadius == 0.03
+    assert ifc_sds.Directrix.is_a("IfcIndexedPolyCurve")
+
+    read_back = read_swept_disk_solid(ifc_sds)
+    assert isinstance(read_back, geo_so.SweptDiskSolid)
+    assert read_back.radius == 0.05
+    assert read_back.inner_radius == 0.03
+    assert isinstance(read_back.directrix, geo_cu.IndexedPolyCurve)

--- a/tests/core/geom/test_composite_curve.py
+++ b/tests/core/geom/test_composite_curve.py
@@ -1,0 +1,54 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.curves import composite_curve as read_composite_curve
+from ada.cadit.ifc.write.geom.curves import composite_curve as write_composite_curve
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import solids as geo_so
+from ada.geom.direction import Direction
+from ada.geom.points import Point
+
+
+def _composite() -> geo_cu.CompositeCurve:
+    # Two trimmed-line segments forming an L (parent curves must be bounded).
+    seg1 = geo_cu.TrimmedCurve(
+        basis_curve=geo_cu.Line(pnt=Point(0, 0, 0), dir=Direction(0, 0, 1)),
+        trim1=Point(0, 0, 0),
+        trim2=Point(0, 0, 1),
+        master_representation="CARTESIAN",
+    )
+    seg2 = geo_cu.TrimmedCurve(
+        basis_curve=geo_cu.Line(pnt=Point(0, 0, 1), dir=Direction(0, 1, 0)),
+        trim1=Point(0, 0, 1),
+        trim2=Point(0, 1, 1),
+        master_representation="CARTESIAN",
+    )
+    return geo_cu.CompositeCurve(
+        segments=[
+            geo_cu.CompositeCurveSegment(parent_curve=seg1),
+            geo_cu.CompositeCurveSegment(parent_curve=seg2),
+        ]
+    )
+
+
+def test_composite_curve_ifc_roundtrip():
+    cc = _composite()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_cc = write_composite_curve(cc, f)
+
+    assert ifc_cc.is_a("IfcCompositeCurve")
+    assert len(ifc_cc.Segments) == 2
+    assert ifc_cc.Segments[0].ParentCurve.is_a("IfcTrimmedCurve")
+
+    back = read_composite_curve(ifc_cc)
+    assert isinstance(back, geo_cu.CompositeCurve)
+    assert len(back.segments) == 2
+    assert isinstance(back.segments[0].parent_curve, geo_cu.TrimmedCurve)
+
+
+def test_composite_curve_occ_build_via_backend():
+    # Sweep a disk along the composite directrix (routes wire build through the backend).
+    sds = geo_so.SweptDiskSolid(directrix=_composite(), radius=0.05)
+    occ_shape = active_backend().build(Geometry("cc", sds))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")

--- a/tests/core/geom/test_curve_bounded_plane.py
+++ b/tests/core/geom/test_curve_bounded_plane.py
@@ -1,0 +1,49 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.surfaces import curve_bounded_plane as read_cbp
+from ada.cadit.ifc.write.geom.surfaces import curve_bounded_plane as write_cbp
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+
+
+def _square_curve() -> geo_cu.IndexedPolyCurve:
+    return geo_cu.IndexedPolyCurve(
+        segments=[
+            geo_cu.Edge(Point(0, 0, 0), Point(1, 0, 0)),
+            geo_cu.Edge(Point(1, 0, 0), Point(1, 1, 0)),
+            geo_cu.Edge(Point(1, 1, 0), Point(0, 1, 0)),
+            geo_cu.Edge(Point(0, 1, 0), Point(0, 0, 0)),
+        ]
+    )
+
+
+def _cbp() -> geo_su.CurveBoundedPlane:
+    plane = geo_su.Plane(position=Axis2Placement3D(Point(0, 0, 0), Direction(0, 0, 1), Direction(1, 0, 0)))
+    return geo_su.CurveBoundedPlane(basis_surface=plane, outer_boundary=_square_curve(), inner_boundaries=[])
+
+
+def test_curve_bounded_plane_occ_build():
+    occ_shape = active_backend().build(Geometry("cbp", _cbp()))
+    assert active_backend().shape_type(occ_shape) in ("face", "shell", "compound")
+
+
+def test_curve_bounded_plane_ifc_roundtrip():
+    cbp = _cbp()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_cbp = write_cbp(cbp, f)
+
+    assert ifc_cbp.is_a("IfcCurveBoundedPlane")
+    # OuterBoundary must be an IfcCurve, not a topological IfcEdgeLoop (the previous bug).
+    assert ifc_cbp.OuterBoundary.is_a("IfcCurve")
+    assert ifc_cbp.OuterBoundary.is_a("IfcIndexedPolyCurve")
+    assert ifc_cbp.BasisSurface.is_a("IfcPlane")
+
+    back = read_cbp(ifc_cbp)
+    assert isinstance(back, geo_su.CurveBoundedPlane)
+    assert isinstance(back.outer_boundary, geo_cu.IndexedPolyCurve)
+    assert back.inner_boundaries == []

--- a/tests/core/geom/test_elementary_surfaces.py
+++ b/tests/core/geom/test_elementary_surfaces.py
@@ -1,10 +1,8 @@
 import ifcopenshell
 
-from ada.cadit.ifc.read.geom.surfaces import (
-    cylindrical_surface as read_cyl,
-    spherical_surface as read_sph,
-    toroidal_surface as read_tor,
-)
+from ada.cadit.ifc.read.geom.surfaces import cylindrical_surface as read_cyl
+from ada.cadit.ifc.read.geom.surfaces import spherical_surface as read_sph
+from ada.cadit.ifc.read.geom.surfaces import toroidal_surface as read_tor
 from ada.cadit.ifc.write.geom.surfaces import (
     create_cylindrical_surface,
     create_spherical_surface,

--- a/tests/core/geom/test_elementary_surfaces.py
+++ b/tests/core/geom/test_elementary_surfaces.py
@@ -1,0 +1,49 @@
+import ifcopenshell
+
+from ada.cadit.ifc.read.geom.surfaces import (
+    cylindrical_surface as read_cyl,
+    spherical_surface as read_sph,
+    toroidal_surface as read_tor,
+)
+from ada.cadit.ifc.write.geom.surfaces import (
+    create_cylindrical_surface,
+    create_spherical_surface,
+    create_toroidal_surface,
+)
+from ada.geom import surfaces as geo_su
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+
+
+def _pos() -> Axis2Placement3D:
+    return Axis2Placement3D(Point(1, 2, 3), Direction(0, 0, 1), Direction(1, 0, 0))
+
+
+def test_cylindrical_surface_roundtrip():
+    cs = geo_su.CylindricalSurface(position=_pos(), radius=0.75)
+    f = ifcopenshell.file(schema="IFC4")
+    ifc = create_cylindrical_surface(cs, f)
+    assert ifc.is_a("IfcCylindricalSurface")
+    back = read_cyl(ifc)
+    assert isinstance(back, geo_su.CylindricalSurface)
+    assert back.radius == 0.75
+    assert back.position.location.is_equal(Point(1, 2, 3))
+
+
+def test_spherical_surface_roundtrip():
+    ss = geo_su.SphericalSurface(position=_pos(), radius=1.25)
+    f = ifcopenshell.file(schema="IFC4")
+    back = read_sph(create_spherical_surface(ss, f))
+    assert isinstance(back, geo_su.SphericalSurface)
+    assert back.radius == 1.25
+
+
+def test_toroidal_surface_roundtrip():
+    ts = geo_su.ToroidalSurface(position=_pos(), major_radius=2.0, minor_radius=0.4)
+    f = ifcopenshell.file(schema="IFC4")
+    ifc = create_toroidal_surface(ts, f)
+    assert ifc.is_a("IfcToroidalSurface")
+    back = read_tor(ifc)
+    assert isinstance(back, geo_su.ToroidalSurface)
+    assert (back.major_radius, back.minor_radius) == (2.0, 0.4)

--- a/tests/core/geom/test_polygonal_face_set.py
+++ b/tests/core/geom/test_polygonal_face_set.py
@@ -1,0 +1,58 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.surfaces import polygonal_face_set as read_polygonal_face_set
+from ada.cadit.ifc.write.geom.surfaces import polygonal_face_set as write_polygonal_face_set
+from ada.geom import Geometry
+from ada.geom import surfaces as geo_su
+from ada.geom.points import Point
+
+
+def _unit_cube_pfs() -> geo_su.PolygonalFaceSet:
+    """A unit cube as a polygonal face set: 8 corners, 6 quad faces (1-based indices)."""
+    coordinates = [
+        Point(0, 0, 0),
+        Point(1, 0, 0),
+        Point(1, 1, 0),
+        Point(0, 1, 0),
+        Point(0, 0, 1),
+        Point(1, 0, 1),
+        Point(1, 1, 1),
+        Point(0, 1, 1),
+    ]
+    faces = [
+        [1, 2, 3, 4],  # bottom
+        [5, 6, 7, 8],  # top
+        [1, 2, 6, 5],  # front
+        [2, 3, 7, 6],  # right
+        [3, 4, 8, 7],  # back
+        [4, 1, 5, 8],  # left
+    ]
+    return geo_su.PolygonalFaceSet(coordinates=coordinates, faces=faces, closed=True)
+
+
+def test_polygonal_face_set_occ_build():
+    pfs = _unit_cube_pfs()
+    occ_shape = active_backend().build(Geometry("pfs", pfs))
+    # A sewn closed n-gon set comes back as a shell (or compound of shells).
+    assert active_backend().shape_type(occ_shape) in ("shell", "solid", "compound")
+
+
+def test_polygonal_face_set_ifc_roundtrip():
+    pfs = _unit_cube_pfs()
+
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_pfs = write_polygonal_face_set(pfs, f)
+
+    assert ifc_pfs.is_a("IfcPolygonalFaceSet")
+    assert ifc_pfs.Closed is True
+    assert len(ifc_pfs.Faces) == 6
+    assert len(ifc_pfs.Coordinates.CoordList) == 8
+
+    read_back = read_polygonal_face_set(ifc_pfs)
+    assert isinstance(read_back, geo_su.PolygonalFaceSet)
+    assert len(read_back.coordinates) == 8
+    assert read_back.faces == pfs.faces
+    assert read_back.closed is True
+    # First coordinate survives the round-trip.
+    assert read_back.coordinates[0].is_equal(pfs.coordinates[0])

--- a/tests/core/geom/test_polygonal_face_set.py
+++ b/tests/core/geom/test_polygonal_face_set.py
@@ -1,8 +1,12 @@
 import ifcopenshell
 
 from ada.cad import active_backend
-from ada.cadit.ifc.read.geom.surfaces import polygonal_face_set as read_polygonal_face_set
-from ada.cadit.ifc.write.geom.surfaces import polygonal_face_set as write_polygonal_face_set
+from ada.cadit.ifc.read.geom.surfaces import (
+    polygonal_face_set as read_polygonal_face_set,
+)
+from ada.cadit.ifc.write.geom.surfaces import (
+    polygonal_face_set as write_polygonal_face_set,
+)
 from ada.geom import Geometry
 from ada.geom import surfaces as geo_su
 from ada.geom.points import Point

--- a/tests/core/geom/test_rational_bspline_surface.py
+++ b/tests/core/geom/test_rational_bspline_surface.py
@@ -1,0 +1,61 @@
+import ifcopenshell
+
+from ada.cadit.ifc.read.geom.surfaces import bspline_surface_with_knots as read_bspline
+from ada.cadit.ifc.write.geom.surfaces import bspline_surface_with_knots as write_bspline
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+from ada.geom.points import Point
+
+
+def _rational_surface() -> geo_su.RationalBSplineSurfaceWithKnots:
+    # Minimal bilinear (degree 1x1) 2x2 patch with non-uniform weights.
+    cps = [[Point(0, 0, 0), Point(0, 1, 0)], [Point(1, 0, 0), Point(1, 1, 1)]]
+    return geo_su.RationalBSplineSurfaceWithKnots(
+        u_degree=1,
+        v_degree=1,
+        control_points_list=cps,
+        surface_form=geo_su.BSplineSurfaceForm.UNSPECIFIED,
+        u_closed=False,
+        v_closed=False,
+        self_intersect=False,
+        u_multiplicities=[2, 2],
+        v_multiplicities=[2, 2],
+        u_knots=[0.0, 1.0],
+        v_knots=[0.0, 1.0],
+        knot_spec=geo_cu.KnotType.UNSPECIFIED,
+        weights_data=[[1.0, 0.5], [0.5, 2.0]],
+    )
+
+
+def test_rational_bspline_surface_preserves_weights():
+    surf = _rational_surface()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_surf = write_bspline(surf, f)
+    assert ifc_surf.is_a("IfcRationalBSplineSurfaceWithKnots")
+
+    back = read_bspline(ifc_surf)
+    # Previously the reader downcast this to a non-rational surface, dropping the weights.
+    assert isinstance(back, geo_su.RationalBSplineSurfaceWithKnots)
+    assert back.weights_data == [[1.0, 0.5], [0.5, 2.0]]
+
+
+def test_non_rational_bspline_surface_stays_non_rational():
+    surf = _rational_surface()
+    plain = geo_su.BSplineSurfaceWithKnots(
+        u_degree=surf.u_degree,
+        v_degree=surf.v_degree,
+        control_points_list=surf.control_points_list,
+        surface_form=surf.surface_form,
+        u_closed=surf.u_closed,
+        v_closed=surf.v_closed,
+        self_intersect=surf.self_intersect,
+        u_multiplicities=surf.u_multiplicities,
+        v_multiplicities=surf.v_multiplicities,
+        u_knots=surf.u_knots,
+        v_knots=surf.v_knots,
+        knot_spec=surf.knot_spec,
+    )
+    f = ifcopenshell.file(schema="IFC4")
+    back = read_bspline(write_bspline(plain, f))
+    assert isinstance(back, geo_su.BSplineSurfaceWithKnots)
+    assert not isinstance(back, geo_su.RationalBSplineSurfaceWithKnots)

--- a/tests/core/geom/test_rational_bspline_surface.py
+++ b/tests/core/geom/test_rational_bspline_surface.py
@@ -1,7 +1,9 @@
 import ifcopenshell
 
 from ada.cadit.ifc.read.geom.surfaces import bspline_surface_with_knots as read_bspline
-from ada.cadit.ifc.write.geom.surfaces import bspline_surface_with_knots as write_bspline
+from ada.cadit.ifc.write.geom.surfaces import (
+    bspline_surface_with_knots as write_bspline,
+)
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 from ada.geom.points import Point

--- a/tests/core/geom/test_surface_of_revolution.py
+++ b/tests/core/geom/test_surface_of_revolution.py
@@ -1,0 +1,35 @@
+import ifcopenshell
+
+from ada.cadit.ifc.read.geom.surfaces import surface_of_revolution as read_sor
+from ada.cadit.ifc.write.geom.surfaces import create_surface_of_revolution as write_sor
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis1Placement
+from ada.geom.points import Point
+
+
+def _sor() -> geo_su.SurfaceOfRevolution:
+    # A slanted line generatrix revolved about Z -> a cone-like surface of revolution.
+    gen = geo_cu.Line(pnt=Point(1, 0, 0), dir=Direction(1, 0, 1))
+    return geo_su.SurfaceOfRevolution(
+        swept_curve=gen,
+        axis_position=Axis1Placement(location=Point(0, 0, 0), axis=Direction(0, 0, 1)),
+    )
+
+
+def test_surface_of_revolution_roundtrip():
+    sor = _sor()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_sor = write_sor(sor, f)
+
+    assert ifc_sor.is_a("IfcSurfaceOfRevolution")
+    # Generatrix is wrapped in an open profile per the IFC SweptCurve type.
+    assert ifc_sor.SweptCurve.is_a("IfcArbitraryOpenProfileDef")
+    assert ifc_sor.SweptCurve.Curve.is_a("IfcLine")
+    assert ifc_sor.AxisPosition.is_a("IfcAxis1Placement")
+
+    back = read_sor(ifc_sor)
+    assert isinstance(back, geo_su.SurfaceOfRevolution)
+    assert isinstance(back.swept_curve, geo_cu.Line)
+    assert back.axis_position.axis.is_equal(Direction(0, 0, 1))

--- a/tests/core/geom/test_trimmed_curve.py
+++ b/tests/core/geom/test_trimmed_curve.py
@@ -1,0 +1,76 @@
+import ifcopenshell
+
+from ada.cad import active_backend
+from ada.cadit.ifc.read.geom.curves import trimmed_curve as read_trimmed_curve
+from ada.cadit.ifc.write.geom.curves import create_trimmed_curve as write_trimmed_curve
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import solids as geo_so
+from ada.geom.direction import Direction
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+
+
+def _line_segment() -> geo_cu.TrimmedCurve:
+    return geo_cu.TrimmedCurve(
+        basis_curve=geo_cu.Line(pnt=Point(0, 0, 0), dir=Direction(0, 0, 1)),
+        trim1=Point(0, 0, 0),
+        trim2=Point(0, 0, 1),
+        master_representation="CARTESIAN",
+    )
+
+
+def _circle_arc() -> geo_cu.TrimmedCurve:
+    circle = geo_cu.Circle(
+        position=Axis2Placement3D(Point(0, 0, 0), Direction(0, 0, 1), Direction(1, 0, 0)),
+        radius=1.0,
+    )
+    return geo_cu.TrimmedCurve(
+        basis_curve=circle,
+        trim1=Point(1, 0, 0),
+        trim2=Point(0, 1, 0),
+        master_representation="CARTESIAN",
+    )
+
+
+def test_trimmed_line_ifc_roundtrip():
+    tc = _line_segment()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_tc = write_trimmed_curve(tc, f)
+
+    assert ifc_tc.is_a("IfcTrimmedCurve")
+    assert ifc_tc.BasisCurve.is_a("IfcLine")
+
+    read_back = read_trimmed_curve(ifc_tc)
+    assert isinstance(read_back, geo_cu.TrimmedCurve)
+    assert isinstance(read_back.basis_curve, geo_cu.Line)
+    assert read_back.trim1.is_equal(Point(0, 0, 0))
+    assert read_back.trim2.is_equal(Point(0, 0, 1))
+
+
+def test_trimmed_circle_ifc_roundtrip():
+    tc = _circle_arc()
+    f = ifcopenshell.file(schema="IFC4")
+    ifc_tc = write_trimmed_curve(tc, f)
+
+    assert ifc_tc.BasisCurve.is_a("IfcCircle")
+
+    read_back = read_trimmed_curve(ifc_tc)
+    assert isinstance(read_back.basis_curve, geo_cu.Circle)
+    assert read_back.basis_curve.radius == 1.0
+    assert read_back.trim1.is_equal(Point(1, 0, 0))
+
+
+def test_trimmed_line_occ_build_via_backend():
+    # Route the TrimmedCurve->wire build through active_backend().build() by using it as a
+    # SweptDiskSolid directrix (a straight segment swept by a disk -> a cylinder).
+    sds = geo_so.SweptDiskSolid(directrix=_line_segment(), radius=0.1)
+    occ_shape = active_backend().build(Geometry("tc_line", sds))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")
+
+
+def test_trimmed_circle_arc_occ_build_via_backend():
+    # A quarter-circle arc directrix swept by a disk -> a quarter torus.
+    sds = geo_so.SweptDiskSolid(directrix=_circle_arc(), radius=0.1)
+    occ_shape = active_backend().build(Geometry("tc_arc", sds))
+    assert active_backend().shape_type(occ_shape) in ("solid", "shell", "compound")


### PR DESCRIPTION
Implements **Tiers 1–3** of the #47 IFC geometry-primitive audit (targeting IFC4 / IFC4x3).

Refreshes the stale #47 checklist with a full audit of `ada.geom` vs the authoritative IFC4 / IFC4x3 (`IFC4X3_ADD2`) schema, then closes the gaps in priority order. Each change is a complete vertical slice: backend-neutral geom dataclass → geom-level IFC write → IFC read + dispatch → OCC build routed through `active_backend().build()` → round-trip test.

## Tier 1 — common primitives that had no class
- **IfcPolygonalFaceSet** — compact n-gon tessellation.
- **IfcSweptDiskSolid** (+Polygonal) — disk swept along a directrix (pipes/rods).
- **IfcTrimmedCurve** — bounded line/circle/ellipse; also adds bare `IfcLine`/`IfcCircle`/`IfcEllipse` read dispatch.
- **IfcFacetedBrep** / **IfcFacetedBrepWithVoids** — planar-polygon manifold B-rep; wires the plain `Face`/`PolyLoop` path across all layers.

## Tier 2 — close read/write asymmetries & fix bugs
- **read** for `IfcExtrudedAreaSolidTapered` (fixes dispatch order — base reader swallowed tapers) and `IfcFixedReferenceSweptAreaSolid`.
- **IfcRectangularPyramid** — write + read + OCC build (was class-only).
- **fix**: `IfcRationalBSplineSurfaceWithKnots` read preserves weights; `advanced_face` read dispatches all surface types.
- **R/W** for `IfcCylindricalSurface` / `IfcSphericalSurface` / `IfcToroidalSurface`.
- **fix**: `IfcCurveBoundedPlane` write emitted an invalid `IfcEdgeLoop` (and raised on real inputs) — now emits an `IfcCurve`; read added.
- `ConicalSurface` resolved — no `IfcConicalSurface` exists; docstring corrected, kept for STEP/SAT.

## Tier 3 — broader coverage
- **IfcCompositeCurve** — ordered bounded parent-curve segments; new general `write_curve()` dispatch.
- **IfcCsgSolid** — read-through to the CSG tree root (primitive or boolean result).
- **IfcSurfaceOfRevolution** — generatrix revolved about an axis; the IFC target for revolution/conical surfaces.

Remaining niche items (offset/surface-associated curves, rectangular-trimmed/curve-bounded surfaces, tapered revolve, boxed half-space, advanced-brep-with-voids) and the IFC4x3 alignment family are documented as deferred in #47 with rationale.

## Backend routing
All new geom classes and IFC code are backend-neutral; OCC builders live in the OCC backend and are reached only via `active_backend().build()`. `AdacppBackend.build` raises `NotImplementedError` for unported types by design.

## Tests
Every slice has a round-trip test. geom + IFC + SAT + STEP + plate/loft API suites all pass (223 passed, 1 skipped on the touched areas) with no regressions.

See #47 for the full ✅/◑/❌ coverage matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)