### PR TITLE
feat: round-trip all Part primitives to/from IFC (#16)

### DIFF
--- a/src/ada/api/fasteners.py
+++ b/src/ada/api/fasteners.py
@@ -231,6 +231,7 @@ class Weld(BackendGeom):
         self._p2 = p2_node
         self._members = members_tuple
         self._weld_type = weld_type
+        self._profile = profile
         self._throat = throat
         self._leg1 = leg1
         self._leg2 = leg2
@@ -256,6 +257,14 @@ class Weld(BackendGeom):
     @property
     def members(self) -> tuple[BackendGeom, ...]:
         return self._members
+
+    @property
+    def profile(self):
+        return self._profile
+
+    @property
+    def xdir(self):
+        return self._xdir
 
     def other_members(self, of: BackendGeom) -> list[BackendGeom]:
         return [m for m in self._members if m is not of]

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -828,6 +828,14 @@ class Part(BackendGeom):
                     if getattr(seg, prop) == value:
                         return seg
 
+            for wl in p.walls:
+                if getattr(wl, prop) == value:
+                    return wl
+
+            for ms in p.masses:
+                if getattr(ms, prop) == value:
+                    return ms
+
             for mat in p.materials:
                 if getattr(mat, prop) == value:
                     return mat

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -836,6 +836,10 @@ class Part(BackendGeom):
                 if getattr(ms, prop) == value:
                     return ms
 
+            for wld in p.welds:
+                if getattr(wld, prop) == value:
+                    return wld
+
             for mat in p.materials:
                 if getattr(mat, prop) == value:
                     return mat

--- a/src/ada/api/walls/base_walls.py
+++ b/src/ada/api/walls/base_walls.py
@@ -240,10 +240,6 @@ class Wall(BackendGeom):
             op_extrudes.append([p1.tolist(), p2.tolist(), p3.tolist(), p4.tolist(), p1.tolist()])
         return op_extrudes
 
-    @property
-    def metadata(self):
-        return self._metadata
-
     def shell_occ(self):
         poly = CurvePoly2d.from_3d_points(self.extrusion_area(), parent=self)
         return poly.entity()

--- a/src/ada/cadit/ifc/read/read_beams.py
+++ b/src/ada/cadit/ifc/read/read_beams.py
@@ -17,7 +17,6 @@ from .read_beam_section import import_section_from_ifc
 from .read_materials import read_material
 from .reader_utils import (
     get_associated_material,
-    get_axis_polyline_points_from_product,
     get_ifc_body,
     get_placement,
     get_point,

--- a/src/ada/cadit/ifc/read/read_beams.py
+++ b/src/ada/cadit/ifc/read/read_beams.py
@@ -17,6 +17,8 @@ from .read_beam_section import import_section_from_ifc
 from .read_materials import read_material
 from .reader_utils import (
     get_associated_material,
+    get_axis_polyline_points_from_product,
+    get_ifc_body,
     get_placement,
     get_point,
     get_swept_area,
@@ -47,11 +49,17 @@ def import_ifc_beam(ifc_elem, name, ifc_store: IfcStore) -> Beam:
         raise ValueError("Number of items objects attached to axis is not 1")
 
     axis = axes[0].Items[0]
-    if axis.is_a("IfcPolyline") and len(axis.Points) != 2:
-        return import_polyline_beam(ifc_elem, axis, name, sec, mat, ifc_store)
-    elif axis.is_a("IfcTrimmedCurve"):
+
+    # Dispatch on the body solid type — the authoritative discriminator. (The axis curve type
+    # is unreliable: a swept beam's axis is an IfcIndexedPolyCurve, not an IfcPolyline.)
+    body_solid = get_ifc_body(ifc_elem)
+    body_type = body_solid.is_a()
+    if body_type == "IfcRevolvedAreaSolid":
         return import_revolved_beam(ifc_elem, axis, name, sec, mat, ifc_store)
+    elif body_type == "IfcFixedReferenceSweptAreaSolid":
+        return import_polyline_beam(ifc_elem, axis, name, sec, mat, ifc_store)
     else:
+        # IfcExtrudedAreaSolid (straight) or IfcExtrudedAreaSolidTapered (→ BeamTapered)
         return import_straight_beam(ifc_elem, axis, name, sec, mat, ifc_store)
 
 
@@ -76,10 +84,7 @@ def import_straight_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) ->
         place = Placement.from_4x4_matrix(local_placement)
         extra_opts["placement"] = place
 
-    return Beam(
-        name,
-        p1,
-        p2,
+    common = dict(
         sec=sec,
         mat=mat,
         up=local_y,
@@ -88,6 +93,17 @@ def import_straight_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) ->
         units=ifc_store.assembly.units,
         **extra_opts,
     )
+
+    # A tapered extrusion (IfcExtrudedAreaSolidTapered) carries an EndSweptArea — reconstruct
+    # the BeamTapered subtype with its end section rather than collapsing to a prismatic Beam.
+    body_solid = get_ifc_body(ifc_elem)
+    if body_solid.is_a("IfcExtrudedAreaSolidTapered"):
+        from ada import BeamTapered
+
+        end_sec = import_section_from_ifc(body_solid.EndSweptArea, units=ifc_store.assembly.units)
+        return BeamTapered(name, p1, p2, tap=end_sec, **common)
+
+    return Beam(name, p1, p2, **common)
 
 
 def import_revolved_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) -> Beam:
@@ -118,4 +134,25 @@ def import_revolved_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) ->
 
 
 def import_polyline_beam(ifc_elem, axis, name, sec, mat, ifc_store: IfcStore) -> Beam:
-    raise NotImplementedError("Reading beams swept along IfcPolyLines of length > 2 is not yet supported")
+    """A beam swept along a multi-point polyline directrix (IfcFixedReferenceSweptAreaSolid) →
+    BeamSweep. The Axis polyline is the sweep curve (written from beam.curve)."""
+    from ada import BeamSweep
+    from ada.api.curves import CurvePoly2d
+
+    # The sweep directrix is written by write_curve_poly as an IfcIndexedPolyCurve (points in
+    # a CartesianPointList), not an IfcPolyline (list of CartesianPoints) — handle both.
+    if axis.is_a("IfcIndexedPolyCurve"):
+        coords = [tuple(float(c) for c in pt) for pt in axis.Points.CoordList]
+    else:
+        coords = [tuple(float(c) for c in p.Coordinates) for p in axis.Points]
+    curve = CurvePoly2d.from_3d_points(coords)
+
+    return BeamSweep(
+        name,
+        curve=curve,
+        sec=sec,
+        mat=mat,
+        guid=ifc_elem.GlobalId,
+        ifc_store=ifc_store,
+        units=ifc_store.assembly.units,
+    )

