### PR TITLE
fix: write swept welds to IFC without p1/p2

### DIFF
--- a/src/ada/cadit/ifc/write/write_fasteners.py
+++ b/src/ada/cadit/ifc/write/write_fasteners.py
@@ -9,6 +9,7 @@ from ada.cadit.ifc.utils import (
     write_elem_property_sets,
 )
 from ada.cadit.ifc.write.shapes.prim_extrude_area import generate_ifc_prim_extrude_geom
+from ada.cadit.ifc.write.shapes.prim_sweep_area import generate_ifc_prim_sweep_geom
 
 if TYPE_CHECKING:
     import ifcopenshell
@@ -20,6 +21,24 @@ if TYPE_CHECKING:
 # https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/lexical/Pset_FastenerWeld.htm
 
 
+def _weld_axis_points(weld: Weld) -> list | None:
+    """Reference-curve points for the weld's Axis representation.
+
+    Linear welds carry explicit ``p1``/``p2`` endpoints; swept welds
+    leave those ``None`` and instead define their path via
+    ``sweep_curve`` (see ``ada.api.fasteners.Weld``). Follow the full
+    curve so the axis matches a curved bead, not just its chord.
+    Returns ``None`` when no path is available.
+    """
+    if weld.p1 is not None and weld.p2 is not None:
+        return [weld.p1.p, weld.p2.p]
+
+    pts = getattr(weld.sweep_curve, "points3d", None)
+    if pts:
+        return list(pts)
+    return None
+
+
 def write_ifc_fastener(weld: Weld) -> ifcopenshell.entity_instance:
     if weld.parent is None:
         raise ValueError("Parent cannot be None for IFC export")
@@ -28,10 +47,25 @@ def write_ifc_fastener(weld: Weld) -> ifcopenshell.entity_instance:
     ifc_store = a.ifc_store
     f = a.ifc_store.f
 
-    axis = create_axis(f, [weld.p1.p, weld.p2.p], ifc_store.get_context("Axis"))
-    geom = generate_ifc_prim_extrude_geom(weld.geometry, f)
-    body = f.createIfcShapeRepresentation(ifc_store.get_context("Body"), "Body", "SweptSolid", [geom])
-    shape = f.create_entity("IfcProductDefinitionShape", Name=None, Description=None, Representations=[axis, body])
+    # Body geometry: dispatch on the wrapped primitive. A linear weld
+    # wraps a PrimExtrude (SweptSolid); a swept weld a PrimSweep
+    # (AdvancedSweptSolid). Mirrors the maps in write_shapes.py.
+    geometry = weld.geometry
+    if type(geometry).__name__ == "PrimSweep":
+        geom = generate_ifc_prim_sweep_geom(geometry, f)
+        body_repr_type = "AdvancedSweptSolid"
+    else:
+        geom = generate_ifc_prim_extrude_geom(geometry, f)
+        body_repr_type = "SweptSolid"
+    body = f.createIfcShapeRepresentation(ifc_store.get_context("Body"), "Body", body_repr_type, [geom])
+
+    representations = [body]
+    axis_points = _weld_axis_points(weld)
+    if axis_points is not None:
+        axis = create_axis(f, axis_points, ifc_store.get_context("Axis"))
+        representations.insert(0, axis)
+
+    shape = f.create_entity("IfcProductDefinitionShape", Name=None, Description=None, Representations=representations)
 
     ifc_fastener = f.create_entity(
         "IfcFastener",


### PR DESCRIPTION
## Problem

`write_ifc_fastener` assumed every `Weld` was a linear, two-point extrude and unconditionally dereferenced `weld.p1.p` / `weld.p2.p`. Swept welds — those constructed with `sweep_curve=` instead of `p1`/`p2` — leave `p1`/`p2` as `None` by design (see `ada.api.fasteners.Weld`), so exporting one raised:

```
AttributeError: 'NoneType' object has no attribute 'p'
  at create_axis(f, [weld.p1.p, weld.p2.p], ...)
```

The body geometry was also hardcoded to `generate_ifc_prim_extrude_geom` + `"SweptSolid"`, which is wrong for a swept weld (its `geometry` is a `PrimSweep`).

## Fix

- **Body representation** dispatches on the wrapped primitive: `PrimExtrude → SweptSolid` via `generate_ifc_prim_extrude_geom`, `PrimSweep → AdvancedSweptSolid` via `generate_ifc_prim_sweep_geom`. This mirrors the maps already in `write_shapes.py`.
- **Axis representation** is derived from `p1`/`p2` when present, otherwise from the sweep curve's `points3d` (the full path, so the axis follows a curved bead rather than just its chord). It is omitted when neither is available.

No behaviour change for linear welds: same axis endpoints and `SweptSolid` body as before.

## Testing

A model containing swept welds now exports to IFC without error; linear-weld export is unchanged.