### PR TITLE
feat: streaming conversion + FEA bake, leaner concept objects, audit-panel and curved-plate/SAT fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,42 @@ jobs:
 
       - name: Run Tests
         run: pixi run -e tests-adacpp test-core
+
+  test-rest:
+    name: Test viewer REST API
+    runs-on: ubuntu-latest
+    # tests/comms/rest is excluded from the core/full/pr tasks because it needs
+    # the viewer-api stack; run it here with a live Postgres so the DB-backed
+    # admin/audit tests actually execute instead of skipping.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: adapytest
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          pixi-version: v0.68.0
+          environments: >-
+            viewer-api-tests
+          cache: true
+
+      - name: Run Tests
+        env:
+          ADA_TEST_POSTGRES_URL: postgresql://postgres:test@localhost:5432/adapytest
+        run: pixi run -e viewer-api-tests test-rest

--- a/src/ada/api/beams/base_bm.py
+++ b/src/ada/api/beams/base_bm.py
@@ -394,6 +394,8 @@ class Beam(BackendGeom):
     @section.setter
     def section(self, value: Section):
         old = self._section
+        if value is old:
+            return
         self._section = value
         self._section.refs.append(self)
         old.refs.remove(self)

--- a/src/ada/api/containers/sections.py
+++ b/src/ada/api/containers/sections.py
@@ -146,22 +146,35 @@ class Sections(NumericMapped):
         # quick lookup by name
         if section.name in self._name_map:
             existing = self._name_map[section.name]
-            # dedupe refs using a set
-            existing_refs = set(existing.refs)
+            # ``consolidate_sections`` funnels one add() per source section into
+            # the same ``existing`` — tens of thousands of calls for a large FEM.
+            # Two things must stay amortised-O(N), not O(N²) (this was the
+            # dominant Genie-XML write cost, mirroring the Materials.add fix):
+            #   * membership via an id()-keyed set cached on the section, instead
+            #     of rebuilding ``set(existing.refs)`` (O(N)) on every call.
+            #   * the pointer flip writes ``ref._section`` / ``ref._taper``
+            #     DIRECTLY. The Beam.section setter does an O(N)
+            #     ``old.refs.remove(self)`` (guid __eq__ scan) against the
+            #     growing target list; FemSection/BeamTapered setters are plain
+            #     assignments, so bypassing the property is safe and refs are
+            #     rebuilt here via the id-set.
+            existing_refs = existing.refs
+            ref_ids = getattr(existing, "_ref_id_set", None)
+            if ref_ids is None or len(ref_ids) != len(existing_refs):
+                ref_ids = {id(r) for r in existing_refs}
+                existing._ref_id_set = ref_ids
             for ref in section.refs:
-                # redirect the ref to the existing section
                 if isinstance(ref, BeamTapered):
                     if existing.equal_props(ref.section):
-                        ref.section = existing
+                        ref._section = existing
                     elif existing.equal_props(ref.taper):
-                        ref.taper = existing
-                else:
-                    if existing.equal_props(ref.section):
-                        ref.section = existing
-                # append only new refs
-                if ref not in existing_refs:
-                    existing.refs.append(ref)
-                    existing_refs.add(ref)
+                        ref._taper = existing
+                elif existing.equal_props(ref.section):
+                    ref._section = existing
+                rid = id(ref)
+                if rid not in ref_ids:
+                    existing_refs.append(ref)
+                    ref_ids.add(rid)
             return existing
 
         # assign a fresh unique id

--- a/src/ada/api/curves.py
+++ b/src/ada/api/curves.py
@@ -155,17 +155,32 @@ class CurveOpen2d:
         self._parent = parent
         self._orientation = Placement(origin, xdir=xdir, zdir=normal) if orientation is None else orientation
         self._placement = Placement()
+        # Derived structures (3D points, 2D/3D segments, indexed lists, nodes)
+        # are the bulk of a curve's footprint + build time. Keep only the cheap
+        # inputs (2D points + orientation) eager; build the rest lazily on first
+        # access via ``_ensure_built`` so instantiating large numbers of plates
+        # is cheap and resident memory stays small until geometry is read.
         self._segments = None
+        self._segments3d = None
         self._seg_index = None
         self._seg_global_points = None
         self._nodes = None
+        self._points3d = None
 
         points = self._points_fix(points)
 
         self._radiis = {i: x[-1] for i, x in enumerate(points) if len(x) == 3}
         self._points2d = [Point(p[:2]) for p in points]
+        self._raw_points = points  # retained for the deferred segment build
+
+    def _ensure_built(self):
+        """Realise the deferred derived structures (idempotent). Called by the
+        ``points3d`` / ``segments`` / ``nodes`` / ``seg_*`` getters on first
+        access; the result is byte-identical to the historical eager build."""
+        if self._segments is not None:
+            return
         self._points3d = [Point(x) for x in self._orientation.transform_local_points_back_to_global(self._points2d)]
-        self._points_to_segments(points, tol)
+        self._points_to_segments(self._raw_points, self._tol)
 
     def _points_fix(self, points):
         # Check to see if the points are clockwise
@@ -238,6 +253,8 @@ class CurveOpen2d:
 
     @property
     def seg_global_points(self):
+        if self._seg_global_points is None:
+            self._ensure_built()
         return self._seg_global_points
 
     @property
@@ -250,10 +267,14 @@ class CurveOpen2d:
 
     @property
     def points3d(self) -> list[Point[float, float, float]]:
+        if self._points3d is None:
+            self._ensure_built()
         return self._points3d
 
     @property
     def nodes(self) -> list[Node]:
+        if self._nodes is None:
+            self._ensure_built()
         return self._nodes
 
     @property
@@ -305,14 +326,20 @@ class CurveOpen2d:
 
     @property
     def seg_index(self):
+        if self._seg_index is None:
+            self._ensure_built()
         return self._seg_index
 
     @property
     def segments(self) -> list[LineSegment | ArcSegment]:
+        if self._segments is None:
+            self._ensure_built()
         return self._segments
 
     @property
     def segments3d(self) -> list[LineSegment | ArcSegment]:
+        if self._segments3d is None:
+            self._ensure_built()
         return self._segments3d
 
     @property

--- a/src/ada/api/spatial/assembly.py
+++ b/src/ada/api/spatial/assembly.py
@@ -280,16 +280,23 @@ class Assembly(Part):
         writer_postprocessor: Callable[[ET.Element, Part], None] = None,
         embed_sat=False,
         streaming=False,
+        merge_strategy=None,
     ):
         # ``streaming`` emits the per-object <structure> entries straight to the
         # file instead of building the whole ElementTree DOM, cutting peak RSS on
         # large FEM-derived models. Geometry-identical to the DOM writer. Not
         # available with embed_sat (the SAT path shares one whole-model CDATA
         # body), so fall back there.
+        #
+        # ``merge_strategy`` (None | "none" | "coplanar" | ...) sources plates
+        # from the object-free vectorized FEM-shell face engine instead of
+        # materialising Plate objects — only honoured on the streaming path.
         if streaming and not embed_sat:
             from ada.cadit.gxml.write.stream_xml import write_xml_stream
 
-            write_xml_stream(self, destination_xml, writer_postprocessor=writer_postprocessor)
+            write_xml_stream(
+                self, destination_xml, writer_postprocessor=writer_postprocessor, merge_strategy=merge_strategy
+            )
         else:
             from ada.cadit.gxml.write.write_xml import write_xml
 

--- a/src/ada/api/spatial/assembly.py
+++ b/src/ada/api/spatial/assembly.py
@@ -226,6 +226,7 @@ class Assembly(Part):
         progress_callback: Callable[[int, int], None] = None,
         geom_repr_override: dict[str, GeomRepr] = None,
         streaming=False,
+        merge_strategy=None,
     ) -> ifcopenshell.file:
         import ifcopenshell.validate
 
@@ -248,7 +249,13 @@ class Assembly(Part):
             if not self.ifc_store.f.by_type("IfcProduct"):
                 from ada.cadit.ifc.write.stream_ifc import stream_assembly_to_ifc
 
-                stream_assembly_to_ifc(self, destination, include_fem=include_fem, progress_callback=progress_callback)
+                stream_assembly_to_ifc(
+                    self,
+                    destination,
+                    include_fem=include_fem,
+                    progress_callback=progress_callback,
+                    merge_strategy=merge_strategy,
+                )
                 if validate:
                     ifcopenshell.validate.validate(destination, logger)
                 logger.info("IFC file creation complete (streaming)")

--- a/src/ada/api/spatial/assembly.py
+++ b/src/ada/api/spatial/assembly.py
@@ -275,11 +275,25 @@ class Assembly(Part):
         return self.ifc_store.f
 
     def to_genie_xml(
-        self, destination_xml, writer_postprocessor: Callable[[ET.Element, Part], None] = None, embed_sat=False
+        self,
+        destination_xml,
+        writer_postprocessor: Callable[[ET.Element, Part], None] = None,
+        embed_sat=False,
+        streaming=False,
     ):
-        from ada.cadit.gxml.write.write_xml import write_xml
+        # ``streaming`` emits the per-object <structure> entries straight to the
+        # file instead of building the whole ElementTree DOM, cutting peak RSS on
+        # large FEM-derived models. Geometry-identical to the DOM writer. Not
+        # available with embed_sat (the SAT path shares one whole-model CDATA
+        # body), so fall back there.
+        if streaming and not embed_sat:
+            from ada.cadit.gxml.write.stream_xml import write_xml_stream
 
-        write_xml(self, destination_xml, writer_postprocessor=writer_postprocessor, embed_sat=embed_sat)
+            write_xml_stream(self, destination_xml, writer_postprocessor=writer_postprocessor)
+        else:
+            from ada.cadit.gxml.write.write_xml import write_xml
+
+            write_xml(self, destination_xml, writer_postprocessor=writer_postprocessor, embed_sat=embed_sat)
         logger.info(f'Genie XML file "{destination_xml}" created')
 
         return destination_xml

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -791,7 +791,12 @@ class Part(BackendGeom):
         logger.info("Conversion complete")
 
     def iter_objects_from_fem(
-        self, beams: bool = True, plates: bool = True, detached: bool = True, mat_cache: dict | None = None
+        self,
+        beams: bool = True,
+        plates: bool = True,
+        detached: bool = True,
+        mat_cache: dict | None = None,
+        merge_strategy=None,
     ) -> Iterable[Beam | Plate]:
         """Lazily build concept objects from this part's FEM mesh.
 
@@ -802,9 +807,16 @@ class Part(BackendGeom):
         are yielded before plates.
 
         ``detached`` (default) yields transient plates carrying no material
-        back-reference, so each frees as soon as the consumer drops it. Unlike
-        ``create_objects_from_fem`` there is no coplanar/colinear merge —
-        merging needs the whole set resident.
+        back-reference, so each frees as soon as the consumer drops it.
+
+        ``merge_strategy`` selects how shells fold into plates: ``None`` (default)
+        keeps the legacy 1:1 element→plate mapping; any strategy value
+        (``"coplanar"``/...) sources plates from the object-free vectorized face
+        engine (:func:`ada.fem.formats.mesh_faces.faces_from_fem`) and wraps each
+        merged face in a single transient :class:`Plate`. This is the one place
+        the merge strategy lives, so every streaming consumer (Genie XML, IFC,
+        STEP) folds shells the same way. Beams are unaffected (they fold via the
+        colinear pass on the object create path; the strategy is shell-only).
 
         ``mat_cache`` (name → :class:`Material`) lets the caller pin which
         material objects the plates reference — pass the already-consolidated
@@ -821,10 +833,38 @@ class Part(BackendGeom):
         if beams:
             for elem in self.fem.elements.lines:
                 yield line_elem_to_beam(elem, self)
-        if plates:
+        if not plates:
+            return
+        if merge_strategy is None:
             mat_dict: dict = {} if mat_cache is None else mat_cache
             for elem in self.fem.elements.shell:
                 yield from convert_shell_elem_to_plates(elem, self, mat_dict, detached=detached)
+        else:
+            yield from self._iter_merged_plates_from_fem(merge_strategy, detached, mat_cache)
+
+    def _iter_merged_plates_from_fem(self, merge_strategy, detached: bool, mat_cache: dict | None):
+        """Wrap each object-free merged :class:`FaceData` in one transient Plate.
+
+        Bounded: builds and yields a single Plate at a time. Tri/quad faces take
+        the fast ``Plate.from_fem_shell`` path; merged N-gons use the general
+        ``from_3d_points``."""
+        from ada import Plate
+        from ada.fem.formats.mesh_faces import faces_from_fem
+
+        # name -> Material, resolved once from this part's shell sections so the
+        # wrapped plates reference the real material object (faces carry names).
+        mats: dict = dict(mat_cache) if mat_cache else {}
+        for sec in self.fem.sections.shells:
+            mat = getattr(sec, "material", None)
+            if mat is not None and mat.name not in mats:
+                mats[mat.name] = mat
+
+        for face in faces_from_fem(self.fem, merge_strategy):
+            mat = mats.get(face.material, face.material)
+            if len(face.outline) <= 4:
+                yield Plate.from_fem_shell(face.name, face.outline, face.thickness, mat=mat, parent=self, detached=detached)
+            else:
+                yield Plate.from_3d_points(face.name, face.outline, face.thickness, mat=mat, parent=self)
 
     def get_part(self, name: str, search_all_parts_in_assembly=False) -> Part | None:
         """Get part by name."""
@@ -1433,6 +1473,7 @@ class Part(BackendGeom):
         writer: str = "occ",
         schema: str = "AP242",
         fuse_fem: bool = True,
+        merge_strategy=None,
     ):
         # The "stream" writer authors AP242 B-rep text directly from parametric
         # geometry without building any OCC/adacpp shapes — constant memory, so
@@ -1440,12 +1481,18 @@ class Part(BackendGeom):
         # covers extruded solids only (plates, straight beams, straight pipe
         # segments); other geometry is skipped. ``fuse_fem`` streams Beam/Plate
         # straight from the FEM mesh when they aren't built (no concept-object
-        # peak). See cadit.step.write.ap242_stream.
+        # peak); ``merge_strategy`` folds shells via the shared object-free face
+        # engine. See cadit.step.write.ap242_stream.
         if writer == "stream":
             from ada.cadit.step.write.ap242_stream import write_step_stream
 
             return write_step_stream(
-                self, destination_file, schema=schema, progress_callback=progress_callback, fuse_fem=fuse_fem
+                self,
+                destination_file,
+                schema=schema,
+                progress_callback=progress_callback,
+                fuse_fem=fuse_fem,
+                merge_strategy=merge_strategy,
             )
         if writer != "occ":
             raise ValueError(f"unknown writer {writer!r}; expected 'occ' or 'stream'")

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -862,7 +862,9 @@ class Part(BackendGeom):
         for face in faces_from_fem(self.fem, merge_strategy):
             mat = mats.get(face.material, face.material)
             if len(face.outline) <= 4:
-                yield Plate.from_fem_shell(face.name, face.outline, face.thickness, mat=mat, parent=self, detached=detached)
+                yield Plate.from_fem_shell(
+                    face.name, face.outline, face.thickness, mat=mat, parent=self, detached=detached
+                )
             else:
                 yield Plate.from_3d_points(face.name, face.outline, face.thickness, mat=mat, parent=self)
 

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -1441,16 +1441,21 @@ class Part(BackendGeom):
         evict_solid_cache: bool = True,
         writer: str = "occ",
         schema: str = "AP242",
+        fuse_fem: bool = True,
     ):
         # The "stream" writer authors AP242 B-rep text directly from parametric
         # geometry without building any OCC/adacpp shapes — constant memory, so
         # it does not OOM on large FEM models the way the OCC XCAF path does. It
         # covers extruded solids only (plates, straight beams, straight pipe
-        # segments); other geometry is skipped. See cadit.step.write.ap242_stream.
+        # segments); other geometry is skipped. ``fuse_fem`` streams Beam/Plate
+        # straight from the FEM mesh when they aren't built (no concept-object
+        # peak). See cadit.step.write.ap242_stream.
         if writer == "stream":
             from ada.cadit.step.write.ap242_stream import write_step_stream
 
-            return write_step_stream(self, destination_file, schema=schema, progress_callback=progress_callback)
+            return write_step_stream(
+                self, destination_file, schema=schema, progress_callback=progress_callback, fuse_fem=fuse_fem
+            )
         if writer != "occ":
             raise ValueError(f"unknown writer {writer!r}; expected 'occ' or 'stream'")
 

--- a/src/ada/api/spatial/part.py
+++ b/src/ada/api/spatial/part.py
@@ -907,32 +907,23 @@ class Part(BackendGeom):
     def consolidate_sections(self, include_self=True):
         """Moves all sections from all sub-parts to this part"""
         from ada import Beam
-        from ada.fem import FemSection
 
         new_sections = Sections(parent=self)
-        refs_num = 0
 
         for sec in self.get_all_sections(include_self=include_self):
             res = new_sections.add(sec)
             if res.guid == sec.guid:
                 continue
-            refs = [r for r in sec.refs]
-            for elem in refs:
-                refs_num += 1
-                sec.refs.pop(sec.refs.index(elem))
-                if elem not in res.refs:
-                    res.refs.append(elem)
-                if isinstance(elem, (Beam, FemSection)):
-                    if isinstance(elem, BeamTapered) and res.guid == elem.taper.guid:
-                        if not res.equal_props(elem.taper):
-                            raise ValueError(f"Section {res} and {elem.taper} have different properties")
-                        elem.taper = res
-                    else:
-                        if not res.equal_props(elem.section):
-                            raise ValueError(f"Section {res} and {elem.section} have different properties")
-                        elem.section = res
-                else:
-                    raise NotImplementedError(f"Not yet support section {type(elem)=}")
+            # ``Sections.add`` above already redirected every ``sec.refs``
+            # element's section/taper pointer to ``res`` and merged them into
+            # ``res.refs`` via the ``_ref_id_set`` cache (O(N) amortised, only
+            # for props-matching refs). Just drop the orphaned source list — the
+            # sec_map check below raises if add() left any beam unconsolidated
+            # (e.g. a same-name section with mismatched properties). The old
+            # per-element ``pop(index(...))`` + ``elem not in res.refs`` +
+            # ``elem.section = res`` was three O(N) ops against a growing list,
+            # i.e. O(N²) and the dominant Genie-XML write cost.
+            sec.refs.clear()
 
         for part in filter(lambda x: len(x.sections) > 0, self.get_all_parts_in_assembly(include_self=include_self)):
             part.sections = Sections(parent=part)

--- a/src/ada/cadit/gxml/write/stream_xml.py
+++ b/src/ada/cadit/gxml/write/stream_xml.py
@@ -32,7 +32,7 @@ from .write_hinges import add_hinges
 from .write_load_case import add_loads
 from .write_masses import add_masses
 from .write_materials import add_materials
-from .write_plates import add_plate_polygon, thickness_name
+from .write_plates import add_plate_polygon, add_plate_polygon_data, thickness_name
 from .write_sections import add_sections
 from .write_sets import add_sets
 from .write_xml import _XML_TEMPLATE
@@ -43,11 +43,31 @@ from .write_xml import _XML_TEMPLATE
 _MARKER = "ADA__STREAMED_STRUCTURES__"
 
 
-def write_xml_stream(part, xml_file, writer_postprocessor: Callable[[ET.Element, "object"], None] = None) -> None:
+def write_xml_stream(
+    part,
+    xml_file,
+    writer_postprocessor: Callable[[ET.Element, "object"], None] = None,
+    merge_strategy=None,
+) -> None:
+    """Stream a Genie XML.
+
+    ``merge_strategy`` (None | "none" | "coplanar" | ...) switches the *plate*
+    source. ``None`` (default) streams the part's already-built ``Plate`` objects
+    (the legacy concept path). Any strategy value sources plates from the
+    object-free vectorized FEM-shell face engine
+    (:func:`ada.fem.formats.mesh_faces.iter_faces`) instead — no Plate objects
+    are ever materialised. Beams still come from the part's (bounded) beam set.
+    """
     from ada import Beam, BeamTapered, Plate
 
     if not isinstance(xml_file, pathlib.Path):
         xml_file = pathlib.Path(xml_file)
+
+    use_faces = merge_strategy is not None
+    if use_faces:
+        # plate materials live on the FEM shell sections; register them so
+        # add_materials emits them and the streamed face material_refs resolve.
+        _register_shell_materials(part)
 
     part.consolidate_sections()
     part.consolidate_materials()
@@ -64,16 +84,17 @@ def write_xml_stream(part, xml_file, writer_postprocessor: Callable[[ET.Element,
     add_hinges(properties, part)
 
     # The thickness table lives in <properties>, ahead of the streamed plates,
-    # so build it up front from the (already-merged) plate set. Distinct
-    # thicknesses are few; this does not materialise geometry.
+    # so build it up front. Distinct thicknesses are few; this does not
+    # materialise geometry (face path reads them straight off the FEM sections).
     thickness_map: dict[float, str] = {}
     thicknesses_elem = ET.SubElement(properties, "thicknesses")
-    for plate in part.get_all_physical_objects(by_type=Plate):
-        if plate.t not in thickness_map:
-            name = thickness_name(plate.t)
-            thickness_map[plate.t] = name
+    distinct_thicknesses = _shell_thicknesses(part) if use_faces else [p.t for p in part.get_all_physical_objects(by_type=Plate)]
+    for t in distinct_thicknesses:
+        if t not in thickness_map:
+            name = thickness_name(t)
+            thickness_map[t] = name
             tck = ET.Element("thickness", {"name": name, "default": "true"})
-            tck.append(ET.Element("constant_thickness", {"th": str(plate.t)}))
+            tck.append(ET.Element("constant_thickness", {"th": str(t)}))
             thicknesses_elem.append(tck)
 
     # ── marker, then the remaining bounded structure-domain content ─────────
@@ -100,16 +121,51 @@ def write_xml_stream(part, xml_file, writer_postprocessor: Callable[[ET.Element,
         # Match the DOM writer byte-for-byte: tree.write(encoding="utf-8")
         # suppresses the XML declaration, so we emit none either.
         fh.write(head)
-        _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate)
+        _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy)
         fh.write(tail)
 
 
-def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate) -> None:
+def _shell_thicknesses(part) -> list:
+    """Distinct shell-section thicknesses across every FEM under ``part``."""
+    out: list = []
+    seen = set()
+    for p in part.get_all_parts_in_assembly(include_self=True):
+        fem = getattr(p, "fem", None)
+        if fem is None:
+            continue
+        for sec in fem.sections.shells:
+            t = getattr(sec, "thickness", None)
+            if t is not None and t not in seen:
+                seen.add(t)
+                out.append(t)
+    return out
+
+
+def _register_shell_materials(part) -> None:
+    """Add every FEM shell-section material to its part's material container so
+    add_materials emits them and the streamed face ``material_ref`` resolves."""
+    for p in part.get_all_parts_in_assembly(include_self=True):
+        fem = getattr(p, "fem", None)
+        if fem is None:
+            continue
+        for sec in fem.sections.shells:
+            mat = getattr(sec, "material", None)
+            if mat is None:
+                continue
+            if mat.name not in p.materials.name_map:
+                mat.parent = p
+                p.materials.add(mat)
+
+
+def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy) -> None:
     """Serialise one ``<structure>`` subtree at a time and write it out.
 
     Beams precede plates, matching the add_beams → add_plates order of the DOM
     writer. Each object's subtree is built on a throwaway parent, serialised,
     written, and dropped, so peak memory is one object's element tree.
+
+    Plates come from the part's Plate objects (``merge_strategy is None``) or,
+    for any strategy value, from the object-free vectorized face source.
     """
     import itertools
 
@@ -132,8 +188,19 @@ def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate) -> Non
         for child in list(tmp):
             fh.write(ET.tostring(child, encoding="unicode"))
 
-    for plate in part.get_all_physical_objects(by_type=Plate):
-        tmp = ET.Element("structures")
-        add_plate_polygon(plate, thickness_map[plate.t], tmp)
-        for child in list(tmp):
-            fh.write(ET.tostring(child, encoding="unicode"))
+    if merge_strategy is None:
+        for plate in part.get_all_physical_objects(by_type=Plate):
+            tmp = ET.Element("structures")
+            add_plate_polygon(plate, thickness_map[plate.t], tmp)
+            for child in list(tmp):
+                fh.write(ET.tostring(child, encoding="unicode"))
+    else:
+        from ada.fem.formats.mesh_faces import iter_faces
+
+        for face in iter_faces(part, merge_strategy):
+            tmp = ET.Element("structures")
+            add_plate_polygon_data(
+                face.name, face.outline, face.normal, thickness_map[face.thickness], face.material, tmp
+            )
+            for child in list(tmp):
+                fh.write(ET.tostring(child, encoding="unicode"))

--- a/src/ada/cadit/gxml/write/stream_xml.py
+++ b/src/ada/cadit/gxml/write/stream_xml.py
@@ -88,7 +88,9 @@ def write_xml_stream(
     # materialise geometry (face path reads them straight off the FEM sections).
     thickness_map: dict[float, str] = {}
     thicknesses_elem = ET.SubElement(properties, "thicknesses")
-    distinct_thicknesses = _shell_thicknesses(part) if use_faces else [p.t for p in part.get_all_physical_objects(by_type=Plate)]
+    distinct_thicknesses = (
+        _shell_thicknesses(part) if use_faces else [p.t for p in part.get_all_physical_objects(by_type=Plate)]
+    )
     for t in distinct_thicknesses:
         if t not in thickness_map:
             name = thickness_name(t)

--- a/src/ada/cadit/gxml/write/stream_xml.py
+++ b/src/ada/cadit/gxml/write/stream_xml.py
@@ -1,0 +1,139 @@
+"""Streaming Genie-XML writer.
+
+``write_xml`` (the default) builds the entire ``ElementTree`` DOM in memory and
+flushes it once. For a FEM-derived model that DOM is a second full-size copy of
+every plate/beam on top of the concept objects themselves — on a 57k-shell
+jacket it adds ~380 MB of peak RSS.
+
+This writer emits the same document but streams the per-object ``<structure>``
+entries straight to the file: the bounded scaffold (properties, BCs, masses,
+sets, loads, …) is built as a small DOM with a marker where the structures go,
+then each beam/plate ``<structure>`` is serialised one at a time and written,
+holding only one object's subtree at a time instead of the whole tree.
+
+The per-object elements are produced by the *exact* same builders the DOM
+writer uses (:func:`add_straight_beam`, :func:`add_plate_polygon`), so the
+output is geometry-identical — only the assembly strategy differs.
+
+Scope: the parametric (``embed_sat=False``) path only. The SAT-embedded path
+shares one cross-referenced CDATA body and is inherently whole-model, so it
+stays on :func:`write_xml`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import xml.etree.ElementTree as ET
+from typing import Callable
+
+from .write_bcs import add_concept_constraints, add_fem_boundary_conditions
+from .write_equipments import add_equipments
+from .write_hinges import add_hinges
+from .write_load_case import add_loads
+from .write_masses import add_masses
+from .write_materials import add_materials
+from .write_plates import add_plate_polygon, thickness_name
+from .write_sections import add_sections
+from .write_sets import add_sets
+from .write_xml import _XML_TEMPLATE
+
+# A childless placeholder we serialise, then split the scaffold string on, so the
+# streamed beam/plate structures land exactly where the DOM writer would emit
+# them — before the BC / mass entries, matching add_beams/add_plates order.
+_MARKER = "ADA__STREAMED_STRUCTURES__"
+
+
+def write_xml_stream(part, xml_file, writer_postprocessor: Callable[[ET.Element, "object"], None] = None) -> None:
+    from ada import Beam, BeamTapered, Plate
+
+    if not isinstance(xml_file, pathlib.Path):
+        xml_file = pathlib.Path(xml_file)
+
+    part.consolidate_sections()
+    part.consolidate_materials()
+
+    tree = ET.parse(_XML_TEMPLATE)
+    root = tree.getroot()
+    structure_domain = root.find("./model/structure_domain")
+    structures_elem = ET.SubElement(structure_domain, "structures")
+    properties = structure_domain.find("./properties")
+
+    # ── bounded scaffold: properties ────────────────────────────────────────
+    add_sections(properties, part)
+    add_materials(properties, part)
+    add_hinges(properties, part)
+
+    # The thickness table lives in <properties>, ahead of the streamed plates,
+    # so build it up front from the (already-merged) plate set. Distinct
+    # thicknesses are few; this does not materialise geometry.
+    thickness_map: dict[float, str] = {}
+    thicknesses_elem = ET.SubElement(properties, "thicknesses")
+    for plate in part.get_all_physical_objects(by_type=Plate):
+        if plate.t not in thickness_map:
+            name = thickness_name(plate.t)
+            thickness_map[plate.t] = name
+            tck = ET.Element("thickness", {"name": name, "default": "true"})
+            tck.append(ET.Element("constant_thickness", {"th": str(plate.t)}))
+            thicknesses_elem.append(tck)
+
+    # ── marker, then the remaining bounded structure-domain content ─────────
+    ET.SubElement(structures_elem, _MARKER)
+    add_fem_boundary_conditions(structures_elem, part)
+    add_masses(structures_elem, part)
+    add_sets(structure_domain, part)
+    add_loads(root, part)
+    add_concept_constraints(structures_elem, part)
+    add_equipments(root, part)
+
+    if writer_postprocessor:
+        writer_postprocessor(root, part)
+
+    scaffold = ET.tostring(root, encoding="unicode")
+    # ElementTree serialises a childless element as ``<tag />`` (with the space).
+    marker = f"<{_MARKER} />"
+    if marker not in scaffold:  # be liberal about the serialisation variant
+        marker = f"<{_MARKER}></{_MARKER}>"
+    head, tail = scaffold.split(marker, 1)
+
+    xml_file.parent.mkdir(exist_ok=True, parents=True)
+    with open(xml_file, "w", encoding="utf-8") as fh:
+        # Match the DOM writer byte-for-byte: tree.write(encoding="utf-8")
+        # suppresses the XML declaration, so we emit none either.
+        fh.write(head)
+        _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate)
+        fh.write(tail)
+
+
+def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate) -> None:
+    """Serialise one ``<structure>`` subtree at a time and write it out.
+
+    Beams precede plates, matching the add_beams → add_plates order of the DOM
+    writer. Each object's subtree is built on a throwaway parent, serialised,
+    written, and dropped, so peak memory is one object's element tree.
+    """
+    import itertools
+
+    from ada.api.spatial.eq_types import EquipRepr
+    from ada.api.spatial.equipment import Equipment
+
+    from .write_beams import add_straight_beam
+
+    for beam in itertools.chain(
+        part.get_all_physical_objects(by_type=Beam),
+        part.get_all_physical_objects(by_type=BeamTapered),
+    ):
+        # mirror add_beams: equipment beams that aren't AS_IS are emitted by the
+        # equipment writer, not as standalone structures.
+        parent = beam.parent
+        if isinstance(parent, Equipment) and parent.eq_repr != EquipRepr.AS_IS:
+            continue
+        tmp = ET.Element("structures")
+        add_straight_beam(beam, tmp)
+        for child in list(tmp):
+            fh.write(ET.tostring(child, encoding="unicode"))
+
+    for plate in part.get_all_physical_objects(by_type=Plate):
+        tmp = ET.Element("structures")
+        add_plate_polygon(plate, thickness_map[plate.t], tmp)
+        for child in list(tmp):
+            fh.write(ET.tostring(child, encoding="unicode"))

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -47,42 +47,44 @@ def add_plate_sat(plate: Plate, thck_name: str, structures_elem, sw: SatWriter):
     ET.SubElement(sat_reference, "face", {"face_ref": sw.face_map.get(plate.guid)})
 
 
-def add_plate_polygon(plate: Plate, thck_name: str, structures_elem: ET.Element):
+def add_plate_polygon_data(
+    name: str, outline_global, normal, thck_name: str, material_name: str, structures_elem: ET.Element
+):
+    """Emit a ``<flat_plate>`` polygon from raw data (no Plate object).
+
+    The object-free FEM-shell face source (:mod:`ada.fem.formats.mesh_faces`)
+    yields global outlines + normal + refs directly, so the streaming writer can
+    emit plates without ever materialising a :class:`Plate`. Produces the same
+    element shape as :func:`add_plate_polygon` (whose object path round-trips its
+    local poly back to these same global positions)."""
     structure = ET.SubElement(structures_elem, "structure")
     flat_plate = ET.SubElement(
-        structure, "flat_plate", {"name": plate.name, "thickness_ref": thck_name, "material_ref": plate.material.name}
+        structure, "flat_plate", {"name": name, "thickness_ref": thck_name, "material_ref": material_name}
     )
     local_sys = ET.SubElement(flat_plate, "local_system")
     ET.SubElement(
-        local_sys,
-        "vector",
-        {"x": str(plate.poly.normal[0]), "y": str(plate.poly.normal[1]), "z": str(plate.poly.normal[2]), "dir": "z"},
+        local_sys, "vector", {"x": str(normal[0]), "y": str(normal[1]), "z": str(normal[2]), "dir": "z"}
     )
     ET.SubElement(flat_plate, "front")
     ET.SubElement(flat_plate, "back")
     ET.SubElement(flat_plate, "segmentation")
 
-    # Add polygon geometry
     geometry = ET.SubElement(flat_plate, "geometry")
     sheet = ET.SubElement(geometry, "sheet")
     polygons = ET.SubElement(sheet, "polygons")
     polygon = ET.SubElement(polygons, "polygon")
+    for pt in outline_global:
+        ET.SubElement(polygon, "position", {"x": str(pt[0]), "y": str(pt[1]), "z": str(pt[2])})
 
-    # abs_place = plate.placement.get_absolute_placement()
-    # origin = abs_place.origin
-    # for pt in plate.poly.points3d:
-    #    p_tra = origin + pt.copy()
-    #    ET.SubElement(polygon, "position", {"x": str(p_tra[0]), "y": str(p_tra[1]), "z": str(p_tra[2])})
 
+def add_plate_polygon(plate: Plate, thck_name: str, structures_elem: ET.Element):
     abs_place = plate.placement.get_absolute_placement(include_rotations=True)
     ident = Placement()  # identity place
-
-    for pt in plate.poly.points3d:
-        # pt is local in plate coords -> transform to global with rotation+translation
-        p_global = abs_place.transform_array_from_other_place(
-            np.asarray([pt], dtype=float), ident, ignore_translation=False
-        )[0]
-        ET.SubElement(polygon, "position", {"x": str(p_global[0]), "y": str(p_global[1]), "z": str(p_global[2])})
+    outline_global = [
+        abs_place.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
+        for pt in plate.poly.points3d
+    ]
+    add_plate_polygon_data(plate.name, outline_global, plate.poly.normal, thck_name, plate.material.name, structures_elem)
 
 
 def add_plates(structure_domain: ET.Element, part: Part, sw: SatWriter):

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -13,6 +13,20 @@ if TYPE_CHECKING:
     from ada import Part, Plate
 
 
+def thickness_name(t: float) -> str:
+    """Canonical Genie thickness-property name for a plate thickness (m).
+
+    Shared by the DOM writer (:func:`add_plates`) and the streaming writer so
+    both mint identical ``thkNNN`` references for the same thickness.
+    """
+    thick_mm = t * 1000
+    if thick_mm.is_integer():
+        thick_mm_str = f"{int(thick_mm):03d}"
+    else:
+        thick_mm_str = f"{int(thick_mm):03d}_{str(thick_mm).split('.')[1]}"
+    return f"thk{thick_mm_str}"
+
+
 def add_plate_sat(plate: Plate, thck_name: str, structures_elem, sw: SatWriter):
     structure = ET.SubElement(structures_elem, "structure")
     flat_plate = ET.SubElement(
@@ -81,14 +95,7 @@ def add_plates(structure_domain: ET.Element, part: Part, sw: SatWriter):
 
     for plate in part.get_all_physical_objects(by_type=Plate):
         if plate.t not in thickness:
-            thick_mm = plate.t * 1000
-
-            if thick_mm.is_integer():
-                thick_mm_str = f"{int(thick_mm):03d}"
-            else:
-                thick_mm_str = f"{int(thick_mm):03d}_{str(thick_mm).split('.')[1]}"
-            thick_name = f"thk{thick_mm_str}"
-            thickness[plate.t] = thick_name
+            thickness[plate.t] = thickness_name(plate.t)
             tck_elem = ET.Element("thickness", {"name": thickness[plate.t], "default": "true"})
             tck_elem.append(ET.Element("constant_thickness", {"th": str(plate.t)}))
             thickness_elem.append(tck_elem)

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -62,9 +62,7 @@ def add_plate_polygon_data(
         structure, "flat_plate", {"name": name, "thickness_ref": thck_name, "material_ref": material_name}
     )
     local_sys = ET.SubElement(flat_plate, "local_system")
-    ET.SubElement(
-        local_sys, "vector", {"x": str(normal[0]), "y": str(normal[1]), "z": str(normal[2]), "dir": "z"}
-    )
+    ET.SubElement(local_sys, "vector", {"x": str(normal[0]), "y": str(normal[1]), "z": str(normal[2]), "dir": "z"})
     ET.SubElement(flat_plate, "front")
     ET.SubElement(flat_plate, "back")
     ET.SubElement(flat_plate, "segmentation")
@@ -84,7 +82,9 @@ def add_plate_polygon(plate: Plate, thck_name: str, structures_elem: ET.Element)
         abs_place.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
         for pt in plate.poly.points3d
     ]
-    add_plate_polygon_data(plate.name, outline_global, plate.poly.normal, thck_name, plate.material.name, structures_elem)
+    add_plate_polygon_data(
+        plate.name, outline_global, plate.poly.normal, thck_name, plate.material.name, structures_elem
+    )
 
 
 def add_plates(structure_domain: ET.Element, part: Part, sw: SatWriter):

--- a/src/ada/cadit/ifc/write/stream_ifc.py
+++ b/src/ada/cadit/ifc/write/stream_ifc.py
@@ -175,8 +175,14 @@ def stream_assembly_to_ifc(
     destination: str | os.PathLike,
     include_fem: bool = False,
     progress_callback: Callable[[int, int], None] | None = None,
+    merge_strategy=None,
 ) -> None:
-    """Write ``assembly`` to ``destination`` with bounded peak memory."""
+    """Write ``assembly`` to ``destination`` with bounded peak memory.
+
+    ``merge_strategy`` (None | "coplanar" | ...) folds FEM shells into plates via
+    the shared object-free face engine before emit — passed straight through to
+    ``Part.iter_objects_from_fem`` so streamed IFC plates merge the same way the
+    Genie-XML and STEP streamers do."""
     from ada import Beam, Pipe, Plate
     from ada.base.types import GeomRepr
     from ada.cadit.ifc.utils import create_guid, write_elem_property_sets
@@ -327,7 +333,9 @@ def stream_assembly_to_ifc(
         # and free as soon as _emit drops them, so peak memory stays bounded.
         for part, n_shells in fused:
             cnt = 0
-            for pl in part.iter_objects_from_fem(beams=False, plates=True, detached=True, mat_cache=mat_cache):
+            for pl in part.iter_objects_from_fem(
+                beams=False, plates=True, detached=True, mat_cache=mat_cache, merge_strategy=merge_strategy
+            ):
                 _emit(pl)
                 cnt += 1
                 if cnt % 2000 == 0:

--- a/src/ada/cadit/sat/read/bsplinecurves.py
+++ b/src/ada/cadit/sat/read/bsplinecurves.py
@@ -529,6 +529,15 @@ def create_bspline_curve_from_sat(spline_record: AcisRecord) -> geo_cu.BSplineCu
         return create_bspline_curve_from_lawintcur(data_lines)
     elif spl_type == "exactcur":
         return create_bspline_curve_from_exactcur(data_lines)
+    elif spl_type == "parcur":
+        # A parameter-space curve. SESAM exports embed the 3D space curve
+        # directly — ``parcur full nurbs <deg> open …`` then knots, then 3D
+        # rational control points, then a ``0`` and the surface block the
+        # exactcur parser stops before — so the layout past the type token is
+        # identical to exactcur. Reuse it rather than evaluating the 2D UV
+        # curve on the surface. Without this, curved hull-skin plates fall back
+        # to a flat polygon (rendered flat instead of curved).
+        return create_bspline_curve_from_exactcur(data_lines)
     elif spl_type == "exppc":
         return create_pcurve_from_exppc(sub_type)
     else:

--- a/src/ada/cadit/sat/read/curves.py
+++ b/src/ada/cadit/sat/read/curves.py
@@ -176,14 +176,20 @@ def get_edge(coedge: AcisRecord) -> geo_cu.OrientedEdge:
                     pcurve_geom = create_pcurve_2d_from_sat_record(pcurve_record)
                     if pcurve_geom is not None:
                         # Pcurve sense: chunks[7] is forward/reversed.
-                        # Reverse strategy is tunable via env var while
-                        # we sort out the right composition; "auto" uses
-                        # the conservative rule "reverse iff pcurve sense
-                        # disagrees with (edge.sense XOR coedge.sense)".
-                        # Set ADA_PCURVE_REVERSE=never|always|auto|pcurve_only.
+                        #
+                        # ACIS authors the per-coedge pcurve already running in
+                        # the coedge's direction, so it should be attached as-is
+                        # — "never" reverse. The old "auto" heuristic (reverse
+                        # iff the OCC edge direction disagrees with the pcurve
+                        # sense) was a WIP guess and is actually wrong: on the
+                        # OP1 hull-skin it flipped the UV trim on 380/4529 curved
+                        # plates, collapsing them to negative- or zero-area faces
+                        # (rendered as holes). With "never" all 4529 build clean
+                        # with areas matching their 3D boundary. Kept as a tunable
+                        # escape hatch: ADA_PCURVE_REVERSE=never|always|auto|pcurve_only.
                         import os as _os
 
-                        mode = (_os.environ.get("ADA_PCURVE_REVERSE") or "auto").strip().lower()
+                        mode = (_os.environ.get("ADA_PCURVE_REVERSE") or "never").strip().lower()
                         pcurve_sense = "forward"
                         if len(pcurve_record.chunks) > 7 and pcurve_record.chunks[7] in ("forward", "reversed"):
                             pcurve_sense = pcurve_record.chunks[7]

--- a/src/ada/cadit/sat/read/faces.py
+++ b/src/ada/cadit/sat/read/faces.py
@@ -20,6 +20,9 @@ class PlateFactory:
     next_loop_idx = 6
     coedge_ref = 7
 
+    # Coedge row: index of the owning-edge ref ($N).
+    edge_ref_idx = 9
+
     def __init__(self, sat_store: SatStore):
         self.sat_store = sat_store
 
@@ -80,9 +83,27 @@ class PlateFactory:
         loops = list(self._iter_face_loops(face_data_list))
         if not loops:
             return None
+        if len(loops) == 1:
+            return loops[0]
 
         periphery_loop = next((lp for lp in loops if self._loop_type(lp) == "periphery"), None)
-        return periphery_loop if periphery_loop is not None else loops[0]
+        if periphery_loop is not None:
+            return periphery_loop
+
+        # No loop is tagged 'periphery'. SESAM-exported faces carry degenerate
+        # marker loops — a single zero-length point-edge whose coedge.next
+        # points to itself — alongside the real boundary loop. Blindly taking
+        # loops[0] lands on such a marker, the boundary collapses to one point,
+        # and the whole plate is dropped ("0 edges"). Pick the loop that forms
+        # an actual boundary instead: the one with the most distinct edges.
+        return max(loops, key=self._distinct_edge_count)
+
+    def _distinct_edge_count(self, loop: AcisRecord) -> int:
+        try:
+            edges = self.get_edges_from_loop(loop)
+        except Exception:  # noqa: BLE001 - a malformed loop scores 0, never wins
+            return 0
+        return len({e.chunks[self.edge_ref_idx] for e in edges})
 
     def get_points(self, edges: list[AcisRecord]) -> list[tuple[float]]:
         if not edges:
@@ -130,8 +151,7 @@ class PlateFactory:
         self-touching polygon that collapses to a spurious diagonal when the
         downstream vertex dedupe in :meth:`get_points` runs.
         """
-        edge_ref_idx = 9
-        refs = [c.chunks[edge_ref_idx] for c in coedges]
+        refs = [c.chunks[self.edge_ref_idx] for c in coedges]
         counts: dict[str, int] = {}
         for r in refs:
             counts[r] = counts.get(r, 0) + 1
@@ -149,24 +169,22 @@ class PlateFactory:
         # Coedge row
         next_coedge_idx = 6 if coedge_first_direction == "forward" else 7
 
-        next_coedge = True
-        coedge_next_id = coedge_first.chunks[next_coedge_idx]
-        edges = [coedge_first]
-
+        # Walk the coedge ring once, appending each coedge before advancing to
+        # its successor and stopping when we loop back to the start. Appending
+        # *before* the wrap check is what keeps single-coedge loops correct: the
+        # old "seed with the first coedge, then append in the loop" form emitted
+        # the lone coedge twice for a self-referential ring, which then looked
+        # like a whisker pair to `_drop_whisker_coedges` and collapsed the face.
+        edges: list[AcisRecord] = []
+        coedge_id = coedge_start_id
         max_iter = 500
-        i = 0
-        while next_coedge is True:
-            coedge = self.sat_store.get(coedge_next_id)
+        for _ in range(max_iter):
+            coedge = self.sat_store.get(coedge_id)
             edges.append(coedge)
-
-            coedge_next_id = coedge.chunks[next_coedge_idx]
-            if coedge_next_id == coedge_start_id:
-                next_coedge = False
-
-            i += 1
-            if i > max_iter:
-                raise ValueError(f"Found {i} points which is over max={max_iter}")
-        return edges
+            coedge_id = coedge.chunks[next_coedge_idx]
+            if coedge_id == coedge_start_id:
+                return edges
+        raise ValueError(f"Coedge ring did not close within max={max_iter}")
 
     def get_points_from_edge(self, coedge: AcisRecord):
         # Coedge row

--- a/src/ada/cadit/step/write/ap242_stream.py
+++ b/src/ada/cadit/step/write/ap242_stream.py
@@ -948,6 +948,41 @@ def _units_to_step(part):
     return "METRE", None
 
 
+def _part_fuses_from_fem(p) -> bool:
+    """True for a part whose Beam/Plate haven't been materialised but whose FEM
+    mesh carries elements — stream its objects straight from the mesh."""
+    fem = getattr(p, "fem", None)
+    return fem is not None and (len(p.plates) + len(p.beams)) == 0 and len(fem.elements) > 0
+
+
+def _iter_stream_objects(part):
+    """Yield physical objects to stream, fusing Beam/Plate straight from the FEM
+    mesh (``Part.iter_objects_from_fem``, one at a time, detached) when they
+    haven't been materialised — so the whole concept set is never resident (the
+    same win as the IFC streaming writer). Built objects (CAD shapes, pipes, or
+    already-materialised beams/plates) come from the part as before."""
+    from ada import Beam, Plate
+
+    for p in part.get_all_parts_in_assembly(include_self=True):
+        if _part_fuses_from_fem(p):
+            yield from p.iter_objects_from_fem(beams=True, plates=True, detached=True)
+            for o in p.get_all_physical_objects(sub_elements_only=True, pipe_to_segments=True):
+                if not isinstance(o, (Beam, Plate)):  # shapes / pipes / masses still need emitting
+                    yield o
+        else:
+            yield from p.get_all_physical_objects(sub_elements_only=True, pipe_to_segments=True)
+
+
+def _estimate_object_count(part) -> int:
+    n = 0
+    for p in part.get_all_parts_in_assembly(include_self=True):
+        if _part_fuses_from_fem(p):
+            n += len(p.fem.elements)  # rough: shells→plates, lines→beams
+        else:
+            n += sum(1 for _ in p.get_all_physical_objects(sub_elements_only=True, pipe_to_segments=True))
+    return n
+
+
 def write_step_stream(
     part,
     destination_file,
@@ -955,15 +990,24 @@ def write_step_stream(
     schema="AP242",
     assembly=True,
     progress_callback=None,
+    fuse_fem=True,
 ):
     """Stream every supported physical object under ``part`` to a STEP file.
 
     Returns a stats dict: ``{"emitted": int, "skipped": int}``. Kernel-free --
     builds no OCC/adacpp shapes, so it avoids the memory spike that OOMs the OCC
     ``STEPCAFControl_Writer`` path on large FEM models.
+
+    ``fuse_fem`` (default) streams Beam/Plate straight from a part's FEM mesh when
+    they haven't been materialised, so neither the concept objects nor the STEP
+    entities are ever held whole — bounded memory. Set ``False`` to emit only the
+    already-built objects (e.g. an explicit ``fem_to_objects=False`` job).
     """
-    objects = list(part.get_all_physical_objects(pipe_to_segments=True))
-    total = len(objects)
+    if fuse_fem:
+        objects = _iter_stream_objects(part)
+    else:
+        objects = part.get_all_physical_objects(pipe_to_segments=True)
+    total = _estimate_object_count(part)
     lu, lp = _units_to_step(part)
     emitted = 0
     skipped = 0
@@ -994,7 +1038,7 @@ def write_step_stream(
             emitted += 1 if done else 0
             skipped += 0 if done else 1
             if progress_callback is not None:
-                progress_callback(i, total)
+                progress_callback(i, max(total, i))
         writer.end()
 
     logger.info("write_step_stream: emitted %d, skipped %d of %d", emitted, skipped, total)

--- a/src/ada/cadit/step/write/ap242_stream.py
+++ b/src/ada/cadit/step/write/ap242_stream.py
@@ -955,17 +955,20 @@ def _part_fuses_from_fem(p) -> bool:
     return fem is not None and (len(p.plates) + len(p.beams)) == 0 and len(fem.elements) > 0
 
 
-def _iter_stream_objects(part):
+def _iter_stream_objects(part, merge_strategy=None):
     """Yield physical objects to stream, fusing Beam/Plate straight from the FEM
     mesh (``Part.iter_objects_from_fem``, one at a time, detached) when they
     haven't been materialised — so the whole concept set is never resident (the
     same win as the IFC streaming writer). Built objects (CAD shapes, pipes, or
-    already-materialised beams/plates) come from the part as before."""
+    already-materialised beams/plates) come from the part as before.
+
+    ``merge_strategy`` folds shells into plates via the shared object-free face
+    engine (passed straight to ``iter_objects_from_fem``)."""
     from ada import Beam, Plate
 
     for p in part.get_all_parts_in_assembly(include_self=True):
         if _part_fuses_from_fem(p):
-            yield from p.iter_objects_from_fem(beams=True, plates=True, detached=True)
+            yield from p.iter_objects_from_fem(beams=True, plates=True, detached=True, merge_strategy=merge_strategy)
             for o in p.get_all_physical_objects(sub_elements_only=True, pipe_to_segments=True):
                 if not isinstance(o, (Beam, Plate)):  # shapes / pipes / masses still need emitting
                     yield o
@@ -991,6 +994,7 @@ def write_step_stream(
     assembly=True,
     progress_callback=None,
     fuse_fem=True,
+    merge_strategy=None,
 ):
     """Stream every supported physical object under ``part`` to a STEP file.
 
@@ -1002,9 +1006,12 @@ def write_step_stream(
     they haven't been materialised, so neither the concept objects nor the STEP
     entities are ever held whole — bounded memory. Set ``False`` to emit only the
     already-built objects (e.g. an explicit ``fem_to_objects=False`` job).
+
+    ``merge_strategy`` folds shells into plates via the shared object-free face
+    engine before emit (same source the IFC and Genie-XML streamers use).
     """
     if fuse_fem:
-        objects = _iter_stream_objects(part)
+        objects = _iter_stream_objects(part, merge_strategy=merge_strategy)
     else:
         objects = part.get_all_physical_objects(pipe_to_segments=True)
     total = _estimate_object_count(part)

--- a/src/ada/cadit/visual_parity.py
+++ b/src/ada/cadit/visual_parity.py
@@ -74,12 +74,18 @@ class ParityResult:
     errors: dict[str, str] = field(
         default_factory=dict
     )  # format -> error message when that format failed to round-trip
+    # format -> reason a format was deliberately not compared (it structurally
+    # can't represent this source's geometry, so a 0-count isn't a converter
+    # fault). Excluded from the consistency verdict.
+    skipped: dict[str, str] = field(default_factory=dict)
 
     def summary(self) -> str:
         status = "OK" if self.consistent and not self.errors else "MISMATCH"
         parts = [f"{k}={v}" for k, v in self.counts.items()]
         if self.errors:
             parts += [f"{k}=ERR" for k in self.errors]
+        if self.skipped:
+            parts += [f"{k}=SKIP" for k in self.skipped]
         return f"[{status}] expected={self.expected} " + " ".join(parts)
 
 
@@ -150,6 +156,7 @@ def cross_format_parity(
     baseline = assembly_element_count(assembly)
     counts: dict[str, int] = {"source": baseline}
     errors: dict[str, str] = {}
+    skipped: dict[str, str] = {}
 
     tmp_ctx = None
     if work_dir is None:
@@ -162,6 +169,13 @@ def cross_format_parity(
             io = _FORMAT_IO.get(fmt)
             if io is None:
                 errors[fmt] = f"unknown format {fmt!r}"
+                continue
+            reason = _unrepresentable_reason(fmt, assembly)
+            if reason is not None:
+                # The format structurally can't carry this source's geometry, so
+                # a 0-count is the format's limit, not a converter fault — record
+                # and exclude from the verdict instead of flagging a mismatch.
+                skipped[fmt] = reason
                 continue
             writer, reader, suffix = io
             out = work_dir / f"parity{suffix}"
@@ -177,4 +191,29 @@ def cross_format_parity(
 
     mismatches = {k: v for k, v in counts.items() if k != "source" and v != baseline}
     consistent = not mismatches and not errors
-    return ParityResult(counts=counts, expected=baseline, consistent=consistent, mismatches=mismatches, errors=errors)
+    return ParityResult(
+        counts=counts,
+        expected=baseline,
+        consistent=consistent,
+        mismatches=mismatches,
+        errors=errors,
+        skipped=skipped,
+    )
+
+
+def _unrepresentable_reason(fmt: str, assembly: "Assembly") -> str | None:
+    """Why ``fmt`` can't carry ``assembly``'s geometry at all, or None if it can.
+
+    Genie XML is a structural-concept format — it only writes Beam / Plate
+    (Section) elements, not arbitrary B-rep solids. A source made entirely of
+    imported generic ``Shape`` bodies (e.g. a CAD ``.ifc`` / ``.stp`` / ``.sat``)
+    therefore round-trips to an empty XML, which is the format's limit rather
+    than a converter dropping geometry — so we skip it instead of flagging a
+    permanent mismatch. IFC and STEP carry solids, so they're never skipped."""
+    if fmt != "xml":
+        return None
+    from ada import Beam, Plate
+
+    if any(isinstance(o, (Beam, Plate)) for o in assembly.get_all_physical_objects()):
+        return None
+    return "Genie XML carries only Beam/Plate concepts, not generic solids"

--- a/src/ada/cadit/visual_parity.py
+++ b/src/ada/cadit/visual_parity.py
@@ -100,7 +100,24 @@ def load_assembly_auto(path: str | Path) -> "Assembly":
     if ext == ".xml":
         return ada.from_genie_xml(p)
     if ext in (".fem", ".inp", ".sif", ".sin"):
-        return ada.from_fem(p)
+        asm = ada.from_fem(p)
+        # Mirror the FEM->CAD converter (_apply_fem_to_objects): it rebuilds
+        # Beam/Plate concept objects from the mesh before any structure-
+        # preserving export, because those writers emit *concepts*, not the raw
+        # mesh. Without this the parity round-trip exports an objectless
+        # assembly and every format reads back empty — a false "dropped all
+        # geometry", when the converter never exports a bare mesh.
+        asm.create_objects_from_fem(merge=True)
+        # Drop the mesh so the baseline counts the exported concept geometry,
+        # not the auxiliary FEM-mesh viz (mass/spring elements with no concept
+        # representation) that no structure-preserving format carries — else the
+        # source over-counts against every format.
+        from ada.fem import FEM
+
+        for part in asm.get_all_parts_in_assembly(include_self=True):
+            if part.fem is not None and len(part.fem.elements) > 0:
+                part.fem = FEM(part.fem.name, parent=part)
+        return asm
     raise ValueError(f"visual_parity: no loader for source suffix {ext!r}")
 
 

--- a/src/ada/comms/msg_handling/object_metadata.py
+++ b/src/ada/comms/msg_handling/object_metadata.py
@@ -102,6 +102,23 @@ def beam_metadata(
     }
 
 
+def curved_plate_metadata(
+    name: str,
+    thickness: float | None,
+    material: Material | None,
+) -> dict:
+    """Info-panel metadata for a ``PlateCurved``. Mirrors :func:`plate_metadata`
+    (thickness + material) so a curved plate surfaces the same properties a flat
+    plate does; only the ``type`` discriminator differs so the panel can label
+    it ``Curved Plate``."""
+    return {
+        "type": "PlateCurved",
+        "name": name,
+        "thickness": _maybe_float(thickness),
+        "material": material_to_dict(material),
+    }
+
+
 def plate_metadata(
     name: str,
     thickness: float | None,
@@ -139,6 +156,18 @@ def _register_plate(scene: SceneBackend, file_name: str, plate) -> None:
     )
 
 
+def _register_curved_plate(scene: SceneBackend, file_name: str, plate) -> None:
+    name = getattr(plate, "name", None)
+    if not name:
+        return
+    file_meta = scene.object_meta.setdefault(file_name, {})
+    file_meta[name] = curved_plate_metadata(
+        name=name,
+        thickness=getattr(plate, "t", None),
+        material=getattr(plate, "material", None),
+    )
+
+
 def build_object_meta_from_assembly(
     scene: SceneBackend,
     file_name: str,
@@ -167,14 +196,18 @@ def build_object_meta_from_assembly(
 
 
 def _build_cad_index(scene: SceneBackend, file_name: str, assembly: Assembly) -> None:
-    from ada import Beam, Plate
+    from ada import Beam, Plate, PlateCurved
 
     # ``get_all_physical_objects`` already walks every subpart, so we
     # don't iterate ``parts`` ourselves — that would visit each Beam /
-    # Plate N times for an N-part assembly.
+    # Plate N times for an N-part assembly. PlateCurved is a sibling of
+    # Plate (not a subclass), so it needs its own branch or it'd get no
+    # Info-panel metadata.
     for obj in assembly.get_all_physical_objects():
         if isinstance(obj, Beam):
             _register_beam(scene, file_name, obj)
+        elif isinstance(obj, PlateCurved):
+            _register_curved_plate(scene, file_name, obj)
         elif isinstance(obj, Plate):
             _register_plate(scene, file_name, obj)
 

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3700,6 +3700,49 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
         return JSONResponse(run, status_code=202)
 
+    @admin.post("/audit/runs/{run_id}/validate")
+    async def admin_audit_run_validate(
+        run_id: str,
+        request: Request,
+        background_tasks: BackgroundTasks,
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Append a validation (cross-format parity) pass to a finished run —
+        the manual counterpart to the auto-validate toggle. Grows the run's
+        total + reopens it, then enqueues the parity cells under the same run
+        id. 409 if the run isn't finished or has already been validated (the
+        pass runs at most once per run; re-run the audit for a fresh one)."""
+        pool = _require_pool(request)
+        run = await db_module.get_audit_run(pool, run_id)
+        if run is None:
+            raise HTTPException(status_code=404, detail="audit run not found")
+
+        s = _parse_scope(run["scope"], user)
+        s = await _resolve_project_scope(pool, s)
+        if not await scope_can_access(user, s, pool):
+            raise HTTPException(status_code=403, detail="forbidden")
+        if not queue.enabled and run["worker_pool"] != _WASM_POOL:
+            raise HTTPException(status_code=503, detail="conversion disabled (no NATS configured)")
+
+        claimed = await db_module.claim_run_for_validation(pool, run_id)
+        if claimed is None:
+            raise HTTPException(
+                status_code=409,
+                detail="run is not finished, or its validation pass has already been dispatched",
+            )
+        background_tasks.add_task(
+            _audit_dispatch,
+            run_id,
+            s,
+            run["worker_pool"],
+            user.sub,
+            pool,
+            False,  # force_rebuild
+            True,  # validate_only
+            True,  # extend — append into the existing run
+        )
+        return JSONResponse(claimed, status_code=202)
+
     @admin.get("/audit/cell-history")
     async def admin_audit_cell_history(
         request: Request,

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3154,6 +3154,35 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             summary["commented"],
         )
 
+    async def _dispatch_auto_validation(pool, parent: dict) -> None:
+        """Fire a ``validate_only`` parity run for a finished ``auto_validate``
+        conversion run. The claim already stamped the parent so this runs once;
+        any failure here is logged but never breaks the poller tick."""
+        try:
+            s = _parse_scope(parent["scope"], _SystemUser())
+            s = await _resolve_project_scope(pool, s)
+        except Exception:
+            logger.exception("auto-validate: scope resolution failed for run %s", parent["id"])
+            return
+        try:
+            vrun = await db_module.create_audit_run(
+                pool,
+                scope=parent["scope"],
+                worker_pool=parent["worker_pool"],
+                trigger="auto-validate",
+                note=f"auto-validation of {parent['id'][:8]}",
+                created_by="system",
+                parent_run_id=parent["id"],
+            )
+        except Exception:
+            logger.exception("auto-validate: create_audit_run failed for %s", parent["id"])
+            return
+        asyncio.create_task(
+            _audit_dispatch(vrun["id"], s, parent["worker_pool"], "system", pool, False, True),
+            name=f"audit-validate-{vrun['id']}",
+        )
+        logger.info("auto-validate: dispatched validation run %s for %s", vrun["id"], parent["id"])
+
     async def _issue_bot_loop(pool) -> None:
         """Background task: drain (1) finished audit runs + (2)
         failed user-driven conversions per tick. Defensive —
@@ -3189,6 +3218,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         if conv is None:
                             break
                         await _run_issue_bot_for_conversion(pool, conv)
+                    # Auto-validate: each finished auto_validate conversion run
+                    # gets a follow-up validate_only parity run, dispatched once
+                    # (the claim stamps auto_validate_dispatched_at).
+                    while True:
+                        parent = await db_module.claim_audit_run_for_auto_validate(pool)
+                        if parent is None:
+                            break
+                        await _dispatch_auto_validation(pool, parent)
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -3482,6 +3519,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # cross-format parity cells, skipping the conversion grid. The parity job
         # re-derives from source, so it needs no prior conversion outputs.
         validate_only = bool(body.get("validate_only") or False)
+        # auto_validate: once this conversion run finishes, the finished-run
+        # poller fires a follow-up validate_only run for the same scope. Only
+        # meaningful for a worker-pool conversion run (a validation run / a
+        # browser run has nothing to chain).
+        auto_validate = bool(body.get("auto_validate") or False) and not validate_only and not is_wasm
 
         s = _parse_scope(scope_str, user)
         s = await _resolve_project_scope(pool, s)
@@ -3496,6 +3538,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             note=note,
             created_by=user.sub,
             force_rebuild=force_rebuild,
+            auto_validate=auto_validate,
         )
         if is_wasm:
             # Parity cells are a worker-only concern (no browser parity
@@ -3588,6 +3631,77 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 detail="audit run not found or not in running state",
             )
         return JSONResponse(run)
+
+    @admin.post("/audit/runs/{run_id}/re-dispatch")
+    async def admin_audit_run_re_dispatch(
+        run_id: str,
+        request: Request,
+        background_tasks: BackgroundTasks,
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Re-run a prior audit against the same scope / pool / settings.
+
+        Creates a fresh run that mirrors the prior one's ``scope``,
+        ``worker_pool``, ``force_rebuild`` and ``auto_validate`` (linked via
+        ``parent_run_id``), then dispatches it the same way the original was
+        (NATS workers, or the browser WASM engine for a ``wasm`` pool). The
+        cell set is re-enumerated from the scope at dispatch time, so a
+        re-dispatch reflects the scope's current files — not a frozen copy."""
+        pool = _require_pool(request)
+        prior = await db_module.get_audit_run(pool, run_id)
+        if prior is None:
+            raise HTTPException(status_code=404, detail="audit run not found")
+
+        scope_str = prior["scope"]
+        worker_pool = prior["worker_pool"]
+        is_wasm = isinstance(worker_pool, str) and worker_pool.strip().lower() == _WASM_POOL
+        if not is_wasm and not queue.enabled:
+            raise HTTPException(status_code=503, detail="conversion disabled (no NATS configured)")
+
+        s = _parse_scope(scope_str, user)
+        s = await _resolve_project_scope(pool, s)
+        if not await scope_can_access(user, s, pool):
+            raise HTTPException(status_code=403, detail="forbidden")
+
+        run = await db_module.create_audit_run(
+            pool,
+            scope=scope_str,
+            worker_pool=worker_pool,
+            trigger="re-dispatch",
+            note=f"re-run of {run_id[:8]}",
+            created_by=user.sub,
+            force_rebuild=prior["force_rebuild"],
+            auto_validate=prior["auto_validate"],
+            parent_run_id=run_id,
+        )
+        if is_wasm:
+            background_tasks.add_task(_audit_dispatch_wasm, run["id"], s, pool)
+        else:
+            background_tasks.add_task(
+                _audit_dispatch,
+                run["id"],
+                s,
+                worker_pool,
+                user.sub,
+                pool,
+                prior["force_rebuild"],
+                False,
+            )
+        return JSONResponse(run, status_code=202)
+
+    @admin.get("/audit/cell-history")
+    async def admin_audit_cell_history(
+        request: Request,
+        key: str,
+        target: str,
+        limit: int = 50,
+    ) -> JSONResponse:
+        """Historic results for one ``(source key, target_format)`` cell across
+        every run — newest first. Drives the grid's right-click 'show history'
+        table so an operator can see how one conversion has trended."""
+        pool = _require_pool(request)
+        rows = await db_module.audit_log_history_for_cell(pool, key, target, limit=limit)
+        return JSONResponse({"key": key, "target_format": target, "history": rows})
 
     @admin.get("/audit/runs/{run_id}/cells")
     async def admin_audit_run_cells(

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3155,33 +3155,28 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
 
     async def _dispatch_auto_validation(pool, parent: dict) -> None:
-        """Fire a ``validate_only`` parity run for a finished ``auto_validate``
-        conversion run. The claim already stamped the parent so this runs once;
-        any failure here is logged but never breaks the poller tick."""
+        """Append a validation (cross-format parity) pass to a finished
+        ``auto_validate`` conversion run — *into the same run*, not a new one.
+        The run's total grows by the parity cell count and it reopens to
+        ``running`` until those cells land (then it re-finishes). The claim
+        already stamped the parent so this runs once; failures are logged but
+        never break the poller tick."""
         try:
             s = _parse_scope(parent["scope"], _SystemUser())
             s = await _resolve_project_scope(pool, s)
         except Exception:
             logger.exception("auto-validate: scope resolution failed for run %s", parent["id"])
             return
+        # Awaited (not fire-and-forget) so the run is reopened with its parity
+        # cells before the issue-bot drain in the same tick can claim it.
         try:
-            vrun = await db_module.create_audit_run(
-                pool,
-                scope=parent["scope"],
-                worker_pool=parent["worker_pool"],
-                trigger="auto-validate",
-                note=f"auto-validation of {parent['id'][:8]}",
-                created_by="system",
-                parent_run_id=parent["id"],
+            await _audit_dispatch(
+                parent["id"], s, parent["worker_pool"], "system", pool,
+                False, validate_only=True, extend=True,
             )
+            logger.info("auto-validate: appended validation cells to run %s", parent["id"])
         except Exception:
-            logger.exception("auto-validate: create_audit_run failed for %s", parent["id"])
-            return
-        asyncio.create_task(
-            _audit_dispatch(vrun["id"], s, parent["worker_pool"], "system", pool, False, True),
-            name=f"audit-validate-{vrun['id']}",
-        )
-        logger.info("auto-validate: dispatched validation run %s for %s", vrun["id"], parent["id"])
+            logger.exception("auto-validate: dispatch failed for run %s", parent["id"])
 
     async def _issue_bot_loop(pool) -> None:
         """Background task: drain (1) finished audit runs + (2)
@@ -3204,7 +3199,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         try:
             while True:
                 try:
-                    # Drain audit runs first (each represents many
+                    # Auto-validate first: a finished auto_validate run gets its
+                    # parity cells appended (reopening it to 'running'), so the
+                    # issue-bot below only claims a run once it's *truly* done —
+                    # conversions and validation together. Claimed once (the
+                    # claim stamps auto_validate_dispatched_at).
+                    while True:
+                        parent = await db_module.claim_audit_run_for_auto_validate(pool)
+                        if parent is None:
+                            break
+                        await _dispatch_auto_validation(pool, parent)
+                    # Drain finished audit runs (each represents many
                     # failures batched into one sync, more valuable
                     # to keep current).
                     while True:
@@ -3218,14 +3223,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         if conv is None:
                             break
                         await _run_issue_bot_for_conversion(pool, conv)
-                    # Auto-validate: each finished auto_validate conversion run
-                    # gets a follow-up validate_only parity run, dispatched once
-                    # (the claim stamps auto_validate_dispatched_at).
-                    while True:
-                        parent = await db_module.claim_audit_run_for_auto_validate(pool)
-                        if parent is None:
-                            break
-                        await _dispatch_auto_validation(pool, parent)
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -3277,6 +3274,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         pool,
         force_rebuild: bool = False,
         validate_only: bool = False,
+        extend: bool = False,
     ) -> None:
         """Enumerate the scope's files × the converter matrix and
         enqueue one regular convert job per cell. Cached cells
@@ -3288,6 +3286,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         every cell is re-converted from source. Used for perf
         measurement runs where a 4-hour audit re-run mustn't
         short-circuit 80% of cells against prior outputs.
+
+        ``extend`` *appends* the enumerated cells to an already-finished run
+        (growing its total + reopening it) instead of setting the total from
+        scratch — the auto-validation pass uses this to fold its parity cells
+        into the conversion run rather than spawning a separate run. With
+        ``extend`` an empty cell set is a no-op (the finished run is left as
+        is) rather than a zero-total finish.
 
         Errors during enumeration / enqueue surface as a ``failed``
         audit row on the cell that tripped them — the run still
@@ -3304,12 +3309,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             cells = await _audit_run_list_cells(scope_obj, validate_only)
         except Exception:
             logger.exception("audit run %s: scope listing failed", run_id)
-            await db_module.set_audit_run_total(pool, run_id, 0)
+            if not extend:
+                await db_module.set_audit_run_total(pool, run_id, 0)
             return
 
-        await db_module.set_audit_run_total(pool, run_id, len(cells))
-        if not cells:
-            return
+        if extend:
+            if not cells:
+                return  # nothing to append; leave the finished run untouched
+            await db_module.extend_audit_run_total(pool, run_id, len(cells))
+        else:
+            await db_module.set_audit_run_total(pool, run_id, len(cells))
+            if not cells:
+                return
 
         for source_key, target_format in cells:
             # Parity cells produce no derived blob, so there is nothing to cache

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3171,8 +3171,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # cells before the issue-bot drain in the same tick can claim it.
         try:
             await _audit_dispatch(
-                parent["id"], s, parent["worker_pool"], "system", pool,
-                False, validate_only=True, extend=True,
+                parent["id"],
+                s,
+                parent["worker_pool"],
+                "system",
+                pool,
+                False,
+                validate_only=True,
+                extend=True,
             )
             logger.info("auto-validate: appended validation cells to run %s", parent["id"])
         except Exception:

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3743,6 +3743,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         return JSONResponse(claimed, status_code=202)
 
+    @admin.delete("/audit/runs/{run_id}")
+    async def admin_audit_run_delete(
+        run_id: str,
+        request: Request,
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Delete an audit run and its audit_log rows (parity rows cascade).
+        Refuses a still-running run — cancel it first — so an in-flight sweep
+        can't be deleted out from under its workers."""
+        pool = _require_pool(request)
+        run = await db_module.get_audit_run(pool, run_id)
+        if run is None:
+            raise HTTPException(status_code=404, detail="audit run not found")
+        if run["status"] == "running":
+            raise HTTPException(status_code=409, detail="cancel the run before deleting it")
+        deleted = await db_module.delete_audit_run(pool, run_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="audit run not found")
+        return JSONResponse({"deleted": run_id})
+
     @admin.get("/audit/cell-history")
     async def admin_audit_cell_history(
         request: Request,

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -984,7 +984,12 @@ def _via_fea_result(
     else:
         from ada.fem.formats.sesam.results.read_sif import read_sif_file
 
-        result = read_sif_file(str(src_path))
+        # Bound peak RSS to one step the way the SIN path does: load only the
+        # requested step (or the first step in the file when the caller didn't
+        # pick one) instead of materialising every step's RV* records. The GLB
+        # render only colours one (step, field); a 20-mode eigen SIF that used
+        # to hit multi-GB now stays at one step's footprint.
+        result = read_sif_file(str(src_path), step=(int(step) if step is not None else "first"))
 
     on_progress("selecting-field", 0.50)
     if step is None or field is None:

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -628,8 +628,15 @@ def _export_with_ada(
     source_ext: str | None = None,
     merge_fem_objects: bool | None = None,
     reconstruct_surfaces: bool | None = None,
-) -> bytes:
-    """Run the matching ada exporter and read back the produced bytes.
+) -> bytes | pathlib.Path:
+    """Run the matching ada exporter; return the output as bytes or a path.
+
+    GLB tessellates into a ``BytesIO`` and is returned as bytes. The
+    disk-writing targets (IFC, Genie XML) return ``out_path`` itself —
+    ownership transfers to the caller, which streams the file straight to
+    object storage rather than reading it back into a RAM buffer (the
+    streaming writers already keep peak memory bounded; reading the whole
+    result back would undo that).
 
     ``merge_meshes`` is the per-job override for the ada-loadable →
     GLB pipeline. ``True`` (default) merges every geometry into one
@@ -690,7 +697,7 @@ def _export_with_ada(
     else:
         raise UnsupportedFormat(f"unknown target format: {target_format!r}")
     on_progress("ready", 1.0)
-    return out_path.read_bytes()
+    return out_path
 
 
 # A STEP file on disk above this size loads into one OCC compound that OOM-kills
@@ -759,6 +766,7 @@ def _via_ada(
     """
     suffix = ".glb" if target_format == "glb" else f".{target_format}"
     out_path = pathlib.Path(tempfile.mkstemp(suffix=suffix)[1])
+    result: bytes | pathlib.Path = b""
     try:
         if source_ext in {".step", ".stp"} and target_format == "glb" and _should_stream_step(src_path, step_streamer):
             # Stream solid-by-solid: bounded memory, no whole-model OCC load.
@@ -767,12 +775,13 @@ def _via_ada(
             on_progress("streaming-step", 0.1)
             stream_step_to_glb(src_path, out_path, tolerant=True, on_progress=on_progress)
             on_progress("ready", 1.0)
-            return out_path.read_bytes()
+            result = out_path
+            return result
 
         on_progress("parsing", 0.15)
         model = _load_with_ada(src_path, source_ext)
         _apply_fem_to_objects(model, source_ext, target_format, fem_to_objects, merge_fem_objects, reconstruct_surfaces)
-        return _export_with_ada(
+        result = _export_with_ada(
             model,
             target_format,
             out_path,
@@ -782,11 +791,17 @@ def _via_ada(
             merge_fem_objects=merge_fem_objects,
             reconstruct_surfaces=reconstruct_surfaces,
         )
+        return result
     finally:
-        try:
-            out_path.unlink()
-        except OSError:
-            pass
+        # When we hand back the path itself, ownership transfers to the
+        # caller (the subprocess child moves it into the result slot), so we
+        # must NOT delete it here. Bytes results — and the empty temp file
+        # GLB never writes (it tessellates into a BytesIO) — get cleaned up.
+        if not isinstance(result, pathlib.Path):
+            try:
+                out_path.unlink()
+            except OSError:
+                pass
 
 
 def _via_bundle(
@@ -834,8 +849,9 @@ def _via_bundle(
         )
         suffix = ".glb" if target_format == "glb" else f".{target_format}"
         out_path = pathlib.Path(tempfile.mkstemp(suffix=suffix)[1])
+        result: bytes | pathlib.Path = b""
         try:
-            return _export_with_ada(
+            result = _export_with_ada(
                 model,
                 target_format,
                 out_path,
@@ -845,11 +861,15 @@ def _via_bundle(
                 merge_fem_objects=opts.get("merge_fem_objects"),
                 reconstruct_surfaces=opts.get("reconstruct_surfaces"),
             )
+            return result
         finally:
-            try:
-                out_path.unlink()
-            except OSError:
-                pass
+            # Path result → ownership transfers to the caller; only clean up
+            # when the bytes are already in hand (see _via_ada).
+            if not isinstance(result, pathlib.Path):
+                try:
+                    out_path.unlink()
+                except OSError:
+                    pass
     finally:
         tmp.cleanup()
 
@@ -1094,7 +1114,7 @@ def _via_ada_to_step(
     fem_to_objects: bool | None = None,
     merge_fem_objects: bool | None = None,
     reconstruct_surfaces: bool | None = None,
-) -> bytes:
+) -> pathlib.Path:
     """Ada-loadable source → STEP via the OCC writer.
 
     Primary use is the IFC → STEP interop case (no STEP writer in
@@ -1114,6 +1134,7 @@ def _via_ada_to_step(
         _apply_fem_to_objects(model, source_ext, "step", fem_to_objects, merge_fem_objects, reconstruct_surfaces)
     on_progress("writing-step", 0.55)
     out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
+    returned_path = False
     try:
         if is_fem:
             # A FEM mesh rebuilds into extruded plates/straight beams, which the
@@ -1140,12 +1161,16 @@ def _via_ada_to_step(
         else:
             model.to_stp(str(out_path))
         on_progress("ready", 1.0)
-        return out_path.read_bytes()
+        returned_path = True
+        return out_path
     finally:
-        try:
-            out_path.unlink()
-        except OSError:
-            pass
+        # Ownership of the STEP file transfers to the caller on success; only
+        # remove it if we bailed before returning the path.
+        if not returned_path:
+            try:
+                out_path.unlink()
+            except OSError:
+                pass
 
 
 # NOTE: _INCLUDE_RE / _inline_abaqus_includes / _find_writer_output /
@@ -1334,7 +1359,7 @@ def convert(
     step: int | None = None,
     field: str | None = None,
     options: dict | None = None,
-) -> bytes:
+) -> bytes | pathlib.Path:
     """Convert a local source file to the requested target format.
 
     Dispatches via :class:`ConverterRegistry` — every viable (from,
@@ -1345,8 +1370,14 @@ def convert(
 
     The worker streams the source from object storage into a tempfile
     and passes its path here, so we never round-trip the full payload
-    through a `bytes` buffer in memory. Output is still returned as
-    bytes — the worker uploads it via `Storage.put_bytes`.
+    through a `bytes` buffer in memory. Output is returned as **bytes or
+    a path**: GLB / mesh / FEA-result handlers build their output in RAM
+    and return bytes; the disk-writing exporters (IFC, Genie XML, STEP)
+    return the ``pathlib.Path`` of the file they wrote, transferring
+    ownership to the caller, which streams it to object storage via
+    `Storage.put_path` instead of reading it back into a buffer. Direct
+    callers that want bytes should read the path themselves (see the
+    `ada audit` repro path / `result_bytes` helper).
 
     ``step`` / ``field`` only apply to FEA result sources (.sif /
     .sin). When unset the FEA handler picks the first available pair,
@@ -1386,6 +1417,21 @@ def convert(
         )
     opts = options or {}
     return handler(src_path, progress, step=step, field=field, **opts)
+
+
+def result_bytes(result: bytes | pathlib.Path) -> bytes:
+    """Materialise a :func:`convert` result as bytes.
+
+    ``convert`` returns bytes for in-RAM handlers and a ``pathlib.Path`` for
+    the disk-writing exporters (so the worker can stream the file straight to
+    storage). Direct callers that genuinely need the bytes — the ``ada audit``
+    repro CLI, unit tests — funnel through here. Reading a large path back into
+    RAM is exactly what the worker avoids, so reserve this for the
+    small/diagnostic callers, not the hot upload path.
+    """
+    if isinstance(result, pathlib.Path):
+        return result.read_bytes()
+    return bytes(result)
 
 
 def supported_extensions() -> Iterable[str]:

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -464,6 +464,17 @@ def fea_meta_key_for(source_key: str) -> str:
     return f"_derived/{src}{_FEA_META_SUFFIX}"
 
 
+# Suffix for the SIF byte-offset index sidecar (see
+# ada.fem.formats.sesam.results.sif_index). Built once per SIF deck; lets the
+# worker range-fetch only one result step's bytes instead of the whole file.
+_SIF_INDEX_SUFFIX = ".sifindex.json"
+
+
+def sif_index_key_for(source_key: str) -> str:
+    src = source_key.strip("/")
+    return f"_derived/{src}{_SIF_INDEX_SUFFIX}"
+
+
 def is_derived_key(key: str) -> bool:
     return key.lstrip("/").startswith("_derived/")
 

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -663,7 +663,16 @@ def _export_with_ada(
         import os
 
         streaming = os.environ.get("ADA_IFC_STREAMING", "").strip().lower() not in _FALSE
-        model.to_ifc(destination=str(out_path), streaming=streaming)
+        # On the streaming path, fold FEM shells via the shared object-free face
+        # engine instead of emitting one plate per element (matches the Genie-XML
+        # and STEP streamers). merge_fem_objects -> coplanar/none; falls back to
+        # 1:1 for non-FEM sources or curved-plate reconstruction.
+        ms = None
+        recon = bool(reconstruct_surfaces) if reconstruct_surfaces is not None else False
+        if streaming and source_ext is not None and source_ext.lower() in _FEM_SOURCE_EXTS and not recon:
+            merge = True if merge_fem_objects is None else bool(merge_fem_objects)
+            ms = "coplanar" if merge else "none"
+        model.to_ifc(destination=str(out_path), streaming=streaming, merge_strategy=ms)
     elif target_format == "xml":
         on_progress("writing-xml", 0.55)
         recon = bool(reconstruct_surfaces) if reconstruct_surfaces is not None else False
@@ -1114,7 +1123,17 @@ def _via_ada_to_step(
             # worker on large jackets/ships — the writer fuses Beam/Plate straight
             # from the mesh. The OCC XCAF writer would instead accumulate every
             # solid plus a full entity-graph copy. fem_to_objects=False opts out.
-            stats = model.to_stp(str(out_path), writer="stream", fuse_fem=(fem_to_objects is not False))
+            # Fold FEM shells via the shared object-free face engine (matches the
+            # Genie-XML and IFC streamers) unless curved-plate reconstruction is
+            # requested. merge_fem_objects -> coplanar/none.
+            recon = bool(reconstruct_surfaces) if reconstruct_surfaces is not None else False
+            ms = None
+            if not recon:
+                merge = True if merge_fem_objects is None else bool(merge_fem_objects)
+                ms = "coplanar" if merge else "none"
+            stats = model.to_stp(
+                str(out_path), writer="stream", fuse_fem=(fem_to_objects is not False), merge_strategy=ms
+            )
             skipped = (stats or {}).get("skipped", 0)
             if skipped:
                 logger.warning(f"streaming STEP writer skipped {skipped} non-extrudable object(s)")

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -584,15 +584,38 @@ def _apply_fem_to_objects(
     recon = bool(reconstruct_surfaces) if reconstruct_surfaces is not None else False
     # The IFC streaming writer fuses shell elements into plates one at a time
     # (Part.iter_objects_from_fem), so leave plates unbuilt — build beams only —
-    # and let the writer stream them, keeping peak memory bounded. Curved-plate
-    # reconstruction (advanced faces) isn't handled by the text emitter, so it
-    # still takes the full build.
+    # and let the writer stream them, keeping peak memory bounded. The Genie-XML
+    # streaming writer does the same via the object-free vectorized face source
+    # (mesh_faces). Curved-plate reconstruction (advanced faces) isn't handled by
+    # either text emitter, so it still takes the full build.
     skip_plates = False
     if target_format == "ifc" and not recon:
         import os
 
         skip_plates = os.environ.get("ADA_IFC_STREAMING", "").strip().lower() not in _FALSE
+    elif _gxml_face_streaming(source_ext, target_format, recon):
+        skip_plates = True
     model.create_objects_from_fem(merge=merge, reconstruct_surfaces=recon, skip_plates=skip_plates)
+
+
+def _gxml_face_streaming(source_ext: str, target_format: str, reconstruct_surfaces: bool) -> bool:
+    """Whether FEM→Genie-XML streams plates from the object-free vectorized face
+    source instead of materialising Plate objects.
+
+    Gated by ``ADA_GXML_STREAMING`` (default on; only an explicit falsy value
+    reverts to the full object build + DOM writer). Not used for curved-plate
+    reconstruction (the parametric face emitter can't express advanced faces).
+    Shared by ``_apply_fem_to_objects`` (skip the plate build) and
+    ``_export_with_ada`` (use the streaming writer) so they stay consistent."""
+    if target_format != "xml":
+        return False
+    if source_ext.lower() not in _FEM_SOURCE_EXTS:
+        return False
+    if reconstruct_surfaces:
+        return False
+    import os
+
+    return os.environ.get("ADA_GXML_STREAMING", "").strip().lower() not in _FALSE
 
 
 def _export_with_ada(
@@ -602,6 +625,9 @@ def _export_with_ada(
     on_progress: ProgressFn,
     *,
     merge_meshes: bool | None = None,
+    source_ext: str | None = None,
+    merge_fem_objects: bool | None = None,
+    reconstruct_surfaces: bool | None = None,
 ) -> bytes:
     """Run the matching ada exporter and read back the produced bytes.
 
@@ -640,7 +666,18 @@ def _export_with_ada(
         model.to_ifc(destination=str(out_path), streaming=streaming)
     elif target_format == "xml":
         on_progress("writing-xml", 0.55)
-        model.to_genie_xml(destination_xml=str(out_path))
+        recon = bool(reconstruct_surfaces) if reconstruct_surfaces is not None else False
+        if source_ext is not None and _gxml_face_streaming(source_ext, target_format, recon):
+            # Object-free path: plates stream from the vectorized FEM-shell face
+            # source (no Plate objects, no DOM). merge_fem_objects -> strategy.
+            merge = True if merge_fem_objects is None else bool(merge_fem_objects)
+            model.to_genie_xml(
+                destination_xml=str(out_path),
+                streaming=True,
+                merge_strategy=("coplanar" if merge else "none"),
+            )
+        else:
+            model.to_genie_xml(destination_xml=str(out_path))
     else:
         raise UnsupportedFormat(f"unknown target format: {target_format!r}")
     on_progress("ready", 1.0)
@@ -732,6 +769,9 @@ def _via_ada(
             out_path,
             on_progress,
             merge_meshes=merge_meshes,
+            source_ext=source_ext,
+            merge_fem_objects=merge_fem_objects,
+            reconstruct_surfaces=reconstruct_surfaces,
         )
     finally:
         try:
@@ -792,6 +832,9 @@ def _via_bundle(
                 out_path,
                 on_progress,
                 merge_meshes=opts.get("merge_meshes"),
+                source_ext=entry_ext,
+                merge_fem_objects=opts.get("merge_fem_objects"),
+                reconstruct_surfaces=opts.get("reconstruct_surfaces"),
             )
         finally:
             try:

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -1055,16 +1055,23 @@ def _via_ada_to_step(
 
     on_progress("parsing", 0.15)
     model = _load_with_ada(src_path, source_ext)
-    _apply_fem_to_objects(model, source_ext, "step", fem_to_objects, merge_fem_objects, reconstruct_surfaces)
+    is_fem = source_ext.lower() in _FEM_SOURCE_EXTS
+    if not is_fem:
+        # IFC/CAD source: materialise any FEM-derived concept objects up front
+        # (a no-op when there is no mesh) before the OCC writer runs.
+        _apply_fem_to_objects(model, source_ext, "step", fem_to_objects, merge_fem_objects, reconstruct_surfaces)
     on_progress("writing-step", 0.55)
     out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
     try:
-        if source_ext.lower() in _FEM_SOURCE_EXTS:
+        if is_fem:
             # A FEM mesh rebuilds into extruded plates/straight beams, which the
-            # streaming AP242 writer emits one-at-a-time at constant memory. The
-            # default OCC XCAF writer instead accumulates every solid plus a full
-            # entity-graph copy and OOMs the worker on large jackets/ships.
-            stats = model.to_stp(str(out_path), writer="stream")
+            # streaming AP242 writer emits one-at-a-time at constant memory. We
+            # deliberately do NOT pre-build them here: the create_objects_from_fem
+            # phase (not the writer) was the multi-GB peak that OOM-killed the
+            # worker on large jackets/ships — the writer fuses Beam/Plate straight
+            # from the mesh. The OCC XCAF writer would instead accumulate every
+            # solid plus a full entity-graph copy. fem_to_objects=False opts out.
+            stats = model.to_stp(str(out_path), writer="stream", fuse_fem=(fem_to_objects is not False))
             skipped = (stats or {}).get("skipped", 0)
             if skipped:
                 logger.warning(f"streaming STEP writer skipped {skipped} non-extrudable object(s)")

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -1235,6 +1235,26 @@ async def set_audit_run_total(
     )
 
 
+async def extend_audit_run_total(pool: asyncpg.Pool, run_id: str, delta: int) -> None:
+    """Grow a finished run's ``total`` by ``delta`` and reopen it to
+    ``running`` (clearing ``finished_at``). Used to append cells — an
+    auto-validation parity pass — to an existing run instead of spawning a
+    separate one: once the appended cells land, the normal counter-bump
+    re-finishes the same run. Aborted runs are left aborted. Caller guards
+    ``delta > 0``."""
+    await pool.execute(
+        """
+        UPDATE audit_runs
+        SET total = total + $2,
+            status = CASE WHEN status = 'aborted' THEN 'aborted' ELSE 'running' END,
+            finished_at = CASE WHEN status = 'aborted' THEN finished_at ELSE NULL END
+        WHERE id = $1
+        """,
+        run_id,
+        delta,
+    )
+
+
 async def list_audit_runs(
     pool: asyncpg.Pool,
     *,

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -1157,6 +1157,10 @@ def _audit_run_row(r) -> dict:
         "failed": r["failed"],
         "skipped": r["skipped"],
         "created_by": r["created_by"],
+        "seq": _opt("seq"),
+        # Idle time excluded from the run's active duration (gap before a later
+        # validation pass). The UI shows (finished_at - started_at) - idle_ms.
+        "idle_ms": _opt("idle_ms") or 0,
         "force_rebuild": _opt("force_rebuild") or False,
         "auto_validate": _opt("auto_validate") or False,
         "parent_run_id": str(parent_run_id) if parent_run_id else None,
@@ -1248,6 +1252,13 @@ async def extend_audit_run_total(pool: asyncpg.Pool, run_id: str, delta: int) ->
         """
         UPDATE audit_runs
         SET total = total + $2,
+            -- Fold the idle gap (since this run last finished) into idle_ms so
+            -- the displayed duration stays block-active time, not wall clock.
+            -- RHS reads the pre-update finished_at / status.
+            idle_ms = idle_ms + CASE
+                WHEN status <> 'aborted' AND finished_at IS NOT NULL
+                THEN GREATEST(0, (EXTRACT(EPOCH FROM (NOW() - finished_at)) * 1000)::bigint)
+                ELSE 0 END,
             status = CASE WHEN status = 'aborted' THEN 'aborted' ELSE 'running' END,
             finished_at = CASE WHEN status = 'aborted' THEN finished_at ELSE NULL END
         WHERE id = $1
@@ -1255,6 +1266,19 @@ async def extend_audit_run_total(pool: asyncpg.Pool, run_id: str, delta: int) ->
         run_id,
         delta,
     )
+
+
+async def delete_audit_run(pool: asyncpg.Pool, run_id: str) -> bool:
+    """Delete an audit run and its audit_log rows. ``audit_parity`` rows cascade
+    on the run delete; ``audit_log`` is ON DELETE SET NULL, so we remove those
+    rows explicitly rather than orphaning them as run-less audit entries.
+    Returns True if a run was deleted, False if it didn't exist."""
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("DELETE FROM audit_log WHERE audit_run_id = $1", run_id)
+            res = await conn.execute("DELETE FROM audit_runs WHERE id = $1", run_id)
+    # asyncpg returns a command tag like "DELETE 1".
+    return res.split()[-1] != "0"
 
 
 async def list_audit_runs(
@@ -1274,8 +1298,8 @@ async def list_audit_runs(
     args.append(min(max(limit, 1), 200))
     rows = await pool.fetch(
         f"""
-        SELECT id, scope, worker_pool, trigger, started_at, finished_at,
-               status, note, total, ok, failed, skipped, created_by,
+        SELECT id, seq, scope, worker_pool, trigger, started_at, finished_at,
+               status, note, total, ok, failed, skipped, created_by, idle_ms,
                force_rebuild, auto_validate, parent_run_id, auto_validate_dispatched_at,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs
@@ -1291,8 +1315,8 @@ async def list_audit_runs(
 async def get_audit_run(pool: asyncpg.Pool, run_id: str) -> dict | None:
     row = await pool.fetchrow(
         """
-        SELECT id, scope, worker_pool, trigger, started_at, finished_at,
-               status, note, total, ok, failed, skipped, created_by,
+        SELECT id, seq, scope, worker_pool, trigger, started_at, finished_at,
+               status, note, total, ok, failed, skipped, created_by, idle_ms,
                force_rebuild, auto_validate, parent_run_id, auto_validate_dispatched_at,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs WHERE id = $1

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -1141,6 +1141,7 @@ def _audit_run_row(r) -> dict:
             return None
 
     issue_bot_synced_at = _opt("issue_bot_synced_at")
+    parent_run_id = _opt("parent_run_id")
     return {
         "id": str(r["id"]),
         "scope": r["scope"],
@@ -1156,6 +1157,8 @@ def _audit_run_row(r) -> dict:
         "skipped": r["skipped"],
         "created_by": r["created_by"],
         "force_rebuild": _opt("force_rebuild") or False,
+        "auto_validate": _opt("auto_validate") or False,
+        "parent_run_id": str(parent_run_id) if parent_run_id else None,
         "issue_bot_status": _opt("issue_bot_status"),
         "issue_bot_last_error": _opt("issue_bot_last_error"),
         "issue_bot_synced_at": (issue_bot_synced_at.isoformat() if issue_bot_synced_at else None),
@@ -1171,6 +1174,8 @@ async def create_audit_run(
     note: str | None = None,
     created_by: str | None = None,
     force_rebuild: bool = False,
+    auto_validate: bool = False,
+    parent_run_id: str | None = None,
 ) -> dict:
     """Open a new audit_runs row in ``status='running'``. Returns the
     fresh row (including its server-generated UUID + started_at) so
@@ -1182,11 +1187,18 @@ async def create_audit_run(
     short-circuit so every viable cell actually re-converts.
     Persisted on the row so the admin UI can show "this was a
     force-rebuild" badge.
+
+    ``auto_validate`` asks the finished-run poller to fire a follow-up
+    ``validate_only`` parity run once this run finishes. ``parent_run_id``
+    links a derived run (the validation child, or a re-dispatched copy)
+    back to its source.
     """
     row = await pool.fetchrow(
         """
-        INSERT INTO audit_runs (scope, worker_pool, trigger, note, created_by, force_rebuild)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO audit_runs
+            (scope, worker_pool, trigger, note, created_by, force_rebuild,
+             auto_validate, parent_run_id)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING *
         """,
         scope,
@@ -1195,6 +1207,8 @@ async def create_audit_run(
         note,
         created_by,
         force_rebuild,
+        auto_validate,
+        parent_run_id,
     )
     return _audit_run_row(row)
 
@@ -1240,7 +1254,7 @@ async def list_audit_runs(
         f"""
         SELECT id, scope, worker_pool, trigger, started_at, finished_at,
                status, note, total, ok, failed, skipped, created_by,
-               force_rebuild,
+               force_rebuild, auto_validate, parent_run_id,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs
         {where}
@@ -1257,7 +1271,7 @@ async def get_audit_run(pool: asyncpg.Pool, run_id: str) -> dict | None:
         """
         SELECT id, scope, worker_pool, trigger, started_at, finished_at,
                status, note, total, ok, failed, skipped, created_by,
-               force_rebuild,
+               force_rebuild, auto_validate, parent_run_id,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs WHERE id = $1
         """,
@@ -1645,6 +1659,71 @@ async def claim_audit_run_for_issue_bot(
         """,
     )
     return _audit_run_row(row) if row else None
+
+
+async def claim_audit_run_for_auto_validate(pool: asyncpg.Pool):
+    """Atomically claim the oldest finished ``auto_validate`` run whose
+    validation pass hasn't been dispatched yet. Stamps
+    ``auto_validate_dispatched_at`` in the same statement so a concurrent tick
+    / replica can't double-fire. Returns the claimed run row or ``None``."""
+    row = await pool.fetchrow(
+        """
+        UPDATE audit_runs
+        SET auto_validate_dispatched_at = NOW()
+        WHERE id = (
+            SELECT id FROM audit_runs
+            WHERE status = 'finished'
+              AND auto_validate = TRUE
+              AND auto_validate_dispatched_at IS NULL
+            ORDER BY finished_at ASC NULLS LAST
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING id, scope, worker_pool, trigger, started_at, finished_at,
+                  status, note, total, ok, failed, skipped, created_by,
+                  force_rebuild, auto_validate, parent_run_id,
+                  issue_bot_status, issue_bot_last_error, issue_bot_synced_at
+        """,
+    )
+    return _audit_run_row(row) if row else None
+
+
+async def audit_log_history_for_cell(
+    pool: asyncpg.Pool,
+    key: str,
+    target_format: str,
+    *,
+    limit: int = 50,
+) -> list[dict]:
+    """Historic ``audit_log`` results for one ``(source key, target_format)``
+    cell across every run — newest first. Powers the per-cell 'show history'
+    table so an operator can spot run-to-run regressions for one conversion."""
+    rows = await pool.fetch(
+        """
+        SELECT id, ts, status, error, duration_ms, peak_rss_kb,
+               worker_image_tag, audit_run_id
+        FROM audit_log
+        WHERE key = $1 AND target_format = $2
+        ORDER BY id DESC
+        LIMIT $3
+        """,
+        key,
+        target_format,
+        min(max(limit, 1), 500),
+    )
+    return [
+        {
+            "id": r["id"],
+            "ts": r["ts"].isoformat() if r["ts"] else None,
+            "status": r["status"],
+            "error": r["error"],
+            "duration_ms": r["duration_ms"],
+            "peak_rss_kb": r["peak_rss_kb"],
+            "worker_image_tag": r["worker_image_tag"],
+            "audit_run_id": str(r["audit_run_id"]) if r["audit_run_id"] else None,
+        }
+        for r in rows
+    ]
 
 
 async def mark_audit_run_issue_bot(

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -1142,6 +1142,7 @@ def _audit_run_row(r) -> dict:
 
     issue_bot_synced_at = _opt("issue_bot_synced_at")
     parent_run_id = _opt("parent_run_id")
+    av_dispatched = _opt("auto_validate_dispatched_at")
     return {
         "id": str(r["id"]),
         "scope": r["scope"],
@@ -1159,6 +1160,7 @@ def _audit_run_row(r) -> dict:
         "force_rebuild": _opt("force_rebuild") or False,
         "auto_validate": _opt("auto_validate") or False,
         "parent_run_id": str(parent_run_id) if parent_run_id else None,
+        "auto_validate_dispatched_at": (av_dispatched.isoformat() if av_dispatched else None),
         "issue_bot_status": _opt("issue_bot_status"),
         "issue_bot_last_error": _opt("issue_bot_last_error"),
         "issue_bot_synced_at": (issue_bot_synced_at.isoformat() if issue_bot_synced_at else None),
@@ -1274,7 +1276,7 @@ async def list_audit_runs(
         f"""
         SELECT id, scope, worker_pool, trigger, started_at, finished_at,
                status, note, total, ok, failed, skipped, created_by,
-               force_rebuild, auto_validate, parent_run_id,
+               force_rebuild, auto_validate, parent_run_id, auto_validate_dispatched_at,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs
         {where}
@@ -1291,7 +1293,7 @@ async def get_audit_run(pool: asyncpg.Pool, run_id: str) -> dict | None:
         """
         SELECT id, scope, worker_pool, trigger, started_at, finished_at,
                status, note, total, ok, failed, skipped, created_by,
-               force_rebuild, auto_validate, parent_run_id,
+               force_rebuild, auto_validate, parent_run_id, auto_validate_dispatched_at,
                issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         FROM audit_runs WHERE id = $1
         """,
@@ -1704,6 +1706,29 @@ async def claim_audit_run_for_auto_validate(pool: asyncpg.Pool):
                   force_rebuild, auto_validate, parent_run_id,
                   issue_bot_status, issue_bot_last_error, issue_bot_synced_at
         """,
+    )
+    return _audit_run_row(row) if row else None
+
+
+async def claim_run_for_validation(pool: asyncpg.Pool, run_id: str):
+    """Atomically mark one *specific* finished run as having its validation
+    pass dispatched (the manual 'Validate' button). Returns the run if newly
+    claimed, or ``None`` when it's already been validated, isn't finished, or
+    doesn't exist — so a validation is appended at most once per run, whether
+    via the auto-validate toggle or the button."""
+    row = await pool.fetchrow(
+        """
+        UPDATE audit_runs
+        SET auto_validate_dispatched_at = NOW()
+        WHERE id = $1
+          AND status = 'finished'
+          AND auto_validate_dispatched_at IS NULL
+        RETURNING id, scope, worker_pool, trigger, started_at, finished_at,
+                  status, note, total, ok, failed, skipped, created_by,
+                  force_rebuild, auto_validate, parent_run_id, auto_validate_dispatched_at,
+                  issue_bot_status, issue_bot_last_error, issue_bot_synced_at
+        """,
+        run_id,
     )
     return _audit_run_row(row) if row else None
 

--- a/src/ada/comms/rest/migrations/015_audit_run_auto_validate.sql
+++ b/src/ada/comms/rest/migrations/015_audit_run_auto_validate.sql
@@ -1,0 +1,19 @@
+-- 015_audit_run_auto_validate.sql — chain a validation pass after a run.
+--
+-- ``auto_validate = TRUE`` on a conversion run asks the system to
+-- automatically fire a follow-up ``validate_only`` (cross-format
+-- parity) run for the same scope once the conversion run finishes.
+-- The finished-run poller claims such runs and stamps
+-- ``auto_validate_dispatched_at`` so the validation is dispatched
+-- exactly once even with concurrent ticks / replicas.
+--
+-- ``parent_run_id`` links a child (validation, or re-dispatched) run
+-- back to the run it was derived from, so the UI can show lineage and
+-- the poller can tell whether a run already spawned its validation.
+
+ALTER TABLE audit_runs ADD COLUMN auto_validate BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE audit_runs ADD COLUMN parent_run_id UUID REFERENCES audit_runs(id) ON DELETE SET NULL;
+ALTER TABLE audit_runs ADD COLUMN auto_validate_dispatched_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS audit_runs_parent_run_idx
+    ON audit_runs (parent_run_id) WHERE parent_run_id IS NOT NULL;

--- a/src/ada/comms/rest/migrations/016_audit_run_seq_and_idle.sql
+++ b/src/ada/comms/rest/migrations/016_audit_run_seq_and_idle.sql
@@ -1,0 +1,27 @@
+-- 016_audit_run_seq_and_idle.sql — friendly run number + idle-aware duration.
+--
+-- ``seq`` is a human-referrable monotonic run number ("Run #42"), backfilled
+-- in started_at order; new runs increment via a sequence. The UUID stays the
+-- canonical id; seq is just a short label an operator can refer to.
+--
+-- ``idle_ms`` accumulates the idle gap whenever a finished run is reopened to
+-- append a later validation pass. The displayed duration is then
+-- (finished_at - started_at) - idle_ms = the conversion block + the validation
+-- block, instead of the wall-clock span that would wrongly include the hours
+-- of idle time between a run and a validation triggered much later.
+
+ALTER TABLE audit_runs ADD COLUMN idle_ms BIGINT NOT NULL DEFAULT 0;
+
+-- seq: backfill existing rows in chronological order, then hand new inserts a
+-- sequence default so numbering stays monotonic.
+ALTER TABLE audit_runs ADD COLUMN seq BIGINT;
+WITH ordered AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY started_at, id) AS rn FROM audit_runs
+)
+UPDATE audit_runs a SET seq = o.rn FROM ordered o WHERE a.id = o.id;
+CREATE SEQUENCE IF NOT EXISTS audit_runs_seq_seq;
+SELECT setval('audit_runs_seq_seq', COALESCE((SELECT MAX(seq) FROM audit_runs), 0) + 1, false);
+ALTER TABLE audit_runs ALTER COLUMN seq SET DEFAULT nextval('audit_runs_seq_seq');
+ALTER TABLE audit_runs ALTER COLUMN seq SET NOT NULL;
+ALTER SEQUENCE audit_runs_seq_seq OWNED BY audit_runs.seq;
+CREATE UNIQUE INDEX IF NOT EXISTS audit_runs_seq_idx ON audit_runs (seq);

--- a/src/ada/comms/rest/storage.py
+++ b/src/ada/comms/rest/storage.py
@@ -44,6 +44,21 @@ from .scope import Scope
 _GZIP_MAGIC = b"\x1f\x8b"
 
 
+def _gzip_file(src: pathlib.Path, dst: pathlib.Path, *, chunk_size: int = 1 << 20) -> None:
+    """Stream-gzip ``src`` into ``dst`` a chunk at a time.
+
+    Used by :meth:`Storage.put_path` so a text output (IFC / Genie XML) can
+    be compressed without holding either the plain or the gzipped payload
+    whole in RAM — the opposite of ``gzip.compress(data)`` which needs both.
+    """
+    with open(src, "rb") as fi, gzip.open(dst, "wb") as fo:
+        while True:
+            block = fi.read(chunk_size)
+            if not block:
+                break
+            fo.write(block)
+
+
 @dataclass(frozen=True)
 class FileEntry:
     """Bucket-level file entry. ``key`` is scope-relative — the
@@ -250,6 +265,86 @@ class Storage:
                 return
 
         await obs.put_async(self._store, full, data)
+
+    async def put_path(
+        self,
+        scope: Scope,
+        key: str,
+        src_path: pathlib.Path,
+        *,
+        content_encoding: str | None = None,
+        pre_compressed: bool = False,
+    ) -> None:
+        """Stream a local file to object storage without buffering it whole.
+
+        The mirror of :meth:`put_bytes` for output that already lives on
+        disk (a conversion writer's tempfile). obstore reads the file and
+        uploads via multipart, so peak RSS stays at the chunk size rather
+        than the full payload — the whole point of this method is to NOT
+        hand a multi-hundred-MB ``bytes`` object to the upload. Used by the
+        worker for large derived outputs (STEP / IFC / GLB) that otherwise
+        get materialised in RAM twice (child read-back + parent buffer).
+
+        ``content_encoding="gzip"``:
+
+        * ``pre_compressed=True`` — the file at ``src_path`` is already
+          gzipped; we just attach the Content-Encoding attribute and stream
+          it up as-is.
+        * ``pre_compressed=False`` — we stream-gzip ``src_path`` into a
+          sibling temp file first (chunked, never the whole payload in RAM),
+          upload that, then delete it. Costs one extra bounded disk pass but
+          keeps the ergonomics identical to ``put_bytes``.
+        """
+        if content_encoding is not None and content_encoding != "gzip":
+            raise ValueError(f"unsupported content_encoding: {content_encoding!r}")
+
+        full = self._full_key(scope, key)
+        src_path = pathlib.Path(src_path)
+
+        if content_encoding == "gzip" and not pre_compressed:
+            gz_path = src_path.with_name(src_path.name + ".gz")
+            try:
+                _gzip_file(src_path, gz_path)
+                await self._put_file_stream(full, gz_path, content_encoding="gzip")
+            finally:
+                try:
+                    gz_path.unlink()
+                except OSError:
+                    pass
+            return
+
+        await self._put_file_stream(full, src_path, content_encoding=content_encoding)
+
+    async def _put_file_stream(
+        self,
+        full: str,
+        path: pathlib.Path,
+        *,
+        content_encoding: str | None = None,
+    ) -> None:
+        """Multipart-upload a local file at ``full`` (already scope-prefixed).
+
+        Opens the file fresh for each attempt so the LocalStore
+        attribute-unsupported retry doesn't replay a consumed cursor.
+        """
+        if content_encoding is not None:
+            try:
+                with open(path, "rb") as fh:
+                    await obs.put_async(
+                        self._store,
+                        full,
+                        fh,
+                        use_multipart=True,
+                        attributes={"Content-Encoding": content_encoding},
+                    )
+                return
+            except NotImplementedError:
+                # LocalStore has no attribute slot — fall through and write
+                # the bytes plain. The gzip magic header still lets the read
+                # path recognise compressed content.
+                pass
+        with open(path, "rb") as fh:
+            await obs.put_async(self._store, full, fh, use_multipart=True)
 
     async def get_range(self, scope: Scope, key: str, start: int, length: int) -> bytes:
         """Read ``[start, start+length)`` raw bytes of an object — no gzip

--- a/src/ada/comms/rest/subprocess_convert.py
+++ b/src/ada/comms/rest/subprocess_convert.py
@@ -41,6 +41,7 @@ import logging
 import os
 import pathlib
 import resource as _resource_mod  # noqa: F401 — imported for posterity
+import shutil
 import signal
 import sys
 import tempfile
@@ -49,6 +50,23 @@ import traceback
 from typing import Any, Awaitable, Callable, Optional
 
 logger = logging.getLogger("ada")
+
+
+def _move_into_result(src: str, dst: pathlib.Path) -> None:
+    """Move the handler's output file into the result slot.
+
+    ``os.replace`` is an atomic rename when ``src`` and ``dst`` share a
+    filesystem (they normally do — both under ``$TMPDIR``), so the
+    multi-hundred-MB output never gets copied. Cross-device falls back to a
+    chunked copy + unlink so a split ``/tmp`` mount still works."""
+    try:
+        os.replace(src, dst)
+    except OSError:
+        shutil.copyfile(src, dst)
+        try:
+            os.unlink(src)
+        except OSError:
+            pass
 
 
 @dataclasses.dataclass
@@ -65,7 +83,11 @@ class ConvertSample:
 
 @dataclasses.dataclass
 class IsolatedConvertResult:
-    out_bytes: Optional[bytes]
+    # Path to the conversion output on disk (in a per-job work dir), or None
+    # on failure. The caller streams it to storage (Storage.put_path) without
+    # reading it into RAM, then calls cleanup_output(). Carrying a path rather
+    # than bytes is what keeps a multi-hundred-MB output off the parent heap.
+    out_path: Optional[pathlib.Path]
     error: Optional[str]  # exception message from child, when present
     traceback: Optional[str]  # python traceback string from child
     exit_code: int  # 0 success; >0 clean error; <0 = -signal
@@ -73,6 +95,22 @@ class IsolatedConvertResult:
     samples: list[ConvertSample]
     final_metrics: dict  # {cpu_user_ms, cpu_sys_ms, peak_rss_kb, read_bytes, write_bytes}
     profile_bytes: Optional[bytes] = None  # cProfile dump from child, when enabled
+
+    def cleanup_output(self) -> None:
+        """Remove the on-disk output file and its work dir. Idempotent and
+        safe when ``out_path`` is None — the caller invokes it in a finally
+        once the upload (or its failure handling) is done."""
+        if self.out_path is None:
+            return
+        try:
+            self.out_path.unlink()
+        except OSError:
+            pass
+        try:
+            self.out_path.parent.rmdir()
+        except OSError:
+            pass
+        self.out_path = None
 
 
 def _proc_stats(pid: int, started_at: float) -> Optional[ConvertSample]:
@@ -199,7 +237,7 @@ def _signal_child(pid: int, sig: int) -> None:
 
 
 async def run_isolated_convert(
-    convert_fn: Callable[..., bytes],
+    convert_fn: Callable[..., "bytes | pathlib.Path"],
     src_path: pathlib.Path,
     source_key: str,
     target_format: str,
@@ -314,9 +352,15 @@ async def run_isolated_convert(
                             pass
                 if out is None:
                     out = b""
-                if not isinstance(out, (bytes, bytearray, memoryview)):
-                    raise TypeError(f"convert returned {type(out).__name__}, expected bytes")
-                result_path.write_bytes(bytes(out))
+                if isinstance(out, (bytes, bytearray, memoryview)):
+                    result_path.write_bytes(bytes(out))
+                elif isinstance(out, (str, os.PathLike)):
+                    # Handler wrote its output to disk and handed back the
+                    # path; move it into the result slot rather than reading
+                    # it into RAM here (the big-STEP child-copy we're killing).
+                    _move_into_result(os.fspath(out), result_path)
+                else:
+                    raise TypeError(f"convert returned {type(out).__name__}, expected bytes or a path")
                 os._exit(0)
             except BaseException as exc:  # noqa: BLE001 — propagate verbatim
                 # Even on failure, dump whatever profile data was
@@ -528,13 +572,17 @@ async def run_isolated_convert(
             # treated as an error.
             exit_code = -signal.SIGTERM
 
-    out_bytes: Optional[bytes] = None
+    out_path: Optional[pathlib.Path] = None
     error_msg: Optional[str] = None
     error_tb: Optional[str] = None
     profile_bytes: Optional[bytes] = None
+    success = exit_code == 0 and result_path.exists()
     try:
-        if exit_code == 0 and result_path.exists():
-            out_bytes = result_path.read_bytes()
+        if success:
+            # Hand the output back as a path; the caller streams it to storage
+            # and calls cleanup_output() afterwards. We deliberately do NOT
+            # read it into RAM here — that buffer was the parent-side peak.
+            out_path = result_path
         if exit_code != 0 and err_path.exists():
             try:
                 d = json.loads(err_path.read_text())
@@ -548,16 +596,25 @@ async def run_isolated_convert(
             except OSError:
                 pass
     finally:
-        for p in (result_path, err_path, profile_path):
+        # Small sidecars are always reclaimed. The result file + its work dir
+        # survive on success (ownership passes to the caller); on any failure
+        # we drop them too so a crashed/oomed job leaves no tmp residue.
+        for p in (err_path, profile_path):
             try:
                 if p.exists():
                     p.unlink()
             except OSError:
                 pass
-        try:
-            work_dir.rmdir()
-        except OSError:
-            pass
+        if not success:
+            try:
+                if result_path.exists():
+                    result_path.unlink()
+            except OSError:
+                pass
+            try:
+                work_dir.rmdir()
+            except OSError:
+                pass
 
     if exit_code < 0 and error_msg is None:
         if oomed:
@@ -594,7 +651,7 @@ async def run_isolated_convert(
         final_metrics.setdefault("peak_rss_kb", max(s.peak_rss_kb for s in samples))
 
     return IsolatedConvertResult(
-        out_bytes=out_bytes,
+        out_path=out_path,
         error=error_msg,
         traceback=error_tb,
         exit_code=exit_code,

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -1312,9 +1312,7 @@ async def _process_one(
             # Stream the output file straight to object storage (multipart) —
             # never reading it into a parent-side bytes buffer. cleanup_output()
             # drops the tmpfile + work dir once the upload settles either way.
-            await storage.put_path(
-                scope, job.derived_key, iresult.out_path, content_encoding=derived_encoding
-            )
+            await storage.put_path(scope, job.derived_key, iresult.out_path, content_encoding=derived_encoding)
         except Exception as exc:
             logger.exception("worker: upload failed for %s", job.derived_key)
             trace = tb_module.format_exc()

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -662,6 +662,98 @@ async def _run_utility_job(
     await _audit_done(db_pool, job_id, "done", None, started_at)
 
 
+async def _try_reduced_sif_source(
+    storage: Storage,
+    scope: Scope,
+    source_key: str,
+    step: int | None,
+    src_path: pathlib.Path,
+) -> bool:
+    """Range-fetch just one result step of a SIF deck instead of the whole file.
+
+    When a byte-offset index sidecar exists (built by a prior conversion), the
+    bytes of every *other* step are skipped: only the target step's RV records
+    plus the step-invariant mesh / RDPOINTS / control rows are fetched and
+    concatenated into ``src_path`` — a smaller, still-valid SIF the normal
+    reader parses. A 969 MB deck becomes a ~340 MB read, and re-picking a mode
+    in the viewer stops re-downloading the whole file.
+
+    Returns True on success; False (with ``src_path`` untouched) to fall back
+    to the full streaming download. Skipped when the source is gzip-stored —
+    range offsets address the *uncompressed* file.
+    """
+    from ada.fem.formats.sesam.results.sif_index import SifStepIndex
+
+    from .converter import sif_index_key_for
+
+    index_key = sif_index_key_for(source_key)
+    try:
+        idx_bytes = await storage.get_bytes(scope, index_key)
+    except FileNotFoundError:
+        return False
+    except Exception:
+        logger.exception("worker: reading SIF index %s failed (non-fatal)", index_key)
+        return False
+
+    try:
+        idx = SifStepIndex.from_json(idx_bytes)
+    except Exception:
+        logger.warning("worker: SIF index %s unreadable; full download", index_key)
+        return False
+
+    try:
+        if await storage.is_gzip_stored(scope, source_key):
+            return False
+    except Exception:
+        return False
+
+    target = step if step is not None else idx.default_step()
+    if target not in idx.steps:
+        return False
+
+    ranges = idx.include_ranges(target)
+    try:
+        with open(src_path, "wb") as fo:
+            for s, e in ranges:
+                fo.write(await storage.get_range(scope, source_key, s, e - s))
+    except Exception:
+        logger.exception("worker: SIF range-fetch for %s failed; full download", source_key)
+        return False
+
+    fetched = sum(e - s for s, e in ranges)
+    logger.info(
+        "worker: SIF reduced read %s step %s — %d/%d bytes (%.0f%%)",
+        source_key,
+        target,
+        fetched,
+        idx.size,
+        100.0 * fetched / max(idx.size, 1),
+    )
+    return True
+
+
+async def _ensure_sif_index(storage: Storage, scope: Scope, source_key: str, src_path: pathlib.Path) -> None:
+    """Build + upload the SIF byte-offset index sidecar if absent.
+
+    One-time cheap byte scan (no float parsing) of the full local deck so later
+    picks of other steps range-fetch a reduced file. Best-effort: a failure
+    here never fails the job — it just means the next pick scans the whole file
+    again."""
+    from ada.fem.formats.sesam.results.sif_index import build_sif_index
+
+    from .converter import sif_index_key_for
+
+    index_key = sif_index_key_for(source_key)
+    try:
+        if await storage.exists(scope, index_key):
+            return
+        idx = await asyncio.to_thread(build_sif_index, src_path)
+        await storage.put_bytes(scope, index_key, idx.to_json())
+        logger.info("worker: built SIF index for %s (%d steps)", source_key, len(idx.steps))
+    except Exception:
+        logger.exception("worker: building SIF index for %s failed (non-fatal)", source_key)
+
+
 async def _process_one(
     job_id: str,
     queue: JobQueue,
@@ -763,9 +855,17 @@ async def _process_one(
     src_fd, src_name = tempfile.mkstemp(suffix=src_suffix)
     os.close(src_fd)
     src_path = pathlib.Path(src_name)
+    # A SIF deck with a cached byte-offset index range-fetches only the target
+    # step (reduced, still-valid SIF) instead of the whole ~1 GB file. Falls
+    # back to the full stream when there's no index / it's gzip-stored / fetch
+    # fails. ``sif_reduced`` gates the post-convert index build below.
+    sif_reduced = False
     try:
         try:
-            await storage.stream_to_path(scope, job.source_key, src_path)
+            if src_suffix.lower() == ".sif":
+                sif_reduced = await _try_reduced_sif_source(storage, scope, job.source_key, job.step, src_path)
+            if not sif_reduced:
+                await storage.stream_to_path(scope, job.source_key, src_path)
         except FileNotFoundError as exc:
             logger.warning("worker: source %s missing for job %s", job.source_key, job_id)
             await queue.update(job_id, status=JOB_STATUS_ERROR, stage="loading", error=str(exc))
@@ -1162,6 +1262,13 @@ async def _process_one(
 
         await queue.update(job_id, status=JOB_STATUS_DONE, stage="ready", progress=1.0, error=None)
         await _audit_done(db_pool, job_id, "done", None, started_at, metrics=metrics)
+
+        # First full conversion of a SIF deck: build + cache the byte-offset
+        # index so subsequent step/field picks range-fetch one step instead of
+        # the whole file. Skipped when we already read a reduced file (the
+        # index existed) or the source isn't a SIF. Best-effort.
+        if src_suffix.lower() == ".sif" and not sif_reduced:
+            await _ensure_sif_index(storage, scope, job.source_key, src_path)
     finally:
         try:
             src_path.unlink()

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -1088,7 +1088,7 @@ async def _process_one(
             return
 
         # Map the isolated result back to the existing audit/error flow.
-        if iresult.exit_code != 0 or iresult.out_bytes is None:
+        if iresult.exit_code != 0 or iresult.out_path is None:
             err_msg = iresult.error or "convert subprocess produced no output"
             trace = iresult.traceback
             # Recognize BundleError by name in the error message rather
@@ -1124,15 +1124,18 @@ async def _process_one(
             )
             return
 
-        out_bytes = iresult.out_bytes
-
         await queue.update(job_id, stage="uploading", progress=0.95)
         # Gzip text-format outputs (IFC, Genie XML); GLB is binary geometry
         # that doesn't compress meaningfully and is what the in-browser
         # viewer fetches on the hot path.
         derived_encoding = "gzip" if job.target_format in {"ifc", "xml"} else None
         try:
-            await storage.put_bytes(scope, job.derived_key, out_bytes, content_encoding=derived_encoding)
+            # Stream the output file straight to object storage (multipart) —
+            # never reading it into a parent-side bytes buffer. cleanup_output()
+            # drops the tmpfile + work dir once the upload settles either way.
+            await storage.put_path(
+                scope, job.derived_key, iresult.out_path, content_encoding=derived_encoding
+            )
         except Exception as exc:
             logger.exception("worker: upload failed for %s", job.derived_key)
             trace = tb_module.format_exc()
@@ -1149,6 +1152,8 @@ async def _process_one(
                 metrics=metrics,
             )
             return
+        finally:
+            iresult.cleanup_output()
 
         # Conversion + upload succeeded — collect metrics and (optionally)
         # the cProfile dump from the child.

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -386,6 +386,35 @@ async def _run_fea_meta_compute(
     await _audit_done(db_pool, job_id, "done", None, started_at)
 
 
+def _parity_child(src_path, source_key, target_format, on_progress, *, formats=()):
+    """``convert_fn``-shaped wrapper that runs the cross-format parity check and
+    returns its result as JSON bytes.
+
+    Parity re-derives the source to ifc/xml/step and reloads each — easily a
+    multi-GB peak on a large model. Running it through ``run_isolated_convert``
+    (this function in the forked child) instead of a worker threadpool means an
+    OOM is SIGKILLed by the per-job memory watchdog and fails the cell, rather
+    than taking the whole worker pod down."""
+    import json as _json
+    import pathlib as _pl
+
+    from ada.cadit.visual_parity import parity_for_source_file
+
+    on_progress("parity", 0.2)
+    res = parity_for_source_file(_pl.Path(src_path), tuple(formats))
+    on_progress("ready", 1.0)
+    return _json.dumps(
+        {
+            "counts": res.counts,
+            "expected": res.expected,
+            "consistent": res.consistent,
+            "mismatches": res.mismatches,
+            "errors": res.errors,
+            "summary": res.summary(),
+        }
+    ).encode("utf-8")
+
+
 async def _run_parity_validation(
     *,
     job: Job,
@@ -395,6 +424,7 @@ async def _run_parity_validation(
     db_pool: "asyncpg.Pool | None",
     started_at: float,
     _on_progress: Callable[[str, float], Awaitable[None]],
+    timeout_s: float | None = None,
 ) -> None:
     """Cross-format visual-parity validation for one source (target_format=='parity').
 
@@ -404,28 +434,76 @@ async def _run_parity_validation(
     table and the cell is audited done/error (a mismatch maps to ``error`` so it
     surfaces in the run's failed cells). Never raises.
 
-    Re-deriving (rather than reading the stored GLB) is deliberate: the stored GLB
-    is mesh-merged, so its scene-entry count is not the object count — the parity
-    check must reload with merging off, which ``parity_for_source_file`` does.
+    Runs in the same memory-capped forked child the convert path uses
+    (``run_isolated_convert``): re-deriving + reloading several formats can spike
+    RAM, and a blow-up must die in isolation (cell fails as OOM) rather than
+    OOM-killing the worker pod. Re-deriving (rather than reading the stored GLB)
+    is deliberate: the stored GLB is mesh-merged, so its scene-entry count isn't
+    the object count — the check reloads with merging off.
     """
+    import json
+
     job_id = job.job_id
     suffix = pathlib.PurePosixPath(job.source_key).suffix.lower()
     formats = tuple(t for t in ("ifc", "xml", "step") if t in ConverterRegistry.targets_for(suffix))
 
-    # Lazy import keeps the FEM/CAD stack out of the worker import path until
-    # a parity job actually runs (same pattern as _run_fea_meta_compute).
-    from ada.cadit.visual_parity import parity_for_source_file
+    async def _cancel_check() -> bool:
+        if db_pool is None:
+            return False
+        try:
+            return await db_module.audit_is_cancelled(db_pool, job_id)
+        except Exception:
+            return False
 
-    await _on_progress("parity", 0.20)
-    loop = asyncio.get_running_loop()
     try:
-        result = await loop.run_in_executor(None, functools.partial(parity_for_source_file, src_path, formats))
+        iresult: IsolatedConvertResult = await run_isolated_convert(
+            _parity_child,
+            src_path,
+            job.source_key,
+            "parity",
+            convert_kwargs={"formats": list(formats)},
+            on_progress=_on_progress,
+            timeout_s=timeout_s,
+            cancel_check=_cancel_check,
+        )
     except Exception as exc:
-        logger.exception("worker: parity validation failed for %s", job.source_key)
-        trace = tb_module.format_exc()
+        logger.exception("worker: parity subprocess wrapper failed for %s", job.source_key)
         await queue.update(job_id, status=JOB_STATUS_ERROR, stage="parity", error=str(exc))
-        await _audit_done(db_pool, job_id, "error", str(exc), started_at, traceback=trace)
+        await _audit_done(db_pool, job_id, "error", str(exc), started_at, traceback=tb_module.format_exc())
         return
+
+    metrics = dict(iresult.final_metrics)
+
+    # User cancellation: the watchdog reaped the child; the row is already
+    # 'cancelled' (set by the cancel endpoint) — don't flip it to error.
+    if iresult.signal_name == "CANCELLED":
+        try:
+            await queue.update(job_id, status="cancelled", stage="parity", error="cancelled by user")
+        except Exception:
+            pass
+        iresult.cleanup_output()
+        return
+
+    # OOM / timeout / crash / no-output: the child died (memory watchdog
+    # SIGKILL, timeout, SIGSEGV) — surface as an error cell, pod intact.
+    if iresult.exit_code != 0 or iresult.out_path is None:
+        err = iresult.error or "parity subprocess produced no output"
+        if iresult.signal_name:
+            logger.warning("worker: parity child for %s ended via %s", job.source_key, iresult.signal_name)
+        await queue.update(job_id, status=JOB_STATUS_ERROR, stage="parity", error=err)
+        await _audit_done(db_pool, job_id, "error", err, started_at, traceback=iresult.traceback, metrics=metrics)
+        iresult.cleanup_output()
+        return
+
+    try:
+        payload = json.loads(iresult.out_path.read_text())
+    except Exception as exc:
+        logger.exception("worker: parity result decode failed for %s", job.source_key)
+        await queue.update(job_id, status=JOB_STATUS_ERROR, stage="parity", error=str(exc))
+        await _audit_done(db_pool, job_id, "error", str(exc), started_at, metrics=metrics)
+        iresult.cleanup_output()
+        return
+    iresult.cleanup_output()
 
     if db_pool is not None:
         try:
@@ -433,22 +511,22 @@ async def _run_parity_validation(
                 db_pool,
                 job_id=job_id,
                 source_key=job.source_key,
-                baseline=result.expected,
-                counts=result.counts,
-                consistent=result.consistent,
-                mismatches=result.mismatches,
-                errors=result.errors,
+                baseline=payload["expected"],
+                counts=payload["counts"],
+                consistent=payload["consistent"],
+                mismatches=payload["mismatches"],
+                errors=payload["errors"],
             )
         except Exception:
             logger.exception("worker: insert_audit_parity failed for %s", job.source_key)
 
-    if result.consistent:
+    if payload["consistent"]:
         await queue.update(job_id, status=JOB_STATUS_DONE, stage="ready", progress=1.0, error=None)
-        await _audit_done(db_pool, job_id, "done", None, started_at)
+        await _audit_done(db_pool, job_id, "done", None, started_at, metrics=metrics)
     else:
-        msg = result.summary()
+        msg = payload.get("summary") or "parity mismatch"
         await queue.update(job_id, status=JOB_STATUS_ERROR, stage="ready", progress=1.0, error=msg)
-        await _audit_done(db_pool, job_id, "error", msg, started_at)
+        await _audit_done(db_pool, job_id, "error", msg, started_at, metrics=metrics)
 
 
 async def _run_component_build(
@@ -1107,6 +1185,7 @@ async def _process_one(
                 db_pool=db_pool,
                 started_at=started_at,
                 _on_progress=_on_progress,
+                timeout_s=timeout_s,
             )
             return
 

--- a/src/ada/core/vector_transforms.py
+++ b/src/ada/core/vector_transforms.py
@@ -223,8 +223,16 @@ def normal_to_points_in_plane(points_) -> Direction:
             if is_parallel(v1, v2) is False:
                 break
 
-    # the cross product is a vector normal to the plane
-    return Direction(np.cross(v1, v2)).get_normalized()
+    # the cross product is a vector normal to the plane. ``np.cross`` carries
+    # heavy per-call overhead (moveaxis / normalize_axis_tuple) that dominates
+    # for these length-3 vectors, so author the cross product by hand — this is
+    # the single largest cost in the Genie/SAT plate-read path.
+    normal = (
+        v1[1] * v2[2] - v1[2] * v2[1],
+        v1[2] * v2[0] - v1[0] * v2[2],
+        v1[0] * v2[1] - v1[1] * v2[0],
+    )
+    return Direction(normal).get_normalized()
 
 
 def linear_2dtransform_rotate(origin, point, degrees) -> np.ndarray:

--- a/src/ada/core/vector_utils.py
+++ b/src/ada/core/vector_utils.py
@@ -350,25 +350,42 @@ def create_right_hand_vectors_xv_yv_from_zv(z_vector: Iterable) -> tuple[Directi
         x_vector = np.array([1, 0, 0])
 
     # Calculate the y_vector using the cross product
-    y_vector = np.cross(z_vector, x_vector)
+    y_vector = fast_cross(z_vector, x_vector)
     y_vector = y_vector / np.linalg.norm(y_vector)  # normalize y_vector
 
     # Adjust x_vector by recalculating the cross product of y_vector and z_vector for right-handedness
-    x_vector = np.cross(y_vector, z_vector)
+    x_vector = fast_cross(y_vector, z_vector)
     x_vector = x_vector / np.linalg.norm(x_vector)  # normalize x_vector
 
     return Direction(*x_vector), Direction(*y_vector)
 
 
+def fast_cross(a, b) -> np.ndarray:
+    """Cross product of two length-3 vectors without ``np.cross`` overhead.
+
+    ``np.cross`` spends most of its time in ``moveaxis`` / ``normalize_axis_tuple``
+    bookkeeping that is pure waste for fixed length-3 inputs. Authoring the three
+    components by hand is several times faster and is the dominant per-object cost
+    in the Genie/SAT plate-read placement path.
+    """
+    return np.array(
+        (
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        )
+    )
+
+
 def calc_xvec(y_vec, z_vec) -> np.ndarray:
-    return np.cross(y_vec, z_vec)
+    return fast_cross(y_vec, z_vec)
 
 
 def calc_yvec(x_vec, z_vec=None) -> np.ndarray:
     if z_vec is None:
         calc_zvec(x_vec)
 
-    return np.cross(z_vec, x_vec)
+    return fast_cross(z_vec, x_vec)
 
 
 def calc_zvec(x_vec, y_vec=None) -> np.ndarray:
@@ -382,7 +399,7 @@ def calc_zvec(x_vec, y_vec=None) -> np.ndarray:
             z_vec = np.array(Y)
         return z_vec
     else:
-        return np.cross(x_vec, y_vec)
+        return fast_cross(x_vec, y_vec)
 
 
 def get_centroid(points) -> Point:

--- a/src/ada/fem/formats/mesh_faces.py
+++ b/src/ada/fem/formats/mesh_faces.py
@@ -269,30 +269,37 @@ def _block_primitives(blk: _ShellBlock) -> _Primitives:
 # ── strategies ──────────────────────────────────────────────────────────────
 
 
+def faces_from_fem(fem, strategy=MergeStrategy.COPLANAR, ndigits: int = 6) -> Iterator[FaceData]:
+    """Yield merged CAD faces for a single ``FEM`` mesh (one part).
+
+    The per-FEM core; :func:`iter_faces` walks an assembly and calls this for
+    each part. ``Part.iter_objects_from_fem`` also delegates here so the object
+    and object-free streams share one strategy-aware source."""
+    strategy = MergeStrategy.from_value(strategy)
+    if strategy in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
+        raise NotImplementedError(f"merge strategy {strategy.value!r} not yet wired into the vectorized face source")
+    if fem is None or len(fem.elements) == 0:
+        return
+    for blk in _shell_blocks(fem):
+        prims = _block_primitives(blk)
+        if len(prims) == 0:
+            continue
+        if strategy == MergeStrategy.NONE:
+            for j in range(len(prims)):
+                yield prims.face(j)
+        else:
+            yield from _coplanar_block(prims, ndigits)
+
+
 def iter_faces(part, strategy=MergeStrategy.COPLANAR, ndigits: int = 6) -> Iterator[FaceData]:
     """Yield merged CAD faces for every FEM mesh under ``part`` (Part or Assembly).
 
     Object-free: walks each sub-part's array-backed shell mesh, never building
     Plate/Elem objects.
     """
-    strategy = MergeStrategy.from_value(strategy)
-    if strategy in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
-        raise NotImplementedError(f"merge strategy {strategy.value!r} not yet wired into the vectorized face source")
-
     parts = part.get_all_parts_in_assembly(include_self=True) if hasattr(part, "get_all_parts_in_assembly") else [part]
     for p in parts:
-        fem = getattr(p, "fem", None)
-        if fem is None or len(fem.elements) == 0:
-            continue
-        for blk in _shell_blocks(fem):
-            prims = _block_primitives(blk)
-            if len(prims) == 0:
-                continue
-            if strategy == MergeStrategy.NONE:
-                for j in range(len(prims)):
-                    yield prims.face(j)
-            else:
-                yield from _coplanar_block(prims, ndigits)
+        yield from faces_from_fem(getattr(p, "fem", None), strategy, ndigits)
 
 
 def _coplanar_block(prims: _Primitives, ndigits: int) -> Iterator[FaceData]:

--- a/src/ada/fem/formats/mesh_faces.py
+++ b/src/ada/fem/formats/mesh_faces.py
@@ -1,0 +1,388 @@
+"""Object-free, vectorized FEM-shell → CAD-face source.
+
+The FEM→CAD writers historically rebuilt one ``Plate`` per shell element and
+then merged those objects (``concept_merge``). That materialises tens of
+thousands of objects just to throw most away — the dominant memory/time cost of
+FEM→CAD export.
+
+This module produces the *merged faces* directly from the array-backed mesh
+(``MeshArrays``: ``coords`` + per-block ``conn`` row-indices), with **no Plate
+or Elem objects built**. Each strategy is a vectorized function over the mesh
+arrays that yields lightweight :class:`FaceData` records (raw outline + refs);
+a streaming writer turns those into ``<flat_plate>`` text one at a time.
+
+Strategies (``MergeStrategy``):
+
+* ``NONE``     — identity: one face per shell element (non-coplanar quads split
+  into two triangles, mirroring the legacy 1:1 conversion).
+* ``COPLANAR`` — edge-adjacent coplanar shells sharing material+thickness merged
+  into their union polygon. The *grouping* (plane buckets + edge-connected
+  components) is computed here vectorized; the union itself reuses the tested
+  :func:`merge_coplanar_loops_by_edge_cancellation` core on raw point loops, so
+  the result is geometrically equivalent to the object-based merge.
+
+``SURFACE`` (curved-panel reconstruction) and ``PANEL`` (structured-quad region
+growing) slot in behind the same :func:`iter_faces` interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterator
+
+import numpy as np
+
+from ada.config import logger
+
+
+class MergeStrategy(str, Enum):
+    NONE = "none"
+    COPLANAR = "coplanar"
+    SURFACE = "surface"
+    PANEL = "panel"
+
+    @classmethod
+    def from_value(cls, value) -> "MergeStrategy":
+        if isinstance(value, cls):
+            return value
+        if value is None:
+            return cls.NONE
+        if isinstance(value, bool):  # legacy merge=True/False
+            return cls.COPLANAR if value else cls.NONE
+        return cls(str(value).lower())
+
+
+@dataclass
+class FaceData:
+    """A single planar CAD face, as raw data (no Plate object)."""
+
+    name: str
+    outline: np.ndarray  # (k, 3) global coordinates
+    normal: np.ndarray  # (3,) unit normal
+    material: str
+    thickness: float
+
+
+# ── substrate ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _ShellBlock:
+    coords: np.ndarray  # (N, 3) the shared node coords
+    conn: np.ndarray  # (M, k) row-indices into coords
+    el_ids: np.ndarray  # (M,)
+    materials: list  # length-M material names
+    thicknesses: np.ndarray  # (M,) float
+
+
+def _ensure_array_backed(fem):
+    from ada.api.mesh.containers import ArrayElements, to_array_backed
+
+    if not isinstance(fem.elements, ArrayElements):
+        to_array_backed(fem)
+    return fem.elements._store
+
+
+def _shell_blocks(fem) -> Iterator[_ShellBlock]:
+    """Yield one :class:`_ShellBlock` per shell element block, with per-element
+    material name + thickness resolved from the block's ``fem_secs``."""
+    from ada.fem.shapes.definitions import ShellShapes
+
+    store = _ensure_array_backed(fem)
+    coords = store.coords
+    for ctype, blk in store.blocks.items():
+        if not isinstance(ctype, ShellShapes):
+            continue
+        m = blk.conn.shape[0]
+        fem_secs = blk.fem_secs
+        materials: list = [None] * m
+        thicknesses = np.zeros(m, dtype=np.float64)
+        usable = np.zeros(m, dtype=bool)
+        if fem_secs is not None:
+            for i, fs in enumerate(fem_secs):
+                # No section, or a solid/thickness-less section (2D continuum
+                # elements) -> not a plate; skip (mirrors convert_shell_elem).
+                t = getattr(fs, "thickness", None) if fs is not None else None
+                mat = getattr(fs, "material", None) if fs is not None else None
+                if t is None or mat is None:
+                    continue
+                materials[i] = mat.name
+                thicknesses[i] = float(t)
+                usable[i] = True
+        if not usable.any():
+            continue
+        rows = np.nonzero(usable)[0]
+        yield _ShellBlock(
+            coords=coords,
+            conn=blk.conn[rows],
+            el_ids=blk.el_ids[rows],
+            materials=[materials[r] for r in rows],
+            thicknesses=thicknesses[rows],
+        )
+
+
+def _newell_normals(pts: np.ndarray) -> np.ndarray:
+    """Vectorized Newell normal for a batch of polygons ``pts`` (M, k, 3)."""
+    p = pts
+    pn = np.roll(p, -1, axis=1)
+    nx = np.sum((p[:, :, 1] - pn[:, :, 1]) * (p[:, :, 2] + pn[:, :, 2]), axis=1)
+    ny = np.sum((p[:, :, 2] - pn[:, :, 2]) * (p[:, :, 0] + pn[:, :, 0]), axis=1)
+    nz = np.sum((p[:, :, 0] - pn[:, :, 0]) * (p[:, :, 1] + pn[:, :, 1]), axis=1)
+    n = np.stack([nx, ny, nz], axis=1)
+    ln = np.linalg.norm(n, axis=1, keepdims=True)
+    ln[ln == 0] = 1.0
+    return n / ln
+
+
+def _canonical_sign(normals: np.ndarray, tol: float) -> np.ndarray:
+    """+1/-1 per row so a face and its flip share a plane bucket (first
+    significant component made positive)."""
+    sign = np.ones(normals.shape[0], dtype=np.float64)
+    chosen = np.zeros(normals.shape[0], dtype=bool)
+    for c in range(3):
+        comp = normals[:, c]
+        take = (~chosen) & (np.abs(comp) > tol)
+        sign[take] = np.sign(comp[take])
+        chosen |= take
+    sign[sign == 0] = 1.0
+    return sign
+
+
+# ── strategies ──────────────────────────────────────────────────────────────
+
+
+def iter_faces(part, strategy=MergeStrategy.COPLANAR, ndigits: int = 6) -> Iterator[FaceData]:
+    """Yield merged CAD faces for every FEM mesh under ``part`` (Part or Assembly).
+
+    Object-free: walks each sub-part's array-backed shell mesh, never building
+    Plate/Elem objects.
+    """
+    strategy = MergeStrategy.from_value(strategy)
+    if strategy in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
+        raise NotImplementedError(f"merge strategy {strategy.value!r} not yet wired into the vectorized face source")
+
+    parts = part.get_all_parts_in_assembly(include_self=True) if hasattr(part, "get_all_parts_in_assembly") else [part]
+    for p in parts:
+        fem = getattr(p, "fem", None)
+        if fem is None or len(fem.elements) == 0:
+            continue
+        if strategy == MergeStrategy.NONE:
+            yield from _none_faces(fem)
+        else:
+            yield from _coplanar_faces(fem, ndigits=ndigits)
+
+
+def _is_coplanar_quad(pts: np.ndarray) -> np.ndarray:
+    """(M,) bool: vectorized, bit-for-bit replica of ``vector_utils.is_coplanar``
+    for a batch of quads ``pts`` (M,4,3).
+
+    The legacy quad-split decision (``convert_shell_elem_to_plates``) uses
+    ``is_coplanar``'s *exact* ``== 0`` plane test — not a tolerance — so on a
+    curved mesh nearly every warped quad splits into two triangles. To produce
+    the same primitive decomposition we must match that exactly. The arithmetic
+    and operand order mirror the scalar implementation; IEEE-symmetric negation
+    makes the plane-offset association bit-identical."""
+    p0, p1, p2, p3 = pts[:, 0], pts[:, 1], pts[:, 2], pts[:, 3]
+    v1 = p1 - p0
+    v2 = p2 - p0
+    a = v1[:, 1] * v2[:, 2] - v2[:, 1] * v1[:, 2]
+    b = v2[:, 0] * v1[:, 2] - v1[:, 0] * v2[:, 2]
+    c = v1[:, 0] * v2[:, 1] - v1[:, 1] * v2[:, 0]
+    neg_d = a * p0[:, 0] + b * p0[:, 1] + c * p0[:, 2]
+    return a * p3[:, 0] + b * p3[:, 1] + c * p3[:, 2] - neg_d == 0
+
+
+# ── primitives ──────────────────────────────────────────────────────────────
+# The merge operates on *primitive faces*, mirroring the legacy conversion: a
+# coplanar quad or a triangle is one primitive; a non-coplanar (warped) quad is
+# split into two triangles. Both NONE and COPLANAR build the same primitive set,
+# so they agree on geometry — COPLANAR just additionally folds edge-adjacent
+# coplanar primitives together.
+
+
+class _Primitives:
+    """Per-block primitive faces, as node-row tuples into the shared coords."""
+
+    def __init__(self, coords, rows, names, mats, ts, normals):
+        self.coords = coords
+        self.rows = rows  # list[tuple[int, ...]] of node row-indices
+        self.names = names
+        self.mats = mats
+        self.ts = ts
+        self.normals = normals  # (P, 3)
+
+    def __len__(self):
+        return len(self.rows)
+
+    def outline(self, j) -> np.ndarray:
+        return self.coords[list(self.rows[j])]
+
+    def face(self, j, name=None) -> FaceData:
+        return FaceData(name or self.names[j], self.outline(j), self.normals[j], self.mats[j], self.ts[j])
+
+
+def _block_primitives(blk: _ShellBlock) -> _Primitives:
+    conn = blk.conn
+    coords = blk.coords
+    k = conn.shape[1]
+    planar = _is_coplanar_quad(coords[conn]) if k == 4 else np.ones(conn.shape[0], dtype=bool)
+
+    rows: list[tuple] = []
+    names: list[str] = []
+    mats: list = []
+    ts: list[float] = []
+    for i in range(conn.shape[0]):
+        eid = int(blk.el_ids[i])
+        mat = blk.materials[i]
+        t = float(blk.thicknesses[i])
+        ring = conn[i]
+        if k == 4 and not planar[i]:
+            # warped quad -> two triangles (matches convert_shell_elem_to_plates)
+            rows.append((int(ring[0]), int(ring[1]), int(ring[2])))
+            names.append(f"sh{eid}")
+            mats.append(mat)
+            ts.append(t)
+            rows.append((int(ring[0]), int(ring[2]), int(ring[3])))
+            names.append(f"sh{eid}_1")
+            mats.append(mat)
+            ts.append(t)
+        else:
+            rows.append(tuple(int(r) for r in ring))
+            names.append(f"sh{eid}")
+            mats.append(mat)
+            ts.append(t)
+
+    # batched Newell normals, grouped by vertex count (tri vs quad)
+    normals = np.zeros((len(rows), 3), dtype=np.float64)
+    by_len: dict[int, list[int]] = {}
+    for j, r in enumerate(rows):
+        by_len.setdefault(len(r), []).append(j)
+    for length, idxs in by_len.items():
+        batch = coords[np.array([rows[j] for j in idxs], dtype=np.int64)]  # (G, length, 3)
+        nb = _newell_normals(batch)
+        normals[np.array(idxs)] = nb
+
+    return _Primitives(coords, rows, names, mats, ts, normals)
+
+
+# ── strategies ──────────────────────────────────────────────────────────────
+
+
+def iter_faces(part, strategy=MergeStrategy.COPLANAR, ndigits: int = 6) -> Iterator[FaceData]:
+    """Yield merged CAD faces for every FEM mesh under ``part`` (Part or Assembly).
+
+    Object-free: walks each sub-part's array-backed shell mesh, never building
+    Plate/Elem objects.
+    """
+    strategy = MergeStrategy.from_value(strategy)
+    if strategy in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
+        raise NotImplementedError(f"merge strategy {strategy.value!r} not yet wired into the vectorized face source")
+
+    parts = part.get_all_parts_in_assembly(include_self=True) if hasattr(part, "get_all_parts_in_assembly") else [part]
+    for p in parts:
+        fem = getattr(p, "fem", None)
+        if fem is None or len(fem.elements) == 0:
+            continue
+        for blk in _shell_blocks(fem):
+            prims = _block_primitives(blk)
+            if len(prims) == 0:
+                continue
+            if strategy == MergeStrategy.NONE:
+                for j in range(len(prims)):
+                    yield prims.face(j)
+            else:
+                yield from _coplanar_block(prims, ndigits)
+
+
+def _coplanar_block(prims: _Primitives, ndigits: int) -> Iterator[FaceData]:
+    tol = 10.0 ** (-ndigits)
+    normals = prims.normals
+    sign = _canonical_sign(normals, tol)
+    ncanon = np.round(normals * sign[:, None], ndigits)
+    p0 = prims.coords[np.array([r[0] for r in prims.rows], dtype=np.int64)]
+    # offset from the RAW normal then signed (matches _plate_plane_key: it dots
+    # the un-rounded normal with p0, applies the canonical sign, then rounds).
+    offset = np.round(sign * np.sum(normals * p0, axis=1), ndigits)
+    thick_q = np.round(np.array(prims.ts), ndigits)
+
+    # plane bucket key: (material, thickness, canonical-normal, offset)
+    buckets: dict[tuple, list[int]] = {}
+    for j in range(len(prims)):
+        key = (prims.mats[j], float(thick_q[j]), tuple(ncanon[j]), float(offset[j]))
+        buckets.setdefault(key, []).append(j)
+
+    for idxs in buckets.values():
+        yield from _merge_plane_bucket(prims, idxs, ndigits)
+
+
+def _merge_plane_bucket(prims: _Primitives, idxs: list[int], ndigits: int) -> Iterator[FaceData]:
+    """Split a plane bucket into edge-connected components, merge each."""
+    if len(idxs) == 1:
+        yield prims.face(idxs[0])
+        return
+
+    parent = list(range(len(idxs)))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    # edge-connectivity by shared node identity (conformal mesh: shared edge ==
+    # shared node rows); two primitives sharing an edge are in one component.
+    edge_owner: dict[tuple, int] = {}
+    for li, j in enumerate(idxs):
+        r = prims.rows[j]
+        k = len(r)
+        for e in range(k):
+            a, b = r[e], r[(e + 1) % k]
+            ek = (a, b) if a <= b else (b, a)
+            if ek in edge_owner:
+                union(li, edge_owner[ek])
+            else:
+                edge_owner[ek] = li
+
+    comps: dict[int, list[int]] = {}
+    for li in range(len(idxs)):
+        comps.setdefault(find(li), []).append(li)
+
+    for comp in comps.values():
+        cj = [idxs[li] for li in comp]
+        if len(cj) == 1:
+            yield prims.face(cj[0])
+        else:
+            yield from _merge_component(prims, cj, ndigits)
+
+
+def _merge_component(prims: _Primitives, cj: list[int], ndigits: int) -> Iterator[FaceData]:
+    from ada.core.vector_utils import (
+        merge_coplanar_loops_by_edge_cancellation,
+        project_points_to_local_2d,
+    )
+    from ada.fem.formats.concept_merge import _loop_is_simple_2d
+
+    ref = cj[0]
+    name = f"{prims.names[ref]}_m"
+    loops = [prims.outline(j) for j in cj]
+    merged = merge_coplanar_loops_by_edge_cancellation(loops, ndigits=ndigits)
+    if merged is not None:
+        try:
+            pts2d, _ = project_points_to_local_2d(merged)
+            if _loop_is_simple_2d(pts2d):
+                outline = np.asarray(merged, dtype=float)
+                yield FaceData(name, outline, _newell_normals(outline[None])[0], prims.mats[ref], prims.ts[ref])
+                return
+        except Exception as exc:  # best-effort: degenerate merge -> keep originals
+            logger.debug(f"coplanar merge fell back for {name!r}: {exc}")
+    # best-effort contract: merge only when it collapses cleanly, else keep all.
+    for j in cj:
+        yield prims.face(j)
+
+

--- a/src/ada/fem/formats/mesh_faces.py
+++ b/src/ada/fem/formats/mesh_faces.py
@@ -152,27 +152,6 @@ def _canonical_sign(normals: np.ndarray, tol: float) -> np.ndarray:
 # ── strategies ──────────────────────────────────────────────────────────────
 
 
-def iter_faces(part, strategy=MergeStrategy.COPLANAR, ndigits: int = 6) -> Iterator[FaceData]:
-    """Yield merged CAD faces for every FEM mesh under ``part`` (Part or Assembly).
-
-    Object-free: walks each sub-part's array-backed shell mesh, never building
-    Plate/Elem objects.
-    """
-    strategy = MergeStrategy.from_value(strategy)
-    if strategy in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
-        raise NotImplementedError(f"merge strategy {strategy.value!r} not yet wired into the vectorized face source")
-
-    parts = part.get_all_parts_in_assembly(include_self=True) if hasattr(part, "get_all_parts_in_assembly") else [part]
-    for p in parts:
-        fem = getattr(p, "fem", None)
-        if fem is None or len(fem.elements) == 0:
-            continue
-        if strategy == MergeStrategy.NONE:
-            yield from _none_faces(fem)
-        else:
-            yield from _coplanar_faces(fem, ndigits=ndigits)
-
-
 def _is_coplanar_quad(pts: np.ndarray) -> np.ndarray:
     """(M,) bool: vectorized, bit-for-bit replica of ``vector_utils.is_coplanar``
     for a batch of quads ``pts`` (M,4,3).
@@ -391,5 +370,3 @@ def _merge_component(prims: _Primitives, cj: list[int], ndigits: int) -> Iterato
     # best-effort contract: merge only when it collapses cleanly, else keep all.
     for j in cj:
         yield prims.face(j)
-
-

--- a/src/ada/fem/formats/sesam/results/read_sif.py
+++ b/src/ada/fem/formats/sesam/results/read_sif.py
@@ -115,10 +115,30 @@ RESULT_CARDS = [
     cards.RDFORCES,
 ]
 
+# Per-step result cards whose rows carry an ``ires`` (result/step id) field.
+# These are the multi-step, high-row-count cards the single-step filter
+# targets — RVNODDIS/RVSTRESS/RVFORCES each hold every step's records in one
+# contiguous block. The RD* metadata cards in RESULT_CARDS are per-deck (one
+# block, no steps) and are always kept in full.
+_RV_STEP_CARDS = frozenset({cards.RVNODDIS.name, cards.RVSTRESS.name, cards.RVFORCES.name})
+
+# Column index of ``ires`` in a parsed RV* row. Rows drop the card name on
+# parse (``split()[1:]``), so the components list ``["nfield", "ires", ...]``
+# maps to row positions ``0, 1, ...`` → ``ires`` is at index 1.
+_RV_IRES_COL = 1
+
 
 @dataclass
 class SifReader:
     file: Iterator
+
+    # Result-step filter. ``None`` loads every step (full back-compat). An int
+    # keeps only that step's RV* records; the sentinel ``"first"`` locks onto
+    # the ``ires`` of the first data row encountered. Filtering at parse time
+    # caps peak RSS at one step instead of materialising every step's records
+    # at once — the SIF analogue of ``read_sin_file(step=...)``. Only RV* cards
+    # (see ``_RV_STEP_CARDS``) are filtered; RD* metadata cards stay whole.
+    step: int | str | None = None
 
     nodes: np.ndarray = None
     node_ids: np.ndarray = None
@@ -179,6 +199,33 @@ class SifReader:
     def read_results(self, result_variable: str, first_line: str) -> tuple:
         for data in self._read_multi_line_statements(result_variable, first_line):
             yield data
+
+    def _read_results_for_step(self, result_variable: str, first_line: str, step: int | str):
+        """Like :meth:`read_results` but yields only the block's control record
+        plus the rows whose ``ires`` matches ``step``.
+
+        ``step`` is an int (keep that step) or the sentinel ``"first"`` (lock
+        onto the ``ires`` of the first data row). The underlying generator is
+        always drained to completion so the file cursor still lands past the
+        whole card block; non-matching rows are dropped as we go, capping
+        resident rows at one step rather than the whole multi-step deck.
+        """
+        rows = self.read_results(result_variable, first_line)
+        # Row 0 is the block's control record — every consumer skips it via
+        # ``[1:]``. Always keep it so that contract still holds post-filter.
+        try:
+            control = next(rows)
+        except StopIteration:
+            return
+        yield control
+
+        target = None if step == "first" else int(step)
+        for row in rows:
+            ires = int(row[_RV_IRES_COL]) if len(row) > _RV_IRES_COL else None
+            if target is None:
+                target = ires  # "first": lock onto the first data row's step
+            if ires == target:
+                yield row
 
     def get_sections(self) -> dict[int, Section]:
         import math
@@ -413,7 +460,12 @@ class SifReader:
 
         res_card = self._result_map.get(token)
         if res_card is not None:
-            rows = list(self.read_results(token, stripped))
+            if self.step is not None and token in _RV_STEP_CARDS:
+                # Single-step mode: keep only the requested step's RV* rows so
+                # an N-step deck costs ~1/N the RAM (see SifReader.step).
+                rows = list(self._read_results_for_step(token, stripped, self.step))
+            else:
+                rows = list(self.read_results(token, stripped))
             # SIF result cards (RVNODDIS / RVSTRESS / RVFORCES / etc.)
             # commonly hold 100k–10M rows. Each row as a Python
             # ``list[float]`` carries ~136 bytes of list overhead +
@@ -552,14 +604,24 @@ class SifReader:
         return {int(x[1]): x for x in res}
 
 
-def read_sif_file(sif_file: str | pathlib.Path) -> FEAResult:
+def read_sif_file(sif_file: str | pathlib.Path, *, step: int | str | None = None) -> FEAResult:
+    """Parse a Sesam SIF result deck into a :class:`FEAResult`.
+
+    ``step`` bounds memory the way :func:`read_sin_file` does: ``None`` loads
+    every result step (full fidelity — used by the picker/metadata path and
+    every existing caller); an int loads only that step; the sentinel
+    ``"first"`` loads the first step in the file. A GLB render only colours one
+    (step, field), so the converter passes a single step and keeps peak RSS to
+    one step's RV* records instead of the whole multi-step deck (a 20-mode
+    eigen deck drops ~20×).
+    """
     # Sif2Mesh.convert() calls sif_file.parent to find sibling
     # SESTRA.MLG / SESTRA.LIS files; coerce here so callers passing a
     # plain string (e.g. the legacy converter pipeline's
     # `read_sif_file(str(src_path))`) don't trip an AttributeError.
     sif_file = pathlib.Path(sif_file)
     with open(sif_file, "r") as f:
-        sif = SifReader(f)
+        sif = SifReader(f, step=step)
         sif.load()
 
     s2m = Sif2Mesh(sif)

--- a/src/ada/fem/formats/sesam/results/read_sif.py
+++ b/src/ada/fem/formats/sesam/results/read_sif.py
@@ -122,11 +122,6 @@ RESULT_CARDS = [
 # block, no steps) and are always kept in full.
 _RV_STEP_CARDS = frozenset({cards.RVNODDIS.name, cards.RVSTRESS.name, cards.RVFORCES.name})
 
-# Column index of ``ires`` in a parsed RV* row. Rows drop the card name on
-# parse (``split()[1:]``), so the components list ``["nfield", "ires", ...]``
-# maps to row positions ``0, 1, ...`` → ``ires`` is at index 1.
-_RV_IRES_COL = 1
-
 
 @dataclass
 class SifReader:
@@ -200,32 +195,57 @@ class SifReader:
         for data in self._read_multi_line_statements(result_variable, first_line):
             yield data
 
-    def _read_results_for_step(self, result_variable: str, first_line: str, step: int | str):
-        """Like :meth:`read_results` but yields only the block's control record
-        plus the rows whose ``ires`` matches ``step``.
+    def _read_results_for_step(self, startswith: str, first_line: str, step: int | str):
+        """Single-pass RV* reader that float-parses only the control row and
+        the rows whose ``ires`` matches ``step``.
 
         ``step`` is an int (keep that step) or the sentinel ``"first"`` (lock
-        onto the ``ires`` of the first data row). The underlying generator is
-        always drained to completion so the file cursor still lands past the
-        whole card block; non-matching rows are dropped as we go, capping
-        resident rows at one step rather than the whole multi-step deck.
-        """
-        rows = self.read_results(result_variable, first_line)
-        # Row 0 is the block's control record — every consumer skips it via
-        # ``[1:]``. Always keep it so that contract still holds post-filter.
-        try:
-            control = next(rows)
-        except StopIteration:
-            return
-        yield control
+        onto the ``ires`` of the first data row). This mirrors the boundary
+        logic of :meth:`_read_multi_line_statements` line-for-line, but a row
+        whose step doesn't match is walked only far enough to find the next
+        row boundary — its tokens are never ``float()``-converted or
+        accumulated. On a 9-step deck that skips ~8/9 of the per-token float
+        work (the parse hotspot), on top of the memory saved by not keeping
+        the other steps' rows.
 
+        The block's first record is the control row (every consumer skips it
+        via ``[1:]``), so it is always kept; ``ires`` lives at raw token index
+        2 (card name + ``nfield`` precede it).
+        """
         target = None if step == "first" else int(step)
-        for row in rows:
-            ires = int(row[_RV_IRES_COL]) if len(row) > _RV_IRES_COL else None
-            if target is None:
-                target = ires  # "first": lock onto the first data row's step
-            if ires == target:
-                yield row
+
+        # Row 0 is the control record — always materialised so the [1:]
+        # contract downstream still holds.
+        curr = [float(x) for x in first_line.split()[1:]]
+        keep = True
+
+        while True:
+            stripped = next(self.file).strip()
+
+            # End of the card block: a line that's neither a new card record
+            # nor a numeric continuation. Identical predicate to
+            # _read_multi_line_statements.
+            if stripped.startswith(startswith) is False and stripped[0].isnumeric() is False and stripped[0] != "-":
+                self._last_line = stripped
+                if keep:
+                    yield curr
+                break
+
+            if stripped.startswith(startswith):
+                # New record: flush the previous one (if kept), then decide
+                # whether this one matches the target step from its ires alone.
+                if keep:
+                    yield curr
+                parts = stripped.split()
+                ires = int(float(parts[2])) if len(parts) > 2 else None
+                if target is None:
+                    target = ires  # "first": lock onto the first data row
+                keep = ires == target
+                curr = [float(x) for x in parts[1:]] if keep else None
+            else:
+                # Continuation line — only pay the float cost when keeping.
+                if keep:
+                    curr += [float(x) for x in stripped.split()]
 
     def get_sections(self) -> dict[int, Section]:
         import math

--- a/src/ada/fem/formats/sesam/results/read_sif.py
+++ b/src/ada/fem/formats/sesam/results/read_sif.py
@@ -821,7 +821,14 @@ class Sif2Mesh:
         return {key: tdresref[value[1]][-1] for key, value in rdresref.items()}
 
     def get_nodal_data(self) -> list[NodalFieldData]:
-        return get_nodal_results(self.sif.get_result(cards.RVNODDIS.name)[0][1])
+        # Guard the no-RVNODDIS case symmetric to get_field_data's RVSTRESS /
+        # RVFORCES checks. The streaming reader loads one RV card at a time, so
+        # a STRESS/FORCES-only pass has no RVNODDIS block — return no nodal data
+        # rather than IndexError on an empty get_result.
+        res = self.sif.get_result(cards.RVNODDIS.name)
+        if not res:
+            return []
+        return get_nodal_results(res[0][1])
 
     def get_field_data(self) -> list[ElementFieldData | NodalFieldData]:
         sif = self.sif

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -194,18 +194,27 @@ class SinReader(SifReader):
                 self._static_results.append(rec)
         self._static_loaded = True
 
-    def load_step(self, step: int | None) -> None:
+    def load_step(self, step: int | None, cards: "set[str] | None" = None) -> None:
         """(Re)materialise just the per-step RV* result tables for
         ``step`` on top of the static blocks. ``step is None`` reads every
         step (the full-materialise path). Cheap to call repeatedly: the
-        mesh/section/RDPOINTS blocks are not touched."""
+        mesh/section/RDPOINTS blocks are not touched.
+
+        ``cards`` restricts which RV blocks are gathered — e.g. just
+        ``{"RVNODDIS"}`` when only the nodal field is being emitted. The bake
+        iterates one field at a time, so loading only that field's card avoids
+        re-gathering the other cards (and, on a range-backed byte source,
+        re-fetching their pages) once per field."""
         if not getattr(self, "_static_loaded", False):
             self._load_static()
         self.step = step
+        want = None if cards is None else set(cards)
         # Fresh per-step results = static (RDPOINTS …) + this step's RV*.
         self.results = list(self._static_results)
         for card in _RESULT_CARDS:
             if card.name not in _RV_TYPE_NAMES:
+                continue
+            if want is not None and card.name not in want:
                 continue
             rec = self._read_result_card(card, step=step)
             if rec is not None:
@@ -284,6 +293,11 @@ class SinMetadata:
 
 
 _RV_TYPE_NAMES = ("RVNODDIS", "RVSTRESS", "RVFORCES")
+
+# Element field name (as the adapter advertises it) → its RV card, so the
+# streaming reader gathers only that field's card per step instead of all of
+# them once per field. Nodal fields use their card name directly (RVNODDIS).
+_ELEM_FIELD_TO_CARD = {"STRESS": "RVSTRESS", "FORCES": "RVFORCES"}
 
 
 def read_sin_metadata(sin_file: str | pathlib.Path) -> SinMetadata:
@@ -409,16 +423,16 @@ class SinStreamReader:
     def _step_values(self) -> list[float]:
         return [float(s) for s in self._steps]
 
-    def _load_step(self, step: int):
+    def _load_step(self, step: int, cards: "set[str] | None" = None):
         """Materialise just one step's FEAResult from the shared SinFile.
 
         The mesh topology is step-invariant, so :meth:`Sif2Mesh.get_sif_mesh`
         — the dominant per-step cost (a pure-Python pass over every element:
         groupby, type resolution, node-order reconciliation) — is run **once**
         and the built ``Mesh`` reused for every subsequent step. Only the
-        per-step RV* field extraction (``get_sif_results``) re-runs. This is
-        what keeps the per-step bake from regressing badly on speed vs the
-        full-materialise path while staying memory-bounded. (No LIS/MLG
+        per-step RV* field extraction (``get_sif_results``) re-runs. ``cards``
+        restricts which RV blocks are gathered so a per-field bake pass reads
+        only that field's card, not every field's records. (No LIS/MLG
         enrichment here — same as before; the source is a bare SinFile.)"""
         from ada.fem.formats.sesam.results.read_sif import Sif2Mesh
         from ada.fem.results.common import FEAResult, FEATypes
@@ -429,7 +443,7 @@ class SinStreamReader:
             self._reader = SinReader(sin=self.sin)
             self._reader._load_static()
         reader = self._reader
-        reader.load_step(int(step))
+        reader.load_step(int(step), cards=cards)
         s2m = Sif2Mesh(reader)
         if self._mesh is None:
             self._mesh = s2m.get_sif_mesh()
@@ -460,6 +474,20 @@ class SinStreamReader:
             return self._rep
         return FEAResultStreamAdapter(self._load_step(self._steps[idx]))
 
+    def _field_adapter(self, idx: int, card: str | None):
+        """Adapter over step ``idx`` loading only ``card``'s block (one field).
+
+        Reuses the cached step-0 representative when available; every other
+        step gathers just the one RV card instead of all three — so iterating a
+        field no longer re-reads (and, on a range source, re-fetches) the other
+        fields' records once per field."""
+        from ada.fem.results.artefacts import FEAResultStreamAdapter
+
+        if idx == 0 and self._rep is not None:
+            return self._rep
+        cards = {card} if card else None
+        return FEAResultStreamAdapter(self._load_step(self._steps[idx], cards=cards))
+
     def _with_global_steps(self, specs):
         import dataclasses
 
@@ -480,8 +508,10 @@ class SinStreamReader:
         import dataclasses
 
         labels = self._step_values()
+        # A nodal field's name is its RV card (RVNODDIS) — gather only that one.
+        card = field_name if field_name in _RV_TYPE_NAMES else None
         for i in range(len(self._steps)):
-            ad = self._adapter_for(i)
+            ad = self._field_adapter(i, card)
             emitted = 0
             for sv in ad.iter_field_steps(field_name):
                 yield dataclasses.replace(sv, step_index=i, step_value=labels[i])
@@ -496,8 +526,9 @@ class SinStreamReader:
         import dataclasses
 
         labels = self._step_values()
+        card = _ELEM_FIELD_TO_CARD.get(spec.name)
         for i in range(len(self._steps)):
-            ad = self._adapter_for(i)
+            ad = self._field_adapter(i, card)
             ad_spec = next(
                 (s for s in ad.element_field_specs() if s.name == spec.name and s.elem_type == spec.elem_type),
                 None,

--- a/src/ada/fem/formats/sesam/results/sif_index.py
+++ b/src/ada/fem/formats/sesam/results/sif_index.py
@@ -1,0 +1,199 @@
+"""Byte-offset index for Sesam SIF result decks → cheap single-step reads.
+
+A SIF deck holds every result step's RV* records (RVNODDIS / RVSTRESS /
+RVFORCES) in one contiguous block per card, and those blocks are 70%+ of a
+large file. ``read_sif_file(step=...)`` already avoids *materialising* the
+other steps, but it still has to *scan* the whole file line-by-line to find
+the target step's records, and the worker still downloads the whole file.
+
+This module records, in one cheap byte scan, the byte span of every step
+inside each RV* block. With that index, the bytes that belong to steps other
+than the target can be skipped entirely:
+
+* :meth:`SifStepIndex.include_ranges` returns the byte ranges to read for a
+  given step — the whole file *minus* the other steps' spans. Control rows,
+  mesh, sections, RDPOINTS and inter-block gaps fall in the kept gaps
+  automatically (they're never inside a step span), so a reader fed the
+  concatenated ranges sees a valid, smaller SIF.
+* The async worker range-fetches those ranges from object storage
+  (``storage.get_range``) into a reduced tempfile — so a re-pick of one mode
+  reads ~⅓ of a 969 MB deck instead of all of it, and the *download* shrinks
+  by the same factor. The reduced file is parsed by the normal
+  :func:`read_sif_file`; no S3 client is needed inside the conversion child.
+
+The index is a small JSON sidecar (``_derived/<src>.sifindex.json``) built the
+first time a deck is converted and reused on every later pick.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass
+
+# RV* result cards whose rows carry an ``ires`` (step id) at raw token index 2
+# (card name + ``nfield`` precede it). Mirrors read_sif._RV_STEP_CARDS, kept
+# local so this module has no import cycle with the parser.
+_RV_CARDS = frozenset({"RVNODDIS", "RVSTRESS", "RVFORCES"})
+
+# Index format version — bump if the build logic changes meaning so a stale
+# sidecar is rejected rather than silently misread.
+INDEX_VERSION = 1
+
+
+@dataclass
+class SifStepIndex:
+    """Byte-span index of a SIF deck's per-step RV* records.
+
+    ``step_spans`` is a flat list of ``(ires, start, end)`` byte ranges, one
+    per contiguous same-step run inside an RV* block. Everything *not* covered
+    by a span (control rows, mesh, RDPOINTS, gaps) is step-invariant and always
+    kept. Offsets are into the *uncompressed* file, so range reads only work
+    against identity-stored objects.
+    """
+
+    version: int
+    size: int
+    steps: list[int]
+    fields: list[str]
+    step_spans: list[tuple[int, int, int]]
+
+    def include_ranges(self, step: int) -> list[tuple[int, int]]:
+        """Byte ranges to read for ``step`` — the file minus every other
+        step's spans. Adjacent/abutting kept regions are merged so the caller
+        issues as few range requests as possible."""
+        exclude = sorted((s, e) for (ires, s, e) in self.step_spans if ires != step)
+        include: list[tuple[int, int]] = []
+        cur = 0
+        for s, e in exclude:
+            if s > cur:
+                include.append((cur, s))
+            cur = max(cur, e)
+        if cur < self.size:
+            include.append((cur, self.size))
+        return include
+
+    def default_step(self) -> int:
+        if not self.steps:
+            raise ValueError("SIF index has no result steps")
+        return self.steps[0]
+
+    # ── serialization ──────────────────────────────────────────────
+    def to_json(self) -> bytes:
+        return json.dumps(
+            {
+                "version": self.version,
+                "size": self.size,
+                "steps": self.steps,
+                "fields": self.fields,
+                # JSON has no tuples; store as flat triples.
+                "step_spans": [[i, s, e] for (i, s, e) in self.step_spans],
+            }
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json(cls, data: bytes | str) -> "SifStepIndex":
+        d = json.loads(data)
+        if int(d.get("version", -1)) != INDEX_VERSION:
+            raise ValueError(f"unsupported SIF index version {d.get('version')!r}")
+        return cls(
+            version=int(d["version"]),
+            size=int(d["size"]),
+            steps=[int(x) for x in d["steps"]],
+            fields=[str(x) for x in d["fields"]],
+            step_spans=[(int(i), int(s), int(e)) for (i, s, e) in d["step_spans"]],
+        )
+
+
+def build_sif_index(path: str | pathlib.Path) -> SifStepIndex:
+    """Scan a SIF file once (no float parsing) and record per-step RV byte spans.
+
+    The scan is pure byte/line work — ``startswith`` + ``tell`` — so it's a
+    fraction of the cost of a full parse. The first record of each RV block is
+    the control row (every consumer skips it via ``[1:]``); it is left out of
+    the step spans so it stays in the kept region.
+    """
+    path = pathlib.Path(path)
+    size = path.stat().st_size
+
+    spans: list[tuple[int, int, int]] = []
+    steps: set[int] = set()
+    fields: set[str] = set()
+
+    cur_card: str | None = None  # card name of the block currently being scanned
+    cur_ires: int | None = None  # step of the open span, or None if no span open
+    span_start = 0
+
+    def close_span(end: int) -> None:
+        nonlocal cur_ires, span_start
+        if cur_ires is not None:
+            spans.append((cur_ires, span_start, end))
+            cur_ires = None
+
+    off = 0
+    with open(path, "rb") as f:
+        for line in f:
+            n = len(line)
+            s = line.lstrip()
+            head = s[:1]
+            if head.isalpha():
+                tok = s.split(None, 1)[0].decode("ascii", "replace")
+                if tok in _RV_CARDS:
+                    fields.add(tok)
+                    if tok != cur_card:
+                        # New RV block. This first record is the control row —
+                        # leave it unspanned (kept in the gap). Close any span
+                        # left open by the previous block.
+                        close_span(off)
+                        cur_card = tok
+                    else:
+                        # Data row: its ires drives the span boundaries.
+                        parts = s.split()
+                        ires = int(float(parts[2])) if len(parts) > 2 else None
+                        if ires != cur_ires:
+                            close_span(off)
+                            if ires is not None:
+                                cur_ires = ires
+                                span_start = off
+                                steps.add(ires)
+                else:
+                    # Non-RV card starts: any open RV span ends here.
+                    if cur_card in _RV_CARDS:
+                        close_span(off)
+                    cur_card = tok
+            # else: numeric continuation line — extends the open span implicitly
+            # (we only close on a card-start), so nothing to do.
+            off += n
+
+    close_span(size)
+
+    return SifStepIndex(
+        version=INDEX_VERSION,
+        size=size,
+        steps=sorted(steps),
+        fields=sorted(fields),
+        step_spans=spans,
+    )
+
+
+def assemble_reduced_local(path: str | pathlib.Path, ranges: list[tuple[int, int]], out: str | pathlib.Path) -> int:
+    """Concatenate ``ranges`` of ``path`` into ``out`` (a reduced SIF on disk).
+
+    Local-file analogue of the worker's range-fetch-and-assemble — used by
+    tests and any non-storage caller. Returns the byte count written.
+    """
+    path = pathlib.Path(path)
+    out = pathlib.Path(out)
+    written = 0
+    with open(path, "rb") as fi, open(out, "wb") as fo:
+        for start, end in ranges:
+            fi.seek(start)
+            remaining = end - start
+            while remaining > 0:
+                chunk = fi.read(min(remaining, 1 << 20))
+                if not chunk:
+                    break
+                fo.write(chunk)
+                written += len(chunk)
+                remaining -= len(chunk)
+    return written

--- a/src/ada/fem/formats/sesam/results/sif_index.py
+++ b/src/ada/fem/formats/sesam/results/sif_index.py
@@ -37,32 +37,48 @@ from dataclasses import dataclass
 _RV_CARDS = frozenset({"RVNODDIS", "RVSTRESS", "RVFORCES"})
 
 # Index format version — bump if the build logic changes meaning so a stale
-# sidecar is rejected rather than silently misread.
-INDEX_VERSION = 1
+# sidecar is rejected rather than silently misread. v2 tags each span with its
+# RV card so the streaming reader can read one (card, step) at a time.
+INDEX_VERSION = 2
 
 
 @dataclass
 class SifStepIndex:
     """Byte-span index of a SIF deck's per-step RV* records.
 
-    ``step_spans`` is a flat list of ``(ires, start, end)`` byte ranges, one
-    per contiguous same-step run inside an RV* block. Everything *not* covered
-    by a span (control rows, mesh, RDPOINTS, gaps) is step-invariant and always
-    kept. Offsets are into the *uncompressed* file, so range reads only work
-    against identity-stored objects.
+    ``step_spans`` is a flat list of ``(card, ires, start, end)`` byte ranges,
+    one per contiguous same-step run inside an RV* block. Everything *not*
+    covered by a span (control rows, mesh, RDPOINTS, gaps) is step-invariant and
+    always kept. Offsets are into the *uncompressed* file, so range reads only
+    work against identity-stored objects.
     """
 
     version: int
     size: int
     steps: list[int]
     fields: list[str]
-    step_spans: list[tuple[int, int, int]]
+    step_spans: list[tuple[str, int, int, int]]
 
     def include_ranges(self, step: int) -> list[tuple[int, int]]:
         """Byte ranges to read for ``step`` — the file minus every other
         step's spans. Adjacent/abutting kept regions are merged so the caller
         issues as few range requests as possible."""
-        exclude = sorted((s, e) for (ires, s, e) in self.step_spans if ires != step)
+        return self._invert((s, e) for (_card, ires, s, e) in self.step_spans if ires != step)
+
+    def header_ranges(self) -> list[tuple[int, int]]:
+        """Byte ranges of the step-invariant deck — the file minus *every*
+        step's RV data (control rows, mesh, sections, RDPOINTS and gaps are
+        kept). The streaming reader parses this once, then reads each step's RV
+        bytes on demand."""
+        return self._invert((s, e) for (_card, _ires, s, e) in self.step_spans)
+
+    def step_spans_for(self, card: str, step: int) -> list[tuple[int, int]]:
+        """Byte ranges of ``card``'s records for ``step`` (data rows only — the
+        control row stays in the header)."""
+        return [(s, e) for (c, ires, s, e) in self.step_spans if c == card and ires == step]
+
+    def _invert(self, exclude_iter) -> list[tuple[int, int]]:
+        exclude = sorted(exclude_iter)
         include: list[tuple[int, int]] = []
         cur = 0
         for s, e in exclude:
@@ -86,8 +102,8 @@ class SifStepIndex:
                 "size": self.size,
                 "steps": self.steps,
                 "fields": self.fields,
-                # JSON has no tuples; store as flat triples.
-                "step_spans": [[i, s, e] for (i, s, e) in self.step_spans],
+                # JSON has no tuples; store as flat [card, ires, start, end].
+                "step_spans": [[c, i, s, e] for (c, i, s, e) in self.step_spans],
             }
         ).encode("utf-8")
 
@@ -101,7 +117,7 @@ class SifStepIndex:
             size=int(d["size"]),
             steps=[int(x) for x in d["steps"]],
             fields=[str(x) for x in d["fields"]],
-            step_spans=[(int(i), int(s), int(e)) for (i, s, e) in d["step_spans"]],
+            step_spans=[(str(c), int(i), int(s), int(e)) for (c, i, s, e) in d["step_spans"]],
         )
 
 
@@ -116,7 +132,7 @@ def build_sif_index(path: str | pathlib.Path) -> SifStepIndex:
     path = pathlib.Path(path)
     size = path.stat().st_size
 
-    spans: list[tuple[int, int, int]] = []
+    spans: list[tuple[str, int, int, int]] = []
     steps: set[int] = set()
     fields: set[str] = set()
 
@@ -125,9 +141,9 @@ def build_sif_index(path: str | pathlib.Path) -> SifStepIndex:
     span_start = 0
 
     def close_span(end: int) -> None:
-        nonlocal cur_ires, span_start
-        if cur_ires is not None:
-            spans.append((cur_ires, span_start, end))
+        nonlocal cur_ires
+        if cur_ires is not None and cur_card is not None:
+            spans.append((cur_card, cur_ires, span_start, end))
             cur_ires = None
 
     off = 0

--- a/src/ada/fem/formats/sesam/results/sif_stream.py
+++ b/src/ada/fem/formats/sesam/results/sif_stream.py
@@ -23,8 +23,12 @@ import copy
 import io
 import pathlib
 
-from ada.fem.formats.sesam.results.read_sif import SifReader, Sif2Mesh, _RV_STEP_CARDS
-from ada.fem.formats.sesam.results.sif_index import SifStepIndex, assemble_reduced_local, build_sif_index
+from ada.fem.formats.sesam.results.read_sif import _RV_STEP_CARDS, Sif2Mesh, SifReader
+from ada.fem.formats.sesam.results.sif_index import (
+    SifStepIndex,
+    assemble_reduced_local,
+    build_sif_index,
+)
 
 # Read RV cards in a stable order so each step's block is rebuilt the same way.
 _RV_ORDER = ("RVNODDIS", "RVSTRESS", "RVFORCES")

--- a/src/ada/fem/formats/sesam/results/sif_stream.py
+++ b/src/ada/fem/formats/sesam/results/sif_stream.py
@@ -1,0 +1,256 @@
+"""Memory-bounded ``FEAStreamReader`` for Sesam SIF result decks.
+
+The default SIF bake path materialises the whole multi-step ``FEAResult`` in
+RAM (``FEAResultStreamAdapter(read_sif_file(path))``) — fine for small decks,
+but a many-mode deck holds every step at once and blows the worker's memory
+budget. This reader is the SIF analogue of :class:`SinStreamReader`: it parses
+the step-invariant part of the deck (mesh, sections, RDPOINTS and the RV*
+control rows) **once**, then reads only one step's RV* bytes at a time using
+the byte-offset index (:mod:`sif_index`). At most ~2 steps are ever resident.
+
+Like the SIN streamer this is a memory-for-time trade — the bake calls
+``iter_field_steps`` once per field, so each step's RV bytes are re-read per
+field — so it is gated off by default (``ADA_FEA_SIF_STREAMER``) and only
+turned on for decks that would otherwise OOM. The SIF→artefact mapping itself
+is not reimplemented: each step is mapped through the validated
+:class:`Sif2Mesh` + ``FEAResultStreamAdapter`` path; only the per-step
+orchestration and the global ``(n_steps, step_values)`` of the specs are new.
+"""
+
+from __future__ import annotations
+
+import copy
+import io
+import pathlib
+
+from ada.fem.formats.sesam.results.read_sif import SifReader, Sif2Mesh, _RV_STEP_CARDS
+from ada.fem.formats.sesam.results.sif_index import SifStepIndex, assemble_reduced_local, build_sif_index
+
+# Read RV cards in a stable order so each step's block is rebuilt the same way.
+_RV_ORDER = ("RVNODDIS", "RVSTRESS", "RVFORCES")
+
+# Element field name (as the adapter advertises it) → the RV card it comes from.
+# Lets ``iter_element_field_steps`` load only that field's card block per step
+# instead of every step's whole record set (the SIF layout is columnar by card,
+# so each field is one contiguous block — reading just it keeps the bake to a
+# single pass with no per-field re-reads).
+_ELEM_FIELD_TO_CARD = {"STRESS": "RVSTRESS", "FORCES": "RVFORCES"}
+
+# Sentinel appended when parsing a step's RV bytes so the line-based reader hits
+# a clean block end (a non-card, non-numeric line) instead of running off the
+# end of the buffer (which a generator turns into a RuntimeError under PEP 479).
+_END_SENTINEL = "ZZZEND\n"
+
+
+class SifStreamReader:
+    """Per-step streaming reader over a SIF deck, backed by a byte-offset index."""
+
+    def __init__(self, path: str | pathlib.Path, index: SifStepIndex | None = None) -> None:
+        self.path = pathlib.Path(path)
+        self.index = index if index is not None else build_sif_index(self.path)
+        self._steps = self.index.steps
+
+        self._static: SifReader | None = None  # mesh/sections/RDPOINTS + RV control rows
+        self._rd_results: list | None = None  # non-RV result cards (RDPOINTS, RDSTRESS, ...)
+        self._control: dict | None = None  # card -> control row (block row 0)
+        self._mesh = None  # step-invariant Mesh, built once
+        self._rep = None  # FEAResultStreamAdapter over the first step (geometry/specs/beams)
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> "SifStreamReader":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ── static (step-invariant) parse, once ───────────────────────────
+    def _ensure_static(self) -> None:
+        if self._static is not None:
+            return
+        # The header is the deck minus every step's RV data — it still carries
+        # the mesh, sections, RDPOINTS and each RV block's control row.
+        import tempfile
+
+        hdr = pathlib.Path(tempfile.mkstemp(suffix=".SIF")[1])
+        try:
+            assemble_reduced_local(self.path, self.index.header_ranges(), hdr)
+            with open(hdr, "r") as f:
+                sif = SifReader(f)
+                sif.load()
+        finally:
+            try:
+                hdr.unlink()
+            except OSError:
+                pass
+
+        self._static = sif
+        self._rd_results = [(c, r) for (c, r) in sif.results if c not in _RV_STEP_CARDS]
+        self._control = {c: r[0] for (c, r) in sif.results if c in _RV_STEP_CARDS and len(r) > 0}
+
+    def _read_step_rows(self, card: str, step: int) -> list:
+        """Parse ``card``'s data rows for ``step`` from their byte spans.
+
+        Returns the data rows only (no control row); the caller prepends the
+        cached control row so the ``[1:]`` contract every consumer relies on
+        still holds."""
+        spans = self.index.step_spans_for(card, step)
+        if not spans:
+            return []
+        chunks: list[bytes] = []
+        with open(self.path, "rb") as f:
+            for s, e in spans:
+                f.seek(s)
+                chunks.append(f.read(e - s))
+        text = b"".join(chunks).decode("latin-1")
+        if not text.endswith("\n"):
+            text += "\n"
+        text += _END_SENTINEL
+
+        it = io.StringIO(text)
+        reader = SifReader(it)
+        try:
+            first = next(it)
+        except StopIteration:
+            return []
+        # read_results yields every record it sees (the [1:] drop is the
+        # consumer's job), so feeding it data rows returns all of them.
+        return list(reader.read_results(card, first.strip()))
+
+    def _load_step(self, step: int, cards: "set[str] | None" = None):
+        """Materialise one step's FEAResult: cached static mesh + this step's RV.
+
+        ``cards`` restricts which RV blocks are read — e.g. just ``{"RVNODDIS"}``
+        when only the nodal displacement field is being emitted — so a per-field
+        bake pass reads only that field's block, not every field's records."""
+        from ada.fem.results.common import FEAResult, FEATypes
+
+        self._ensure_static()
+        assert self._static is not None and self._control is not None and self._rd_results is not None
+
+        want = set(_RV_ORDER) if cards is None else set(cards)
+        rv_results = []
+        for card in _RV_ORDER:
+            if card not in want:
+                continue
+            control = self._control.get(card)
+            if control is None:
+                continue
+            data = self._read_step_rows(card, step)
+            if not data:
+                continue
+            rv_results.append((card, [control, *data]))
+
+        # Shallow copy shares the big mesh/section arrays; only results swap.
+        reader = copy.copy(self._static)
+        reader.results = list(self._rd_results) + rv_results
+
+        s2m = Sif2Mesh(reader)
+        if self._mesh is None:
+            self._mesh = s2m.get_sif_mesh()
+        s2m.mesh = self._mesh  # reuse; get_sif_results resolves element ids against it
+        results = s2m.get_sif_results()
+        return FEAResult(
+            self.path.stem,
+            FEATypes.SESAM,
+            results=results,
+            mesh=self._mesh,
+            results_file_path=self.path,
+            step_name_map=s2m.get_result_name_map(),
+            software_version="N/A",
+        )
+
+    def _adapter_for(self, idx: int):
+        """Adapter over step ``idx`` with *all* fields — for geometry/specs only.
+        Step 0 is cached as the representative; per-field iteration uses the
+        narrower :meth:`_field_adapter` so it never re-reads other fields."""
+        from ada.fem.results.artefacts import FEAResultStreamAdapter
+
+        if idx == 0:
+            if self._rep is None:
+                if not self._steps:
+                    raise RuntimeError("SIF result has no RV* result steps to bake")
+                self._rep = FEAResultStreamAdapter(self._load_step(self._steps[0]))
+            return self._rep
+        return FEAResultStreamAdapter(self._load_step(self._steps[idx]))
+
+    def _field_adapter(self, idx: int, card: str | None):
+        """Adapter over step ``idx`` loading only ``card``'s block (one field).
+
+        Reusing the cached step-0 representative when it's available avoids a
+        redundant re-read of step 0; every other step loads just the one card."""
+        from ada.fem.results.artefacts import FEAResultStreamAdapter
+
+        if idx == 0 and self._rep is not None:
+            return self._rep
+        cards = {card} if card else None
+        return FEAResultStreamAdapter(self._load_step(self._steps[idx], cards=cards))
+
+    def _step_values(self) -> list[float]:
+        return [float(s) for s in self._steps]
+
+    def _with_global_steps(self, specs):
+        import dataclasses
+
+        labels = self._step_values()
+        return [dataclasses.replace(s, n_steps=len(labels), step_values=labels) for s in specs]
+
+    # ── FEAStreamReader protocol ──────────────────────────────────────
+    def read_mesh_geometry(self):
+        return self._adapter_for(0).read_mesh_geometry()
+
+    def field_specs(self):
+        return self._with_global_steps(self._adapter_for(0).field_specs())
+
+    def element_field_specs(self):
+        return self._with_global_steps(self._adapter_for(0).element_field_specs())
+
+    def iter_field_steps(self, field_name: str):
+        import dataclasses
+
+        labels = self._step_values()
+        # A nodal field's name is its RV card (RVNODDIS) — read only that block.
+        card = field_name if field_name in _RV_ORDER else None
+        for i in range(len(self._steps)):
+            ad = self._field_adapter(i, card)
+            emitted = 0
+            for sv in ad.iter_field_steps(field_name):
+                yield dataclasses.replace(sv, step_index=i, step_value=labels[i])
+                emitted += 1
+            if emitted != 1:
+                raise RuntimeError(
+                    f"SIF nodal field {field_name!r} yielded {emitted} steps at step "
+                    f"index {i} (expected 1) — field missing or duplicated for a step"
+                )
+
+    def iter_element_field_steps(self, spec):
+        import dataclasses
+
+        labels = self._step_values()
+        card = _ELEM_FIELD_TO_CARD.get(spec.name)
+        for i in range(len(self._steps)):
+            ad = self._field_adapter(i, card)
+            ad_spec = next(
+                (s for s in ad.element_field_specs() if s.name == spec.name and s.elem_type == spec.elem_type),
+                None,
+            )
+            if ad_spec is None:
+                raise RuntimeError(f"SIF element field {spec.name!r}/{spec.elem_type} missing at step index {i}")
+            if ad_spec.element_labels != spec.element_labels:
+                raise RuntimeError(f"SIF element field {spec.name!r} element order drifted at step index {i}")
+            for esv in ad.iter_element_field_steps(ad_spec):
+                yield dataclasses.replace(esv, step_index=i, step_value=labels[i])
+
+    def try_solid_beams(self):
+        return self._adapter_for(0).try_solid_beams()
+
+    def try_history_records(self):
+        return None
+
+    def try_fem_concepts(self):
+        return None
+
+    def try_groups(self):
+        return None

--- a/src/ada/fem/formats/sesam/results/sif_stream.py
+++ b/src/ada/fem/formats/sesam/results/sif_stream.py
@@ -55,6 +55,8 @@ class SifStreamReader:
         self._control: dict | None = None  # card -> control row (block row 0)
         self._mesh = None  # step-invariant Mesh, built once
         self._rep = None  # FEAResultStreamAdapter over the first step (geometry/specs/beams)
+        self._eig = None  # EigenDataSummary from a sibling SESTRA.LIS, if present
+        self._eig_loaded = False
 
     # ── lifecycle ─────────────────────────────────────────────────────
     def close(self) -> None:
@@ -188,14 +190,52 @@ class SifStreamReader:
         cards = {card} if card else None
         return FEAResultStreamAdapter(self._load_step(self._steps[idx], cards=cards))
 
-    def _step_values(self) -> list[float]:
+    def _ensure_lis(self) -> None:
+        """Load a sibling SESTRA.LIS eigen-frequency table once, if present —
+        the same enrichment the full-materialise path applies."""
+        if self._eig_loaded:
+            return
+        self._eig_loaded = True
+        lis = self.path.parent / "SESTRA.LIS"
+        if not lis.exists():
+            return
+        try:
+            from ada.fem.formats.sesam.results._results import get_eigen_data
+
+            self._eig = get_eigen_data(lis)
+        except Exception:
+            self._eig = None
+
+    def _plain_labels(self) -> list[float]:
         return [float(s) for s in self._steps]
+
+    def _nodal_labels(self) -> list[float]:
+        """Step labels for nodal fields: eigen frequency per step from
+        SESTRA.LIS, falling back to the IRES step index. Matches the full path,
+        which sets ``NodalFieldData.eigen_freq`` from LIS so the adapter's
+        ``step_values`` become frequencies for nodal fields only."""
+        self._ensure_lis()
+        if self._eig is None:
+            return self._plain_labels()
+        out = []
+        for s in self._steps:
+            em = self._eig.get_eigenmode(int(s))
+            out.append(float(em.f_hz) if em is not None and em.f_hz is not None else float(s))
+        return out
+
+    def _labels_for(self, support: str) -> list[float]:
+        # Only nodal fields are LIS-enriched (mirrors the convert loop, which
+        # skips non-NodalFieldData); element/gauss fields keep the step index.
+        return self._nodal_labels() if support == "nodal" else self._plain_labels()
 
     def _with_global_steps(self, specs):
         import dataclasses
 
-        labels = self._step_values()
-        return [dataclasses.replace(s, n_steps=len(labels), step_values=labels) for s in specs]
+        out = []
+        for s in specs:
+            labels = self._labels_for(s.support)
+            out.append(dataclasses.replace(s, n_steps=len(labels), step_values=labels))
+        return out
 
     # ── FEAStreamReader protocol ──────────────────────────────────────
     def read_mesh_geometry(self):
@@ -210,7 +250,7 @@ class SifStreamReader:
     def iter_field_steps(self, field_name: str):
         import dataclasses
 
-        labels = self._step_values()
+        labels = self._nodal_labels()
         # A nodal field's name is its RV card (RVNODDIS) — read only that block.
         card = field_name if field_name in _RV_ORDER else None
         for i in range(len(self._steps)):
@@ -228,7 +268,7 @@ class SifStreamReader:
     def iter_element_field_steps(self, spec):
         import dataclasses
 
-        labels = self._step_values()
+        labels = self._plain_labels()  # element fields aren't LIS-enriched
         card = _ELEM_FIELD_TO_CARD.get(spec.name)
         for i in range(len(self._steps)):
             ad = self._field_adapter(i, card)

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -2115,24 +2115,23 @@ def _make_rmed_reader(path: pathlib.Path) -> "FEAStreamReader":
 
 
 def _make_sif_reader(path: pathlib.Path) -> "FEAStreamReader":
-    # Default: the full-materialise adapter — fastest, and it enriches step
-    # labels from SESTRA.LIS eigen-frequencies. ADA_FEA_SIF_STREAMER opts into
-    # the per-step SifStreamReader instead: peak RSS stays flat in step count
-    # (one step resident at a time, via the byte-offset index) for many-mode
-    # decks whose full result would OOM the worker. Memory-for-time trade — the
-    # bake re-reads each step's RV bytes once per field — so it is off by
-    # default and turned on only for decks that need it. On the streamer path
-    # step labels are the IRES mode index (no LIS enrichment), mirroring SIN.
+    # Default: the per-step SifStreamReader — peak result RSS stays flat in step
+    # count (one step resident at a time, via the byte-offset index), so a
+    # many-mode deck can't OOM the bake. It streams per *field* (each RV card is
+    # one contiguous block), so it's a single pass, ~+11% wall vs the full
+    # materialise, and it enriches nodal step labels from SESTRA.LIS just like
+    # the adapter. ADA_FEA_SIF_STREAMER=0/false/off forces the full-materialise
+    # adapter (e.g. to rule the streamer out when triaging).
     import os
 
-    if os.environ.get("ADA_FEA_SIF_STREAMER", "").strip().lower() in {"1", "true", "yes", "on"}:
-        from ada.fem.formats.sesam.results.sif_stream import SifStreamReader
+    if os.environ.get("ADA_FEA_SIF_STREAMER", "").strip().lower() in {"0", "false", "no", "off"}:
+        from ada.fem.formats.sesam.results.read_sif import read_sif_file
 
-        return SifStreamReader(path)
+        return FEAResultStreamAdapter(read_sif_file(path))
 
-    from ada.fem.formats.sesam.results.read_sif import read_sif_file
+    from ada.fem.formats.sesam.results.sif_stream import SifStreamReader
 
-    return FEAResultStreamAdapter(read_sif_file(path))
+    return SifStreamReader(path)
 
 
 def _make_sin_reader(path: pathlib.Path) -> "FEAStreamReader":

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -2115,6 +2115,21 @@ def _make_rmed_reader(path: pathlib.Path) -> "FEAStreamReader":
 
 
 def _make_sif_reader(path: pathlib.Path) -> "FEAStreamReader":
+    # Default: the full-materialise adapter — fastest, and it enriches step
+    # labels from SESTRA.LIS eigen-frequencies. ADA_FEA_SIF_STREAMER opts into
+    # the per-step SifStreamReader instead: peak RSS stays flat in step count
+    # (one step resident at a time, via the byte-offset index) for many-mode
+    # decks whose full result would OOM the worker. Memory-for-time trade — the
+    # bake re-reads each step's RV bytes once per field — so it is off by
+    # default and turned on only for decks that need it. On the streamer path
+    # step labels are the IRES mode index (no LIS enrichment), mirroring SIN.
+    import os
+
+    if os.environ.get("ADA_FEA_SIF_STREAMER", "").strip().lower() in {"1", "true", "yes", "on"}:
+        from ada.fem.formats.sesam.results.sif_stream import SifStreamReader
+
+        return SifStreamReader(path)
+
     from ada.fem.formats.sesam.results.read_sif import read_sif_file
 
     return FEAResultStreamAdapter(read_sif_file(path))

--- a/src/ada/geom/direction.py
+++ b/src/ada/geom/direction.py
@@ -35,6 +35,9 @@ def _is_parallel_tuples(a_tup: tuple[float, ...], b_tup: tuple[float, ...], angl
 
 
 class Direction(np.ndarray, ImmutableNDArrayMixin):
+    # Slots for the two lazy caches drop the ~304 B per-instance __dict__; a
+    # plate/beam holds several Directions, so this is the dominant saving.
+    __slots__ = ("_normalized", "_length")
     __array_priority__ = 10.0
     precision: int | None = None
     _cache: weakref.WeakValueDictionary[tuple[float, ...], Direction] = weakref.WeakValueDictionary()
@@ -68,23 +71,23 @@ class Direction(np.ndarray, ImmutableNDArrayMixin):
         return float(self[2])
 
     def get_normalized(self) -> Direction:
-        cached = self.__dict__.get("_normalized")
+        cached = getattr(self, "_normalized", None)
         if cached is None:
             length = np.linalg.norm(self)
             if length == 0.0:
                 raise ValueError("Cannot normalize a zero‐length vector")
             unit = (self / length).view(Direction)
             unit.flags.writeable = False
-            self.__dict__["_normalized"] = unit
+            self._normalized = unit
             return unit
         return cached
 
     def get_length(self) -> float:
-        length = self.__dict__.get("_length")
+        length = getattr(self, "_length", None)
         if length is None:
             tup = (float(self[0]), float(self[1]), float(self[2]))
             length = _length_cached(tup)  # your existing cached helper
-            self.__dict__["_length"] = length
+            self._length = length
         return length
 
     def get_angle(self, other: Direction, as_degrees=False) -> float:

--- a/src/ada/geom/points.py
+++ b/src/ada/geom/points.py
@@ -29,6 +29,10 @@ def _make_key_and_array(
 class ImmutableNDArrayMixin:
     """Block in-place mutation and catch in-place ufuncs to return new instances."""
 
+    # Empty slots so this mixin doesn't reintroduce a per-instance __dict__ on
+    # the Point / Direction ndarray subclasses (which set __slots__ themselves).
+    __slots__ = ()
+
     def __setitem__(self, idx, val):
         raise TypeError(f"{type(self).__name__} is immutable")
 
@@ -57,6 +61,10 @@ class ImmutableNDArrayMixin:
 
 
 class Point(np.ndarray, ImmutableNDArrayMixin):
+    # No instance attributes: __slots__ = () drops the ~304 B per-instance
+    # __dict__ (a Point holds none). ndarray still provides __weakref__, so the
+    # value-interning _cache below keeps working.
+    __slots__ = ()
     precision: int | None = None
     _cache: weakref.WeakValueDictionary[tuple[float, ...], Point] = weakref.WeakValueDictionary()
 

--- a/src/ada/materials/metals/base_models.py
+++ b/src/ada/materials/metals/base_models.py
@@ -256,6 +256,12 @@ class CarbonSteel(Metal):
     ]
     EC3_S_RED = [1.0, 1.0, 1.0, 1.0, 1.0, 0.78, 0.47, 0.23, 0.11, 0.06, 0.04, 0.02, 0.0]
 
+    # (start, stop, step) of the default EC3 thermal grid (deg C), built lazily
+    # by ``temp_range`` on first thermal-property access. Modifiable: override
+    # the class attribute for a different default resolution, pass ``temp_range``
+    # to ``__init__``, or assign ``mat.temp_range = <array>`` per instance.
+    TEMP_RANGE_BOUNDS = (20, 1210, 5)
+
     def __init__(
         self,
         grade: Literal["S355", "S420"] = "S355",
@@ -306,7 +312,11 @@ class CarbonSteel(Metal):
         )
         # Manually override variables
 
-        self._temp_range = np.arange(20, 1210, 5) if temp_range is None else temp_range
+        # Lazy: the EC3 temperature grid (~2 KB) is only needed for thermal /
+        # fire analysis (E_therm / sigy_therm / kappa / cp). Building it per
+        # material dominated the per-object footprint when many objects are
+        # created with a string material, so defer it to first access.
+        self._temp_range = temp_range
 
     def __repr__(self):
         return (
@@ -321,6 +331,8 @@ class CarbonSteel(Metal):
 
     @property
     def temp_range(self):
+        if self._temp_range is None:
+            self._temp_range = np.arange(*self.TEMP_RANGE_BOUNDS)
         return self._temp_range
 
     @temp_range.setter
@@ -333,7 +345,7 @@ class CarbonSteel(Metal):
         self._cp = None
 
     def _calc_e_therm(self) -> list[float] | None:
-        E_red_fac = np.interp(self._temp_range, CarbonSteel.EC3_TEMP, CarbonSteel.EC3_E_RED)
+        E_red_fac = np.interp(self.temp_range, CarbonSteel.EC3_TEMP, CarbonSteel.EC3_E_RED)
         return [self._E * x for x in E_red_fac]
 
     @property
@@ -343,7 +355,7 @@ class CarbonSteel(Metal):
         return self._e_therm
 
     def _calc_sigy_therm(self) -> list[float] | None:
-        sig_red_fac = np.interp(self._temp_range, CarbonSteel.EC3_TEMP, CarbonSteel.EC3_S_RED)
+        sig_red_fac = np.interp(self.temp_range, CarbonSteel.EC3_TEMP, CarbonSteel.EC3_S_RED)
         return [self._sig_y * x for x in sig_red_fac]
 
     @property
@@ -354,8 +366,9 @@ class CarbonSteel(Metal):
 
     def _calc_kappa(self) -> list[float] | None:
         phase1_end = 780
-        phase1_arr = [self._temp_range[x] for x in np.where(self._temp_range <= phase1_end)]
-        phase2_arr = [self._temp_range[x] for x in np.where(self._temp_range > phase1_end)]
+        tr = self.temp_range
+        phase1_arr = [tr[x] for x in np.where(tr <= phase1_end)]
+        phase2_arr = [tr[x] for x in np.where(tr > phase1_end)]
         phase1 = [54 - t * 3.33 * 0.01 for t in phase1_arr[0]]
         phase2 = [27.3 for x in range(phase2_arr[0].shape[0])]
         return phase1 + phase2
@@ -372,16 +385,11 @@ class CarbonSteel(Metal):
         phase1_end = 600
         phase2_end = 735
         phase3_end = 900
-        phase1_arr = [self._temp_range[x] for x in np.where(self._temp_range <= phase1_end)]
-        phase2_arr = [
-            self._temp_range[x]
-            for x in np.where(np.logical_and(self._temp_range > phase1_end, self._temp_range <= phase2_end))
-        ]
-        phase3_arr = [
-            self._temp_range[x]
-            for x in np.where(np.logical_and(self._temp_range > phase2_end, self._temp_range <= phase3_end))
-        ]
-        phase4_arr = [self._temp_range[x] for x in np.where(self._temp_range > phase3_end)]
+        tr = self.temp_range
+        phase1_arr = [tr[x] for x in np.where(tr <= phase1_end)]
+        phase2_arr = [tr[x] for x in np.where(np.logical_and(tr > phase1_end, tr <= phase2_end))]
+        phase3_arr = [tr[x] for x in np.where(np.logical_and(tr > phase2_end, tr <= phase3_end))]
+        phase4_arr = [tr[x] for x in np.where(tr > phase3_end)]
         phase1 = [425 + 7.73 * 1e-1 * t - 1.69 * 1e-3 * (t**2) + 2.22 * 1e-6 * t**3 for t in phase1_arr[0]]
         phase2 = [666 + 13002 / (738 - t) for t in phase2_arr[0]]
         phase3 = [545 + 17820 / (t - 731) for t in phase3_arr[0]]

--- a/src/ada/occ/geom/surfaces.py
+++ b/src/ada/occ/geom/surfaces.py
@@ -294,13 +294,71 @@ def _build_geom2d_bspline(pcurve_geom):
         return None
 
 
-def _make_edge_from_pcurve(pcurve_geom, face_surface):
+def _pcurve_trim_range(c2d, face_surface, edge_start, edge_end):
+    """Sub-range ``[s_a, s_b]`` of the pcurve whose 3D image spans the edge.
+
+    A single SAT pcurve is often *shared* by several coedges along one UV side
+    of a face — each coedge is a different sub-segment, but the explicit pcurve
+    carries the whole side's UV trajectory. The edge's own ``[t_start, t_end]``
+    is in the 3D-curve's parameter space, which is offset/reversed relative to
+    the pcurve's, so we can't slice the pcurve by it directly. Instead, map the
+    edge's *3D endpoints* into pcurve space: sample the pcurve, push each sample
+    through the surface, and pick the parameters whose 3D images are nearest the
+    edge's two endpoints. Returns ``None`` when the pcurve already matches the
+    edge's length (no trim needed) or the endpoints aren't usable."""
+    if edge_start is None or edge_end is None:
+        return None
+    s0 = float(c2d.FirstParameter())
+    s1 = float(c2d.LastParameter())
+    if abs(s1 - s0) <= 1e-9:
+        return None
+    import numpy as _np
+
+    a = _np.asarray(list(edge_start)[:3], dtype=float)
+    b = _np.asarray(list(edge_end)[:3], dtype=float)
+    edge_len = float(_np.linalg.norm(b - a))
+    if edge_len <= 1e-9:
+        return None
+    tol = 0.05 * edge_len  # endpoints "coincide" within 5% of the edge length
+
+    def _surf3d(s):
+        uv = c2d.Value(s)
+        p = face_surface.Value(uv.X(), uv.Y())
+        return _np.array([p.X(), p.Y(), p.Z()])
+
+    # Cheap common-case test: when the pcurve's own ends already land on the
+    # edge's endpoints (either order), the edge uses the whole pcurve — no trim,
+    # so skip the 200-sample scan. Only a *shared* pcurve (longer than the edge)
+    # extends past the endpoints and needs trimming.
+    e0, e1 = _surf3d(s0), _surf3d(s1)
+    ends_match = (_np.linalg.norm(e0 - a) <= tol and _np.linalg.norm(e1 - b) <= tol) or (
+        _np.linalg.norm(e0 - b) <= tol and _np.linalg.norm(e1 - a) <= tol
+    )
+    if ends_match:
+        return None
+
+    ss = _np.linspace(s0, s1, 200)
+    pts = _np.array([_surf3d(s) for s in ss])
+    s_a = float(ss[int(_np.argmin(_np.linalg.norm(pts - a, axis=1)))])
+    s_b = float(ss[int(_np.argmin(_np.linalg.norm(pts - b, axis=1)))])
+    lo, hi = (s_a, s_b) if s_a <= s_b else (s_b, s_a)
+    if hi - lo <= 1e-9:
+        return None
+    return lo, hi
+
+
+def _make_edge_from_pcurve(pcurve_geom, face_surface, edge_start=None, edge_end=None):
     """Build an OCC edge from a 2D BSpline pcurve + the face's surface.
 
     The 3D parametrization is derived implicitly by OCCT from
     surface(pcurve(t)), so 2D and 3D are guaranteed-consistent.
-    Returns None on any failure so the caller falls back to building
-    from the SAT-supplied 3D BSpline + reparam.
+
+    ``edge_start`` / ``edge_end`` (the coedge's 3D endpoints) let us trim a
+    *shared* pcurve to this coedge's sub-segment — without the trim, a
+    split-edge wire traces the whole UV side twice, self-intersects, and
+    BRepMesh grids only half the face (the hull-skin "missing triangles").
+    Returns None on any failure so the caller falls back to building from the
+    SAT-supplied 3D BSpline + reparam.
     """
     c2d = _build_geom2d_bspline(pcurve_geom)
     if c2d is None:
@@ -308,6 +366,13 @@ def _make_edge_from_pcurve(pcurve_geom, face_surface):
     try:
         first = float(c2d.FirstParameter())
         last = float(c2d.LastParameter())
+        try:
+            trim = _pcurve_trim_range(c2d, face_surface, edge_start, edge_end)
+        except Exception as ex:
+            logger.debug("pcurve trim probe failed, using full range: %s", ex)
+            trim = None
+        if trim is not None:
+            first, last = trim
         maker = BRepBuilderAPI_MakeEdge(c2d, face_surface, first, last)
         if not maker.IsDone():
             return None
@@ -1141,7 +1206,12 @@ def make_face_from_geom(advanced_face: geo_su.AdvancedFace) -> TopoDS_Face:
             supplied_pc = getattr(oe, "pcurve", None) if use_pcurves else None
             occ_edge = None
             if drive_edge_from_pcurve and supplied_pc is not None:
-                occ_edge = _make_edge_from_pcurve(supplied_pc, face_surface)
+                occ_edge = _make_edge_from_pcurve(
+                    supplied_pc,
+                    face_surface,
+                    edge_start=getattr(oe, "start", None),
+                    edge_end=getattr(oe, "end", None),
+                )
                 if occ_edge is not None:
                     # Edge already carries a consistent 2D pcurve from
                     # the constructor; no UpdateEdge needed.

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -470,6 +470,16 @@ class BatchTessellator:
                         ms_curved = self.tessellate_occ_geom(shape, node_ref, obj.color)
                     except UnableToCreateTesselationFromSolidOCCGeom as e:
                         logger.error(e)
+                    except Exception as e:
+                        # A backend that can't build this curved face's wire
+                        # (e.g. adacpp ``build_advanced_face: wire build failed``)
+                        # must not crash the whole model render — fall through to
+                        # the flat-fallback path below for this one plate.
+                        logger.warning(
+                            "PlateCurved %r: solid build failed (%s); using flat representation",
+                            getattr(ada_obj, "name", "?"),
+                            e,
+                        )
                     if ms_curved is not None:
                         pos = getattr(ms_curved, "position", None)
                         idx = getattr(ms_curved, "indices", None)

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -457,6 +457,50 @@ class BatchTessellator:
                                             float(limit[worst]),
                                         )
                                         mesh_ok = False
+
+                                    # Under-coverage guard. Some trimmed B-spline
+                                    # faces defeat BRepMesh: it emits a degenerate
+                                    # centre-fan (a handful of slivers) covering
+                                    # only ~half the surface, regardless of the
+                                    # deflection — the "missing triangles" you see
+                                    # on a few hull-skin plates. The mesh extent is
+                                    # right, so the bbox check above passes it. But
+                                    # a correct *prism* of a (curved or flat) plate
+                                    # has top+bottom faces each at least the flat
+                                    # footprint area, so its mesh area is always
+                                    # >= ~2x the footprint plus the side walls. A
+                                    # ratio well under 2 means the curved faces
+                                    # under-meshed — fall back to the clean flat
+                                    # quad (these plates are near-flat, so it's
+                                    # visually faithful). Healthy plates measure
+                                    # ~2.05; the broken ones ~1.55.
+                                    if mesh_ok and idx_n >= 3:
+                                        tris = verts[_np.asarray(idx, dtype=_np.int64).reshape(-1, 3)]
+                                        mesh_area = float(
+                                            _np.sum(
+                                                0.5
+                                                * _np.linalg.norm(
+                                                    _np.cross(tris[:, 1] - tris[:, 0], tris[:, 2] - tris[:, 0]),
+                                                    axis=1,
+                                                )
+                                            )
+                                        )
+                                        # Newell area of the (planar) flat-footprint loop.
+                                        nrm = _np.zeros(3)
+                                        for _i in range(len(flat_arr)):
+                                            nrm = nrm + _np.cross(flat_arr[_i], flat_arr[(_i + 1) % len(flat_arr)])
+                                        flat_area = 0.5 * float(_np.linalg.norm(nrm))
+                                        if flat_area > 1e-6 and mesh_area < 1.85 * flat_area:
+                                            logger.warning(
+                                                "PlateCurved %r: curved mesh area %.2f m^2 vs %.2f expected "
+                                                "(< 1.85x flat footprint %.2f) — degenerate tessellation, "
+                                                "using flat representation",
+                                                getattr(ada_obj, "name", "?"),
+                                                mesh_area,
+                                                2.0 * flat_area,
+                                                flat_area,
+                                            )
+                                            mesh_ok = False
                                 except Exception:
                                     pass
                             if mesh_ok:

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -275,12 +275,32 @@ def _has_meshable_extent(shape: TopoDS_Shape) -> bool:
     return diag2 > 1e-18  # ~1 nm extent floor
 
 
+def _backend_has_meshable_extent(shape) -> bool:
+    """Backend-agnostic mirror of :func:`_has_meshable_extent` for a non-OCC
+    handle. An empty body crashes adacpp's native tessellator the same way it
+    crashes OCC's (the C++ exception can't cross nanobind), so probe the
+    backend's bbox first — it raises / reports a void box for a geometry-less
+    shape."""
+    from ada.cad import active_backend
+
+    try:
+        xmin, ymin, zmin, xmax, ymax, zmax = active_backend().bbox(shape)
+    except Exception:
+        return False  # "empty bounding box (shape has no geometry)" etc.
+    diag2 = (xmax - xmin) ** 2 + (ymax - ymin) ** 2 + (zmax - zmin) ** 2
+    return diag2 > 1e-18  # ~1 nm extent floor
+
+
 def tessellate_shape(shape: TopoDS_Shape, quality=1.0, render_edges=False, parallel=True) -> TriangleMesh:
     # Backend dispatch: a pythonocc TopoDS uses the rich ShapeTesselator
     # (normals + edges). Any other handle (e.g. an adacpp ShapeHandle) is
     # tessellated through the active backend's tessellate verb (adacpp's native
     # ShapeTesselator port) and adapted to a TriangleMesh with computed normals.
     if not _is_topods_shape(shape):
+        # Empty / void-bbox shape: adacpp's native tessellate crashes on it the
+        # same way OCC's does, so guard here too (see _has_meshable_extent).
+        if not _backend_has_meshable_extent(shape):
+            return _empty_triangle_mesh()
         from ada.cad import active_backend
 
         mesh = active_backend().tessellate(shape)

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -176,6 +176,45 @@ def _drop_runaway_triangles(shape, np_vertices, np_normals):
     return np_vertices, np_normals
 
 
+def _empty_triangle_mesh() -> TriangleMesh:
+    e = np.empty(0, dtype="float32")
+    return TriangleMesh(e, np.empty(0, dtype="uint32"), None, e)
+
+
+def _has_meshable_extent(shape: TopoDS_Shape) -> bool:
+    """False when ``shape`` has nothing to triangulate — an empty body or a
+    void / zero-extent bounding box.
+
+    ``ShapeTesselator.Compute`` derives a *relative* linear deflection from the
+    shape's bounding box, so a void/zero-extent box yields deflection 0 and OCC
+    raises ``std::invalid_argument("The deviation must be greater than 0")``.
+    That's a plain C++ exception (not a ``Standard_Failure``), so pythonocc
+    doesn't translate it to a Python ``RuntimeError`` — it escapes the
+    try/except in :func:`tessellate_shape` and ``std::terminate``\\s the whole
+    process. Empty bodies turn up from round-trips that drop geometry (e.g. a
+    FEM deck whose elements don't convert exports an empty STEP compound), so
+    guard rather than crash."""
+    from OCC.Core.Bnd import Bnd_Box
+
+    try:
+        from OCC.Core.BRepBndLib import brepbndlib
+
+        _add = brepbndlib.Add
+    except (ImportError, AttributeError):
+        from OCC.Core.BRepBndLib import brepbndlib_Add as _add
+
+    box = Bnd_Box()
+    try:
+        _add(shape, box)
+    except Exception:
+        return False
+    if box.IsVoid():
+        return False
+    xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
+    diag2 = (xmax - xmin) ** 2 + (ymax - ymin) ** 2 + (zmax - zmin) ** 2
+    return diag2 > 1e-18  # ~1 nm extent floor
+
+
 def tessellate_shape(shape: TopoDS_Shape, quality=1.0, render_edges=False, parallel=True) -> TriangleMesh:
     # Backend dispatch: a pythonocc TopoDS uses the rich ShapeTesselator
     # (normals + edges). Any other handle (e.g. an adacpp ShapeHandle) is
@@ -188,6 +227,11 @@ def tessellate_shape(shape: TopoDS_Shape, quality=1.0, render_edges=False, paral
         positions = np.ascontiguousarray(mesh.positions, dtype="float32")
         faces = np.ascontiguousarray(mesh.indices, dtype="uint32")
         return TriangleMesh(positions, faces, None, _vertex_normals(positions, faces))
+
+    # Nothing to mesh (empty body / void bbox) → return empty rather than let
+    # OCC SIGABRT on a zero relative deflection. See _has_meshable_extent.
+    if not _has_meshable_extent(shape):
+        return _empty_triangle_mesh()
 
     from OCC.Core.Tesselator import ShapeTesselator
 

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -42,6 +42,66 @@ def _is_topods_shape(shape) -> bool:
     return isinstance(shape, TopoDS_Shape)
 
 
+def _mesh_store_area(ms) -> float:
+    """Total triangle area of a tessellated ``MeshStore`` (position soup +
+    indices). Used to gauge whether a curved-plate prism actually covered its
+    surface vs under-meshed it."""
+    pos = getattr(ms, "position", None)
+    idx = getattr(ms, "indices", None)
+    if pos is None or idx is None:
+        return 0.0
+    verts = np.asarray(pos, dtype=float).reshape(-1, 3)
+    faces = np.asarray(idx, dtype=np.int64).reshape(-1, 3)
+    if len(faces) == 0 or len(verts) == 0:
+        return 0.0
+    tris = verts[faces]
+    return float(np.sum(0.5 * np.linalg.norm(np.cross(tris[:, 1] - tris[:, 0], tris[:, 2] - tris[:, 0]), axis=1)))
+
+
+def _natural_bound_curved_solid(ada_obj):
+    """Rebuild a PlateCurved's solid from its surface over the face's *natural*
+    UV bounds, discarding the trim wire.
+
+    A handful of imported B-spline plate faces carry malformed pcurves (the
+    wire backtracks / duplicates an edge in UV), so BRepMesh grids only ~half
+    the face — the "missing triangles". The underlying surface is sound and its
+    UV box equals the plate's (rectangular) boundary, so a face built straight
+    from the surface over ``UVBounds`` re-meshes fully. Returns an OCC solid
+    (prism by thickness ``t`` along the surface normal), or the bare face when
+    ``t == 0``, or ``None`` if the rebuild can't be done."""
+    face_fn = getattr(ada_obj, "_face_occ", None)
+    if not callable(face_fn):
+        return None
+    try:
+        from OCC.Core.BRep import BRep_Tool
+        from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+        from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism
+        from OCC.Core.BRepTools import breptools
+        from OCC.Core.GeomLProp import GeomLProp_SLProps
+        from OCC.Core.gp import gp_Vec
+
+        face = face_fn()
+        if not _is_topods_shape(face):
+            return None
+        surf = BRep_Tool.Surface(face)
+        umin, umax, vmin, vmax = breptools.UVBounds(face)
+        mf = BRepBuilderAPI_MakeFace(surf, umin, umax, vmin, vmax, 1e-6)
+        if not mf.IsDone():
+            return None
+        nb = mf.Face()
+        t = getattr(ada_obj, "t", None) or 0.0
+        if not t:
+            return nb
+        props = GeomLProp_SLProps(surf, (umin + umax) / 2.0, (vmin + vmax) / 2.0, 1, 1e-6)
+        if not props.IsNormalDefined():
+            return nb
+        n = props.Normal()
+        return BRepPrimAPI_MakePrism(nb, gp_Vec(n.X(), n.Y(), n.Z()).Multiplied(t)).Shape()
+    except Exception as e:  # OCC missing / pathological surface
+        logger.debug("natural-bound curved rebuild failed: %s", e)
+        return None
+
+
 def _shapefix_for_mesh(occ_geom):
     """Run ``ShapeFix_Shape`` on an OCC body so faces that lack p-curves become meshable,
     returning the fixed shape (or ``None`` if pythonocc is absent / the fix fails or no-ops).
@@ -459,38 +519,51 @@ class BatchTessellator:
                                         mesh_ok = False
 
                                     # Under-coverage guard. Some trimmed B-spline
-                                    # faces defeat BRepMesh: it emits a degenerate
-                                    # centre-fan (a handful of slivers) covering
-                                    # only ~half the surface, regardless of the
-                                    # deflection — the "missing triangles" you see
-                                    # on a few hull-skin plates. The mesh extent is
-                                    # right, so the bbox check above passes it. But
-                                    # a correct *prism* of a (curved or flat) plate
-                                    # has top+bottom faces each at least the flat
+                                    # faces defeat BRepMesh: a malformed trim wire
+                                    # (pcurves that backtrack/duplicate in UV) makes
+                                    # it grid only ~half the face, regardless of the
+                                    # deflection — the "missing triangles" on a few
+                                    # hull-skin plates. The mesh extent is right, so
+                                    # the bbox check above passes it. But a correct
+                                    # *prism* of a (curved or flat) plate has
+                                    # top+bottom faces each at least the flat
                                     # footprint area, so its mesh area is always
-                                    # >= ~2x the footprint plus the side walls. A
-                                    # ratio well under 2 means the curved faces
-                                    # under-meshed — fall back to the clean flat
-                                    # quad (these plates are near-flat, so it's
-                                    # visually faithful). Healthy plates measure
-                                    # ~2.05; the broken ones ~1.55.
+                                    # >= ~2x the footprint plus the side walls.
+                                    # Healthy plates measure ~2.05x; the broken ones
+                                    # ~1.55x. When under-covered, first try a
+                                    # natural-bound rebuild (keeps the curve — the
+                                    # surface is sound, only the wire is bad); fall
+                                    # back to the flat quad only if that fails too.
                                     if mesh_ok and idx_n >= 3:
-                                        tris = verts[_np.asarray(idx, dtype=_np.int64).reshape(-1, 3)]
-                                        mesh_area = float(
-                                            _np.sum(
-                                                0.5
-                                                * _np.linalg.norm(
-                                                    _np.cross(tris[:, 1] - tris[:, 0], tris[:, 2] - tris[:, 0]),
-                                                    axis=1,
-                                                )
-                                            )
-                                        )
+                                        mesh_area = _mesh_store_area(ms_curved)
                                         # Newell area of the (planar) flat-footprint loop.
                                         nrm = _np.zeros(3)
                                         for _i in range(len(flat_arr)):
                                             nrm = nrm + _np.cross(flat_arr[_i], flat_arr[(_i + 1) % len(flat_arr)])
                                         flat_area = 0.5 * float(_np.linalg.norm(nrm))
                                         if flat_area > 1e-6 and mesh_area < 1.85 * flat_area:
+                                            mesh_ok = False
+                                            rebuilt = _natural_bound_curved_solid(ada_obj)
+                                            if rebuilt is not None:
+                                                ms_rb = self.tessellate_occ_geom(rebuilt, node_ref, obj.color)
+                                                rb_area = _mesh_store_area(ms_rb)
+                                                # Accept the repaired curve when it now
+                                                # covers (>=1.85x) without overshooting
+                                                # the trim (<=3.5x rules out a surface
+                                                # whose natural box exceeds the real
+                                                # plate — those keep the flat fallback).
+                                                if 1.85 * flat_area <= rb_area <= 3.5 * flat_area:
+                                                    logger.warning(
+                                                        "PlateCurved %r: trim-wire tessellation under-covered "
+                                                        "(%.2f m^2 < %.2f); rebuilt from surface natural bounds "
+                                                        "(%.2f m^2)",
+                                                        getattr(ada_obj, "name", "?"),
+                                                        mesh_area,
+                                                        2.0 * flat_area,
+                                                        rb_area,
+                                                    )
+                                                    yield ms_rb
+                                                    continue
                                             logger.warning(
                                                 "PlateCurved %r: curved mesh area %.2f m^2 vs %.2f expected "
                                                 "(< 1.85x flat footprint %.2f) — degenerate tessellation, "
@@ -500,7 +573,6 @@ class BatchTessellator:
                                                 2.0 * flat_area,
                                                 flat_area,
                                             )
-                                            mesh_ok = False
                                 except Exception:
                                     pass
                             if mesh_ok:

--- a/src/ada/visit/scene_handling/scene_from_part.py
+++ b/src/ada/visit/scene_handling/scene_from_part.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 
 def scene_from_part_or_assembly(part_or_assembly: Part | Assembly, converter: SceneConverter) -> trimesh.Scene:
     import ada.extension.design_extension_schema as design_ext
-    from ada import Assembly, Beam, Plate
-    from ada.comms.msg_handling.object_metadata import beam_metadata, plate_metadata
+    from ada import Assembly, Beam, Plate, PlateCurved
+    from ada.comms.msg_handling.object_metadata import beam_metadata, curved_plate_metadata, plate_metadata
     from ada.config import logger
     from ada.occ.tessellating import BatchTessellator
 
@@ -73,6 +73,8 @@ def scene_from_part_or_assembly(part_or_assembly: Part | Assembly, converter: Sc
         if object_metadata is not None and obj.name:
             if isinstance(obj, Beam):
                 object_metadata[obj.name] = beam_metadata(obj.name, obj.section, obj.material)
+            elif isinstance(obj, PlateCurved):
+                object_metadata[obj.name] = curved_plate_metadata(obj.name, obj.t, obj.material)
             elif isinstance(obj, Plate):
                 object_metadata[obj.name] = plate_metadata(obj.name, obj.t, obj.material)
 

--- a/src/ada/visit/scene_handling/scene_from_part.py
+++ b/src/ada/visit/scene_handling/scene_from_part.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
 def scene_from_part_or_assembly(part_or_assembly: Part | Assembly, converter: SceneConverter) -> trimesh.Scene:
     import ada.extension.design_extension_schema as design_ext
     from ada import Assembly, Beam, Plate, PlateCurved
-    from ada.comms.msg_handling.object_metadata import beam_metadata, curved_plate_metadata, plate_metadata
+    from ada.comms.msg_handling.object_metadata import (
+        beam_metadata,
+        curved_plate_metadata,
+        plate_metadata,
+    )
     from ada.config import logger
     from ada.occ.tessellating import BatchTessellator
 

--- a/src/ada_cli/audit.py
+++ b/src/ada_cli/audit.py
@@ -380,19 +380,29 @@ def cmd_repro(args: argparse.Namespace) -> int:
     print(f"original status={meta.get('status')} error={_short(meta.get('error'), 160)!r}")
 
     # Lazy import — keeps the rest of `ada audit` free of the FEM/CAD stack.
-    from ada.comms.rest.converter import convert
+    from ada.comms.rest.converter import convert, result_bytes
 
     def on_progress(stage: str, frac: float) -> None:
         print(f"  [{frac:5.1%}] {stage}")
 
     try:
-        out = convert(src, str(src), target, on_progress)
+        result = convert(src, str(src), target, on_progress)
+        # convert() returns a path for the disk-writing exporters; the repro
+        # CLI wants the bytes on hand to write its .out copy.
+        out = result_bytes(result)
     except Exception:
         import traceback
 
         sys.stderr.write("\n--- repro raised ---\n")
         traceback.print_exc()
         return 1
+    finally:
+        # Drop the converter's tempfile if it handed us a path.
+        if isinstance(locals().get("result"), pathlib.Path):
+            try:
+                result.unlink()
+            except OSError:
+                pass
 
     out_path = src.with_suffix(f".out.{target.lstrip('.')}")
     out_path.write_bytes(out)

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ada-py-viewer",
-  "version": "0.20.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ada-py-viewer",
-      "version": "0.20.1",
+      "version": "0.24.0",
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
         "@tanstack/react-virtual": "^3.13.24",
@@ -41,7 +41,7 @@
         "tsx": "^4.22.4",
         "typescript": "5.8.2",
         "urdf-loader": "0.12.4",
-        "vite": "^6.4.1",
+        "vite": "^6.4.3",
         "zustand": "5.0.3"
       }
     },
@@ -58,28 +58,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -88,9 +74,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.3.tgz",
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -98,22 +84,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
-      "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.3",
-        "@babel/parser": "^7.27.3",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.27.3",
-        "@babel/types": "^7.27.3",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -129,16 +115,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.3.tgz",
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.3",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -146,14 +132,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -162,30 +148,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -205,9 +201,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -215,9 +211,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -225,9 +221,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -235,27 +231,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.3.tgz",
-      "integrity": "sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
-      "integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -307,48 +303,48 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.3.tgz",
-      "integrity": "sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.3",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -881,18 +877,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/remapping": {
@@ -916,16 +908,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -934,9 +916,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2127,14 +2109,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -2201,6 +2180,19 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2311,9 +2303,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2331,10 +2323,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2437,9 +2430,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2999,9 +2992,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.158",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.158.tgz",
-      "integrity": "sha512-9vcp2xHhkvraY6AHw2WMi+GDSLPX42qe2xjYaVoZqFRJiOcilVQFq9mZmpuHEQpzlgGDelKlV7ZiGcmMsc8WxQ==",
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3163,20 +3156,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
@@ -3611,16 +3590,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3930,14 +3899,23 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4547,11 +4525,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5633,13 +5614,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5933,9 +5907,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -6011,10 +5985,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "overrides": {
     "qs": ">=6.15.2",
-    "esbuild": "$esbuild"
+    "esbuild": "$esbuild",
+    "@babel/core": "^7.29.6",
+    "js-yaml": "^4.2.0"
   },
   "scripts": {
     "prebuild": "node clean.cjs",
@@ -48,7 +50,7 @@
     "tsx": "^4.22.4",
     "typescript": "5.8.2",
     "urdf-loader": "0.12.4",
-    "vite": "^6.4.1",
+    "vite": "^6.4.3",
     "zustand": "5.0.3"
   }
 }

--- a/src/frontend/src/components/admin/AuditRunsTab.tsx
+++ b/src/frontend/src/components/admin/AuditRunsTab.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useEffect, useMemo, useState} from "react";
-import {viewerApi, AuditRun, AuditRunJob, Corpus} from "@/services/viewerApi";
+import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {viewerApi, AuditRun, AuditRunJob, AuditCellHistoryRow, Corpus} from "@/services/viewerApi";
 import {runWasmAuditSweep, WasmSweepProgress} from "@/services/audit/wasmSweep";
 
 // Synthetic worker-pool value routing a run to the in-browser WASM engine.
@@ -153,8 +153,42 @@ const METRIC_COLOR_BUCKETS: {cls: string}[] = [
 const RunGrid: React.FC<{
     jobs: AuditRunJob[];
     metric: MetricKey;
-}> = ({jobs, metric}) => {
+    onCellHistory: (file: string, target: string) => void;
+}> = ({jobs, metric, onCellHistory}) => {
     const grid = useMemo(() => buildGrid(jobs), [jobs]);
+
+    // Right-click (desktop) / long-press (touch) context menu for a cell.
+    const [menu, setMenu] = useState<{x: number; y: number; file: string; target: string} | null>(null);
+    const longPress = useRef<number | null>(null);
+    const openMenu = (x: number, y: number, file: string, target: string) =>
+        setMenu({x, y, file, target});
+    const cancelLongPress = () => {
+        if (longPress.current != null) {
+            window.clearTimeout(longPress.current);
+            longPress.current = null;
+        }
+    };
+    const onTouchStart = (e: React.TouchEvent, file: string, target: string) => {
+        const t = e.touches[0];
+        const x = t.clientX;
+        const y = t.clientY;
+        cancelLongPress();
+        longPress.current = window.setTimeout(() => openMenu(x, y, file, target), 500);
+    };
+    // Close on any outside click / scroll / Escape while the menu is open.
+    useEffect(() => {
+        if (!menu) return;
+        const close = () => setMenu(null);
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setMenu(null); };
+        window.addEventListener("click", close);
+        window.addEventListener("scroll", close, true);
+        window.addEventListener("keydown", onKey);
+        return () => {
+            window.removeEventListener("click", close);
+            window.removeEventListener("scroll", close, true);
+            window.removeEventListener("keydown", onKey);
+        };
+    }, [menu]);
 
     // Per-source cross-format parity result (the dispatcher emits one
     // ``parity`` cell per source). The "Validation" metric colours every cell
@@ -279,8 +313,16 @@ const RunGrid: React.FC<{
                                 return (
                                     <td
                                         key={target}
-                                        className={`px-2 py-1 border ${cls} text-center min-w-[60px] cursor-help`}
+                                        className={`px-2 py-1 border ${cls} text-center min-w-[60px] cursor-context-menu`}
                                         title={cellTooltip(job)}
+                                        onContextMenu={(e) => {
+                                            e.preventDefault();
+                                            openMenu(e.clientX, e.clientY, file, target);
+                                        }}
+                                        onTouchStart={(e) => onTouchStart(e, file, target)}
+                                        onTouchEnd={cancelLongPress}
+                                        onTouchMove={cancelLongPress}
+                                        onTouchCancel={cancelLongPress}
                                     >
                                         {label || "—"}
                                     </td>
@@ -290,6 +332,29 @@ const RunGrid: React.FC<{
                     ))}
                 </tbody>
             </table>
+            {menu && (
+                <div
+                    className="fixed z-50 min-w-[160px] rounded-sm border border-gray-600 bg-gray-900 shadow-lg py-1 text-xs"
+                    style={{left: menu.x, top: menu.y}}
+                    // Keep clicks inside the menu from bubbling to the window
+                    // close-listener before the item handler runs.
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <div className="px-3 py-1 text-[10px] text-gray-500 font-mono truncate max-w-[240px]">
+                        {menu.file} · .{menu.target}
+                    </div>
+                    <button
+                        type="button"
+                        className="w-full text-left px-3 py-1 text-gray-200 hover:bg-gray-700"
+                        onClick={() => {
+                            onCellHistory(menu.file, menu.target);
+                            setMenu(null);
+                        }}
+                    >
+                        Show history
+                    </button>
+                </div>
+            )}
         </div>
     );
 };
@@ -299,6 +364,9 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
     const [workerPool, setWorkerPool] = useState("");
     const [note, setNote] = useState("");
     const [forceRebuild, setForceRebuild] = useState(false);
+    // When on, the run auto-fires a follow-up validate_only parity pass once it
+    // finishes (replaces the old standalone "Run validation" button).
+    const [autoValidate, setAutoValidate] = useState(false);
     const [busy, setBusy] = useState(false);
     const [err, setErr] = useState<string | null>(null);
     // In-browser sweep progress (WASM pool only); null when idle.
@@ -348,7 +416,7 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
         return () => { cancelled = true; };
     }, []);
 
-    const createRun = useCallback(async (validateOnly: boolean) => {
+    const createRun = useCallback(async () => {
         setBusy(true);
         setErr(null);
         setSweepErr(null);
@@ -358,7 +426,7 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
                 worker_pool: workerPool.trim() || null,
                 note: note.trim() || null,
                 force_rebuild: forceRebuild,
-                validate_only: validateOnly,
+                auto_validate: autoValidate,
             });
             setNote("");
             onCreated();
@@ -366,7 +434,7 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
             // browser drives its cells here. Fire-and-forget: the runs list
             // polls and reflects progress from the audit rows the sweep
             // writes; we also surface a local progress line.
-            if (isWasmPool && !validateOnly) {
+            if (isWasmPool) {
                 setSweep({total: 0, completed: 0, current: null});
                 void runWasmAuditSweep(scope, run.id, (p) => setSweep(p))
                     .then(() => onCreated())
@@ -378,11 +446,11 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
         } finally {
             setBusy(false);
         }
-    }, [scope, workerPool, note, forceRebuild, onCreated, isWasmPool]);
+    }, [scope, workerPool, note, forceRebuild, autoValidate, onCreated, isWasmPool]);
 
     const onSubmit = useCallback((e: React.FormEvent) => {
         e.preventDefault();
-        void createRun(false);
+        void createRun();
     }, [createRun]);
 
     return (
@@ -456,21 +524,30 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
                 />
                 <span>Force rebuild</span>
             </label>
+            <label
+                className="text-xs text-gray-300 flex items-center gap-1 h-[30px] mt-auto select-none"
+                title={
+                    isWasmPool
+                        ? "Auto-validate runs on the worker pool only; ignored for in-browser (WASM) sweeps."
+                        : "After this run finishes, automatically start a validation pass " +
+                          "(cross-format visual-parity per source) for the same scope."
+                }
+            >
+                <input
+                    type="checkbox"
+                    checked={autoValidate}
+                    disabled={isWasmPool}
+                    onChange={(e) => setAutoValidate(e.target.checked)}
+                    className="accent-teal-600 disabled:opacity-40"
+                />
+                <span className={isWasmPool ? "opacity-40" : undefined}>Validate after</span>
+            </label>
             <button
                 type="submit"
                 disabled={busy}
                 className="bg-blue-700 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm px-3 py-1 rounded-sm h-[30px]"
             >
                 {busy ? "Starting…" : "Run audit"}
-            </button>
-            <button
-                type="button"
-                onClick={() => void createRun(true)}
-                disabled={busy}
-                title="Validation-only run: cross-format visual-parity per source, no conversions."
-                className="bg-teal-700 hover:bg-teal-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm px-3 py-1 rounded-sm h-[30px]"
-            >
-                {busy ? "Starting…" : "Run validation"}
             </button>
             {err && (
                 <div className="w-full text-xs text-red-400" role="alert">{err}</div>
@@ -530,6 +607,149 @@ const CancelRunButton: React.FC<{
                 {busy ? "Aborting…" : "Cancel run"}
             </button>
             {err && <span className="text-[11px] text-red-400" role="alert">{err}</span>}
+        </div>
+    );
+};
+
+const ReDispatchButton: React.FC<{
+    run: AuditRun;
+    onDispatched: () => void;
+}> = ({run, onDispatched}) => {
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+    const onClick = async () => {
+        if (!window.confirm(
+            `Re-run this audit against "${run.scope}"? A new run is created with the same scope, pool and settings.`,
+        )) {
+            return;
+        }
+        setBusy(true);
+        setErr(null);
+        try {
+            await viewerApi.adminAuditRunReDispatch(run.id);
+            onDispatched();
+        } catch (e) {
+            setErr((e as Error).message || "re-run failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+    return (
+        <div className="flex items-center gap-2">
+            <button
+                type="button"
+                onClick={onClick}
+                disabled={busy}
+                className="text-xs px-2 py-1 border border-blue-700 text-blue-300 hover:bg-blue-900/30 rounded-sm disabled:opacity-50"
+                title="Create a new audit run with this run's scope / pool / settings."
+            >
+                {busy ? "Starting…" : "Re-run audit"}
+            </button>
+            {err && <span className="text-[11px] text-red-400" role="alert">{err}</span>}
+        </div>
+    );
+};
+
+// Cross-run history for one grid cell (source × target), opened from the
+// cell context menu. Newest result first, so a run-to-run regression in
+// duration / peak RSS / status is visible at a glance.
+const CellHistoryModal: React.FC<{
+    cell: {key: string; target: string};
+    onClose: () => void;
+}> = ({cell, onClose}) => {
+    const [rows, setRows] = useState<AuditCellHistoryRow[] | null>(null);
+    const [err, setErr] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setRows(null);
+        setErr(null);
+        (async () => {
+            try {
+                const r = await viewerApi.adminAuditCellHistory(cell.key, cell.target);
+                if (!cancelled) setRows(r.history);
+            } catch (e) {
+                if (!cancelled) setErr((e as Error).message || "history load failed");
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [cell.key, cell.target]);
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+            <div
+                className="bg-gray-900 border border-gray-700 rounded-sm max-w-3xl w-full max-h-[80vh] flex flex-col"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+                    <div className="text-sm text-gray-200 font-mono truncate" title={`${cell.key} .${cell.target}`}>
+                        {cell.key} · .{cell.target}
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-200 text-lg leading-none px-2"
+                        aria-label="Close"
+                    >
+                        ×
+                    </button>
+                </div>
+                <div className="overflow-auto p-2">
+                    {err && <div className="text-xs text-red-400 px-2 py-2" role="alert">{err}</div>}
+                    {!rows && !err && <div className="text-xs text-gray-400 px-2 py-4">Loading…</div>}
+                    {rows && rows.length === 0 && (
+                        <div className="text-xs text-gray-400 px-2 py-4">No historic results for this cell.</div>
+                    )}
+                    {rows && rows.length > 0 && (
+                        <table className="text-xs border-collapse w-full">
+                            <thead className="text-gray-400">
+                                <tr>
+                                    <th className="text-left px-2 py-1 border-b border-gray-700">when</th>
+                                    <th className="text-left px-2 py-1 border-b border-gray-700">status</th>
+                                    <th className="text-right px-2 py-1 border-b border-gray-700">dur</th>
+                                    <th className="text-right px-2 py-1 border-b border-gray-700">peak RSS</th>
+                                    <th className="text-left px-2 py-1 border-b border-gray-700">worker</th>
+                                    <th className="text-left px-2 py-1 border-b border-gray-700">error</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rows.map((h) => (
+                                    <tr key={h.id} className="hover:bg-gray-800/40">
+                                        <td className="px-2 py-1 border-b border-gray-800 text-gray-300 whitespace-nowrap">
+                                            {h.ts ? new Date(h.ts).toLocaleString() : "—"}
+                                        </td>
+                                        <td className="px-2 py-1 border-b border-gray-800 text-gray-200">{h.status}</td>
+                                        <td className="px-2 py-1 border-b border-gray-800 text-right text-gray-300">
+                                            {h.duration_ms != null ? `${(h.duration_ms / 1000).toFixed(1)}s` : "—"}
+                                        </td>
+                                        <td className="px-2 py-1 border-b border-gray-800 text-right text-gray-300">
+                                            {h.peak_rss_kb != null ? `${Math.round(h.peak_rss_kb / 1024)}MB` : "—"}
+                                        </td>
+                                        <td
+                                            className="px-2 py-1 border-b border-gray-800 text-gray-400 font-mono truncate max-w-[120px]"
+                                            title={h.worker_image_tag || ""}
+                                        >
+                                            {h.worker_image_tag || "—"}
+                                        </td>
+                                        <td
+                                            className="px-2 py-1 border-b border-gray-800 text-red-300 truncate max-w-[220px]"
+                                            title={h.error || ""}
+                                        >
+                                            {h.error || ""}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    )}
+                </div>
+            </div>
         </div>
     );
 };
@@ -602,6 +822,8 @@ const AuditRunsTab: React.FC = () => {
     const [metric, setMetric] = useState<MetricKey>("status");
     const [listError, setListError] = useState<string | null>(null);
     const [detailError, setDetailError] = useState<string | null>(null);
+    // Cell whose cross-run history modal is open (from the grid context menu).
+    const [historyCell, setHistoryCell] = useState<{key: string; target: string} | null>(null);
 
     const loadRuns = useCallback(async () => {
         try {
@@ -782,13 +1004,18 @@ const AuditRunsTab: React.FC = () => {
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-2 shrink-0">
-                                    {selectedRun.status === "running" && (
+                                    {selectedRun.status === "running" ? (
                                         <CancelRunButton
                                             run={selectedRun}
                                             onCancelled={() => {
                                                 void loadRuns();
                                                 if (selectedId) void loadDetail(selectedId);
                                             }}
+                                        />
+                                    ) : (
+                                        <ReDispatchButton
+                                            run={selectedRun}
+                                            onDispatched={() => { void loadRuns(); }}
                                         />
                                     )}
                                     <label className="text-xs text-gray-300 flex items-center gap-2">
@@ -810,12 +1037,19 @@ const AuditRunsTab: React.FC = () => {
                                 <div className="text-xs text-red-400 px-3 py-2">{detailError}</div>
                             )}
                             <div className="flex-1 min-h-0 overflow-hidden">
-                                <RunGrid jobs={selectedJobs} metric={metric}/>
+                                <RunGrid
+                                    jobs={selectedJobs}
+                                    metric={metric}
+                                    onCellHistory={(file, target) => setHistoryCell({key: file, target})}
+                                />
                             </div>
                         </>
                     )}
                 </div>
             </div>
+            {historyCell && (
+                <CellHistoryModal cell={historyCell} onClose={() => setHistoryCell(null)}/>
+            )}
         </div>
     );
 };

--- a/src/frontend/src/components/admin/AuditRunsTab.tsx
+++ b/src/frontend/src/components/admin/AuditRunsTab.tsx
@@ -60,7 +60,9 @@ function fmtRunDuration(run: AuditRun): string {
     if (!run.started_at) return "—";
     const start = new Date(run.started_at).getTime();
     const end = run.finished_at ? new Date(run.finished_at).getTime() : Date.now();
-    const ms = Math.max(0, end - start);
+    // Subtract idle time (the gap before a validation pass appended hours
+    // later) so the duration is active-block time, not wall clock.
+    const ms = Math.max(0, end - start - (run.idle_ms ?? 0));
     if (ms < 60_000) return `${(ms / 1000).toFixed(0)}s`;
     if (ms < 3600_000) return `${(ms / 60_000).toFixed(0)}m`;
     return `${(ms / 3600_000).toFixed(1)}h`;
@@ -154,7 +156,8 @@ const RunGrid: React.FC<{
     jobs: AuditRunJob[];
     metric: MetricKey;
     onCellHistory: (file: string, target: string) => void;
-}> = ({jobs, metric, onCellHistory}) => {
+    onCellDetails: (file: string, target: string) => void;
+}> = ({jobs, metric, onCellHistory, onCellDetails}) => {
     const grid = useMemo(() => buildGrid(jobs), [jobs]);
 
     // Right-click (desktop) / long-press (touch) context menu for a cell.
@@ -343,6 +346,16 @@ const RunGrid: React.FC<{
                     <div className="px-3 py-1 text-[10px] text-gray-500 font-mono truncate max-w-[240px]">
                         {menu.file} · .{menu.target}
                     </div>
+                    <button
+                        type="button"
+                        className="w-full text-left px-3 py-1 text-gray-200 hover:bg-gray-700"
+                        onClick={() => {
+                            onCellDetails(menu.file, menu.target);
+                            setMenu(null);
+                        }}
+                    >
+                        Show details
+                    </button>
                     <button
                         type="button"
                         className="w-full text-left px-3 py-1 text-gray-200 hover:bg-gray-700"
@@ -698,6 +711,47 @@ const ValidateRunButton: React.FC<{
     );
 };
 
+// Delete a finished/aborted run and its audit_log rows (parity cascades).
+const DeleteRunButton: React.FC<{
+    run: AuditRun;
+    onDeleted: () => void;
+}> = ({run, onDeleted}) => {
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+    const label = run.seq != null ? `#${run.seq}` : run.scope;
+    const onClick = async () => {
+        if (!window.confirm(
+            `Delete audit run ${label} ("${run.scope}")? Its results are removed permanently.`,
+        )) {
+            return;
+        }
+        setBusy(true);
+        setErr(null);
+        try {
+            await viewerApi.adminAuditRunDelete(run.id);
+            onDeleted();
+        } catch (e) {
+            setErr((e as Error).message || "delete failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+    return (
+        <div className="flex items-center gap-2">
+            <button
+                type="button"
+                onClick={onClick}
+                disabled={busy}
+                className="text-xs px-2 py-1 border border-red-800 text-red-300 hover:bg-red-900/30 rounded-sm disabled:opacity-50"
+                title="Delete this run and its results."
+            >
+                {busy ? "Deleting…" : "Delete"}
+            </button>
+            {err && <span className="text-[11px] text-red-400" role="alert">{err}</span>}
+        </div>
+    );
+};
+
 // Cross-run history for one grid cell (source × target), opened from the
 // cell context menu. Newest result first, so a run-to-run regression in
 // duration / peak RSS / status is visible at a glance.
@@ -802,6 +856,88 @@ const CellHistoryModal: React.FC<{
     );
 };
 
+// Full info for one grid cell — status, metrics and the error — plus the run
+// it belongs to. Opened from the cell context menu so the detail is reachable
+// on touch (no hover tooltip) and gives the whole error on desktop too.
+const CellDetailsModal: React.FC<{
+    run: AuditRun;
+    file: string;
+    target: string;
+    job: AuditRunJob | undefined;
+    onClose: () => void;
+}> = ({run, file, target, job, onClose}) => {
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    const rows: Array<[string, string]> = [];
+    rows.push(["Run", run.seq != null ? `#${run.seq}` : run.id]);
+    rows.push(["Scope", run.scope]);
+    if (run.trigger) rows.push(["Trigger", run.trigger]);
+    rows.push(["Source", file]);
+    rows.push(["Target", `.${target}`]);
+    if (job) {
+        if (job.status) rows.push(["Status", job.status]);
+        if (job.ts) rows.push(["When", new Date(job.ts).toLocaleString()]);
+        if (job.duration_ms != null) rows.push(["Elapsed", fmtMs(job.duration_ms)]);
+        if (job.peak_rss_kb != null) rows.push(["Peak RSS", fmtBytes(job.peak_rss_kb * 1024)]);
+        if (job.cpu_user_ms != null) rows.push(["CPU user", fmtMs(job.cpu_user_ms)]);
+        if (job.cpu_sys_ms != null) rows.push(["CPU sys", fmtMs(job.cpu_sys_ms)]);
+        if (job.read_bytes != null) rows.push(["Read", fmtBytes(job.read_bytes)]);
+        if (job.write_bytes != null) rows.push(["Write", fmtBytes(job.write_bytes)]);
+        if (job.worker_image_tag) rows.push(["Worker", job.worker_image_tag]);
+        if (job.job_id) rows.push(["Job id", job.job_id]);
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+            <div
+                className="bg-gray-900 border border-gray-700 rounded-sm max-w-2xl w-full max-h-[80vh] flex flex-col"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+                    <div className="text-sm text-gray-200 font-mono truncate" title={`${file} .${target}`}>
+                        {file} · .{target}
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-200 text-lg leading-none px-2"
+                        aria-label="Close"
+                    >
+                        ×
+                    </button>
+                </div>
+                <div className="overflow-auto p-3 space-y-3">
+                    {!job && (
+                        <div className="text-xs text-gray-400">No result recorded for this cell yet.</div>
+                    )}
+                    <table className="text-xs">
+                        <tbody>
+                            {rows.map(([k, v]) => (
+                                <tr key={k}>
+                                    <td className="text-gray-400 pr-3 py-0.5 align-top whitespace-nowrap">{k}</td>
+                                    <td className="text-gray-200 font-mono break-all py-0.5">{v}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    {job?.error && (
+                        <div>
+                            <div className="text-xs text-gray-400 mb-1">Error</div>
+                            <pre className="text-xs text-red-300 whitespace-pre-wrap bg-gray-950 border border-gray-800 rounded-sm p-2 overflow-auto max-h-60">
+                                {job.error}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
 const ISSUE_BOT_BADGE: Record<string, {cls: string; label: string}> = {
     done:     {cls: "bg-emerald-900/40 border-emerald-700 text-emerald-200", label: "issues synced"},
     skipped:  {cls: "bg-gray-800 border-gray-600 text-gray-400",             label: "issues skipped"},
@@ -872,6 +1008,8 @@ const AuditRunsTab: React.FC = () => {
     const [detailError, setDetailError] = useState<string | null>(null);
     // Cell whose cross-run history modal is open (from the grid context menu).
     const [historyCell, setHistoryCell] = useState<{key: string; target: string} | null>(null);
+    // Cell whose full-detail modal is open (status/metrics/error).
+    const [detailsCell, setDetailsCell] = useState<{file: string; target: string} | null>(null);
 
     const loadRuns = useCallback(async () => {
         try {
@@ -972,6 +1110,9 @@ const AuditRunsTab: React.FC = () => {
                                 >
                                     <div className="flex justify-between items-baseline">
                                         <span className="font-mono text-gray-200 truncate">
+                                            {run.seq != null && (
+                                                <span className="text-gray-500 mr-1">#{run.seq}</span>
+                                            )}
                                             {run.scope}
                                         </span>
                                         <span className={
@@ -1040,7 +1181,12 @@ const AuditRunsTab: React.FC = () => {
                                         ← list
                                     </button>
                                     <div className="text-xs text-gray-300 min-w-0">
-                                        <div className="font-mono truncate">{selectedRun.scope}</div>
+                                        <div className="font-mono truncate">
+                                            {selectedRun.seq != null && (
+                                                <span className="text-gray-500 mr-1">#{selectedRun.seq}</span>
+                                            )}
+                                            {selectedRun.scope}
+                                        </div>
                                         <div className="text-gray-500">
                                             ok {selectedRun.ok} · failed {selectedRun.failed} ·
                                             skipped {selectedRun.skipped} · total {selectedRun.total}
@@ -1073,6 +1219,14 @@ const AuditRunsTab: React.FC = () => {
                                                 run={selectedRun}
                                                 onDispatched={() => { void loadRuns(); }}
                                             />
+                                            <DeleteRunButton
+                                                run={selectedRun}
+                                                onDeleted={() => {
+                                                    setSelectedId(null);
+                                                    setSelectedRun(null);
+                                                    void loadRuns();
+                                                }}
+                                            />
                                         </>
                                     )}
                                     <label className="text-xs text-gray-300 flex items-center gap-2">
@@ -1098,6 +1252,7 @@ const AuditRunsTab: React.FC = () => {
                                     jobs={selectedJobs}
                                     metric={metric}
                                     onCellHistory={(file, target) => setHistoryCell({key: file, target})}
+                                    onCellDetails={(file, target) => setDetailsCell({file, target})}
                                 />
                             </div>
                         </>
@@ -1106,6 +1261,17 @@ const AuditRunsTab: React.FC = () => {
             </div>
             {historyCell && (
                 <CellHistoryModal cell={historyCell} onClose={() => setHistoryCell(null)}/>
+            )}
+            {detailsCell && selectedRun && (
+                <CellDetailsModal
+                    run={selectedRun}
+                    file={detailsCell.file}
+                    target={detailsCell.target}
+                    job={selectedJobs.find(
+                        (j) => j.key === detailsCell.file && j.target_format === detailsCell.target,
+                    )}
+                    onClose={() => setDetailsCell(null)}
+                />
             )}
         </div>
     );

--- a/src/frontend/src/components/admin/AuditRunsTab.tsx
+++ b/src/frontend/src/components/admin/AuditRunsTab.tsx
@@ -650,6 +650,54 @@ const ReDispatchButton: React.FC<{
     );
 };
 
+// Kick off a cross-format parity validation pass on a finished run. The cells
+// are appended to *this* run (it reopens to 'running' until they land), not a
+// new run. Dispatched at most once per run — the button disables once a
+// validation has already run (via the toggle or a prior click).
+const ValidateRunButton: React.FC<{
+    run: AuditRun;
+    onValidated: () => void;
+}> = ({run, onValidated}) => {
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+    const alreadyValidated = !!run.auto_validate_dispatched_at;
+    const onClick = async () => {
+        if (!window.confirm(
+            `Run validation on "${run.scope}"? Cross-format parity cells are appended to this run.`,
+        )) {
+            return;
+        }
+        setBusy(true);
+        setErr(null);
+        try {
+            await viewerApi.adminAuditRunValidate(run.id);
+            onValidated();
+        } catch (e) {
+            setErr((e as Error).message || "validation failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+    return (
+        <div className="flex items-center gap-2">
+            <button
+                type="button"
+                onClick={onClick}
+                disabled={busy || alreadyValidated}
+                className="text-xs px-2 py-1 border border-teal-700 text-teal-300 hover:bg-teal-900/30 rounded-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                title={
+                    alreadyValidated
+                        ? "Validation already dispatched for this run."
+                        : "Append a cross-format parity validation pass to this run."
+                }
+            >
+                {busy ? "Starting…" : alreadyValidated ? "Validated" : "Validate"}
+            </button>
+            {err && <span className="text-[11px] text-red-400" role="alert">{err}</span>}
+        </div>
+    );
+};
+
 // Cross-run history for one grid cell (source × target), opened from the
 // cell context menu. Newest result first, so a run-to-run regression in
 // duration / peak RSS / status is visible at a glance.
@@ -1013,10 +1061,19 @@ const AuditRunsTab: React.FC = () => {
                                             }}
                                         />
                                     ) : (
-                                        <ReDispatchButton
-                                            run={selectedRun}
-                                            onDispatched={() => { void loadRuns(); }}
-                                        />
+                                        <>
+                                            <ValidateRunButton
+                                                run={selectedRun}
+                                                onValidated={() => {
+                                                    void loadRuns();
+                                                    if (selectedId) void loadDetail(selectedId);
+                                                }}
+                                            />
+                                            <ReDispatchButton
+                                                run={selectedRun}
+                                                onDispatched={() => { void loadRuns(); }}
+                                            />
+                                        </>
                                     )}
                                     <label className="text-xs text-gray-300 flex items-center gap-2">
                                         <span className="hidden sm:inline">Color cells by:</span>

--- a/src/frontend/src/components/info_box_selected_object/ObjectMetadataPanel.tsx
+++ b/src/frontend/src/components/info_box_selected_object/ObjectMetadataPanel.tsx
@@ -70,6 +70,13 @@ type PlateMeta = {
     material?: MaterialDict | null;
 };
 
+type CurvedPlateMeta = {
+    type: 'PlateCurved';
+    name?: string;
+    thickness?: number | null;
+    material?: MaterialDict | null;
+};
+
 type Props = {
     data: any | null;
 };
@@ -230,8 +237,8 @@ const ObjectMetadataPanel: React.FC<Props> = ({data}) => {
     // Panel always renders when there's a selection — even without
     // any structured metadata — because it still hosts the clicked-
     // coordinate row and the cross-model link buttons.
-    const meta = (effectiveData ?? null) as BeamMeta | PlateMeta | null;
-    const known = meta?.type === 'Beam' || meta?.type === 'Plate';
+    const meta = (effectiveData ?? null) as BeamMeta | PlateMeta | CurvedPlateMeta | null;
+    const known = meta?.type === 'Beam' || meta?.type === 'Plate' || meta?.type === 'PlateCurved';
     return (
         <div className="mt-2">
             <button
@@ -259,6 +266,13 @@ const ObjectMetadataPanel: React.FC<Props> = ({data}) => {
                         <>
                             <Row label="Type:">Plate</Row>
                             <Row label="Thickness:">{fmtMm((meta as PlateMeta).thickness)}</Row>
+                            <MaterialRows material={meta.material} />
+                        </>
+                    )}
+                    {meta?.type === 'PlateCurved' && (
+                        <>
+                            <Row label="Type:">Curved Plate</Row>
+                            <Row label="Thickness:">{fmtMm((meta as CurvedPlateMeta).thickness)}</Row>
                             <MaterialRows material={meta.material} />
                         </>
                     )}

--- a/src/frontend/src/components/storage/StorageBrowser.tsx
+++ b/src/frontend/src/components/storage/StorageBrowser.tsx
@@ -40,6 +40,7 @@ import {viewerApi} from "@/services/viewerApi";
 import {useStorageMutations} from "./useStorageMutations";
 import {useLoadQueueStore} from "@/state/loadQueueStore";
 import {buildFileMenuItems, buildFolderMenuItems} from "./storageMenuItems";
+import {writeToClipboard} from "@/utils/clipboard/copySelectionNames";
 import {canLoadIntoSceneLegacy, isFEAResult, isStreamingFEAResult} from "@/utils/scene/fileKinds";
 import {unload_any_source} from "@/utils/scene/handlers/unload_any_source";
 
@@ -391,15 +392,21 @@ const StorageBrowser: React.FC = () => {
     const [renaming, setRenaming] = useState<{kind: "file" | "folder"; path: string} | null>(null);
     // Right-click context menu: items are computed at open time by the
     // same builders that feed the kebab, so the two stay in lockstep.
-    const [ctxMenu, setCtxMenu] = useState<{x: number; y: number; items: KebabMenuItem[]} | null>(null);
+    const [ctxMenu, setCtxMenu] = useState<{
+        x: number;
+        y: number;
+        items: KebabMenuItem[];
+        header?: React.ReactNode;
+    } | null>(null);
     const openCtxMenu = (
         e: {clientX: number; clientY: number; preventDefault?: () => void; stopPropagation?: () => void},
         items: KebabMenuItem[],
+        header?: React.ReactNode,
     ) => {
         if (items.length === 0) return;
         e.preventDefault?.();
         e.stopPropagation?.();
-        setCtxMenu({x: e.clientX, y: e.clientY, items});
+        setCtxMenu({x: e.clientX, y: e.clientY, items, header});
     };
     // In-panel drag state: keys being dragged (for row dimming + the
     // move-to-root strip). Cleared on dragend/drop.
@@ -879,6 +886,7 @@ const StorageBrowser: React.FC = () => {
                     ? () => onLoadStreamer(f.name)
                     : undefined,
             onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
+            onCopyPath: () => void writeToClipboard(f.name),
             onRename: () => setRenaming({kind: "file", path: f.name}),
             onMoveToFolder: () => onMoveSingleToFolder(f.name),
             onDelete: () => void onDeleteFile(f),
@@ -898,6 +906,7 @@ const StorageBrowser: React.FC = () => {
                     ? () => onLoadStreamer(f.name)
                     : undefined,
             onDownload: runtime.isRestMode() ? () => onDownloadFile(f.name) : undefined,
+            onCopyPath: () => void writeToClipboard(f.name),
         });
     };
     const folderMenuItems = (path: string, fileCount: number, isPending: boolean): KebabMenuItem[] =>
@@ -1368,7 +1377,15 @@ const StorageBrowser: React.FC = () => {
                                                 rowKey={`file:${node.file.name}`}
                                                 focused={focusedKey === `file:${node.file.name}`}
                                                 menuItems={items}
-                                                onOpenContextMenu={(e) => openCtxMenu(e, items)}
+                                                onOpenContextMenu={(e) =>
+                                                    openCtxMenu(
+                                                        e,
+                                                        items,
+                                                        <span className="font-mono" title={node.file.name}>
+                                                            {node.file.name}
+                                                        </span>,
+                                                    )
+                                                }
                                                 draggable={canMutate}
                                                 onDragStartRow={onDragStartFile(node.file)}
                                                 onDragEndRow={onDragEndFile}
@@ -1414,7 +1431,15 @@ const StorageBrowser: React.FC = () => {
                                                 rowKey={`folder:${node.path}`}
                                                 focused={focusedKey === `folder:${node.path}`}
                                                 menuItems={items}
-                                                onOpenContextMenu={(e) => openCtxMenu(e, items)}
+                                                onOpenContextMenu={(e) =>
+                                                    openCtxMenu(
+                                                        e,
+                                                        items,
+                                                        <span className="font-mono" title={node.path}>
+                                                            {node.path}/
+                                                        </span>,
+                                                    )
+                                                }
                                                 onDropInto={(e) => void handleDropOnFolder(node.path, e)}
                                                 draggable={canMutate && !isPending}
                                                 onDragStartRow={(e) => {
@@ -1480,6 +1505,7 @@ const StorageBrowser: React.FC = () => {
             {ctxMenu && (
                 <PositionedMenu
                     items={ctxMenu.items}
+                    header={ctxMenu.header}
                     onClose={() => setCtxMenu(null)}
                     anchor={{kind: "point", x: ctxMenu.x, y: ctxMenu.y}}
                 />

--- a/src/frontend/src/components/storage/storageMenuItems.tsx
+++ b/src/frontend/src/components/storage/storageMenuItems.tsx
@@ -24,6 +24,8 @@ export interface FileMenuContext {
     onLoadStreamer?: () => void;
     /** REST mode only. */
     onDownload?: () => void;
+    /** Copy the file's storage path (the key shown in the menu header). */
+    onCopyPath?: () => void;
     onRename?: () => void;
     onMoveToFolder?: () => void;
     onDelete?: () => void;
@@ -57,6 +59,14 @@ export function buildFileMenuItems(
             key: "download",
             label: "Download",
             onClick: ctx.onDownload,
+        });
+    }
+    if (ctx.onCopyPath) {
+        items.push({
+            key: "copy-path",
+            label: "Copy as path",
+            title: "Copy this file's storage path to the clipboard.",
+            onClick: ctx.onCopyPath,
         });
     }
     if (ctx.canMutate && ctx.onRename) {

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -597,6 +597,10 @@ export interface AuditRun {
     // When true, the finished-run poller auto-fires a follow-up
     // validate_only parity run for the same scope once this run finishes.
     auto_validate?: boolean;
+    // Set once a validation pass has been dispatched for this run (via the
+    // toggle or the manual button) — used to gate the "Validate" button so a
+    // run is validated at most once.
+    auto_validate_dispatched_at?: string | null;
     // Set on a derived run (the auto-validation child, or a re-dispatched
     // copy) to the run it was created from.
     parent_run_id?: string | null;
@@ -1639,6 +1643,17 @@ export const viewerApi = {
             {method: "POST"},
         );
         return jsonOrThrow(r, `adminAuditRunReDispatch(${runId})`);
+    },
+
+    /** Admin: append a validation (cross-format parity) pass to a finished
+     * run — folded into the same run, not a new one. 409 if the run isn't
+     * finished or has already been validated. Returns the (reopened) run. */
+    async adminAuditRunValidate(runId: string): Promise<AuditRun> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/admin/audit/runs/${encodeURIComponent(runId)}/validate`,
+            {method: "POST"},
+        );
+        return jsonOrThrow(r, `adminAuditRunValidate(${runId})`);
     },
 
     /** Admin: historic results for one (source key, target_format) cell across

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -594,11 +594,30 @@ export interface AuditRun {
     // short-circuit. Useful as a UI badge so an unexpected slow
     // run is recognisable as a perf measurement vs a regression.
     force_rebuild: boolean;
+    // When true, the finished-run poller auto-fires a follow-up
+    // validate_only parity run for the same scope once this run finishes.
+    auto_validate?: boolean;
+    // Set on a derived run (the auto-validation child, or a re-dispatched
+    // copy) to the run it was created from.
+    parent_run_id?: string | null;
     // M5: issue-bot sync status. NULL until the bot has touched the
     // run; 'syncing' while in flight; terminal 'done'/'skipped'/'failed'.
     issue_bot_status: string | null;
     issue_bot_last_error: string | null;
     issue_bot_synced_at: string | null;
+}
+
+// One historic result for a (source key, target_format) cell — newest
+// first — backing the grid's right-click "show history" table.
+export interface AuditCellHistoryRow {
+    id: number;
+    ts: string | null;
+    status: string;
+    error: string | null;
+    duration_ms: number | null;
+    peak_rss_kb: number | null;
+    worker_image_tag: string | null;
+    audit_run_id: string | null;
 }
 
 // Per-deployment configuration for the audit-failure → issue tracker
@@ -1600,6 +1619,7 @@ export const viewerApi = {
             note?: string | null;
             force_rebuild?: boolean;
             validate_only?: boolean;
+            auto_validate?: boolean;
         },
     ): Promise<AuditRun> {
         const r = await authedFetch(`${runtime.apiBase()}/admin/audit/runs`, {
@@ -1608,6 +1628,31 @@ export const viewerApi = {
             body: JSON.stringify(body),
         });
         return jsonOrThrow(r, "adminAuditRunCreate");
+    },
+
+    /** Admin: re-run a prior audit against the same scope / pool / settings.
+     * The cells are re-enumerated from the scope at dispatch time, so the
+     * re-run reflects the scope's current files. Returns the new run. */
+    async adminAuditRunReDispatch(runId: string): Promise<AuditRun> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/admin/audit/runs/${encodeURIComponent(runId)}/re-dispatch`,
+            {method: "POST"},
+        );
+        return jsonOrThrow(r, `adminAuditRunReDispatch(${runId})`);
+    },
+
+    /** Admin: historic results for one (source key, target_format) cell across
+     * every run, newest first. Backs the grid's right-click "show history". */
+    async adminAuditCellHistory(
+        key: string,
+        target: string,
+        limit = 50,
+    ): Promise<{key: string; target_format: string; history: AuditCellHistoryRow[]}> {
+        const params = new URLSearchParams({key, target, limit: String(limit)});
+        const r = await authedFetch(
+            `${runtime.apiBase()}/admin/audit/cell-history?${params.toString()}`,
+        );
+        return jsonOrThrow(r, "adminAuditCellHistory");
     },
 
     /** Cell matrix for an audit run — drives the in-browser (WASM) sweep

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -578,6 +578,12 @@ export interface AuditEntry {
 // sum equals total.
 export interface AuditRun {
     id: string;
+    // Short, human-referrable monotonic run number ("Run #42"); the UUID id
+    // stays canonical. May be absent on rows from before the seq migration.
+    seq?: number | null;
+    // Idle time (ms) excluded from the active duration — the gap before a
+    // later validation pass folded into the run. UI subtracts it.
+    idle_ms?: number | null;
     scope: string;
     worker_pool: string | null;
     trigger: string;
@@ -1654,6 +1660,18 @@ export const viewerApi = {
             {method: "POST"},
         );
         return jsonOrThrow(r, `adminAuditRunValidate(${runId})`);
+    },
+
+    /** Admin: delete an audit run and its audit_log rows (parity cascades).
+     * 409 if the run is still running — cancel it first. */
+    async adminAuditRunDelete(runId: string): Promise<void> {
+        const r = await authedFetch(
+            `${runtime.apiBase()}/admin/audit/runs/${encodeURIComponent(runId)}`,
+            {method: "DELETE"},
+        );
+        if (!r.ok) {
+            throw new ApiError(`adminAuditRunDelete(${runId})`, r.status, await readDetail(r));
+        }
     },
 
     /** Admin: historic results for one (source key, target_format) cell across

--- a/tests/comms/rest/test_admin_fea_derived.py
+++ b/tests/comms/rest/test_admin_fea_derived.py
@@ -81,7 +81,7 @@ def _put(client: TestClient, key: str, data: bytes) -> None:
                 break
         if storage is not None:
             break
-    asyncio.get_event_loop().run_until_complete(storage.put_bytes(Scope.shared(), key, data))
+    asyncio.run(storage.put_bytes(Scope.shared(), key, data))
 
 
 @pytest.fixture

--- a/tests/comms/rest/test_admin_move_to_folder.py
+++ b/tests/comms/rest/test_admin_move_to_folder.py
@@ -90,7 +90,7 @@ def _put(client: TestClient, key: str, data: bytes) -> None:
                 break
         client.app.state._test_storage = storage
 
-    asyncio.get_event_loop().run_until_complete(storage.put_bytes(Scope.shared(), key, data))
+    asyncio.run(storage.put_bytes(Scope.shared(), key, data))
 
 
 def test_move_to_folder_renames_source_and_derived_siblings(

--- a/tests/comms/rest/test_audit_run_routes.py
+++ b/tests/comms/rest/test_audit_run_routes.py
@@ -1,0 +1,277 @@
+"""Audit-run admin routes + their DB helpers (live Postgres).
+
+Covers the run-management features the audit panel grew: friendly ``seq``,
+idle-aware duration, the manual validate claim, re-dispatch, delete, and the
+per-cell history query. Live-Postgres only (opt-in via ``ADA_TEST_POSTGRES_URL``)
+— audit runs are DB-backed.
+
+The test environment has no NATS, so worker-pool conversion runs can't be
+created through the API (the create route 503s without a queue). The route
+tests therefore use the ``wasm`` pool (accepted without NATS) and seed
+finished runs directly through the DB helpers; the parity dispatch that a real
+``validate`` would enqueue is exercised at the DB-helper level instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as db_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+from ada.comms.rest.scope import Scope  # noqa: E402
+
+POSTGRES_URL = os.environ.get("ADA_TEST_POSTGRES_URL", "").strip()
+needs_postgres = pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="ADA_TEST_POSTGRES_URL not set; skipping live Postgres tests",
+)
+
+pytestmark = needs_postgres
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(url=None, stream="ada", subject="s", kv_bucket="kv", durable="d"),
+        auth=AuthConfig(
+            enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""
+        ),
+        database_url=POSTGRES_URL,
+    )
+
+
+@pytest.fixture
+def db():
+    """Yield ``(pool, run)`` — an asyncpg pool and a runner bound to the *same*
+    event loop (asyncpg connections can't cross loops). Truncates the audit
+    tables for a clean slate."""
+    loop = asyncio.new_event_loop()
+
+    def run(coro):
+        return loop.run_until_complete(coro)
+
+    p = run(db_module.init_pool(POSTGRES_URL))
+    assert p is not None, "init_pool returned None for ADA_TEST_POSTGRES_URL"
+    run(p.execute("TRUNCATE audit_log, audit_parity, audit_runs RESTART IDENTITY CASCADE"))
+    try:
+        yield p, run
+    finally:
+        run(p.close())
+        loop.close()
+
+
+def _storage(client: TestClient):
+    """Pull the app's Storage out of a route closure (same trick as the wasm test)."""
+    for route in client.app.routes:
+        ep = getattr(route, "endpoint", None)
+        for c in getattr(ep, "__closure__", None) or ():
+            v = c.cell_contents
+            if v.__class__.__name__ == "Storage":
+                return v
+    raise RuntimeError("storage not found on app")
+
+
+async def _finish_run(p, *, scope="shared", worker_pool=None, auto_validate=False, n=1):
+    """Create a run, set its total, and close ``n`` cells so it finishes."""
+    run = await db_module.create_audit_run(
+        p, scope=scope, worker_pool=worker_pool, auto_validate=auto_validate
+    )
+    await db_module.set_audit_run_total(p, run["id"], n)
+    for i in range(n):
+        await db_module.insert_audit(
+            p,
+            user_sub=None,
+            scope_kind="shared",
+            scope_id=None,
+            action="convert",
+            key=f"models/f{i}.step",
+            target_format="glb",
+            status="done",
+            duration_ms=10,
+            audit_run_id=run["id"],
+        )
+    return await db_module.get_audit_run(p, run["id"])
+
+
+# ── DB helpers ─────────────────────────────────────────────────────
+
+
+def test_create_run_has_seq_and_idle_defaults(db):
+    pool, run = db
+    r = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None, auto_validate=True))
+    assert isinstance(r["seq"], int) and r["seq"] >= 1
+    assert r["idle_ms"] == 0
+    assert r["auto_validate"] is True
+    assert r["auto_validate_dispatched_at"] is None
+
+
+def test_seq_is_monotonic(db):
+    pool, run = db
+    a = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
+    b = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
+    assert b["seq"] > a["seq"]
+
+
+def test_extend_folds_idle_gap(db):
+    pool, run = db
+    r = run(_finish_run(pool, n=1))
+    # Backdate the finish so the reopen sees a ~1h idle gap.
+    run(pool.execute("UPDATE audit_runs SET finished_at = NOW() - INTERVAL '1 hour' WHERE id = $1", r["id"]))
+    run(db_module.extend_audit_run_total(pool, r["id"], 1))
+    after = run(db_module.get_audit_run(pool, r["id"]))
+    assert after["status"] == "running"
+    assert after["finished_at"] is None
+    assert after["total"] == 2
+    # ~3.6M ms with generous tolerance for clock + execution skew.
+    assert 3_400_000 < after["idle_ms"] < 3_800_000
+
+
+def test_claim_run_for_validation_is_once(db):
+    pool, run = db
+    r = run(_finish_run(pool, n=1))
+    first = run(db_module.claim_run_for_validation(pool, r["id"]))
+    assert first is not None and first["auto_validate_dispatched_at"] is not None
+    assert run(db_module.claim_run_for_validation(pool, r["id"])) is None  # already claimed
+
+
+def test_claim_run_for_validation_skips_running(db):
+    pool, run = db
+    r = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
+    run(db_module.set_audit_run_total(pool, r["id"], 2))  # 2 cells, none closed → running
+    assert run(db_module.claim_run_for_validation(pool, r["id"])) is None
+
+
+def test_claim_auto_validate_only_flagged_runs(db):
+    pool, run = db
+    flagged = run(_finish_run(pool, auto_validate=True, n=1))
+    run(_finish_run(pool, auto_validate=False, n=1))  # must NOT be claimed
+    claimed = run(db_module.claim_audit_run_for_auto_validate(pool))
+    assert claimed is not None and claimed["id"] == flagged["id"]
+    assert run(db_module.claim_audit_run_for_auto_validate(pool)) is None
+
+
+def test_delete_audit_run_removes_log_rows(db):
+    pool, run = db
+    r = run(_finish_run(pool, n=2))
+    assert run(db_module.delete_audit_run(pool, r["id"])) is True
+    assert run(db_module.get_audit_run(pool, r["id"])) is None
+    left = run(pool.fetchval("SELECT count(*) FROM audit_log WHERE audit_run_id = $1", r["id"]))
+    assert left == 0
+    assert run(db_module.delete_audit_run(pool, r["id"])) is False  # already gone
+
+
+def test_cell_history_newest_first(db):
+    pool, run = db
+    r1 = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
+    r2 = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
+    for rr, status, dur in ((r1, "done", 11), (r2, "error", 22)):
+        run(db_module.insert_audit(
+            pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
+            key="models/a.step", target_format="ifc", status=status, duration_ms=dur,
+            error=("boom" if status == "error" else None), audit_run_id=rr["id"],
+        ))
+    # A different target must not leak into the history.
+    run(db_module.insert_audit(
+        pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
+        key="models/a.step", target_format="xml", status="done", audit_run_id=r1["id"],
+    ))
+    hist = run(db_module.audit_log_history_for_cell(pool, "models/a.step", "ifc"))
+    assert [h["status"] for h in hist] == ["error", "done"]  # newest first
+    assert hist[0]["error"] == "boom" and hist[0]["duration_ms"] == 22
+
+
+# ── Routes (TestClient) ────────────────────────────────────────────
+
+
+def test_route_create_exposes_seq(tmp_path):
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        r = client.post("/api/admin/audit/runs", json={"scope": "shared", "worker_pool": "wasm"})
+        assert r.status_code == 202, r.text
+        run = r.json()
+        assert isinstance(run["seq"], int)
+        assert run["auto_validate"] is False  # gated off for wasm
+
+
+def test_route_delete_finished_and_409_running(tmp_path, db):
+    pool, run = db
+    finished = run(_finish_run(pool, worker_pool="wasm", n=1))
+    running = run(db_module.create_audit_run(pool, scope="shared", worker_pool="wasm"))
+    run(db_module.set_audit_run_total(pool, running["id"], 2))  # running
+
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        assert client.delete(f"/api/admin/audit/runs/{running['id']}").status_code == 409
+        assert client.delete(f"/api/admin/audit/runs/{finished['id']}").status_code == 200
+        assert client.get(f"/api/admin/audit/runs/{finished['id']}").status_code == 404
+
+
+def test_route_validate_appends_and_dedups(tmp_path, db):
+    pool, run = db
+    r = run(_finish_run(pool, worker_pool="wasm", n=1))
+    before_total = r["total"]
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        # Parity cells come from enumerating the scope's storage, so stage a
+        # source that yields one (a .step can target ifc/xml/step).
+        run(_storage(client).put_bytes(Scope.shared(), "models/part.step", b"ISO-10303-21;"))
+        r1 = client.post(f"/api/admin/audit/runs/{r['id']}/validate")
+        assert r1.status_code == 202, r1.text
+        after = client.get(f"/api/admin/audit/runs/{r['id']}").json()["run"]
+        assert after["auto_validate_dispatched_at"] is not None
+        assert after["total"] > before_total  # parity cell appended to the same run
+        # Second validate is rejected — a run is validated at most once.
+        assert client.post(f"/api/admin/audit/runs/{r['id']}/validate").status_code == 409
+
+
+def test_route_validate_409_when_running(tmp_path, db):
+    pool, run = db
+    r = run(db_module.create_audit_run(pool, scope="shared", worker_pool="wasm"))
+    run(db_module.set_audit_run_total(pool, r["id"], 2))  # running
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        assert client.post(f"/api/admin/audit/runs/{r['id']}/validate").status_code == 409
+
+
+def test_route_redispatch_links_parent(tmp_path, db):
+    pool, run = db
+    prior = run(_finish_run(pool, worker_pool="wasm", n=1))
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        r = client.post(f"/api/admin/audit/runs/{prior['id']}/re-dispatch")
+        assert r.status_code == 202, r.text
+        new = r.json()
+        assert new["id"] != prior["id"]
+        assert new["parent_run_id"] == prior["id"]
+        assert new["trigger"] == "re-dispatch"
+
+
+def test_route_cell_history(tmp_path, db):
+    pool, run = db
+    r = run(db_module.create_audit_run(pool, scope="shared", worker_pool="wasm"))
+    run(db_module.insert_audit(
+        pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
+        key="models/h.step", target_format="ifc", status="done", duration_ms=7, audit_run_id=r["id"],
+    ))
+    with TestClient(create_app(_settings(tmp_path))) as client:
+        resp = client.get("/api/admin/audit/cell-history", params={"key": "models/h.step", "target": "ifc"})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["key"] == "models/h.step" and body["target_format"] == "ifc"
+        assert len(body["history"]) == 1 and body["history"][0]["status"] == "done"

--- a/tests/comms/rest/test_audit_run_routes.py
+++ b/tests/comms/rest/test_audit_run_routes.py
@@ -54,9 +54,7 @@ def _settings(tmp_path: pathlib.Path) -> Settings:
         port=0,
         static_path="",
         queue=QueueConfig(url=None, stream="ada", subject="s", kv_bucket="kv", durable="d"),
-        auth=AuthConfig(
-            enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""
-        ),
+        auth=AuthConfig(enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""),
         database_url=POSTGRES_URL,
     )
 
@@ -94,9 +92,7 @@ def _storage(client: TestClient):
 
 async def _finish_run(p, *, scope="shared", worker_pool=None, auto_validate=False, n=1):
     """Create a run, set its total, and close ``n`` cells so it finishes."""
-    run = await db_module.create_audit_run(
-        p, scope=scope, worker_pool=worker_pool, auto_validate=auto_validate
-    )
+    run = await db_module.create_audit_run(p, scope=scope, worker_pool=worker_pool, auto_validate=auto_validate)
     await db_module.set_audit_run_total(p, run["id"], n)
     for i in range(n):
         await db_module.insert_audit(
@@ -186,16 +182,35 @@ def test_cell_history_newest_first(db):
     r1 = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
     r2 = run(db_module.create_audit_run(pool, scope="shared", worker_pool=None))
     for rr, status, dur in ((r1, "done", 11), (r2, "error", 22)):
-        run(db_module.insert_audit(
-            pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
-            key="models/a.step", target_format="ifc", status=status, duration_ms=dur,
-            error=("boom" if status == "error" else None), audit_run_id=rr["id"],
-        ))
+        run(
+            db_module.insert_audit(
+                pool,
+                user_sub=None,
+                scope_kind="shared",
+                scope_id=None,
+                action="convert",
+                key="models/a.step",
+                target_format="ifc",
+                status=status,
+                duration_ms=dur,
+                error=("boom" if status == "error" else None),
+                audit_run_id=rr["id"],
+            )
+        )
     # A different target must not leak into the history.
-    run(db_module.insert_audit(
-        pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
-        key="models/a.step", target_format="xml", status="done", audit_run_id=r1["id"],
-    ))
+    run(
+        db_module.insert_audit(
+            pool,
+            user_sub=None,
+            scope_kind="shared",
+            scope_id=None,
+            action="convert",
+            key="models/a.step",
+            target_format="xml",
+            status="done",
+            audit_run_id=r1["id"],
+        )
+    )
     hist = run(db_module.audit_log_history_for_cell(pool, "models/a.step", "ifc"))
     assert [h["status"] for h in hist] == ["error", "done"]  # newest first
     assert hist[0]["error"] == "boom" and hist[0]["duration_ms"] == 22
@@ -265,10 +280,20 @@ def test_route_redispatch_links_parent(tmp_path, db):
 def test_route_cell_history(tmp_path, db):
     pool, run = db
     r = run(db_module.create_audit_run(pool, scope="shared", worker_pool="wasm"))
-    run(db_module.insert_audit(
-        pool, user_sub=None, scope_kind="shared", scope_id=None, action="convert",
-        key="models/h.step", target_format="ifc", status="done", duration_ms=7, audit_run_id=r["id"],
-    ))
+    run(
+        db_module.insert_audit(
+            pool,
+            user_sub=None,
+            scope_kind="shared",
+            scope_id=None,
+            action="convert",
+            key="models/h.step",
+            target_format="ifc",
+            status="done",
+            duration_ms=7,
+            audit_run_id=r["id"],
+        )
+    )
     with TestClient(create_app(_settings(tmp_path))) as client:
         resp = client.get("/api/admin/audit/cell-history", params={"key": "models/h.step", "target": "ifc"})
         assert resp.status_code == 200, resp.text

--- a/tests/comms/rest/test_convert_path_contract.py
+++ b/tests/comms/rest/test_convert_path_contract.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import pathlib
 
-import pytest
 from obstore.store import LocalStore
 
 from ada.comms.rest.converter import convert, result_bytes
@@ -77,9 +76,7 @@ def test_full_chain_fork_to_put_path(tmp_path, fem_files):
         assert iresult.exit_code == 0
         assert iresult.out_path is not None and iresult.out_path.exists()
         try:
-            await storage.put_path(
-                scope, "_derived/beam.xml", iresult.out_path, content_encoding="gzip"
-            )
+            await storage.put_path(scope, "_derived/beam.xml", iresult.out_path, content_encoding="gzip")
         finally:
             iresult.cleanup_output()
         # The work dir + output file are gone once cleanup_output ran.
@@ -98,9 +95,7 @@ def test_full_chain_glb_bytes_path(tmp_path, fem_files):
     scope = Scope.shared()
 
     async def drive() -> bytes:
-        iresult = await run_isolated_convert(
-            convert, src_path=src, source_key=str(src), target_format="glb"
-        )
+        iresult = await run_isolated_convert(convert, src_path=src, source_key=str(src), target_format="glb")
         assert iresult.exit_code == 0
         assert iresult.out_path is not None
         try:

--- a/tests/comms/rest/test_convert_path_contract.py
+++ b/tests/comms/rest/test_convert_path_contract.py
@@ -1,0 +1,113 @@
+"""End-to-end of the path-return upload contract.
+
+The disk-writing exporters (IFC / Genie XML / STEP) hand ``convert`` a
+``pathlib.Path`` so the worker can stream the file to object storage via
+``Storage.put_path`` without ever holding it as a parent-side ``bytes``
+buffer. GLB / mesh handlers still return bytes (they tessellate into a
+BytesIO). These tests pin both halves and the full
+convert→fork→put_path→read-back round-trip the worker runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+
+import pytest
+from obstore.store import LocalStore
+
+from ada.comms.rest.converter import convert, result_bytes
+from ada.comms.rest.scope import Scope
+from ada.comms.rest.storage import Storage
+from ada.comms.rest.subprocess_convert import run_isolated_convert
+
+
+def _fem(fem_files: pathlib.Path) -> pathlib.Path:
+    return fem_files / "sesam/beamMassT1.FEM"
+
+
+def test_convert_returns_path_for_disk_targets(fem_files):
+    # Genie XML is a streaming, disk-writing exporter — convert hands back the
+    # path of the file it wrote, not bytes.
+    src = _fem(fem_files)
+    result = convert(src, str(src), "xml")
+    try:
+        assert isinstance(result, pathlib.Path)
+        assert result.exists()
+        assert b"<" in result.read_bytes()  # looks like XML
+    finally:
+        if isinstance(result, pathlib.Path):
+            result.unlink(missing_ok=True)
+
+
+def test_convert_returns_bytes_for_glb(fem_files):
+    # GLB tessellates into a BytesIO; the in-RAM bytes contract is unchanged.
+    src = _fem(fem_files)
+    result = convert(src, str(src), "glb")
+    assert isinstance(result, (bytes, bytearray))
+    assert len(result) > 0
+
+
+def test_result_bytes_normalises_both(fem_files):
+    src = _fem(fem_files)
+    as_path = convert(src, str(src), "xml")
+    as_bytes = convert(src, str(src), "glb")
+    try:
+        assert isinstance(result_bytes(as_path), bytes)
+        assert result_bytes(as_bytes) is as_bytes or result_bytes(as_bytes) == bytes(as_bytes)
+    finally:
+        if isinstance(as_path, pathlib.Path):
+            as_path.unlink(missing_ok=True)
+
+
+def test_full_chain_fork_to_put_path(tmp_path, fem_files):
+    # Mirror what the worker does: run convert in the forked child, take the
+    # returned out_path, stream it to storage with put_path, and read it back.
+    src = _fem(fem_files)
+    storage = Storage(LocalStore(str(tmp_path)), prefix="")
+    scope = Scope.shared()
+
+    async def drive() -> bytes:
+        iresult = await run_isolated_convert(
+            convert,
+            src_path=src,
+            source_key=str(src),
+            target_format="xml",
+        )
+        assert iresult.exit_code == 0
+        assert iresult.out_path is not None and iresult.out_path.exists()
+        try:
+            await storage.put_path(
+                scope, "_derived/beam.xml", iresult.out_path, content_encoding="gzip"
+            )
+        finally:
+            iresult.cleanup_output()
+        # The work dir + output file are gone once cleanup_output ran.
+        assert iresult.out_path is None
+        return await storage.get_bytes(scope, "_derived/beam.xml")
+
+    data = asyncio.run(drive())
+    assert b"<" in data  # gzip stored, transparently inflated on read
+
+
+def test_full_chain_glb_bytes_path(tmp_path, fem_files):
+    # The bytes branch still round-trips: child writes the bytes into the
+    # result slot, parent streams that file up via put_path.
+    src = _fem(fem_files)
+    storage = Storage(LocalStore(str(tmp_path)), prefix="")
+    scope = Scope.shared()
+
+    async def drive() -> bytes:
+        iresult = await run_isolated_convert(
+            convert, src_path=src, source_key=str(src), target_format="glb"
+        )
+        assert iresult.exit_code == 0
+        assert iresult.out_path is not None
+        try:
+            await storage.put_path(scope, "_derived/beam.glb", iresult.out_path)
+        finally:
+            iresult.cleanup_output()
+        return await storage.get_bytes(scope, "_derived/beam.glb")
+
+    data = asyncio.run(drive())
+    assert data[:4] == b"glTF"  # GLB magic

--- a/tests/comms/rest/test_converter_step_routing.py
+++ b/tests/comms/rest/test_converter_step_routing.py
@@ -28,7 +28,11 @@ def _captured_writer(monkeypatch, source_ext: str) -> str:
     monkeypatch.setattr(Part, "to_stp", fake_to_stp)
 
     out = conv._via_ada_to_step(pathlib.Path(f"dummy{source_ext}"), source_ext, lambda *a, **k: None)
-    assert out  # bytes returned
+    # _via_ada_to_step now returns the path of the STEP file it wrote (ownership
+    # transfers to the caller); the streaming-upload contract.
+    assert isinstance(out, pathlib.Path)
+    assert out.read_bytes()  # the fake writer wrote a non-empty deck
+    out.unlink()
     return recorded["writer"]
 
 

--- a/tests/comms/rest/test_parity_isolation.py
+++ b/tests/comms/rest/test_parity_isolation.py
@@ -1,0 +1,47 @@
+"""Parity validation runs in the memory-capped fork, not the worker process.
+
+Re-deriving a source to ifc/xml/step and reloading each can spike RAM (or trip
+a native CAD crash). The worker runs parity through ``run_isolated_convert`` so
+an OOM / SIGABRT dies in the child — the cell fails — instead of taking the pod
+down. This pins that the child wrapper produces a valid JSON parity result the
+parent can read back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from ada.comms.rest.converter import ConverterRegistry
+from ada.comms.rest.subprocess_convert import run_isolated_convert
+from ada.comms.rest.worker import _parity_child
+
+
+def test_parity_child_runs_in_isolated_fork(fem_files):
+    src = fem_files / "sesam/single_beam.xml"
+    formats = [t for t in ("ifc", "xml", "step") if t in ConverterRegistry.targets_for(".xml")]
+    assert formats, "expected .xml to have structure-preserving targets for parity"
+
+    result = asyncio.run(
+        run_isolated_convert(
+            _parity_child,
+            src,
+            str(src),
+            "parity",
+            convert_kwargs={"formats": formats},
+            timeout_s=300,
+        )
+    )
+
+    # The whole check ran in the forked child and came back cleanly.
+    assert result.exit_code == 0, f"signal={result.signal_name} error={result.error}"
+    assert result.out_path is not None
+    payload = json.loads(result.out_path.read_text())
+    result.cleanup_output()
+
+    assert payload["consistent"] is True
+    assert payload["counts"]["source"] >= 1
+    # Every derived format reloaded to the same element count as the source.
+    for fmt in formats:
+        assert payload["counts"].get(fmt) == payload["expected"]
+    assert payload["summary"].startswith("[OK]")

--- a/tests/comms/rest/test_sif_reduced_source.py
+++ b/tests/comms/rest/test_sif_reduced_source.py
@@ -11,10 +11,8 @@ identically to a full single-step read.
 from __future__ import annotations
 
 import asyncio
-import pathlib
 
 import numpy as np
-import pytest
 from obstore.store import LocalStore
 
 from ada.comms.rest import worker as worker_mod

--- a/tests/comms/rest/test_sif_reduced_source.py
+++ b/tests/comms/rest/test_sif_reduced_source.py
@@ -1,0 +1,107 @@
+"""Worker SIF reduced-source path (index sidecar + range-fetch).
+
+The worker's ``_try_reduced_sif_source`` range-fetches only one result step of
+a SIF deck (using the cached byte-offset index) into a reduced, still-valid
+SIF; ``_ensure_sif_index`` builds + caches that index after the first full
+conversion. These tests drive both against a LocalStore — the same backend the
+no-DB deployments run — and assert the reduced file the worker assembles reads
+identically to a full single-step read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+
+import numpy as np
+import pytest
+from obstore.store import LocalStore
+
+from ada.comms.rest import worker as worker_mod
+from ada.comms.rest.converter import sif_index_key_for
+from ada.comms.rest.scope import Scope
+from ada.comms.rest.storage import Storage
+from ada.fem.formats.sesam.results.read_sif import read_sif_file
+from ada.fem.formats.sesam.results.sif_index import SifStepIndex, build_sif_index
+
+_EIGEN = "cantilever/sesam/eigen/shell/EIGEN_SHELL_CANTILEVER_SESAMR1.SIF"  # 20 steps
+SRC_KEY = "fea/eigen.SIF"
+
+
+def _storage(tmp_path):
+    return Storage(LocalStore(str(tmp_path)), prefix="")
+
+
+def _disp(res):
+    for r in res.results:
+        if getattr(r, "name", None) == "RVNODDIS":
+            return np.asarray(r.values)
+    return None
+
+
+def _upload_source(storage, scope, sif):
+    asyncio.run(storage.put_bytes(scope, SRC_KEY, sif.read_bytes()))
+
+
+def test_ensure_sif_index_builds_then_noops(tmp_path, fem_files):
+    sif = fem_files / _EIGEN
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    _upload_source(storage, scope, sif)
+    idx_key = sif_index_key_for(SRC_KEY)
+
+    assert asyncio.run(storage.exists(scope, idx_key)) is False
+    asyncio.run(worker_mod._ensure_sif_index(storage, scope, SRC_KEY, sif))
+    assert asyncio.run(storage.exists(scope, idx_key)) is True
+
+    idx = SifStepIndex.from_json(asyncio.run(storage.get_bytes(scope, idx_key)))
+    assert idx.steps == list(range(1, 21))
+
+    # Second call is a no-op (doesn't error, index unchanged).
+    asyncio.run(worker_mod._ensure_sif_index(storage, scope, SRC_KEY, sif))
+    idx2 = SifStepIndex.from_json(asyncio.run(storage.get_bytes(scope, idx_key)))
+    assert idx2.step_spans == idx.step_spans
+
+
+def test_reduced_source_no_index_falls_back(tmp_path, fem_files):
+    # Without a cached index the worker must report False so the caller does a
+    # full download.
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    _upload_source(storage, scope, fem_files / _EIGEN)
+    dst = tmp_path / "out.SIF"
+    ok = asyncio.run(worker_mod._try_reduced_sif_source(storage, scope, SRC_KEY, None, dst))
+    assert ok is False
+
+
+def test_reduced_source_reads_one_step(tmp_path, fem_files):
+    sif = fem_files / _EIGEN
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    _upload_source(storage, scope, sif)
+    # Seed the index sidecar (as the first conversion would).
+    asyncio.run(storage.put_bytes(scope, sif_index_key_for(SRC_KEY), build_sif_index(sif).to_json()))
+
+    for step in (None, 4, 20):
+        dst = tmp_path / f"reduced_{step}.SIF"
+        ok = asyncio.run(worker_mod._try_reduced_sif_source(storage, scope, SRC_KEY, step, dst))
+        assert ok is True
+        assert dst.stat().st_size < sif.stat().st_size  # genuinely reduced
+
+        want = step if step is not None else 1
+        reduced = read_sif_file(dst)
+        full = read_sif_file(sif, step=want)
+        assert reduced.get_steps() == [want] == full.get_steps()
+        assert np.allclose(_disp(reduced), _disp(full))
+
+
+def test_reduced_source_unknown_step_falls_back(tmp_path, fem_files):
+    sif = fem_files / _EIGEN
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    _upload_source(storage, scope, sif)
+    asyncio.run(storage.put_bytes(scope, sif_index_key_for(SRC_KEY), build_sif_index(sif).to_json()))
+
+    dst = tmp_path / "out.SIF"
+    ok = asyncio.run(worker_mod._try_reduced_sif_source(storage, scope, SRC_KEY, 999, dst))
+    assert ok is False

--- a/tests/comms/rest/test_storage_put_path.py
+++ b/tests/comms/rest/test_storage_put_path.py
@@ -1,0 +1,127 @@
+"""Streaming file upload (``Storage.put_path``).
+
+``put_path`` is the disk-to-object-store mirror of ``put_bytes``: it
+uploads a local file via obstore multipart so a large conversion output
+never gets materialised as a whole ``bytes`` object on the upload side.
+These tests pin the round-trip semantics (plain, identity, and both gzip
+forms) against a LocalStore — the same backend shape the no-DB / local
+deployments run — plus the gzip header/disk-cleanup invariants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import os
+import pathlib
+
+import pytest
+from obstore.store import LocalStore
+
+from ada.comms.rest.storage import Storage, _gzip_file
+from ada.comms.rest.scope import Scope
+
+
+def _storage(tmp_path: pathlib.Path) -> Storage:
+    return Storage(LocalStore(str(tmp_path)), prefix="")
+
+
+def _src(tmp_path: pathlib.Path, name: str, data: bytes) -> pathlib.Path:
+    p = tmp_path / name
+    p.write_bytes(data)
+    return p
+
+
+def test_put_path_round_trips_plain(tmp_path):
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    payload = os.urandom(3_000_000)  # > one multipart part: exercises the streaming path
+    src = _src(tmp_path, "out.step", payload)
+
+    asyncio.run(storage.put_path(scope, "derived/out.step", src))
+    got = asyncio.run(storage.get_bytes(scope, "derived/out.step"))
+
+    assert got == payload
+
+
+def test_put_path_empty_file(tmp_path):
+    # Empty conversion outputs (seeded empty scenes etc.) must still upload.
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    src = _src(tmp_path, "empty.bin", b"")
+
+    asyncio.run(storage.put_path(scope, "derived/empty.bin", src))
+    assert asyncio.run(storage.get_bytes(scope, "derived/empty.bin")) == b""
+
+
+def test_put_path_gzip_compresses_and_get_bytes_decompresses(tmp_path):
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    payload = b"<xml>" + b"a" * 500_000 + b"</xml>"  # highly compressible, like Genie XML
+    src = _src(tmp_path, "model.xml", payload)
+
+    asyncio.run(storage.put_path(scope, "derived/model.xml", src, content_encoding="gzip"))
+
+    # Stored bytes are gzip (magic header); get_bytes transparently inflates.
+    stored = asyncio.run(storage.get_range(scope, "derived/model.xml", 0, 2))
+    assert stored == b"\x1f\x8b"
+    assert asyncio.run(storage.get_bytes(scope, "derived/model.xml")) == payload
+
+
+def test_put_path_pre_compressed_uploads_as_is(tmp_path):
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    payload = b"already gzipped content" * 1000
+    gz = tmp_path / "blob.ifc.gz"
+    gz.write_bytes(gzip.compress(payload))
+
+    asyncio.run(
+        storage.put_path(scope, "derived/blob.ifc", gz, content_encoding="gzip", pre_compressed=True)
+    )
+
+    assert asyncio.run(storage.get_range(scope, "derived/blob.ifc", 0, 2)) == b"\x1f\x8b"
+    assert asyncio.run(storage.get_bytes(scope, "derived/blob.ifc")) == payload
+
+
+def test_put_path_gzip_does_not_leave_temp_file(tmp_path):
+    # The on-disk gzip staging file must be cleaned up after upload.
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    src = _src(tmp_path, "leak.xml", b"x" * 10_000)
+
+    asyncio.run(storage.put_path(scope, "derived/leak.xml", src, content_encoding="gzip"))
+
+    assert not (tmp_path / "leak.xml.gz").exists()
+    # The original source is left untouched (caller owns its lifecycle).
+    assert src.exists()
+
+
+def test_put_path_rejects_unknown_encoding(tmp_path):
+    storage = _storage(tmp_path)
+    src = _src(tmp_path, "x.bin", b"x")
+    with pytest.raises(ValueError, match="unsupported content_encoding"):
+        asyncio.run(storage.put_path(Scope.shared(), "derived/x.bin", src, content_encoding="br"))
+
+
+def test_put_path_matches_put_bytes(tmp_path):
+    # put_path and put_bytes must be interchangeable from the reader's side.
+    storage = _storage(tmp_path)
+    scope = Scope.shared()
+    payload = b"interchangeable" * 4096
+    src = _src(tmp_path, "a.glb", payload)
+
+    asyncio.run(storage.put_path(scope, "via_path.glb", src))
+    asyncio.run(storage.put_bytes(scope, "via_bytes.glb", payload))
+
+    assert asyncio.run(storage.get_bytes(scope, "via_path.glb")) == asyncio.run(
+        storage.get_bytes(scope, "via_bytes.glb")
+    )
+
+
+def test_gzip_file_helper_streams_round_trip(tmp_path):
+    src = _src(tmp_path, "big.txt", os.urandom(2_500_000))
+    dst = tmp_path / "big.txt.gz"
+    _gzip_file(src, dst, chunk_size=64 * 1024)
+
+    assert dst.read_bytes()[:2] == b"\x1f\x8b"
+    assert gzip.decompress(dst.read_bytes()) == src.read_bytes()

--- a/tests/comms/rest/test_storage_put_path.py
+++ b/tests/comms/rest/test_storage_put_path.py
@@ -18,8 +18,8 @@ import pathlib
 import pytest
 from obstore.store import LocalStore
 
-from ada.comms.rest.storage import Storage, _gzip_file
 from ada.comms.rest.scope import Scope
+from ada.comms.rest.storage import Storage, _gzip_file
 
 
 def _storage(tmp_path: pathlib.Path) -> Storage:
@@ -75,9 +75,7 @@ def test_put_path_pre_compressed_uploads_as_is(tmp_path):
     gz = tmp_path / "blob.ifc.gz"
     gz.write_bytes(gzip.compress(payload))
 
-    asyncio.run(
-        storage.put_path(scope, "derived/blob.ifc", gz, content_encoding="gzip", pre_compressed=True)
-    )
+    asyncio.run(storage.put_path(scope, "derived/blob.ifc", gz, content_encoding="gzip", pre_compressed=True))
 
     assert asyncio.run(storage.get_range(scope, "derived/blob.ifc", 0, 2)) == b"\x1f\x8b"
     assert asyncio.run(storage.get_bytes(scope, "derived/blob.ifc")) == payload

--- a/tests/comms/rest/test_subprocess_timeout.py
+++ b/tests/comms/rest/test_subprocess_timeout.py
@@ -65,7 +65,7 @@ async def test_watchdog_kills_long_running_convert(tmp_path: pathlib.Path):
     assert result.signal_name == "TIMEOUT", (
         f"expected signal_name='TIMEOUT', got {result.signal_name!r} " f"(exit_code={result.exit_code})"
     )
-    assert result.out_bytes is None
+    assert result.out_path is None
     assert result.error is not None
     assert "timeout" in result.error.lower()
     # Watchdog gives 30 s grace before SIGKILL. The synthetic sleeper
@@ -101,7 +101,7 @@ async def test_watchdog_cancels_running_convert(tmp_path: pathlib.Path):
     elapsed = time.monotonic() - started
 
     assert result.signal_name == "CANCELLED", f"got {result.signal_name!r} (exit_code={result.exit_code})"
-    assert result.out_bytes is None
+    assert result.out_path is None
     # First poll fires ~3 s in; SIGTERM reaps the sleeper immediately (5 s grace cap).
     assert elapsed < 12.0, f"cancellation reap too slow: {elapsed:.1f}s"
 
@@ -140,7 +140,7 @@ async def test_memory_watchdog_kills_oom_convert(tmp_path: pathlib.Path, monkeyp
     elapsed = time.monotonic() - started
 
     assert result.signal_name == "OOM", f"expected signal_name='OOM', got {result.signal_name!r} ({result.exit_code})"
-    assert result.out_bytes is None
+    assert result.out_path is None
     assert result.error is not None and "memory" in result.error.lower()
     assert elapsed < 10.0, f"memory watchdog reap too slow: {elapsed:.1f}s"
 
@@ -167,4 +167,8 @@ async def test_no_timeout_lets_short_convert_finish(tmp_path: pathlib.Path):
     )
     assert result.signal_name is None
     assert result.exit_code == 0
-    assert result.out_bytes == b"ok"
+    # Success hands back the output as a path the caller streams + cleans up.
+    assert result.out_path is not None
+    assert result.out_path.read_bytes() == b"ok"
+    result.cleanup_output()
+    assert result.out_path is None

--- a/tests/core/api/plates/test_plate_curved.py
+++ b/tests/core/api/plates/test_plate_curved.py
@@ -529,3 +529,50 @@ def test_round_trip_occ_face_preserves_face_count():
     extruded = plate.extruded_solid_occ()
     found_bspline = any(backend.face_surface_type(f) == "bspline" for f in backend.faces(extruded))
     assert found_bspline, "extruded prism lost its BSpline surface — round-trip dropped curvature"
+
+
+def test_curved_plate_render_covers_footprint(fem_files):
+    """Every rendered PlateCurved must cover at least its flat footprint.
+
+    A correct (curved or flat) plate prism has top+bottom faces each >= the
+    flat footprint area, so the tessellated mesh area is always >= ~2x the
+    footprint. Some trimmed B-spline faces defeat BRepMesh — it emits a
+    degenerate centre-fan covering only ~half the surface ("missing
+    triangles") — and the batch tessellator now detects that (curved mesh
+    area < 1.85x footprint) and falls back to the clean flat quad. This pins
+    the invariant: no PlateCurved ships an under-covered mesh.
+    """
+    import numpy as np
+    import trimesh
+
+    src = fem_files / "sesam/curved_plates.xml"
+    if not src.exists():
+        pytest.skip(f"fixture not present: {src}")
+
+    asm = ada.from_genie_xml(src)
+    curved = [o for o in asm.get_all_physical_objects() if type(o).__name__ == "PlateCurved"]
+    assert curved, "fixture should contain PlateCurved objects"
+
+    def _footprint_area(o):
+        fb = getattr(o, "_flat_fallback_pts", None)
+        if not fb or len(fb) < 3:
+            return None
+        pts = np.array([list(p)[:3] for p in fb])
+        n = np.zeros(3)
+        for i in range(len(pts)):
+            n = n + np.cross(pts[i], pts[(i + 1) % len(pts)])
+        return 0.5 * float(np.linalg.norm(n))
+
+    checked = 0
+    for o in curved:
+        fa = _footprint_area(o)
+        if not fa or fa < 1e-6:
+            continue
+        sub = ada.Assembly("s") / (ada.Part("p") / o)
+        scene = sub.to_trimesh_scene(merge_meshes=False)
+        mesh_area = sum(g.area for g in scene.geometry.values() if isinstance(g, trimesh.Trimesh))
+        # >= 1.85x footprint: a correct prism is ~2x + walls; the degenerate
+        # centre-fan (the bug) lands ~1.5x and must have fallen back to flat.
+        assert mesh_area >= 1.85 * fa, f"{o.name}: mesh area {mesh_area:.3f} < 1.85 x footprint {fa:.3f}"
+        checked += 1
+    assert checked > 0

--- a/tests/core/cadit/gxml/test_sesam_write_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_write_xml.py
@@ -25,6 +25,46 @@ def test_create_sesam_xml_from_mixed(mixed_model, tmp_path):
     mixed_model.to_genie_xml(xml_file)
 
 
+def test_streaming_xml_byte_identical_to_dom(tmp_path):
+    # The streaming writer must produce byte-identical output to the DOM writer;
+    # it only changes the assembly strategy (per-object flush vs whole-tree),
+    # not the geometry. Cover beams + a (mergeable) plate pair. ``to_genie_xml``
+    # consolidates sections/materials in place, so build a fresh model per
+    # writer rather than writing the same object twice.
+    def build():
+        p = ada.Part("P") / (
+            ada.Beam("bm1", (0, 0, 0), (10, 0, 0), "IPE300"),
+            ada.Plate("pl1", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.2),
+            ada.Plate("pl2", [(10, 0), (20, 0), (20, 10), (10, 10)], 0.2),
+        )
+        return ada.Assembly("a") / p
+
+    dom = tmp_path / "dom.xml"
+    stream = tmp_path / "stream.xml"
+    build().to_genie_xml(dom, streaming=False)
+    build().to_genie_xml(stream, streaming=True)
+
+    assert dom.read_bytes() == stream.read_bytes()
+
+
+def test_streaming_xml_from_fem_byte_identical(fem_files, tmp_path):
+    # FEM-source path: load a Sesam mesh, rebuild + merge concept objects, then
+    # confirm the streaming writer matches the DOM writer byte-for-byte on the
+    # merged model (the case the streaming writer exists for). Fresh load per
+    # writer — to_genie_xml consolidates in place.
+    def build():
+        a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+        a.create_objects_from_fem(merge=True)
+        return a
+
+    dom = tmp_path / "dom.xml"
+    stream = tmp_path / "stream.xml"
+    build().to_genie_xml(dom, streaming=False)
+    build().to_genie_xml(stream, streaming=True)
+
+    assert dom.read_bytes() == stream.read_bytes()
+
+
 def test_create_sesam_xml_with_plate(tmp_path):
     pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1)
     a = ada.Assembly("a") / pl

--- a/tests/core/cadit/gxml/test_sesam_write_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_write_xml.py
@@ -1,7 +1,18 @@
 import xml.etree.ElementTree as ET
 
+import numpy as np
+import pytest
+
 import ada
 from ada.api.spatial.eq_types import EquipRepr
+
+
+def _poly_area(outline) -> float:
+    p = np.asarray(outline, dtype=float)
+    n = np.zeros(3)
+    for i in range(len(p)):
+        n += np.cross(p[i], p[(i + 1) % len(p)])
+    return 0.5 * float(np.linalg.norm(n))
 
 
 def test_roundtrip_xml(fem_files, tmp_path):
@@ -45,6 +56,37 @@ def test_streaming_xml_byte_identical_to_dom(tmp_path):
     build().to_genie_xml(stream, streaming=True)
 
     assert dom.read_bytes() == stream.read_bytes()
+
+
+def test_streaming_xml_face_source_object_free(fem_files, tmp_path):
+    # merge_strategy sources plates from the vectorized object-free FEM-shell
+    # face engine: no Plate objects are materialised, and the output is
+    # geometrically equivalent (same covered area) to the object merge.
+    from ada.cadit.gxml.store import GxmlStore
+
+    ref = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    ref.create_objects_from_fem(merge=True)
+    ref_area = 0.0
+    for pl in ref.get_all_physical_objects(by_type=ada.Plate):
+        ap = pl.placement.get_absolute_placement(include_rotations=True)
+        ident = ada.Placement()
+        glob = [
+            ap.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
+            for pt in pl.poly.points3d
+        ]
+        ref_area += _poly_area(glob)
+
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    a.create_objects_from_fem(skip_plates=True, merge=True)  # beams only
+    dest = tmp_path / "faces.xml"
+    a.to_genie_xml(dest, streaming=True, merge_strategy="coplanar")
+
+    # object-free: the part never materialised any Plate
+    assert len(list(a.get_all_physical_objects(by_type=ada.Plate))) == 0
+
+    plates = list(GxmlStore(dest).iter_plates_from_xml())
+    assert len(plates) >= 1
+    assert sum(_poly_area(p.nodes) for p in plates) == pytest.approx(ref_area, rel=1e-4)
 
 
 def test_streaming_xml_from_fem_byte_identical(fem_files, tmp_path):

--- a/tests/core/cadit/sat/test_bspline_parser.py
+++ b/tests/core/cadit/sat/test_bspline_parser.py
@@ -6,6 +6,34 @@ from ada.geom import Geometry
 from ada.geom.surfaces import AdvancedFace
 
 
+def test_parcur_curve_parses_as_rational_3d_nurbs():
+    """A SESAM ``parcur`` (parameter-space) edge curve embeds the 3D space
+    curve directly, in the same layout as ``exactcur``: header, knot line, 3D
+    rational control points, then a ``0`` and the surface block. The reader must
+    parse the 3D rational NURBS (not fall back to a flat polygon). Control points
+    are a rational quadratic — an arc — straight off a curved hull-skin plate."""
+    from ada.cadit.sat.read.bsplinecurves import create_bspline_curve_from_exactcur
+    from ada.geom.curves import RationalBSplineCurveWithKnots
+
+    data_lines = [
+        "parcur full nurbs 2 open 2",
+        "1.1780972450961715 2 1.5707963267948966 2",
+        "48.845150584360894 31.478354290456362 90.5 1",
+        "48.750000000000007 31.248640459224561 90.499999999999972 0.98078528040306567",
+        "48.75 31 90.5 1",
+        "0",
+        "spline forward { exactsur full nurbs 2 3 both open open none none 2 2 }",
+    ]
+    curve = create_bspline_curve_from_exactcur(data_lines)
+    assert isinstance(curve, RationalBSplineCurveWithKnots)
+    assert curve.degree == 2
+    assert len(curve.control_points_list) == 3
+    # Rational (weights present) → the middle weight (0.9807…) is what gives the
+    # edge its curvature; if it were dropped the plate would render flat.
+    assert len(curve.weights_data) == 3
+    assert curve.weights_data[1] == pytest.approx(0.98078528, abs=1e-6)
+
+
 @pytest.mark.skip(reason="Not yet implemented")
 def test_read_b_spline_surf_w_knots_2_sat(example_files, tmp_path, monkeypatch):
     # OCC-only SAT/STEP read + validity check (lazy-imported so the module

--- a/tests/core/cadit/sat/test_pcurve_orientation.py
+++ b/tests/core/cadit/sat/test_pcurve_orientation.py
@@ -1,0 +1,55 @@
+"""Regression: SAT curved-plate pcurves must not be spuriously reversed.
+
+ACIS authors each coedge's parameter-space (UV) curve already running in the
+coedge's direction, so it should be attached to the OCC edge as-is. The old
+default reversal heuristic (``ADA_PCURVE_REVERSE=auto``) flipped the UV trim on
+many curved plates, collapsing the face to a negative- or zero-area region that
+renders as a hole. On the OP1 hull-skin it broke 380 of 4529 curved plates.
+
+``curved_plate.sat`` is a single-face reproduction: its OCC face area comes out
+negative under the old reversal and positive (correct) with the no-reverse
+default. We assert a positive area to lock the default in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _occ_face_areas(advanced_face) -> list[float]:
+    from OCC.Core.BRepGProp import brepgprop
+    from OCC.Core.GProp import GProp_GProps
+    from OCC.Core.TopAbs import TopAbs_FACE
+    from OCC.Core.TopExp import TopExp_Explorer
+    from OCC.Core.TopoDS import topods
+
+    import ada
+    from ada.geom import Geometry
+
+    occ = ada.Shape("s", Geometry(0, advanced_face)).solid_occ()
+    areas = []
+    exp = TopExp_Explorer(occ, TopAbs_FACE)
+    while exp.More():
+        gp = GProp_GProps()
+        brepgprop.SurfaceProperties(topods.Face(exp.Current()), gp)
+        areas.append(gp.Mass())
+        exp.Next()
+    return areas
+
+
+def test_curved_plate_face_has_positive_area(example_files):
+    pytest.importorskip("OCC")
+    from ada.cadit.sat.store import SatReaderFactory
+
+    rf = SatReaderFactory(str(example_files / "sat_files/curved_plate.sat"))
+    rf.load_sat_data_from_file()
+
+    faces = list(rf.iter_advanced_faces())
+    assert faces, "expected at least one advanced face in curved_plate.sat"
+
+    for _rec, advanced_face in faces:
+        areas = _occ_face_areas(advanced_face)
+        assert areas, "advanced face produced no OCC faces"
+        # A reversed pcurve trim collapses the area negative or to ~0.
+        for area in areas:
+            assert area > 1e-3, f"degenerate/reversed face area {area} (pcurve over-reversed?)"

--- a/tests/core/cadit/sat/test_plate_factory_empty_edges.py
+++ b/tests/core/cadit/sat/test_plate_factory_empty_edges.py
@@ -15,9 +15,78 @@ import pytest
 
 from ada.cadit.sat.exceptions import ACISInsufficientPointsError
 from ada.cadit.sat.read.faces import PlateFactory
+from ada.cadit.sat.read.sat_entities import AcisRecord
 
 
 def test_get_points_on_empty_edges_raises_insufficient_points():
     factory = PlateFactory.__new__(PlateFactory)  # bypass __init__; we don't touch sat_store
     with pytest.raises(ACISInsufficientPointsError):
         factory.get_points([])
+
+
+class _FakeStore:
+    """Minimal SatStore stand-in: resolves ``$N`` / ``N`` refs to records."""
+
+    def __init__(self, records: dict[int, AcisRecord]):
+        self._records = records
+
+    def get(self, sat_id):
+        if isinstance(sat_id, str):
+            sat_id = int(sat_id.lstrip("$"))
+        return self._records[sat_id]
+
+
+def _factory_with(records: dict[int, AcisRecord]) -> PlateFactory:
+    factory = PlateFactory.__new__(PlateFactory)
+    factory.sat_store = _FakeStore(records)
+    return factory
+
+
+def _build_marker_loop_face() -> tuple[PlateFactory, AcisRecord, AcisRecord]:
+    """A SESAM-style face with three loops: a degenerate point-edge marker
+    (single self-referential coedge), the real 4-coedge boundary, then another
+    marker. Returns (factory, face_record, real_loop)."""
+    recs: dict[int, AcisRecord] = {}
+
+    def add(s: str) -> AcisRecord:
+        r = AcisRecord.from_string(s)
+        recs[r.index] = r
+        return r
+
+    # Degenerate marker coedge: next-pointer (idx 6) points to itself.
+    add("-10 coedge $-1 -1 -1 $-1 $10 $10 $-1 $1000 forward $100 $-1 #")
+    # Real boundary ring: 20->21->22->23->20, four distinct edges.
+    add("-20 coedge $-1 -1 -1 $-1 $21 $23 $-1 $2000 forward $101 $-1 #")
+    add("-21 coedge $-1 -1 -1 $-1 $22 $20 $-1 $2001 forward $101 $-1 #")
+    add("-22 coedge $-1 -1 -1 $-1 $23 $21 $-1 $2002 forward $101 $-1 #")
+    add("-23 coedge $-1 -1 -1 $-1 $20 $22 $-1 $2003 forward $101 $-1 #")
+    # Second degenerate marker.
+    add("-30 coedge $-1 -1 -1 $-1 $30 $30 $-1 $3000 forward $102 $-1 #")
+    # Loops chained via next-loop (idx 6); coedge ref at idx 7; none tagged.
+    add("-100 loop $-1 -1 -1 $-1 $101 $10 $-1 unknown #")
+    real = add("-101 loop $-1 -1 -1 $-1 $102 $20 $-1 unknown #")
+    add("-102 loop $-1 -1 -1 $-1 $-1 $30 $-1 unknown #")
+    # Face: loop pointer at idx 7 -> first loop.
+    face = AcisRecord.from_string("-1 face $-1 -1 -1 $-1 $-1 $100 $-1 $-1 $999 forward #")
+    return _factory_with(recs), face, real
+
+
+def test_single_coedge_ring_is_not_duplicated():
+    """A self-referential coedge ring must yield one coedge, not two — else
+    ``_drop_whisker_coedges`` mistakes the duplicate for a whisker pair and
+    collapses the whole face to zero edges."""
+    factory, _face, _real = _build_marker_loop_face()
+    marker_loop = factory.sat_store.get("$100")
+    edges = factory.get_edges_from_loop(marker_loop)
+    assert len(edges) == 1
+    # And the real boundary ring walks to exactly its four coedges.
+    real_edges = factory.get_edges_from_loop(factory.sat_store.get("$101"))
+    assert [e.index for e in real_edges] == [20, 21, 22, 23]
+
+
+def test_primary_loop_skips_degenerate_marker_loops():
+    """When no loop is tagged 'periphery', the boundary loop (most distinct
+    edges) wins over the degenerate marker loops — not blindly loops[0]."""
+    factory, face, real = _build_marker_loop_face()
+    primary = factory._get_primary_loop(face.chunks)
+    assert primary is real

--- a/tests/core/cadit/test_visual_parity.py
+++ b/tests/core/cadit/test_visual_parity.py
@@ -100,3 +100,19 @@ def test_parity_fem_source_rebuilds_objects(fem_files):
     assert r.counts["ifc"] == r.counts["xml"] == r.counts["step"] == r.expected
     assert r.errors == {}
     assert r.consistent is True
+
+
+def test_parity_skips_xml_for_generic_solid_source():
+    """A source made of generic solids (no Beam/Plate) can't round-trip through
+    Genie XML — it carries only structural concepts. Parity must SKIP xml (a
+    permanent format limit, not a converter fault) and stay consistent on the
+    formats that can carry solids."""
+    box = ada.PrimBox("b", (0, 0, 0), (1, 1, 1))
+    asm = ada.Assembly("m") / (ada.Part("p") / box)
+
+    r = cross_format_parity(asm, ("ifc", "xml", "step"))
+
+    assert "xml" in r.skipped
+    assert "xml" not in r.counts and "xml" not in r.mismatches
+    assert r.counts["ifc"] == r.counts["step"] == r.expected
+    assert r.consistent is True

--- a/tests/core/cadit/test_visual_parity.py
+++ b/tests/core/cadit/test_visual_parity.py
@@ -87,3 +87,16 @@ def test_visualized_element_count_excludes_placeholder():
     scene.add_geometry(trimesh.PointCloud([[0, 0, 0]]), node_name="empty")
 
     assert visualized_element_count(scene) == 1
+
+
+def test_parity_fem_source_rebuilds_objects(fem_files):
+    """A FEM source must rebuild Beam/Plate concept objects (as the converter
+    does) before the round-trip; the writers emit concepts, not the raw mesh.
+    Previously parity exported an objectless assembly and read every format back
+    empty (a false "all geometry dropped"). After the fix the source and every
+    format agree."""
+    r = visual_parity.parity_for_source_file(fem_files / "sesam/beamMassT1.FEM", ("ifc", "xml", "step"))
+    assert r.expected > 0
+    assert r.counts["ifc"] == r.counts["xml"] == r.counts["step"] == r.expected
+    assert r.errors == {}
+    assert r.consistent is True

--- a/tests/core/fem/formats/sesam/test_read_sin.py
+++ b/tests/core/fem/formats/sesam/test_read_sin.py
@@ -284,7 +284,9 @@ def test_sin_load_step_card_filter():
 
     reader = SinStreamReader(open_sin(SIN_PATH))
     try:
-        names = lambda res: {getattr(x, "name", None) for x in res.results}
+
+        def names(res):
+            return {getattr(x, "name", None) for x in res.results}
 
         all_cards = names(reader._load_step(1))
         assert "RVNODDIS" in all_cards  # nodal present in the full load

--- a/tests/core/fem/formats/sesam/test_read_sin.py
+++ b/tests/core/fem/formats/sesam/test_read_sin.py
@@ -272,6 +272,34 @@ def test_sin_stream_reader_bake_matches_full(tmp_path):
     assert full == stream, f"differing artefacts: {[n for n in full if full[n] != stream.get(n)]}"
 
 
+def test_sin_load_step_card_filter():
+    """A per-field bake pass loads only that field's RV card, not all of them.
+
+    The bake iterates one field at a time, so the streaming reader gathers just
+    the RV card for the field being emitted — ~3x fewer record reads (and page
+    fetches on a range source) on a multi-step deck. Here we assert the filter
+    keeps exactly the requested card's field and drops the others."""
+    from ada.fem.formats.sesam.results.read_sin import SinStreamReader
+    from ada.fem.formats.sesam.results.sin_reader import open_sin
+
+    reader = SinStreamReader(open_sin(SIN_PATH))
+    try:
+        names = lambda res: {getattr(x, "name", None) for x in res.results}
+
+        all_cards = names(reader._load_step(1))
+        assert "RVNODDIS" in all_cards  # nodal present in the full load
+
+        nodal_only = names(reader._load_step(1, cards={"RVNODDIS"}))
+        assert "RVNODDIS" in nodal_only
+        assert "STRESS" not in nodal_only  # element field's card was skipped
+
+        stress_only = names(reader._load_step(1, cards={"RVSTRESS"}))
+        assert "STRESS" in stress_only
+        assert "RVNODDIS" not in stress_only  # nodal card was skipped
+    finally:
+        reader.close()
+
+
 def test_bake_artefacts_on_artefact_sink_ships_each_file(tmp_path):
     """The ``on_artefact`` sink must fire once per artefact (manifest last)
     and yield the same bytes as a normal bake — even when the sink deletes

--- a/tests/core/fem/results/test_fea_artefacts.py
+++ b/tests/core/fem/results/test_fea_artefacts.py
@@ -810,8 +810,11 @@ def test_make_stream_reader_dispatches_by_extension(fem_files, tmp_path):
 
     sif = fem_files / "sesam/1EL_SHELL_R1.SIF"
     if sif.exists():
+        from ada.fem.formats.sesam.results.sif_stream import SifStreamReader
+
+        # SIF defaults to the memory-bounded streaming reader.
         with make_stream_reader(sif) as r:
-            assert isinstance(r, FEAResultStreamAdapter)
+            assert isinstance(r, SifStreamReader)
 
     with pytest.raises(ValueError, match="no streaming reader"):
         make_stream_reader(tmp_path / "nope.frd")

--- a/tests/core/fem/results/test_read_sif_step_filter.py
+++ b/tests/core/fem/results/test_read_sif_step_filter.py
@@ -1,0 +1,104 @@
+"""Single-step SIF reading bounds peak memory.
+
+A SIF result deck holds every step's RV* records (RVNODDIS / RVSTRESS /
+RVFORCES) in one contiguous block; the legacy reader materialised all of
+them even though a GLB render only colours one (step, field). The
+``step=`` filter — the SIF analogue of ``read_sin_file(step=...)`` — keeps
+only the requested step, so an N-step deck costs ~1/N the RAM. These tests
+pin the filter's correctness (values identical to the full read), the
+``"first"`` sentinel, full back-compat, and that memory actually drops.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tracemalloc
+
+import numpy as np
+import pytest
+
+from ada.fem.formats.sesam.results.read_sif import read_sif_file
+
+_EIGEN = "cantilever/sesam/eigen/shell/EIGEN_SHELL_CANTILEVER_SESAMR1.SIF"  # 20 steps
+_ONE_STEP = "sesam/2EL_SHELL_R1.SIF"  # single step
+
+
+def _disp(res, step):
+    for r in res.results:
+        if getattr(r, "name", None) == "RVNODDIS" and int(r.step) == step:
+            return np.asarray(r.values)
+    return None
+
+
+def test_full_read_unchanged(fem_files):
+    # step=None (the default every existing caller uses) loads every step.
+    res = read_sif_file(fem_files / _EIGEN)
+    assert res.get_steps() == list(range(1, 21))
+
+
+def test_step_filter_loads_single_step(fem_files):
+    res = read_sif_file(fem_files / _EIGEN, step=3)
+    assert res.get_steps() == [3]
+    # Both fields present in that deck filter down to the one step.
+    grouped = {k: sorted(int(d.step) for d in v) for k, v in res.get_results_grouped_by_field_value().items()}
+    assert grouped == {"RVNODDIS": [3], "STRESS": [3]}
+
+
+def test_step_first_sentinel_loads_first_step(fem_files):
+    res = read_sif_file(fem_files / _EIGEN, step="first")
+    assert res.get_steps() == [1]
+
+
+def test_single_step_values_match_full(fem_files):
+    # The filtered read must be byte-for-byte the same data the full read
+    # produces for that step — only the *other* steps are dropped.
+    full = read_sif_file(fem_files / _EIGEN)
+    s3 = read_sif_file(fem_files / _EIGEN, step=3)
+    a, b = _disp(full, 3), _disp(s3, 3)
+    assert a is not None and b is not None
+    assert a.shape == b.shape
+    assert np.allclose(a, b)
+    # Mesh is step-invariant and must be identical.
+    assert full.mesh.nodes.coords.shape == s3.mesh.nodes.coords.shape
+    assert np.allclose(full.mesh.nodes.coords, s3.mesh.nodes.coords)
+
+
+def test_first_equals_full_step_one(fem_files):
+    full = read_sif_file(fem_files / _EIGEN)
+    first = read_sif_file(fem_files / _EIGEN, step="first")
+    assert np.allclose(_disp(full, 1), _disp(first, 1))
+
+
+def test_one_step_file_unaffected(fem_files):
+    # A single-step deck must read identically whether or not the filter runs.
+    full = read_sif_file(fem_files / _ONE_STEP)
+    first = read_sif_file(fem_files / _ONE_STEP, step="first")
+    assert full.get_steps() == first.get_steps()
+    s = full.get_steps()[0]
+    assert np.allclose(_disp(full, s), _disp(first, s))
+
+
+def test_step_filter_bounds_memory(fem_files):
+    # Peak allocation for one step must be well below the full multi-step read.
+    f = fem_files / _EIGEN
+
+    tracemalloc.start()
+    read_sif_file(f)
+    _, peak_full = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    tracemalloc.start()
+    read_sif_file(f, step="first")
+    _, peak_first = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # 20 steps → single step should be a large fraction smaller. Assert a
+    # conservative half to stay robust against allocator noise.
+    assert peak_first < 0.6 * peak_full, f"peak_first={peak_first} peak_full={peak_full}"
+
+
+def test_missing_step_yields_no_field(fem_files):
+    # Asking for a step that isn't in the deck yields a result with no field
+    # data for it (the converter surfaces that as a clean error upstream).
+    res = read_sif_file(fem_files / _EIGEN, step=999)
+    assert res.get_steps() == []

--- a/tests/core/fem/results/test_read_sif_step_filter.py
+++ b/tests/core/fem/results/test_read_sif_step_filter.py
@@ -11,11 +11,9 @@ pin the filter's correctness (values identical to the full read), the
 
 from __future__ import annotations
 
-import pathlib
 import tracemalloc
 
 import numpy as np
-import pytest
 
 from ada.fem.formats.sesam.results.read_sif import read_sif_file
 

--- a/tests/core/fem/results/test_sif_index.py
+++ b/tests/core/fem/results/test_sif_index.py
@@ -10,8 +10,6 @@ file reads byte-identical to a full single-step read.
 
 from __future__ import annotations
 
-import pathlib
-
 import numpy as np
 import pytest
 
@@ -53,6 +51,7 @@ def test_build_index_steps_and_fields(fem_files):
 def test_include_ranges_excludes_other_steps(fem_files):
     idx = build_sif_index(fem_files / _EIGEN)
     ranges = idx.include_ranges(3)
+
     # Every step-3 span is fully covered; no step-≠3 span overlaps the ranges.
     def covered(a, b):
         return any(s <= a and b <= e for s, e in ranges)

--- a/tests/core/fem/results/test_sif_index.py
+++ b/tests/core/fem/results/test_sif_index.py
@@ -57,7 +57,7 @@ def test_include_ranges_excludes_other_steps(fem_files):
     def covered(a, b):
         return any(s <= a and b <= e for s, e in ranges)
 
-    for ires, s, e in idx.step_spans:
+    for _card, ires, s, e in idx.step_spans:
         if ires == 3:
             assert covered(s, e), f"step-3 span {s},{e} not kept"
         else:

--- a/tests/core/fem/results/test_sif_index.py
+++ b/tests/core/fem/results/test_sif_index.py
@@ -1,0 +1,121 @@
+"""SIF byte-offset index → reduced single-step reads.
+
+The index records each result step's RV* byte spans so a reader can be fed
+only the bytes for one step (the file minus the other steps), cutting the
+download + parse of a big multi-step deck. These tests pin: the build is
+correct, ``include_ranges`` keeps everything that isn't another step,
+the JSON sidecar round-trips, and — the load-bearing invariant — a reduced
+file reads byte-identical to a full single-step read.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from ada.fem.formats.sesam.results.read_sif import read_sif_file
+from ada.fem.formats.sesam.results.sif_index import (
+    INDEX_VERSION,
+    SifStepIndex,
+    assemble_reduced_local,
+    build_sif_index,
+)
+
+_EIGEN = "cantilever/sesam/eigen/shell/EIGEN_SHELL_CANTILEVER_SESAMR1.SIF"  # 20 steps
+_ONE_STEP = "sesam/2EL_SHELL_R1.SIF"
+
+
+def _disp(res):
+    for r in res.results:
+        if getattr(r, "name", None) == "RVNODDIS":
+            return np.asarray(r.values)
+    return None
+
+
+def _reduced_read(tmp_path, sif, idx, step):
+    ranges = idx.include_ranges(step)
+    red = tmp_path / f"reduced_s{step}.SIF"
+    assemble_reduced_local(sif, ranges, red)
+    return read_sif_file(red), ranges
+
+
+def test_build_index_steps_and_fields(fem_files):
+    idx = build_sif_index(fem_files / _EIGEN)
+    assert idx.steps == list(range(1, 21))
+    assert set(idx.fields) == {"RVNODDIS", "RVSTRESS"}
+    # 20 steps × 2 RV cards = 40 contiguous step spans.
+    assert len(idx.step_spans) == 40
+    assert idx.size == (fem_files / _EIGEN).stat().st_size
+
+
+def test_include_ranges_excludes_other_steps(fem_files):
+    idx = build_sif_index(fem_files / _EIGEN)
+    ranges = idx.include_ranges(3)
+    # Every step-3 span is fully covered; no step-≠3 span overlaps the ranges.
+    def covered(a, b):
+        return any(s <= a and b <= e for s, e in ranges)
+
+    for ires, s, e in idx.step_spans:
+        if ires == 3:
+            assert covered(s, e), f"step-3 span {s},{e} not kept"
+        else:
+            assert not any(rs < e and s < re for rs, re in ranges), f"step-{ires} span leaked"
+
+
+def test_reduced_read_matches_full_single_step(tmp_path, fem_files):
+    sif = fem_files / _EIGEN
+    idx = build_sif_index(sif)
+    for step in (1, 3, 20):
+        reduced, ranges = _reduced_read(tmp_path, sif, idx, step)
+        full = read_sif_file(sif, step=step)
+        assert reduced.get_steps() == [step] == full.get_steps()
+        a, b = _disp(full), _disp(reduced)
+        assert a is not None and b is not None
+        assert a.shape == b.shape and np.allclose(a, b)
+        # The reduced file is strictly smaller than the whole deck.
+        assert sum(e - s for s, e in ranges) < idx.size
+
+
+def test_reduced_mesh_matches(tmp_path, fem_files):
+    sif = fem_files / _EIGEN
+    idx = build_sif_index(sif)
+    reduced, _ = _reduced_read(tmp_path, sif, idx, 5)
+    full = read_sif_file(sif, step=5)
+    assert np.allclose(reduced.mesh.nodes.coords, full.mesh.nodes.coords)
+
+
+def test_json_round_trip(fem_files):
+    idx = build_sif_index(fem_files / _EIGEN)
+    again = SifStepIndex.from_json(idx.to_json())
+    assert again.size == idx.size
+    assert again.steps == idx.steps
+    assert again.fields == idx.fields
+    assert again.step_spans == idx.step_spans
+
+
+def test_json_version_mismatch_rejected(fem_files):
+    idx = build_sif_index(fem_files / _EIGEN)
+    import json
+
+    d = json.loads(idx.to_json())
+    d["version"] = INDEX_VERSION + 99
+    with pytest.raises(ValueError, match="unsupported SIF index version"):
+        SifStepIndex.from_json(json.dumps(d))
+
+
+def test_single_step_file(tmp_path, fem_files):
+    sif = fem_files / _ONE_STEP
+    idx = build_sif_index(sif)
+    assert len(idx.steps) == 1
+    step = idx.default_step()
+    reduced, _ = _reduced_read(tmp_path, sif, idx, step)
+    full = read_sif_file(sif)
+    assert reduced.get_steps() == full.get_steps()
+    assert np.allclose(_disp(reduced), _disp(full))
+
+
+def test_default_step_is_first(fem_files):
+    idx = build_sif_index(fem_files / _EIGEN)
+    assert idx.default_step() == 1

--- a/tests/core/fem/results/test_sif_stream.py
+++ b/tests/core/fem/results/test_sif_stream.py
@@ -77,34 +77,71 @@ def test_stream_reader_element_values_match_adapter(fem_files):
             assert np.allclose(x.values, y.values)
 
 
-def test_make_sif_reader_gate_defaults_off(fem_files, monkeypatch):
+def test_make_sif_reader_defaults_to_streaming(fem_files, monkeypatch):
     sif = fem_files / _EIGEN
     monkeypatch.delenv("ADA_FEA_SIF_STREAMER", raising=False)
     with make_stream_reader(sif) as r:
-        assert isinstance(r, FEAResultStreamAdapter)
+        assert isinstance(r, SifStreamReader)  # streaming is the default now
 
-    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "1")
+    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "off")
     with make_stream_reader(sif) as r:
-        assert isinstance(r, SifStreamReader)
+        assert isinstance(r, FEAResultStreamAdapter)  # explicit opt-out
 
 
-def test_bake_blobs_identical_streaming_vs_default(tmp_path, fem_files, monkeypatch):
-    # End-to-end: the bake's field blobs must be byte-identical with the
-    # streamer on vs off — the streamer only changes memory, not output.
+def test_stream_reader_nodal_labels_lis_enriched(fem_files):
+    # The eigen fixture ships a sibling SESTRA.LIS; the streamer must reproduce
+    # the full path's eigen-frequency step labels for nodal fields (not the
+    # bare mode index), and leave element fields on the step index.
+    sif = fem_files / _EIGEN
+    ref = FEAResultStreamAdapter(read_sif_file(sif))
+    strm = SifStreamReader(sif)
+
+    ref_n = {s.name: s.step_values for s in ref.field_specs() if s.support == "nodal"}
+    strm_n = {s.name: s.step_values for s in strm.field_specs() if s.support == "nodal"}
+    assert ref_n and ref_n.keys() == strm_n.keys()
+    for name in ref_n:
+        assert np.allclose(ref_n[name], strm_n[name])
+    # LIS was actually applied: the labels are frequencies, not 1..20.
+    assert not np.allclose(strm_n["RVNODDIS"], np.arange(1, 21, dtype=float))
+
+    ref_e = {(s.name, s.elem_type): s.step_values for s in ref.element_field_specs()}
+    strm_e = {(s.name, s.elem_type): s.step_values for s in strm.element_field_specs()}
+    for key in ref_e:
+        assert np.allclose(ref_e[key], strm_e[key])
+
+
+def test_bake_blobs_identical_streaming_vs_full(tmp_path, fem_files, monkeypatch):
+    # End-to-end: the bake's field blobs AND the manifest field step_values
+    # (LIS-enriched) must match between the streamer and the full-materialise
+    # adapter — the streamer only changes memory, not output.
+    import json
+
     sif = fem_files / _EIGEN
 
-    monkeypatch.delenv("ADA_FEA_SIF_STREAMER", raising=False)
-    bake_def = bake_fea_artefacts_from_source(sif, tmp_path / "default", src_key=sif.stem)
+    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "off")  # force full-materialise
+    bake_full = bake_fea_artefacts_from_source(sif, tmp_path / "full", src_key=sif.stem)
 
-    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "1")
+    monkeypatch.delenv("ADA_FEA_SIF_STREAMER", raising=False)  # default = streaming
     bake_strm = bake_fea_artefacts_from_source(sif, tmp_path / "stream", src_key=sif.stem)
 
     def blobs(d):
         return sorted(p.name for p in d.iterdir() if p.suffix == ".bin")
 
-    names = blobs(bake_def.out_dir)
+    names = blobs(bake_full.out_dir)
     assert names and names == blobs(bake_strm.out_dir)
     for name in names:
-        a = (bake_def.out_dir / name).read_bytes()
+        a = (bake_full.out_dir / name).read_bytes()
         b = (bake_strm.out_dir / name).read_bytes()
-        assert a == b, f"blob {name} differs between default and streaming bake"
+        assert a == b, f"blob {name} differs between full and streaming bake"
+
+    def field_steps(bake):
+        m = json.loads(bake.manifest_path.read_text())
+        return {f["name_canonical"]: [s["value"] for s in f["steps"]] for f in m["fields"]}
+
+    full_steps, strm_steps = field_steps(bake_full), field_steps(bake_strm)
+    assert full_steps and full_steps.keys() == strm_steps.keys()
+    for name in full_steps:
+        assert np.allclose(full_steps[name], strm_steps[name]), f"step values differ for {name}"
+    # The nodal field carries LIS eigen-frequencies, not the bare 1..20 index.
+    nodal = next(v for k, v in strm_steps.items() if not np.allclose(v, np.arange(1, 21)))
+    assert nodal[0] > 1.5

--- a/tests/core/fem/results/test_sif_stream.py
+++ b/tests/core/fem/results/test_sif_stream.py
@@ -1,0 +1,110 @@
+"""Streaming SIF bake reader (`SifStreamReader`) + its env gate.
+
+The streaming reader keeps one step resident at a time (via the byte-offset
+index) so a many-mode SIF can bake without materialising the whole result. It
+must produce *exactly* what the default full-materialise adapter produces —
+these tests pin that equivalence at the reader level (mesh, specs, every
+per-step value) and end-to-end (the bake's field blobs are byte-identical with
+the flag off vs on). The gate (`ADA_FEA_SIF_STREAMER`) defaults off.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from ada.fem.formats.sesam.results.read_sif import read_sif_file
+from ada.fem.formats.sesam.results.sif_stream import SifStreamReader
+from ada.fem.results.artefacts import (
+    FEAResultStreamAdapter,
+    bake_fea_artefacts_from_source,
+    make_stream_reader,
+)
+
+_EIGEN = "cantilever/sesam/eigen/shell/EIGEN_SHELL_CANTILEVER_SESAMR1.SIF"  # 20 steps
+
+
+def test_stream_reader_mesh_and_specs_match_adapter(fem_files):
+    sif = fem_files / _EIGEN
+    ref = FEAResultStreamAdapter(read_sif_file(sif))
+    strm = SifStreamReader(sif)
+
+    g1, g2 = ref.read_mesh_geometry(), strm.read_mesh_geometry()
+    assert g1.points.shape == g2.points.shape
+    assert np.allclose(g1.points, g2.points)
+
+    assert {s.name for s in ref.field_specs()} == {s.name for s in strm.field_specs()}
+    # The streamer advertises the global step count, not a single step's.
+    for s in strm.field_specs():
+        assert s.n_steps == 20
+    assert {(s.name, s.elem_type) for s in ref.element_field_specs()} == {
+        (s.name, s.elem_type) for s in strm.element_field_specs()
+    }
+
+
+def test_stream_reader_nodal_values_match_adapter(fem_files):
+    sif = fem_files / _EIGEN
+    ref = FEAResultStreamAdapter(read_sif_file(sif))
+    strm = SifStreamReader(sif)
+    for spec in strm.field_specs():
+        if spec.support != "nodal":
+            continue
+        a = list(ref.iter_field_steps(spec.name))
+        b = list(strm.iter_field_steps(spec.name))
+        assert len(a) == len(b) == 20
+        for x, y in zip(a, b):
+            assert x.values.shape == y.values.shape
+            assert np.allclose(x.values, y.values)
+
+
+def test_stream_reader_element_values_match_adapter(fem_files):
+    sif = fem_files / _EIGEN
+    ref = FEAResultStreamAdapter(read_sif_file(sif))
+    strm = SifStreamReader(sif)
+    ref_specs = {(s.name, s.elem_type): s for s in ref.element_field_specs()}
+    strm_specs = strm.element_field_specs()
+    assert strm_specs  # the eigen shell deck has element STRESS
+    for spec in strm_specs:
+        rspec = ref_specs[(spec.name, spec.elem_type)]
+        assert spec.element_labels == rspec.element_labels  # order is load-bearing
+        a = list(ref.iter_element_field_steps(rspec))
+        b = list(strm.iter_element_field_steps(spec))
+        assert len(a) == len(b) == 20
+        for x, y in zip(a, b):
+            assert x.values.shape == y.values.shape
+            assert np.allclose(x.values, y.values)
+
+
+def test_make_sif_reader_gate_defaults_off(fem_files, monkeypatch):
+    sif = fem_files / _EIGEN
+    monkeypatch.delenv("ADA_FEA_SIF_STREAMER", raising=False)
+    with make_stream_reader(sif) as r:
+        assert isinstance(r, FEAResultStreamAdapter)
+
+    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "1")
+    with make_stream_reader(sif) as r:
+        assert isinstance(r, SifStreamReader)
+
+
+def test_bake_blobs_identical_streaming_vs_default(tmp_path, fem_files, monkeypatch):
+    # End-to-end: the bake's field blobs must be byte-identical with the
+    # streamer on vs off — the streamer only changes memory, not output.
+    sif = fem_files / _EIGEN
+
+    monkeypatch.delenv("ADA_FEA_SIF_STREAMER", raising=False)
+    bake_def = bake_fea_artefacts_from_source(sif, tmp_path / "default", src_key=sif.stem)
+
+    monkeypatch.setenv("ADA_FEA_SIF_STREAMER", "1")
+    bake_strm = bake_fea_artefacts_from_source(sif, tmp_path / "stream", src_key=sif.stem)
+
+    def blobs(d):
+        return sorted(p.name for p in d.iterdir() if p.suffix == ".bin")
+
+    names = blobs(bake_def.out_dir)
+    assert names and names == blobs(bake_strm.out_dir)
+    for name in names:
+        a = (bake_def.out_dir / name).read_bytes()
+        b = (bake_strm.out_dir / name).read_bytes()
+        assert a == b, f"blob {name} differs between default and streaming bake"

--- a/tests/core/fem/results/test_sif_stream.py
+++ b/tests/core/fem/results/test_sif_stream.py
@@ -10,10 +10,7 @@ the flag off vs on). The gate (`ADA_FEA_SIF_STREAMER`) defaults off.
 
 from __future__ import annotations
 
-import pathlib
-
 import numpy as np
-import pytest
 
 from ada.fem.formats.sesam.results.read_sif import read_sif_file
 from ada.fem.formats.sesam.results.sif_stream import SifStreamReader

--- a/tests/core/fem/test_mesh_faces.py
+++ b/tests/core/fem/test_mesh_faces.py
@@ -85,3 +85,39 @@ def test_surface_and_panel_not_yet_implemented(fem_files):
     for strat in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
         with pytest.raises(NotImplementedError):
             list(iter_faces(a, strat))
+
+
+def _part_with_fem(fem_files):
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    return a.get_all_parts_in_assembly(include_self=True)[0]
+
+
+def test_iter_objects_from_fem_strategy_merges_plates(fem_files):
+    # The merge strategy lives on the generator: every streaming consumer (Genie
+    # XML, IFC, STEP) folds shells the same way through iter_objects_from_fem.
+    raw = list(_part_with_fem(fem_files).iter_objects_from_fem(beams=False, plates=True, merge_strategy=None))
+    merged = list(_part_with_fem(fem_files).iter_objects_from_fem(beams=False, plates=True, merge_strategy="coplanar"))
+
+    assert all(isinstance(p, ada.Plate) for p in raw + merged)
+    assert len(raw) == 4
+    assert len(merged) == 1  # 4 coplanar shells fold to one plate object
+
+    def total(plates):
+        s = 0.0
+        for pl in plates:
+            ap = pl.placement.get_absolute_placement(include_rotations=True)
+            ident = ada.Placement()
+            glob = [
+                ap.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
+                for pt in pl.poly.points3d
+            ]
+            s += _poly_area(glob)
+        return s
+
+    assert total(merged) == pytest.approx(total(raw), rel=1e-6)
+
+
+def test_iter_objects_from_fem_default_unchanged(fem_files):
+    # merge_strategy=None must keep the legacy 1:1 element->plate behaviour.
+    plates = list(_part_with_fem(fem_files).iter_objects_from_fem(beams=False, plates=True))
+    assert len(plates) == 4

--- a/tests/core/fem/test_mesh_faces.py
+++ b/tests/core/fem/test_mesh_faces.py
@@ -1,0 +1,87 @@
+"""Vectorized, object-free FEM-shell -> CAD-face source."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import ada
+from ada.fem.formats.mesh_faces import FaceData, MergeStrategy, iter_faces
+
+
+def _poly_area(outline) -> float:
+    p = np.asarray(outline, dtype=float)
+    n = np.zeros(3)
+    for i in range(len(p)):
+        n += np.cross(p[i], p[(i + 1) % len(p)])
+    return 0.5 * float(np.linalg.norm(n))
+
+
+def _total_area(faces) -> float:
+    return sum(_poly_area(f.outline) for f in faces)
+
+
+def test_merge_strategy_from_value():
+    assert MergeStrategy.from_value(None) is MergeStrategy.NONE
+    assert MergeStrategy.from_value(True) is MergeStrategy.COPLANAR
+    assert MergeStrategy.from_value(False) is MergeStrategy.NONE
+    assert MergeStrategy.from_value("coplanar") is MergeStrategy.COPLANAR
+    assert MergeStrategy.from_value(MergeStrategy.NONE) is MergeStrategy.NONE
+
+
+def test_none_strategy_one_face_per_shell(fem_files):
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    faces = list(iter_faces(a, MergeStrategy.NONE))
+    assert all(isinstance(f, FaceData) for f in faces)
+    # beamMassT1's plate is a 2x2 grid of coplanar quad shells.
+    assert len(faces) == 4
+    assert _total_area(faces) == pytest.approx(100.0, rel=1e-6)
+
+
+def test_coplanar_merges_and_conserves_area(fem_files):
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    none = list(iter_faces(a, MergeStrategy.NONE))
+
+    b = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    coplanar = list(iter_faces(b, MergeStrategy.COPLANAR))
+
+    # the 4 coplanar shells fold into a single plate, same covered area.
+    assert len(coplanar) < len(none)
+    assert len(coplanar) == 1
+    assert _total_area(coplanar) == pytest.approx(_total_area(none), rel=1e-6)
+
+
+def test_coplanar_geometrically_equivalent_to_object_merge(fem_files):
+    # The vectorized merge need not reproduce the object merge byte-for-byte, but
+    # it must cover the same surface (same merged regions, within tolerance).
+    ref = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    ref.create_objects_from_fem(merge=True)
+    obj_area = 0.0
+    for pl in ref.get_all_physical_objects(by_type=ada.Plate):
+        ap = pl.placement.get_absolute_placement(include_rotations=True)
+        ident = ada.Placement()
+        glob = [
+            ap.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
+            for pt in pl.poly.points3d
+        ]
+        obj_area += _poly_area(glob)
+
+    vec = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    vec_area = _total_area(iter_faces(vec, MergeStrategy.COPLANAR))
+
+    assert vec_area == pytest.approx(obj_area, rel=1e-6)
+
+
+def test_object_free_no_plates_built(fem_files):
+    # Consuming the face source must not materialise concept Plate objects on
+    # the part (the whole point of the vectorized path).
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    list(iter_faces(a, MergeStrategy.COPLANAR))
+    assert len(list(a.get_all_physical_objects(by_type=ada.Plate))) == 0
+
+
+def test_surface_and_panel_not_yet_implemented(fem_files):
+    a = ada.from_fem(fem_files / "sesam/beamMassT1.FEM")
+    for strat in (MergeStrategy.SURFACE, MergeStrategy.PANEL):
+        with pytest.raises(NotImplementedError):
+            list(iter_faces(a, strat))

--- a/tests/core/geom/test_fem_shell_fast_path.py
+++ b/tests/core/geom/test_fem_shell_fast_path.py
@@ -93,11 +93,36 @@ def test_from_fem_shell_bypasses_lru_and_segcreator(monkeypatch):
     assert counts["segcreator"] == 0
 
     # Sanity: the general path DOES hit both (guards against a no-op monkeypatch).
+    # SegCreator is now built lazily (CurveOpen2d defers segments to first
+    # access), so read .segments to realise it.
     counts.update(lru=0, segcreator=0)
     for _ in range(50):
-        CurvePoly2d.from_3d_points(pts)
+        c = CurvePoly2d.from_3d_points(pts)
+        _ = c.segments
     assert counts["lru"] > 0
     assert counts["segcreator"] > 0
+
+
+def test_general_curve_defers_segments_until_accessed(monkeypatch):
+    """The general CurveOpen2d path builds 2D points eagerly but defers
+    SegCreator (the segment / 3D build) until a derived structure is read."""
+    import ada.core.curve_utils as cu
+
+    n = {"segcreator": 0}
+    orig = cu.SegCreator
+
+    class Counting(orig):
+        def __init__(self, *a, **k):
+            n["segcreator"] += 1
+            super().__init__(*a, **k)
+
+    monkeypatch.setattr(cu, "SegCreator", Counting)
+
+    c = CurvePoly2d.from_3d_points(CASES["tilted_quad"])
+    assert c.points2d is not None  # 2D inputs are eager
+    assert n["segcreator"] == 0  # ...but segments are not built yet
+    _ = c.segments  # first access realises them
+    assert n["segcreator"] > 0
 
 
 def test_fem_conversion_uses_fast_path():

--- a/tests/core/occ/test_pcurve_trim.py
+++ b/tests/core/occ/test_pcurve_trim.py
@@ -10,7 +10,6 @@ maps an edge's 3D endpoints back to the correct pcurve sub-range.
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
 occ = pytest.importorskip("OCC.Core.Geom2d")
@@ -47,9 +46,7 @@ def test_trim_picks_subrange_for_split_edge():
     c2d = _line_pcurve((0.0, 0.0), (0.0, 10.0))
     # This coedge only covers the upper half (3D y: 5 -> 10); its t-range
     # (length 5) is half the pcurve's mapped length (10) -> trim required.
-    lo, hi = _pcurve_trim_range(
-        c2d, surf, edge_start=(0.0, 5.0, 0.0), edge_end=(0.0, 10.0, 0.0)
-    )
+    lo, hi = _pcurve_trim_range(c2d, surf, edge_start=(0.0, 5.0, 0.0), edge_end=(0.0, 10.0, 0.0))
     # native param s: 0..1 maps to v 0..10, so y in [5,10] -> s in [0.5, 1.0].
     assert lo == pytest.approx(0.5, abs=0.02)
     assert hi == pytest.approx(1.0, abs=0.02)
@@ -59,12 +56,7 @@ def test_no_trim_when_edge_uses_full_pcurve():
     surf = _xy_plane()
     c2d = _line_pcurve((0.0, 0.0), (0.0, 10.0))
     # Edge length (10) == pcurve mapped length -> not a split edge -> no trim.
-    assert (
-        _pcurve_trim_range(
-            c2d, surf, edge_start=(0.0, 0.0, 0.0), edge_end=(0.0, 10.0, 0.0)
-        )
-        is None
-    )
+    assert _pcurve_trim_range(c2d, surf, edge_start=(0.0, 0.0, 0.0), edge_end=(0.0, 10.0, 0.0)) is None
 
 
 def test_no_trim_without_endpoints():

--- a/tests/core/occ/test_pcurve_trim.py
+++ b/tests/core/occ/test_pcurve_trim.py
@@ -1,0 +1,73 @@
+"""Shared-pcurve trim for split coedges (``_pcurve_trim_range``).
+
+A single SAT pcurve is often shared by several coedges along one UV side of a
+face — each coedge is a sub-segment, but the explicit pcurve carries the whole
+side's trajectory. Without trimming each edge to its own sub-range, the wire
+traces the side multiple times, self-intersects in UV, and BRepMesh grids only
+part of the face (the hull-skin "missing triangles"). This pins that the trim
+maps an edge's 3D endpoints back to the correct pcurve sub-range.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+occ = pytest.importorskip("OCC.Core.Geom2d")
+from OCC.Core.Geom import Geom_Plane  # noqa: E402
+from OCC.Core.Geom2d import Geom2d_BSplineCurve  # noqa: E402
+from OCC.Core.gp import gp_Ax3, gp_Dir, gp_Pnt, gp_Pnt2d  # noqa: E402
+from OCC.Core.TColgp import TColgp_Array1OfPnt2d  # noqa: E402
+from OCC.Core.TColStd import TColStd_Array1OfInteger, TColStd_Array1OfReal  # noqa: E402
+
+from ada.occ.geom.surfaces import _pcurve_trim_range  # noqa: E402
+
+
+def _line_pcurve(p0, p1):
+    """Degree-1 2D BSpline from ``p0`` to ``p1`` with native param range [0, 1]."""
+    poles = TColgp_Array1OfPnt2d(1, 2)
+    poles.SetValue(1, gp_Pnt2d(*p0))
+    poles.SetValue(2, gp_Pnt2d(*p1))
+    knots = TColStd_Array1OfReal(1, 2)
+    knots.SetValue(1, 0.0)
+    knots.SetValue(2, 1.0)
+    mults = TColStd_Array1OfInteger(1, 2)
+    mults.SetValue(1, 2)
+    mults.SetValue(2, 2)
+    return Geom2d_BSplineCurve(poles, knots, mults, 1)
+
+
+def _xy_plane():
+    return Geom_Plane(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)))
+
+
+def test_trim_picks_subrange_for_split_edge():
+    surf = _xy_plane()
+    # pcurve runs the full v side u=0, v: 0 -> 10 (native param 0..1).
+    c2d = _line_pcurve((0.0, 0.0), (0.0, 10.0))
+    # This coedge only covers the upper half (3D y: 5 -> 10); its t-range
+    # (length 5) is half the pcurve's mapped length (10) -> trim required.
+    lo, hi = _pcurve_trim_range(
+        c2d, surf, edge_start=(0.0, 5.0, 0.0), edge_end=(0.0, 10.0, 0.0)
+    )
+    # native param s: 0..1 maps to v 0..10, so y in [5,10] -> s in [0.5, 1.0].
+    assert lo == pytest.approx(0.5, abs=0.02)
+    assert hi == pytest.approx(1.0, abs=0.02)
+
+
+def test_no_trim_when_edge_uses_full_pcurve():
+    surf = _xy_plane()
+    c2d = _line_pcurve((0.0, 0.0), (0.0, 10.0))
+    # Edge length (10) == pcurve mapped length -> not a split edge -> no trim.
+    assert (
+        _pcurve_trim_range(
+            c2d, surf, edge_start=(0.0, 0.0, 0.0), edge_end=(0.0, 10.0, 0.0)
+        )
+        is None
+    )
+
+
+def test_no_trim_without_endpoints():
+    surf = _xy_plane()
+    c2d = _line_pcurve((0.0, 0.0), (0.0, 10.0))
+    assert _pcurve_trim_range(c2d, surf, None, None) is None

--- a/tests/core/visit/test_tessellating.py
+++ b/tests/core/visit/test_tessellating.py
@@ -92,23 +92,21 @@ def test_batch_tessellate_solids_matches_per_object():
         assert b.normal is not None and len(b.normal) == len(b.position)
 
 
-def test_tessellate_empty_compound_does_not_abort():
-    """An empty body (void bbox) used to SIGABRT the process: ShapeTesselator
-    derives a *relative* deflection from the bbox, so a void box gives
-    deflection 0 and OCC raises a std::invalid_argument that escapes pythonocc's
-    exception translation. Empty STEP compounds turn up from FEM round-trips
-    that drop geometry; tessellate_shape must return an empty mesh, not crash."""
-    import pytest
-
-    pytest.importorskip("OCC", reason="unit test of the pythonocc empty-shape tessellation guard")
-    from OCC.Core.BRep import BRep_Builder
-    from OCC.Core.TopoDS import TopoDS_Compound
-
+def test_tessellate_empty_shape_does_not_abort():
+    """An empty body (void bbox) used to crash the process on *both* backends:
+    OCC's ShapeTesselator derives a relative deflection from the bbox (0 →
+    std::invalid_argument that escapes pythonocc), and adacpp's native
+    tessellator throws an untranslatable nanobind exception. Empty bodies turn
+    up from round-trips that drop geometry; ``tessellate_shape`` must return an
+    empty mesh, not crash. Built through ``active_backend()`` (a box cut by
+    itself → geometry-less shape) so it covers whichever backend is active."""
+    from ada.cad import active_backend
+    from ada.geom.booleans import BoolOpEnum
     from ada.occ.tessellating import tessellate_shape
 
-    comp = TopoDS_Compound()
-    BRep_Builder().MakeCompound(comp)
+    be = active_backend()
+    empty = be.boolean(BoolOpEnum.DIFFERENCE, be.make_box(1.0, 1.0, 1.0), be.make_box(1.0, 1.0, 1.0))
 
-    tm = tessellate_shape(comp)  # must not abort the interpreter
+    tm = tessellate_shape(empty)  # must not abort the interpreter
     assert len(tm.faces) == 0
     assert len(tm.positions) == 0

--- a/tests/core/visit/test_tessellating.py
+++ b/tests/core/visit/test_tessellating.py
@@ -90,3 +90,22 @@ def test_batch_tessellate_solids_matches_per_object():
         assert np.array_equal(np.asarray(a.indices), np.asarray(b.indices))
         assert a.material == b.material
         assert b.normal is not None and len(b.normal) == len(b.position)
+
+
+def test_tessellate_empty_compound_does_not_abort():
+    """An empty body (void bbox) used to SIGABRT the process: ShapeTesselator
+    derives a *relative* deflection from the bbox, so a void box gives
+    deflection 0 and OCC raises a std::invalid_argument that escapes pythonocc's
+    exception translation. Empty STEP compounds turn up from FEM round-trips
+    that drop geometry; tessellate_shape must return an empty mesh, not crash."""
+    from OCC.Core.BRep import BRep_Builder
+    from OCC.Core.TopoDS import TopoDS_Compound
+
+    from ada.occ.tessellating import tessellate_shape
+
+    comp = TopoDS_Compound()
+    BRep_Builder().MakeCompound(comp)
+
+    tm = tessellate_shape(comp)  # must not abort the interpreter
+    assert len(tm.faces) == 0
+    assert len(tm.positions) == 0

--- a/tests/core/visit/test_tessellating.py
+++ b/tests/core/visit/test_tessellating.py
@@ -98,6 +98,9 @@ def test_tessellate_empty_compound_does_not_abort():
     deflection 0 and OCC raises a std::invalid_argument that escapes pythonocc's
     exception translation. Empty STEP compounds turn up from FEM round-trips
     that drop geometry; tessellate_shape must return an empty mesh, not crash."""
+    import pytest
+
+    pytest.importorskip("OCC", reason="unit test of the pythonocc empty-shape tessellation guard")
     from OCC.Core.BRep import BRep_Builder
     from OCC.Core.TopoDS import TopoDS_Compound
 


### PR DESCRIPTION
Large branch off `main` covering performance, streaming conversion/FEA, the audit panel, parity validation, and curved-plate/SAT geometry fixes. Grouped below by area.

## Performance — leaner concept objects + hot paths
- `__slots__` on `Point`/`Direction`; defer `CurveOpen2d` derived structures; build the CarbonSteel EC3 thermal grid lazily (configurable bounds).
- Section consolidation made O(N) (was the Genie-XML write bottleneck); hand-authored 3-vector cross products in the placement hot path.
- FEM→STEP streaming writer fused to drop the `create_objects` peak.

## Streaming conversion (bounded memory)
- Object-free, vectorized FEM-shell → CAD-face source with a shared `MergeStrategy`; one strategy-bearing generator feeds the streaming Genie-XML, IFC, and STEP writers.
- DOM-free streaming `to_genie_xml` (byte-identical to the DOM writer).
- Path-return upload contract: disk-writing exporters hand back a file path; the worker streams it to object storage via multipart instead of buffering the whole output in RAM (kills the ~800 MB STEP double-buffer).

## Streaming FEA results (Sesam SIF / SIN)
- Single-step SIF reads bound peak memory on FEA→GLB; byte-offset index + range-fetch so re-picking a step reads a fraction of a multi-GB deck.
- Streaming SIF bake reader (per-card, memory-bounded), LIS-enriched and defaulted on.
- `SinStreamReader` gathers one RV card per field (no per-field re-reads).

## Audit panel (hosted viewer)
- Re-run from a finished run; "Validate after" toggle and a manual "Validate" button (folds the parity pass into the same run, not a new one); delete a run; friendly run `#seq`; idle-aware duration; per-cell cross-run history + a details modal (desktop right-click / mobile long-press).
- Postgres-backed tests for the audit routes, and the `comms/rest` suite now runs in CI against a live Postgres.

## Parity validation
- Runs in the memory-capped fork so an OOM/native abort fails the cell instead of the worker.
- Don't `SIGABRT` tessellating an empty / zero-extent shape.
- Rebuild concept objects from a FEM source before the round-trip; skip Genie XML for sources made only of generic solids (a format limit, not a converter fault).

## Curved plates / SAT reader
- **Root-cause fix for "missing triangles":** split coedges along a UV side share one explicit pcurve; trim each coedge's pcurve to its own sub-segment (matched via the coedge's 3D endpoints) so the wire no longer self-intersects and BRepMesh grids the whole face. Across a curved hull-skin model this corrected ~1500 plates.
- Defense-in-depth: rebuild an under-covered curved plate from its surface natural bounds (keeps the curve); flat fallback only as a last resort.
- Parse `parcur` edge curves so curved plates stay curved; recover plates dropped by degenerate SESAM marker loops.

## Frontend
- "Copy as path" in the file context menu; CurvedPlate properties in the object Info panel; vite/js-yaml/@babel security bumps.

### Testing
New unit/integration tests across each area (object-free face source, streaming writers, path contract, SIF/SIN streaming + index, audit routes on Postgres, parity isolation, empty-shape tessellation, pcurve trim, curved-plate coverage). Existing `cadit` / `visit` / `comms/rest` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