--- a/src/ada/cadit/ifc/read/read_fasteners.py
+++ b/src/ada/cadit/ifc/read/read_fasteners.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ada import Weld
+
+from .reader_utils import get_axis_polyline_points_from_product, get_ifc_property_sets
+
+if TYPE_CHECKING:
+    from ada.cadit.ifc.store import IfcStore
+
+
+def import_ifc_fastener(product, name, ifc_store: IfcStore) -> Weld:
+    """Reconstruct a Weld from an IfcFastener (PredefinedType WELD).
+
+    The bead is rebuilt from the persisted profile + xdir and the Axis endpoints; members and
+    groove are not round-tripped (the bead geometry doesn't need them)."""
+    pts = get_axis_polyline_points_from_product(product)
+    p1 = tuple(float(c) for c in pts[0])
+    p2 = tuple(float(c) for c in pts[-1])
+
+    props = get_ifc_property_sets(product).get("Properties", {})
+    weld_type = props.get("weld_type", "FILLET")
+    xdir = tuple(json.loads(props["xdir"])) if props.get("xdir") else None
+    profile = [tuple(p) for p in json.loads(props["profile"])] if props.get("profile") else None
+
+    weld = Weld(name, p1=p1, p2=p2, weld_type=weld_type, members=(), profile=profile, xdir=xdir)
+    weld.guid = product.GlobalId
+    return weld

--- a/src/ada/cadit/ifc/read/read_ifc.py
+++ b/src/ada/cadit/ifc/read/read_ifc.py
@@ -74,6 +74,27 @@ class IfcReader:
             parent = self._resolve_system_parent(system) or assembly
             parent.add_pipe(pipe)
 
+    def resolve_weld_members(self):
+        """Link each imported Weld back to its welded members by GUID.
+
+        Members are persisted as GUIDs on the IfcFastener (read into ``weld.metadata``); they
+        may be imported after the weld, so resolution runs as a post-pass."""
+        import json
+
+        from ada import Weld
+
+        assembly = self.ifc_store.assembly
+        for part in assembly.get_all_parts_in_assembly(include_self=True):
+            for w in part.welds:
+                if not isinstance(w, Weld):
+                    continue
+                raw = w.metadata.get("Properties", {}).get("members")
+                if not raw:
+                    continue
+                resolved = [obj for obj in (assembly.get_by_guid(g) for g in json.loads(raw)) if obj is not None]
+                if resolved:
+                    w._members = tuple(resolved)
+
     def _resolve_system_parent(self, system):
         """The adapy Part that the system services (via IfcRelServicesBuildings → spatial elem)."""
         for rel in system.ServicesBuildings or []:

--- a/src/ada/cadit/ifc/read/read_ifc.py
+++ b/src/ada/cadit/ifc/read/read_ifc.py
@@ -38,7 +38,7 @@ class IfcReader:
         A Pipe is written as an IfcDistributionSystem grouping its IfcPipeSegment/IfcPipeFitting
         members (which the per-product pass skips). Build one Pipe per system from its members and
         add it to the spatial element the system services."""
-        from ada import Node, Pipe
+        from ada import Pipe
 
         from .read_pipe import import_pipe_segment
 

--- a/src/ada/cadit/ifc/read/read_ifc.py
+++ b/src/ada/cadit/ifc/read/read_ifc.py
@@ -32,6 +32,57 @@ class IfcReader:
         mi = MaterialImporter(self.ifc_store)
         mi.load_ifc_materials()
 
+    def load_systems(self):
+        """Reconstruct pipes from IfcDistributionSystem groupings.
+
+        A Pipe is written as an IfcDistributionSystem grouping its IfcPipeSegment/IfcPipeFitting
+        members (which the per-product pass skips). Build one Pipe per system from its members and
+        add it to the spatial element the system services."""
+        from ada import Node, Pipe
+
+        from .read_pipe import import_pipe_segment
+
+        f = self.ifc_store.f
+        assembly = self.ifc_store.assembly
+
+        for system in f.by_type("IfcDistributionSystem"):
+            members = []
+            for rel in system.IsGroupedBy or []:
+                members.extend(rel.RelatedObjects)
+            seg_products = [m for m in members if m.is_a() in ("IfcPipeSegment", "IfcPipeFitting")]
+            if not seg_products:
+                continue
+
+            segments = []
+            for sp in seg_products:
+                try:
+                    segments.append(import_pipe_segment(sp, sp.Name, self.ifc_store))
+                except Exception as e:  # noqa: BLE001 - one bad segment must not drop the pipe
+                    logger.warning(f"Skipping pipe segment {sp.Name} of system {system.Name}: {e}")
+            if not segments:
+                continue
+
+            # Build the Pipe and assign the imported segments directly — Pipe.from_segments would
+            # rebuild the segments from points (losing the straight/elbow decomposition). The
+            # centerline points are only for completeness; the segments carry the real geometry.
+            points = [segments[0].p1, segments[-1].p2]
+            pipe = Pipe(system.Name, points, segments[0].section, segments[0].material, guid=system.GlobalId)
+            pipe._segments = segments
+            for seg in segments:
+                seg.parent = pipe
+
+            parent = self._resolve_system_parent(system) or assembly
+            parent.add_pipe(pipe)
+
+    def _resolve_system_parent(self, system):
+        """The adapy Part that the system services (via IfcRelServicesBuildings → spatial elem)."""
+        for rel in system.ServicesBuildings or []:
+            for spatial in rel.RelatedBuildings:
+                part = self.ifc_store.assembly.get_by_guid(spatial.GlobalId)
+                if part is not None:
+                    return part
+        return None
+
     def load_presentation_layers(self):
         from ada.api.presentation_layers import PresentationLayer, PresentationLayers
 

--- a/src/ada/cadit/ifc/read/read_physical_objects.py
+++ b/src/ada/cadit/ifc/read/read_physical_objects.py
@@ -6,6 +6,7 @@ from ada.config import logger
 
 from .exceptions import NoIfcAxesAttachedError, UnableToConvertBoolResToBeamException
 from .read_beams import import_ifc_beam
+from .read_fasteners import import_ifc_fastener
 from .read_pipe import import_pipe_segment
 from .read_plates import import_ifc_plate
 from .read_shapes import _has_body_representation, import_ifc_shape, import_ifc_sphere
@@ -46,6 +47,9 @@ def import_physical_ifc_elem(product, name, ifc_store: IfcStore):
         except NoIfcAxesAttachedError as e:
             logger.debug(e)
             pass
+
+    if product.is_a("IfcFastener"):
+        return import_ifc_fastener(product, name, ifc_store)
 
     if product.is_a("IfcOpeningElement") is True:
         logger.info(f'skipping opening element "{product}"')

--- a/src/ada/cadit/ifc/read/read_physical_objects.py
+++ b/src/ada/cadit/ifc/read/read_physical_objects.py
@@ -9,6 +9,7 @@ from .read_beams import import_ifc_beam
 from .read_pipe import import_pipe_segment
 from .read_plates import import_ifc_plate
 from .read_shapes import _has_body_representation, import_ifc_shape, import_ifc_sphere
+from .read_wall import import_ifc_wall
 
 if TYPE_CHECKING:
     from ada.cadit.ifc.store import IfcStore
@@ -26,6 +27,13 @@ def import_physical_ifc_elem(product, name, ifc_store: IfcStore):
     if pr_type in ["IfcPlateStandardCase", "IfcPlate"]:
         try:
             return import_ifc_plate(product, name, ifc_store)
+        except NoIfcAxesAttachedError as e:
+            logger.debug(e)
+            pass
+
+    if pr_type in ["IfcWall", "IfcWallStandardCase"]:
+        try:
+            return import_ifc_wall(product, name, ifc_store)
         except NoIfcAxesAttachedError as e:
             logger.debug(e)
             pass

--- a/src/ada/cadit/ifc/read/read_physical_objects.py
+++ b/src/ada/cadit/ifc/read/read_physical_objects.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from ada.cadit.ifc.store import IfcStore
 
 
+def _belongs_to_system(product) -> bool:
+    """True if the product is grouped by an IfcSystem (e.g. a pipe segment in a distribution
+    system) — reconstructed at the system layer, not as a loose element."""
+    for rel in getattr(product, "HasAssignments", None) or []:
+        if rel.is_a("IfcRelAssignsToGroup") and rel.RelatingGroup is not None and rel.RelatingGroup.is_a("IfcSystem"):
+            return True
+    return False
+
+
 def import_physical_ifc_elem(product, name, ifc_store: IfcStore):
     pr_type = product.is_a()
 
@@ -43,10 +52,11 @@ def import_physical_ifc_elem(product, name, ifc_store: IfcStore):
         return None
 
     if product.is_a() in ("IfcPipeSegment", "IfcPipeFitting"):
+        # Segments grouped by an IfcDistributionSystem are reconstructed as a Pipe in
+        # load_systems(); skip them here so they aren't also imported as loose segments.
+        if _belongs_to_system(product):
+            return None
         return import_pipe_segment(product, name, ifc_store)
-
-    if product.is_a("IfcPipeFitting"):
-        logger.info('"IfcPipeFitting" is not yet added')
 
     # Non-physical products (alignment, annotation, grid, positioning) carry only
     # curve/axis representations, never body geometry. Importing them as empty Shapes

--- a/src/ada/cadit/ifc/read/read_shapes.py
+++ b/src/ada/cadit/ifc/read/read_shapes.py
@@ -174,6 +174,21 @@ def import_ifc_sphere(product: ifcopenshell.entity_instance, name, ifc_store: If
     if obj_placement is not None and obj_placement.PlacementRelTo:
         extra_opts["placement"] = Placement.from_4x4_matrix(get_local_placement(obj_placement))
 
+    # A sphere-bodied product marked MassPoint reads back as MassPoint (mass from properties).
+    if product.ObjectType == "MassPoint":
+        from ada.api.mass import MassPoint
+
+        from .reader_utils import get_ifc_property_sets
+
+        mass = get_ifc_property_sets(product).get("Properties", {}).get("mass", 0.0)
+        return MassPoint(
+            name,
+            center,
+            float(mass),
+            radius=float(sphere.Radius),
+            **{k: v for k, v in extra_opts.items() if k == "placement"},
+        )
+
     return PrimSphere(
         name,
         center,

--- a/src/ada/cadit/ifc/read/read_wall.py
+++ b/src/ada/cadit/ifc/read/read_wall.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ada import Placement, Wall
+from ada.config import logger
+
+from .exceptions import NoIfcAxesAttachedError
+from .geom.geom_reader import get_product_definitions
+from .geom.placement import axis3d
+from .reader_utils import get_axis_polyline_points_from_product, get_ifc_property_sets
+
+if TYPE_CHECKING:
+    from ada.cadit.ifc.store import IfcStore
+
+
+def import_ifc_wall(ifc_elem, name, ifc_store: IfcStore) -> Wall:
+    """Reconstruct a Wall from an IfcWall written by write_ifc_wall.
+
+    Points come from the Axis (Curve2D) polyline, height from the body extrusion depth, and
+    thickness/offset from the property set the writer attaches (they can't be recovered
+    unambiguously from the extruded footprint)."""
+    points = [tuple(p) for p in get_axis_polyline_points_from_product(ifc_elem)]
+    if len(points) < 2:
+        raise NoIfcAxesAttachedError(f"IfcWall {name} has no usable Axis polyline")
+
+    height = None
+    for body in get_product_definitions(ifc_elem):
+        depth = getattr(body, "depth", None)
+        if depth is not None:
+            height = float(depth)
+            break
+    if height is None:
+        raise NoIfcAxesAttachedError(f"IfcWall {name} has no extruded body to read the height from")
+
+    props = get_ifc_property_sets(ifc_elem).get("Properties", {})
+    thickness = props.get("thickness")
+    if thickness is None:
+        logger.warning(f"IfcWall {name} has no 'thickness' property; defaulting to 0.1")
+        thickness = 0.1
+    offset = props.get("offset", 0.0)
+
+    place = Placement.from_axis3d(axis3d(ifc_elem.ObjectPlacement.RelativePlacement))
+
+    return Wall(
+        name,
+        points,
+        height=float(height),
+        thickness=float(thickness),
+        offset=float(offset),
+        placement=place,
+        guid=ifc_elem.GlobalId,
+        units=ifc_store.assembly.units,
+    )

--- a/src/ada/cadit/ifc/read/reader_utils.py
+++ b/src/ada/cadit/ifc/read/reader_utils.py
@@ -171,7 +171,17 @@ def add_to_assembly(assembly: Assembly, obj, ifc_parent, elements2part):
 
 
 def add_to_parent(parent: Part | Pipe, obj):
-    from ada import Beam, Part, Pipe, PipeSegElbow, PipeSegStraight, Plate, Shape, Wall
+    from ada import (
+        Beam,
+        Part,
+        Pipe,
+        PipeSegElbow,
+        PipeSegStraight,
+        Plate,
+        Shape,
+        Wall,
+        Weld,
+    )
     from ada.api.plates.base_pl import PlateCurved
 
     if isinstance(obj, Beam):
@@ -180,6 +190,8 @@ def add_to_parent(parent: Part | Pipe, obj):
         parent.add_plate(obj)
     elif isinstance(obj, Wall):
         parent.add_wall(obj)
+    elif isinstance(obj, Weld):
+        parent.add_weld(obj)
     elif issubclass(type(obj), Shape) and isinstance(parent, Part):
         parent.add_shape(obj)
     elif isinstance(obj, (PipeSegStraight, PipeSegElbow)) and isinstance(parent, Part):

--- a/src/ada/cadit/ifc/read/reader_utils.py
+++ b/src/ada/cadit/ifc/read/reader_utils.py
@@ -171,13 +171,15 @@ def add_to_assembly(assembly: Assembly, obj, ifc_parent, elements2part):
 
 
 def add_to_parent(parent: Part | Pipe, obj):
-    from ada import Beam, Part, Pipe, PipeSegElbow, PipeSegStraight, Plate, Shape
+    from ada import Beam, Part, Pipe, PipeSegElbow, PipeSegStraight, Plate, Shape, Wall
     from ada.api.plates.base_pl import PlateCurved
 
     if isinstance(obj, Beam):
         parent.add_beam(obj)
     elif isinstance(obj, (Plate, PlateCurved)):
         parent.add_plate(obj)
+    elif isinstance(obj, Wall):
+        parent.add_wall(obj)
     elif issubclass(type(obj), Shape) and isinstance(parent, Part):
         parent.add_shape(obj)
     elif isinstance(obj, (PipeSegStraight, PipeSegElbow)) and isinstance(parent, Part):

--- a/src/ada/cadit/ifc/store.py
+++ b/src/ada/cadit/ifc/store.py
@@ -268,6 +268,9 @@ class IfcStore:
         # Reconstruct pipes from IfcDistributionSystem groupings (segments were skipped above)
         self.reader.load_systems()
 
+        # Link welds to their members by GUID (members may have been imported after the weld)
+        self.reader.resolve_weld_members()
+
         self.reader.load_presentation_layers()
 
         ifc_file_name = "object" if self.ifc_file_path is None else self.ifc_file_path

--- a/src/ada/cadit/ifc/store.py
+++ b/src/ada/cadit/ifc/store.py
@@ -265,6 +265,9 @@ class IfcStore:
         # Load physical elements
         self.reader.load_objects(data_only=data_only, elements2part=elements2part)
 
+        # Reconstruct pipes from IfcDistributionSystem groupings (segments were skipped above)
+        self.reader.load_systems()
+
         self.reader.load_presentation_layers()
 
         ifc_file_name = "object" if self.ifc_file_path is None else self.ifc_file_path

--- a/src/ada/cadit/ifc/write/geom/solids.py
+++ b/src/ada/cadit/ifc/write/geom/solids.py
@@ -116,19 +116,26 @@ def extruded_area_solid_tapered(
     )
 
 
-def revolved_area_solid(ras: geo_so.RevolvedAreaSolid, f: ifcopenshell.file) -> ifcopenshell.entity_instance:
+def revolved_area_solid(
+    ras: geo_so.RevolvedAreaSolid, f: ifcopenshell.file, profile: ifcopenshell.entity_instance = None
+) -> ifcopenshell.entity_instance:
     """Converts a RevolvedAreaSolid to an IFC representation.
 
     The geom carries the revolution axis in global coordinates (the convention
     both CAD backends build from). ``IfcRevolvedAreaSolid.Axis`` is defined in the
     ``Position`` coordinate system, so we transform global -> local here — keeping
     the geom backend-native while emitting spec-correct IFC.
+
+    ``profile`` lets the caller reuse a parametric profile def (carrying the ADA parameter bag)
+    so the section round-trips exactly — used by the pipe elbow.
     """
     import math
 
     axis3d = ifc_placement_from_axis3d(ras.position, f)
 
-    if isinstance(ras.swept_area, geo_su.ArbitraryProfileDef):
+    if profile is not None:
+        pass
+    elif isinstance(ras.swept_area, geo_su.ArbitraryProfileDef):
         profile = arbitrary_profile_def(ras.swept_area, f)
     else:
         raise NotImplementedError(f"Unsupported swept area type: {type(ras.swept_area)}")

--- a/src/ada/cadit/ifc/write/pipes/elbow_segment.py
+++ b/src/ada/cadit/ifc/write/pipes/elbow_segment.py
@@ -35,12 +35,10 @@ def write_pipe_elbow_seg(ifc_store: IfcStore, pipe_elbow: PipeSegElbow):  # -> i
 
     ifc_elbow = elbow_revolved_solid(pipe_elbow, f, tol)
 
-    parent = ifc_store.get_by_guid(pipe_elbow.parent.guid)
-
-    pfitting_placement = create_local_placement(
-        f,
-        relative_to=parent.ObjectPlacement,
-    )
+    # Elbow geometry is in world coordinates (like the straight segment), so use an identity
+    # placement. This also decouples the segment from the pipe's IFC entity, which no longer
+    # exists when segments are written (the pipe is now an IfcDistributionSystem created after).
+    pfitting_placement = create_local_placement(f)
 
     pfitting = f.create_entity(
         "IfcPipeFitting",

--- a/src/ada/cadit/ifc/write/pipes/elbow_segment.py
+++ b/src/ada/cadit/ifc/write/pipes/elbow_segment.py
@@ -108,15 +108,18 @@ def elbow_revolved_solid(elbow: PipeSegElbow, f, tol=1e-1):
     core_geom = elbow.solid_geom()
     geom: geo_so.RevolvedAreaSolid = core_geom.geometry
 
-    rev_area_solid = igeo_so.revolved_area_solid(geom, f)
+    a = elbow.get_assembly()
+    ifc_store = a.ifc_store
+
+    # Reuse the section's parametric profile (carries the ADA parameter bag) so the elbow
+    # section round-trips exactly, like the straight segment.
+    profile = ifc_store.get_profile_def(elbow.section)
+    rev_area_solid = igeo_so.revolved_area_solid(geom, f, profile)
 
     if core_geom.color is not None:
         add_colour(f, rev_area_solid, str(core_geom.color), core_geom.color)
 
     p1, p2, p3 = elbow.p1.p, elbow.p2.p, elbow.p3.p
-
-    a = elbow.get_assembly()
-    ifc_store = a.ifc_store
 
     body = f.create_entity(
         "IfcShapeRepresentation", ifc_store.get_context("Body"), "Body", "SweptSolid", [rev_area_solid]

--- a/src/ada/cadit/ifc/write/pipes/straight_segment.py
+++ b/src/ada/cadit/ifc/write/pipes/straight_segment.py
@@ -25,7 +25,11 @@ def write_pipe_straight_seg(ifc_store: IfcStore, pipe_seg: PipeSegStraight):  # 
     rp2 = to_real(p2.p)
 
     solid_geo = pipe_seg.solid_geom()
-    solid = igeo_so.extruded_area_solid(solid_geo.geometry, f)
+    # Reuse the section's parametric profile (carries the ADA parameter bag — e.g. an
+    # IfcCircleHollowProfileDef) for the body, like beams do, so the section round-trips
+    # exactly instead of an inline bag-less IfcArbitraryProfileDefWithVoids.
+    profile = ifc_store.get_profile_def(pipe_seg.section)
+    solid = igeo_so.extruded_area_solid(solid_geo.geometry, f, profile)
 
     if solid_geo.color is not None:
         add_colour(f, solid, str(solid_geo.color), solid_geo.color)

--- a/src/ada/cadit/ifc/write/write_fasteners.py
+++ b/src/ada/cadit/ifc/write/write_fasteners.py
@@ -54,6 +54,9 @@ def write_ifc_fastener(weld: Weld) -> ifcopenshell.entity_instance:
             "weld_type": weld.type.value,
             "xdir": json.dumps([float(c) for c in weld.xdir]),
             "profile": json.dumps([[float(c) for c in pt] for pt in weld.profile]),
+            # Member GUIDs are resolved back to the welded elements in a post-import pass
+            # (members may be imported after the weld).
+            "members": json.dumps([m.guid for m in weld.members]),
         },
         ifc_fastener,
         f,

--- a/src/ada/cadit/ifc/write/write_fasteners.py
+++ b/src/ada/cadit/ifc/write/write_fasteners.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
-from ada.cadit.ifc.utils import create_axis, create_property_set
+from ada.cadit.ifc.utils import (
+    create_axis,
+    create_property_set,
+    write_elem_property_sets,
+)
 from ada.cadit.ifc.write.shapes.prim_extrude_area import generate_ifc_prim_extrude_geom
 
 if TYPE_CHECKING:
@@ -40,5 +45,19 @@ def write_ifc_fastener(weld: Weld) -> ifcopenshell.entity_instance:
 
     # https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/lexical/Pset_FastenerWeld.htm
     create_property_set("Pset_FastenerWeld", f, dict(Type1=weld.type.value), ifc_store.owner_history)
+
+    # adapy reconstruction params (geometry/Pset can't carry them): the weld profile + xdir.
+    # p1/p2 come from the Axis; weld_type from Pset_FastenerWeld. Members/groove are not
+    # round-tripped (the bead geometry is rebuilt from profile + p1/p2 + xdir).
+    write_elem_property_sets(
+        {
+            "weld_type": weld.type.value,
+            "xdir": json.dumps([float(c) for c in weld.xdir]),
+            "profile": json.dumps([[float(c) for c in pt] for pt in weld.profile]),
+        },
+        ifc_fastener,
+        f,
+        ifc_store.owner_history,
+    )
 
     return ifc_fastener

--- a/src/ada/cadit/ifc/write/write_ifc.py
+++ b/src/ada/cadit/ifc/write/write_ifc.py
@@ -194,7 +194,9 @@ class IfcWriter:
         return num_mod
 
     def sync_added_welds(self):
-        for weld in self.ifc_store.assembly.welds:
+        # Welds may live on any part, not just the top-level assembly.
+        welds = [w for p in self.ifc_store.assembly.get_all_parts_in_assembly(include_self=True) for w in p.welds]
+        for weld in welds:
             ifc_weld = write_ifc_fastener(weld)
             self.add_related_elements_to_spatial_container([ifc_weld], weld.parent.guid)
             if weld.groove is None:

--- a/src/ada/cadit/ifc/write/write_ifc.py
+++ b/src/ada/cadit/ifc/write/write_ifc.py
@@ -116,6 +116,13 @@ class IfcWriter:
             self.eval_validity(to_be_added, mat_map, rel_mats_map)
 
             ifc_elem = self.add(to_be_added)
+            if ifc_elem is None:
+                # Some objects legitimately produce no IFC entity — e.g. a Pipe whose segments
+                # couldn't be built (write_ifc_pipe returns None). Skip the post-processing
+                # (openings/props/containment) instead of choking on a missing GlobalId.
+                logger.warning(f'"{to_be_added.name}" ({type(to_be_added).__name__}) produced no IFC entity; skipping')
+                to_be_added.change_type = ChangeAction.NOCHANGE
+                continue
             created_ifc_by_obj_guid[to_be_added.guid] = ifc_elem
 
             self.create_ifc_openings(to_be_added, ifc_elem)

--- a/src/ada/cadit/ifc/write/write_ifc.py
+++ b/src/ada/cadit/ifc/write/write_ifc.py
@@ -127,7 +127,10 @@ class IfcWriter:
                 self.ifc_store.owner_history,
             )
 
-            contained_in_spatial[to_be_added.parent.guid].append(ifc_elem)
+            # A Pipe writes an IfcDistributionSystem (not a spatially-containable product) and
+            # contains its own segments in the spatial structure, so skip the generic step.
+            if not isinstance(to_be_added, Pipe):
+                contained_in_spatial[to_be_added.parent.guid].append(ifc_elem)
             to_be_added.change_type = ChangeAction.NOCHANGE
 
             if self.callback is not None:

--- a/src/ada/cadit/ifc/write/write_pipe.py
+++ b/src/ada/cadit/ifc/write/write_pipe.py
@@ -4,11 +4,9 @@ from typing import TYPE_CHECKING
 
 import ifcopenshell
 
-from ada.cadit.ifc.utils import create_local_placement
 from ada.cadit.ifc.write.pipes.elbow_segment import write_pipe_elbow_seg
 from ada.cadit.ifc.write.pipes.straight_segment import write_pipe_straight_seg
 from ada.config import logger
-from ada.core.constants import X, Z
 from ada.core.guid import create_guid
 
 if TYPE_CHECKING:
@@ -20,25 +18,82 @@ def update_ifc_pipe(ifc_store: IfcStore, pipe: Pipe):
     logger.warning("Updating IFC pipe not implemented yet")
 
 
-def write_ifc_pipe(ifc_store: IfcStore, pipe: Pipe):
+def _resolve_spatial_parent(ifc_store: IfcStore, part) -> ifcopenshell.entity_instance:
+    """Nearest IfcSpatialElement ancestor for ``part``.
 
-    ifc_pipe = write_pipe_ifc_elem(ifc_store, pipe)
+    Plant-agnostic: ``IfcRelContainedInSpatialStructure``/``IfcRelServicesBuildings`` accept any
+    IfcSpatialElement (IfcSite/IfcSpatialZone/IfcBuilding in IFC4; IfcFacility/IfcFacilityPart in
+    IFC4x3), so a pipe on a site or plant area works. Walks up when a Part maps to a non-spatial
+    IFC type (e.g. IfcElementAssembly)."""
+    p = part
+    while p is not None:
+        ifc_elem = ifc_store.get_by_guid(p.guid)
+        if ifc_elem is not None and ifc_elem.is_a("IfcSpatialElement"):
+            return ifc_elem
+        p = p.parent
+    raise ValueError(f"No IfcSpatialElement ancestor found for pipe parent {part}")
+
+
+def write_ifc_pipe(ifc_store: IfcStore, pipe: Pipe):
+    """Write a Pipe as a proper IFC distribution system.
+
+    The flow elements (IfcPipeSegment / IfcPipeFitting) are contained in the real spatial
+    structure and grouped by an IfcDistributionSystem (IfcRelAssignsToGroup), which services that
+    spatial element (IfcRelServicesBuildings) — NOT modelled as an IfcSpatialZone."""
+    if pipe.parent is None:
+        raise ValueError("Cannot build ifc element without parent")
+
+    f = ifc_store.f
+    owner_history = ifc_store.owner_history
+
+    spatial = _resolve_spatial_parent(ifc_store, pipe.parent)
 
     segments = []
-
     for param_seg in pipe.segments:
         res = write_pipe_segment(ifc_store, param_seg)
-
         if res is None:
-            logger.error(f'Branch "{param_seg.name}" was not converted to ifc element')
+            logger.error(f'Pipe segment "{param_seg.name}" was not converted to ifc element')
             continue
-
         segments.append(res)
 
-    if segments:
-        ifc_store.writer.add_related_elements_to_spatial_container(segments, ifc_pipe.GlobalId)
+    if not segments:
+        return None
 
-    return ifc_pipe
+    # Contain the flow elements directly in the spatial structure (site/zone/facility/…).
+    ifc_store.writer.add_related_elements_to_spatial_container(segments, spatial.GlobalId)
+
+    # Group them as a distribution system — the functional grouping for a pipe run. The system
+    # carries the pipe's GUID so get_by_guid(pipe.guid) keeps resolving.
+    system = f.create_entity(
+        "IfcDistributionSystem",
+        pipe.guid,
+        owner_history,
+        pipe.name,
+        None,
+        None,
+        None,
+        "NOTDEFINED",
+    )
+    f.create_entity(
+        "IfcRelAssignsToGroup",
+        create_guid(),
+        owner_history,
+        pipe.name,
+        None,
+        RelatedObjects=segments,
+        RelatingGroup=system,
+    )
+    f.create_entity(
+        "IfcRelServicesBuildings",
+        create_guid(),
+        owner_history,
+        pipe.name,
+        None,
+        RelatingSystem=system,
+        RelatedBuildings=[spatial],
+    )
+
+    return system
 
 
 def write_pipe_segment(ifc_store: IfcStore, segment: PipeSegElbow | PipeSegStraight) -> ifcopenshell.entity_instance:
@@ -62,46 +117,3 @@ def write_pipe_segment(ifc_store: IfcStore, segment: PipeSegElbow | PipeSegStrai
     ifc_store.writer.associate_elem_with_material(segment.material, pipe_seg)
 
     return pipe_seg
-
-
-def write_pipe_ifc_elem(ifc_store: IfcStore, pipe: Pipe):
-    if pipe.parent is None:
-        raise ValueError("Cannot build ifc element without parent")
-
-    f = ifc_store.f
-    owner_history = ifc_store.owner_history
-
-    # parent = f.by_guid(pipe.parent.guid)
-    parent = ifc_store.get_by_guid(pipe.parent.guid)
-
-    placement = create_local_placement(
-        f,
-        origin=pipe.n1.p.astype(float).tolist(),
-        loc_x=X,
-        loc_z=Z,
-        relative_to=parent.ObjectPlacement,
-    )
-
-    ifc_elem = f.create_entity(
-        "IfcSpatialZone",
-        pipe.guid,
-        owner_history,
-        pipe.name,
-        "Description",
-        None,
-        placement,
-        None,
-        None,
-        None,
-    )
-
-    f.createIfcRelAggregates(
-        create_guid(),
-        owner_history,
-        "Pipe Container",
-        None,
-        parent,
-        [ifc_elem],
-    )
-
-    return ifc_elem

--- a/src/ada/cadit/ifc/write/write_shapes.py
+++ b/src/ada/cadit/ifc/write/write_shapes.py
@@ -141,15 +141,24 @@ def write_ifc_shape(ifc_store: IfcStore, shape: Shape):
 
     from ada.base.ifc_types import ShapeTypes
 
+    # Mark a MassPoint (sphere-bodied) so it reads back as MassPoint, not PrimSphere, and
+    # persist its mass (geometry alone can't carry it).
+    is_mass_point = isinstance(shape, MassPoint)
+
     ifc_elem = f.create_entity(
         str(shape.ifc_class.value) if isinstance(shape.ifc_class, ShapeTypes) else shape.ifc_class,
         GlobalId=shape.guid,
         OwnerHistory=owner_history,
         Name=shape.name,
-        ObjectType=None,
+        ObjectType="MassPoint" if is_mass_point else None,
         ObjectPlacement=shape_placement,
         Representation=ifc_shape,
     )
+
+    if is_mass_point:
+        from ada.cadit.ifc.utils import write_elem_property_sets
+
+        write_elem_property_sets({"mass": float(shape.mass)}, ifc_elem, f, owner_history)
 
     return ifc_elem
 

--- a/src/ada/cadit/ifc/write/write_wall.py
+++ b/src/ada/cadit/ifc/write/write_wall.py
@@ -10,6 +10,7 @@ from ada.cadit.ifc.utils import (
     create_ifcpolyline,
     create_local_placement,
     tesselate_shape,
+    write_elem_property_sets,
 )
 from ada.config import logger
 from ada.core.constants import O, X, Z
@@ -87,6 +88,16 @@ def write_ifc_wall(ifc_store: IfcStore, wall: Wall):
         ObjectType=None,
         ObjectPlacement=wall_placement,
         Representation=product_shape,
+    )
+
+    # Thickness/offset can't be recovered unambiguously from the extruded footprint, so persist
+    # them as properties for a faithful read-back (mirrors how the pipe elbow round-trips its
+    # bend params). Points come from the Axis polyline and height from the body extrusion depth.
+    write_elem_property_sets(
+        {"thickness": float(wall.thickness), "offset": float(wall.offset)},
+        wall_el,
+        f,
+        owner_history,
     )
 
     return wall_el

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_beam_subtypes.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_beam_subtypes.py
@@ -1,0 +1,29 @@
+import ada
+
+
+def test_roundtrip_beam_tapered(tmp_path):
+    bm = ada.BeamTapered("MyTaper", (0, 0, 0), (0, 0, 1), "IPE400", "IPE300")
+    fp = (ada.Assembly() / (ada.Part("MyPart") / bm)).to_ifc(tmp_path / "taper.ifc", file_obj_only=True)
+
+    a = ada.from_ifc(fp)
+    got = a.get_by_name("MyTaper")
+
+    assert isinstance(got, ada.BeamTapered)
+    assert got.section.h == bm.section.h  # start IPE400
+    assert got.taper.h == bm.taper.h  # end IPE300
+    assert tuple(got.n1.p) == tuple(bm.n1.p)
+    assert tuple(got.n2.p) == tuple(bm.n2.p)
+
+
+def test_roundtrip_beam_sweep(tmp_path):
+    curve = ada.CurvePoly2d.from_3d_points([(0, 0, 0), (1, 0, 0), (1, 1, 0)])
+    bm = ada.BeamSweep("MySweep", curve=curve, sec="IPE300")
+    fp = (ada.Assembly() / (ada.Part("MyPart") / bm)).to_ifc(tmp_path / "sweep.ifc", file_obj_only=True)
+
+    a = ada.from_ifc(fp)
+    got = a.get_by_name("MySweep")
+
+    assert isinstance(got, ada.BeamSweep)
+    assert got.section.type == bm.section.type
+    # sweep curve preserved (3 points)
+    assert len(got.curve.points3d) == 3

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_mass_weld.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_mass_weld.py
@@ -30,3 +30,6 @@ def test_roundtrip_weld(tmp_path):
     assert tuple(float(c) for c in got.p1.p) == (1.0, 0.0, 0.0)
     assert tuple(float(c) for c in got.p2.p) == (1.0, 1.0, 0.0)
     assert tuple(got.xdir) == (-1.0, 0.0, 0.0)
+    # members resolved back to the welded plates by GUID
+    assert {m.name for m in got.members} == {"pl1", "pl2"}
+    assert all(isinstance(m, ada.Plate) for m in got.members)

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_mass_weld.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_mass_weld.py
@@ -1,0 +1,32 @@
+import ada
+from ada.api.mass import MassPoint
+
+
+def test_roundtrip_mass_point(tmp_path):
+    mp = MassPoint("M1", (1, 2, 3), mass=250.0, radius=0.15)
+    fp = (ada.Assembly() / (ada.Part("MyPart") / mp)).to_ifc(tmp_path / "mass.ifc", file_obj_only=True)
+
+    got = ada.from_ifc(fp).get_by_name("M1")
+
+    assert isinstance(got, MassPoint)  # not a plain PrimSphere
+    assert got.mass == 250.0
+    assert got.radius == 0.15
+    assert tuple(float(c) for c in got.cog) == (1.0, 2.0, 3.0)
+
+
+def test_roundtrip_weld(tmp_path):
+    pl_points = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    pl1 = ada.Plate("pl1", pl_points, 0.01)
+    pl2 = ada.Plate("pl2", pl_points, 0.01, placement=ada.Placement((1.0, 0, 0)))
+    weld_profile = [(-0.005, 0.01), (0, 0), (0.005, 0.01)]
+    wld = ada.Weld("weld1", (1, 0, 0), (1, 1, 0), "V", [pl1, pl2], weld_profile, xdir=(-1, 0, 0))
+
+    fp = (ada.Assembly() / (ada.Part("MyPart") / (pl1, pl2, wld))).to_ifc(tmp_path / "weld.ifc", file_obj_only=True)
+
+    got = ada.from_ifc(fp).get_by_name("weld1")
+
+    assert isinstance(got, ada.Weld)
+    assert got.type == ada.WeldType.from_str("V")
+    assert tuple(float(c) for c in got.p1.p) == (1.0, 0.0, 0.0)
+    assert tuple(float(c) for c in got.p2.p) == (1.0, 1.0, 0.0)
+    assert tuple(got.xdir) == (-1.0, 0.0, 0.0)

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_pipe.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_pipe.py
@@ -1,0 +1,35 @@
+import ada
+
+
+def test_roundtrip_pipe_straight(tmp_path):
+    # NOTE: a catalog section name is used because a custom circular-hollow section (e.g.
+    # Section("PSec", "PIPE", r=.., wt=..)) writes as IfcArbitraryProfileDefWithVoids whose
+    # circular geometry the section reader can't yet interpret — a separate section-reader gap.
+    pipe = ada.Pipe("Pipe1", [(0, 0, 0), (0, 0, 3.2)], "PIPE200x5")
+    fp = (ada.Assembly() / (ada.Part("MyPart") / pipe)).to_ifc(tmp_path / "pipe.ifc", file_obj_only=True)
+
+    a = ada.from_ifc(fp)
+    p: ada.Pipe = a.get_by_name("Pipe1")
+
+    assert isinstance(p, ada.Pipe)
+    assert p.parent.name == "MyPart"
+    # one straight segment
+    assert len(p.segments) == 1
+    assert isinstance(p.segments[0], ada.PipeSegStraight)
+
+
+def test_roundtrip_pipe_with_bends(tmp_path):
+    points = [(0, 0, 0), (5, 0, 0), (5, 5, 0), (5, 5, 3)]
+    pipe = ada.Pipe("BentPipe", points, "PIPE200x5")
+    n_straight = sum(isinstance(s, ada.PipeSegStraight) for s in pipe.segments)
+    n_elbow = sum(isinstance(s, ada.PipeSegElbow) for s in pipe.segments)
+
+    fp = (ada.Assembly() / (ada.Part("MyPart") / pipe)).to_ifc(tmp_path / "bent.ifc", file_obj_only=True)
+
+    a = ada.from_ifc(fp)
+    p: ada.Pipe = a.get_by_name("BentPipe")
+
+    assert isinstance(p, ada.Pipe)
+    # segment composition (straights + elbows) preserved
+    assert sum(isinstance(s, ada.PipeSegStraight) for s in p.segments) == n_straight
+    assert sum(isinstance(s, ada.PipeSegElbow) for s in p.segments) == n_elbow

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_pipe.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_pipe.py
@@ -2,10 +2,9 @@ import ada
 
 
 def test_roundtrip_pipe_straight(tmp_path):
-    # NOTE: a catalog section name is used because a custom circular-hollow section (e.g.
-    # Section("PSec", "PIPE", r=.., wt=..)) writes as IfcArbitraryProfileDefWithVoids whose
-    # circular geometry the section reader can't yet interpret — a separate section-reader gap.
-    pipe = ada.Pipe("Pipe1", [(0, 0, 0), (0, 0, 3.2)], "PIPE200x5")
+    # A custom circular-hollow section round-trips exactly via the ADA parameter bag on the
+    # segment's IfcCircleHollowProfileDef.
+    pipe = ada.Pipe("Pipe1", [(0, 0, 0), (0, 0, 3.2)], ada.Section("PSec", "PIPE", r=0.10, wt=5e-3))
     fp = (ada.Assembly() / (ada.Part("MyPart") / pipe)).to_ifc(tmp_path / "pipe.ifc", file_obj_only=True)
 
     a = ada.from_ifc(fp)
@@ -13,14 +12,18 @@ def test_roundtrip_pipe_straight(tmp_path):
 
     assert isinstance(p, ada.Pipe)
     assert p.parent.name == "MyPart"
-    # one straight segment
     assert len(p.segments) == 1
     assert isinstance(p.segments[0], ada.PipeSegStraight)
+    # parametric section preserved (not just the catalog name)
+    sec = p.segments[0].section
+    assert sec.type == ada.Section.TYPES.TUBULAR
+    assert sec.r == 0.10
+    assert sec.wt == 5e-3
 
 
 def test_roundtrip_pipe_with_bends(tmp_path):
     points = [(0, 0, 0), (5, 0, 0), (5, 5, 0), (5, 5, 3)]
-    pipe = ada.Pipe("BentPipe", points, "PIPE200x5")
+    pipe = ada.Pipe("BentPipe", points, ada.Section("PSec", "PIPE", r=0.10, wt=5e-3))
     n_straight = sum(isinstance(s, ada.PipeSegStraight) for s in pipe.segments)
     n_elbow = sum(isinstance(s, ada.PipeSegElbow) for s in pipe.segments)
 
@@ -33,3 +36,9 @@ def test_roundtrip_pipe_with_bends(tmp_path):
     # segment composition (straights + elbows) preserved
     assert sum(isinstance(s, ada.PipeSegStraight) for s in p.segments) == n_straight
     assert sum(isinstance(s, ada.PipeSegElbow) for s in p.segments) == n_elbow
+    # every segment (incl. elbows) round-trips its parametric section via the ADA bag
+    assert n_elbow > 0
+    for s in p.segments:
+        assert s.section.type == ada.Section.TYPES.TUBULAR
+        assert s.section.r == 0.10
+        assert s.section.wt == 5e-3

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_plates.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_plates.py
@@ -2,15 +2,30 @@ import ada
 
 
 def test_roundtrip_plate(tmp_path):
-    plate = ada.Plate("MyPlate", [(0, 0), (1, 0, 0.2), (1, 1), (0, 1)], 20e-3)
+    plate = ada.Plate("MyPlate", [(0, 0), (1, 0), (1, 1), (0, 1)], 20e-3)
 
     fp = (ada.Assembly() / (ada.Part("MyPart") / plate)).to_ifc(tmp_path / "plate1.ifc", file_obj_only=True)
 
     a = ada.from_ifc(fp)
     pl: ada.Plate = a.get_by_name("MyPlate")
-    p = pl.parent
 
-    assert p.name == "MyPart"
+    assert isinstance(pl, ada.Plate)
+    assert pl.parent.name == "MyPart"
+    # geometry preserved: thickness + the 4 distinct polygon corners (the reader may emit
+    # duplicate consecutive points when closing the loop, so dedup before counting)
+    assert pl.t == 20e-3
+    corners = list(dict.fromkeys(tuple(round(c, 6) for c in p) for p in pl.poly.points2d))
+    assert len(corners) == 4
 
-    p.fem = pl.to_fem_obj(0.1, "shell")
-    # a.to_fem("MyFEM_plate_from_ifc_file", "usfos", overwrite=True)
+    # still a valid, meshable plate after the round-trip
+    pl.parent.fem = pl.to_fem_obj(0.1, "shell")
+
+
+def test_roundtrip_plate_with_fillet(tmp_path):
+    # 3rd coord on a corner = fillet radius; the arc survives the round-trip (extra edge point).
+    plate = ada.Plate("FilletPlate", [(0, 0), (1, 0, 0.2), (1, 1), (0, 1)], 20e-3)
+    fp = (ada.Assembly() / (ada.Part("MyPart") / plate)).to_ifc(tmp_path / "plate2.ifc", file_obj_only=True)
+
+    pl: ada.Plate = ada.from_ifc(fp).get_by_name("FilletPlate")
+    assert isinstance(pl, ada.Plate)
+    assert pl.t == 20e-3

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_shape_prims.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_shape_prims.py
@@ -1,0 +1,60 @@
+"""Round-trip coverage for the shape primitives (issue #16).
+
+Shape primitives read back as a generic ada.Shape carrying the equivalent ada.geom geometry
+(the exact Prim* class is not reconstructed by design) — so each test asserts the read-back is a
+Shape whose geometry is the expected geo_so type.
+"""
+
+import pytest
+
+import ada
+from ada.geom import solids as so
+
+
+def _roundtrip(obj, tmp_path):
+    fp = (ada.Assembly() / (ada.Part("MyPart") / obj)).to_ifc(tmp_path / f"{obj.name}.ifc", file_obj_only=True)
+    return ada.from_ifc(fp).get_by_name(obj.name)
+
+
+@pytest.mark.parametrize(
+    "obj_factory,expected_geom",
+    [
+        (lambda: ada.PrimBox("Box", (0, 0, 0), (1, 1, 1)), so.Box),
+        (lambda: ada.PrimCyl("Cyl", (0, 0, 0), (0, 0, 1), 0.3), so.Cylinder),
+        (lambda: ada.PrimCone("Cone", (0, 0, 0), (0, 0, 1), 0.3), so.Cone),
+        (
+            lambda: ada.PrimExtrude("Ext", [(0, 0), (1, 0), (0.5, 1)], 2, (0, 0, 1), (0, 0, 0), (1, 0, 0)),
+            so.ExtrudedAreaSolid,
+        ),
+        (
+            lambda: ada.PrimRevolve(
+                "Rev",
+                points=[(0, 0), (1, 0), (0.5, 1)],
+                origin=(2, 2, 3),
+                xdir=(0, 0, 1),
+                normal=(1, 0, 0),
+                rev_angle=180,
+            ),
+            so.RevolvedAreaSolid,
+        ),
+        (
+            lambda: ada.PrimSweep("Swp", [(0, 0, 0), (1, 0, 0), (1, 1, 0)], [(0, 0), (0.1, 0), (0.1, 0.1), (0, 0.1)]),
+            so.FixedReferenceSweptAreaSolid,
+        ),
+    ],
+)
+def test_roundtrip_shape_primitive(obj_factory, expected_geom, tmp_path):
+    obj = obj_factory()
+    got = _roundtrip(obj, tmp_path)
+
+    assert isinstance(got, ada.Shape)
+    assert got.parent.name == "MyPart"
+    assert isinstance(got.geom.geometry, expected_geom)
+
+
+def test_roundtrip_prim_sphere(tmp_path):
+    # PrimSphere is the one shape primitive reconstructed as its exact class.
+    sphere = ada.PrimSphere("Sph", (1, 2, 3), 0.5)
+    got = _roundtrip(sphere, tmp_path)
+    assert isinstance(got, ada.PrimSphere)
+    assert got.radius == 0.5

--- a/tests/core/cadit/ifc/roundtripping/test_roundtrip_wall.py
+++ b/tests/core/cadit/ifc/roundtripping/test_roundtrip_wall.py
@@ -1,0 +1,20 @@
+import ada
+
+
+def test_roundtrip_wall(tmp_path):
+    points = [(0, 0, 0), (5, 0, 0), (5, 5, 0)]
+    wall = ada.Wall("MyWall", points, height=3.0, thickness=0.15, offset="LEFT")
+
+    fp = (ada.Assembly() / (ada.Part("MyPart") / wall)).to_ifc(tmp_path / "wall.ifc", file_obj_only=True)
+
+    a = ada.from_ifc(fp)
+    w: ada.Wall = a.get_by_name("MyWall")
+
+    assert isinstance(w, ada.Wall)
+    assert w.parent.name == "MyPart"
+    assert w.height == 3.0
+    assert w.thickness == 0.15
+    # offset="LEFT" resolves to -thickness/2
+    assert w.offset == -0.15 / 2
+    # centerline points preserved (2D padded to 3D)
+    assert [tuple(p) for p in w.points] == [(0, 0, 0), (5, 0, 0), (5, 5, 0)]


### PR DESCRIPTION
Closes the read-back gaps so every core primitive a `Part` holds round-trips to **and** from IFC, with a round-trip test per primitive (issue #16). Write worked for all; the gaps were on the read side.

## Read-back fixes
- **Wall** — was never read back (no reader → generic Shape). New `read_wall.py` (points from Axis, height from body extrusion, thickness/offset from a property set the writer now persists); dispatch `IfcWall`/`IfcWallStandardCase`. Also fixed `Wall.metadata` shadowing `Root`'s setter, and `get_by_name` not searching walls/masses/welds.
- **BeamTapered / BeamSweep** — `import_ifc_beam` now dispatches on the **body solid type** (a swept beam's axis is an `IfcIndexedPolyCurve`, not `IfcPolyline`). Tapered→BeamTapered (end section from `EndSweptArea`); fixed-reference→BeamSweep (was a `NotImplementedError` stub).
- **Pipe** — rewritten to **proper IFC structure**: dropped the `IfcSpatialZone` "Pipe Container"; segments are contained in the real spatial structure and grouped by an **`IfcDistributionSystem`** (`IfcRelAssignsToGroup` + `IfcRelServicesBuildings`). Plant-agnostic — resolves the nearest `IfcSpatialElement` (Site/Zone/Facility), never hardcodes `IfcBuilding`. New `load_systems()` reconstructs one `Pipe` per system, preserving the straight/elbow decomposition.
- **Pipe sections** — segment bodies reuse the section's parametric profile (`IfcCircleHollowProfileDef` carrying the `ADA_SectionParameters` bag) instead of an inline bag-less profile, so a custom circular-hollow section round-trips **exactly** (TUBULAR r/wt), not just by catalog name. Straight + elbow.
- **MassPoint** — marked `ObjectType="MassPoint"` + mass persisted; reads back as `MassPoint` (not a plain PrimSphere) with its mass.
- **Weld** — `IfcFastener` now persists the reconstruction params (profile + xdir, weld type); `read_fasteners.py` rebuilds the `Weld` bead from profile + xdir + Axis endpoints. `sync_added_welds` now covers welds on any part. (Members/groove not round-tripped — the bead doesn't need them.)

## Shape primitives
`PrimBox/Cyl/Cone/Extrude/Revolve/Sweep` read back as a generic `Shape` with equivalent `ada.geom` geometry (by design); `PrimSphere` as its exact class.

## Tests
Round-trip tests for beam (incl. tapered/sweep), plate (thickness + corners), pipe (straight + bent, parametric section per segment), wall, all shape prims, mass point, and weld. Full `tests/core/cadit` + `tests/core/api` + `tests/core/geom` green (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)