### PR TITLE
feat: Emit real ACIS SAT in the Genie XML writer so Genie stops rebuilding it on import

### DIFF
--- a/src/ada/api/beams/base_bm.py
+++ b/src/ada/api/beams/base_bm.py
@@ -503,6 +503,28 @@ class Beam(BackendGeom):
     def n1(self) -> Node:
         return self._n1
 
+    def axis_global(self) -> tuple[np.ndarray, np.ndarray]:
+        """This beam's (start, end) in global coordinates.
+
+        The nodes are expressed in the beam's own frame, so a beam inside a
+        placed :class:`~ada.Part` has to be pushed through the accumulated
+        placement. Exporters share this so they cannot disagree on where a beam
+        is — the Genie SAT body imprints the axis onto the plates and the XML
+        references the resulting edge, and the two must land on each other.
+        """
+        from ada.api.transforms import Placement
+
+        p1, p2 = np.asarray(self._n1.p, dtype=float), np.asarray(self._n2.p, dtype=float)
+        if self.placement.is_identity():
+            return p1, p2
+
+        ident = Placement()
+        abs_place = self.placement.get_absolute_placement(include_rotations=True)
+        if not np.allclose(abs_place.rot_matrix, ident.rot_matrix):
+            moved = abs_place.transform_array_from_other_place(np.asarray([p1, p2]), ident)
+            return moved[0], moved[1]
+        return abs_place.origin + p1, abs_place.origin + p2
+
     @n1.setter
     def n1(self, new_node: Node):
         self._n1.remove_obj_from_refs(self)

--- a/src/ada/api/plates/base_pl.py
+++ b/src/ada/api/plates/base_pl.py
@@ -306,6 +306,27 @@ class Plate(BackendGeom):
     def material(self, value: Material):
         self._material = value
 
+    def outline_global(self) -> tuple[np.ndarray, Direction]:
+        """This plate's outline and normal in global coordinates.
+
+        ``poly.points3d`` is expressed in the plate's own frame, so a plate that
+        sits inside a placed :class:`~ada.Part` has to be pushed through the
+        accumulated placement before being written out. Exporters share this so
+        they cannot disagree on where a plate is (the Genie SAT body used to
+        ignore part placements entirely while the polygon writer honoured them).
+        """
+        from ada.api.transforms import Placement
+
+        abs_place = self.placement.get_absolute_placement(include_rotations=True)
+        ident = Placement()
+        outline = abs_place.transform_array_from_other_place(
+            np.asarray(self.poly.points3d, dtype=float), ident, ignore_translation=False
+        )
+        normal = abs_place.transform_array_from_other_place(
+            np.asarray([self.poly.normal], dtype=float), ident, ignore_translation=True
+        )[0]
+        return outline, Direction(*normal)
+
     @property
     def normal(self) -> Direction:
         """Normal vector"""

--- a/src/ada/api/spatial/assembly.py
+++ b/src/ada/api/spatial/assembly.py
@@ -375,24 +375,60 @@ class Assembly(Part):
         self,
         destination_xml,
         writer_postprocessor: Callable[[ET.Element, Part], None] = None,
-        embed_sat=False,
-        streaming=False,
+        embed_sat: bool | None = None,
+        streaming: bool = False,
         merge_strategy=None,
     ):
-        # ``streaming`` emits the per-object <structure> entries straight to the
-        # file instead of building the whole ElementTree DOM, cutting peak RSS on
-        # large FEM-derived models. Geometry-identical to the DOM writer. Not
-        # available with embed_sat (the SAT path shares one whole-model CDATA
-        # body), so fall back there.
-        #
-        # ``merge_strategy`` (None | "none" | "coplanar" | ...) sources plates
-        # from the object-free vectorized FEM-shell face engine instead of
-        # materialising Plate objects — only honoured on the streaming path.
-        if streaming and not embed_sat:
+        """Write a Genie (DNV) concept XML.
+
+        ``embed_sat`` embeds the plate geometry as a ready-built ACIS SAT body
+        that each ``<flat_plate>`` references by face name. Without it the plates
+        are written as bare polygons and Genie must rebuild — and imprint — the
+        ACIS itself on import, which dominates load time on a large model. It
+        needs a CAD backend (see ``CadBackend.imprint_planar_faces``).
+
+        Defaults to ``None`` = on whenever it can be produced. It can't be with
+        ``merge_strategy``, which sources plates from the FEM-shell face engine
+        without ever materialising the ``Plate`` objects the SAT body is built
+        from; asking for both explicitly is contradictory and raises rather than
+        quietly dropping one.
+
+        ``streaming`` emits the per-object ``<structure>`` entries straight to
+        the file instead of building the whole DOM, cutting peak RSS on large
+        FEM-derived models. It composes with ``embed_sat`` (the SAT body itself
+        is inherently whole-model, so only the concept entries stream).
+
+        ``merge_strategy`` (None | "none" | "coplanar" | ...) sources plates from
+        the object-free vectorized FEM-shell face engine — streaming path only.
+        """
+        if merge_strategy is not None:
+            if embed_sat:
+                raise ValueError(
+                    "to_genie_xml: embed_sat=True is incompatible with merge_strategy="
+                    f"{merge_strategy!r} — the SAT body is built from Plate objects, which the "
+                    "merge_strategy face source never materialises. Pass one or the other."
+                )
+            if embed_sat is None:
+                embed_sat = False
+                logger.info("to_genie_xml: merge_strategy set, so plates are written as polygons (no SAT)")
+        elif embed_sat is None:
+            embed_sat = True
+
+        if merge_strategy is not None and not streaming:
+            raise ValueError(
+                f"to_genie_xml: merge_strategy={merge_strategy!r} is only honoured on the streaming "
+                "path; pass streaming=True (it was previously ignored here)."
+            )
+
+        if streaming:
             from ada.cadit.gxml.write.stream_xml import write_xml_stream
 
             write_xml_stream(
-                self, destination_xml, writer_postprocessor=writer_postprocessor, merge_strategy=merge_strategy
+                self,
+                destination_xml,
+                writer_postprocessor=writer_postprocessor,
+                merge_strategy=merge_strategy,
+                embed_sat=embed_sat,
             )
         else:
             from ada.cadit.gxml.write.write_xml import write_xml

--- a/src/ada/cad/__init__.py
+++ b/src/ada/cad/__init__.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import math
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -88,6 +88,63 @@ class Mesh(Protocol):
 
     positions: Any  # flat float buffer, length = 3 * num_vertices
     indices: Any  # flat int buffer,   length = 3 * num_triangles
+
+
+@dataclass(frozen=True)
+class ImprintedEdge:
+    """A straight edge of a :class:`PlanarImprint`, as indices into its ``vertices``."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ImprintedFace:
+    """A planar face of a :class:`PlanarImprint`.
+
+    ``loops[0]`` is the outer boundary and the rest are holes. Each loop is an
+    ordered list of ``(edge index, forward)`` pairs — ``forward`` False means the
+    loop traverses that edge from its ``end`` vertex to its ``start`` vertex.
+    Every loop is wound counter-clockwise about ``normal``.
+    """
+
+    origin: tuple[float, float, float]
+    normal: tuple[float, float, float]
+    ref_direction: tuple[float, float, float]
+    loops: "list[list[tuple[int, bool]]]"
+
+
+@dataclass(frozen=True)
+class PlanarImprint:
+    """The imprinted (mutually split, topologically shared) form of planar outlines.
+
+    Backend-neutral plain data: no kernel handles cross this boundary, so one
+    call covers a whole model rather than re-entering the backend per element
+    (see the perf guardrail on ``vertex_points``). Coincident vertices are
+    merged and an edge shared by several faces appears once, referenced by each
+    — which is what lets a consumer emit shared topology.
+
+    ``sources[i]`` lists the faces the i-th input outline became; an outline
+    crossed by its neighbours splits into several, and one consumed entirely
+    yields an empty list.
+
+    ``curve_sources[i]`` likewise lists the edges the i-th imprint curve became.
+    A beam axis lying on a plate is split wherever another plate crosses it, so
+    it resolves to several edges — Genie's own export references up to 11 for one
+    beam.
+
+    ``free_edges`` indexes the edges that bound no face — an imprint curve with
+    no face under it. They are still reported (and still reachable through
+    ``curve_sources``) because a consumer needs geometry for them; ACIS carries
+    them as wire bodies rather than as face boundaries.
+    """
+
+    vertices: "list[tuple[float, float, float]]"
+    edges: "list[ImprintedEdge]"
+    faces: "list[ImprintedFace]"
+    sources: "list[list[int]]"
+    curve_sources: "list[list[int]]" = field(default_factory=list)
+    free_edges: "list[int]" = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -225,6 +282,12 @@ class CadBackend(Protocol):
     def wires(self, shape: ShapeHandle) -> list[ShapeHandle]: ...
     def wire_points(self, shape: ShapeHandle) -> list[tuple[float, float, float]]: ...
     def unify_coplanar_faces(self, shape: ShapeHandle) -> ShapeHandle: ...
+    def imprint_planar_faces(
+        self,
+        outlines: "list[list[tuple[float, float, float]]]",
+        imprint_curves: "list[list[tuple[float, float, float]]] | None" = None,
+        tolerance: float = 1e-6,
+    ) -> "PlanarImprint": ...
 
 
 class AdacppBackend:
@@ -1494,6 +1557,45 @@ class AdacppBackend:
         if fn is None:
             raise NotImplementedError("adacpp.cad.unify_coplanar_faces is not available in this build")
         return fn(shape)
+
+    def imprint_planar_faces(
+        self,
+        outlines: "list[list[tuple[float, float, float]]]",
+        imprint_curves: "list[list[tuple[float, float, float]]] | None" = None,
+        tolerance: float = 1e-6,
+    ) -> "PlanarImprint":
+        # adacpp.cad.imprint_planar_faces mirrors OccBackend's: BOPAlgo_Builder
+        # General Fuse + Modified() history, returning plain topology data. An
+        # older ada-cpp build without it raises rather than borrowing pythonocc
+        # (see the no-fallback note on `build`).
+        fn = getattr(self._cad, "imprint_planar_faces", None)
+        if fn is None:
+            raise NotImplementedError(
+                "adacpp.cad.imprint_planar_faces is not available in this build — "
+                "rebuild ada-cpp, or use ADAPY_CAD_BACKEND=occ for the imprinted Genie SAT export."
+            )
+        from ada.cad import ImprintedEdge, ImprintedFace, PlanarImprint
+
+        def _pts(seq):
+            return [[float(c) for c in p] for p in seq]
+
+        raw = fn([_pts(o) for o in outlines], [_pts(c) for c in (imprint_curves or [])], float(tolerance))
+        return PlanarImprint(
+            vertices=[tuple(v) for v in raw.vertices],
+            edges=[ImprintedEdge(start=e.start, end=e.end) for e in raw.edges],
+            faces=[
+                ImprintedFace(
+                    origin=tuple(f.origin),
+                    normal=tuple(f.normal),
+                    ref_direction=tuple(f.ref_direction),
+                    loops=[[(int(i), bool(fwd)) for i, fwd in loop] for loop in f.loops],
+                )
+                for f in raw.faces
+            ],
+            sources=[list(s) for s in raw.sources],
+            curve_sources=[list(s) for s in getattr(raw, "curve_sources", [])],
+            free_edges=list(getattr(raw, "free_edges", [])),
+        )
 
 
 def select_backend(prefer: str | None = None) -> CadBackend:

--- a/src/ada/cadit/gxml/read/helpers.py
+++ b/src/ada/cadit/gxml/read/helpers.py
@@ -108,6 +108,33 @@ def _project_to_best_fit_plane(pts):
     return [tuple(p) for p in projected]
 
 
+def _plate_from_3d_points(name, points, t, desired_normal, **kwargs):
+    """``Plate.from_3d_points``, wound to face the way the XML says it does.
+
+    A ``flat_plate`` states its normal outright as a ``<vector>``; the
+    constructor ignores it and derives one from the point order instead. The two
+    disagree about half the time — the points come off the SAT face's loop,
+    whose winding is its own business — and the plate then goes back out facing
+    the other way, which Genie draws inside-out.
+
+    Build it, compare, and rebuild flipped when they disagree. Cheaper would be
+    to reason about the winding up front, but ``CurvePoly2d`` re-orders the
+    outline during construction, so its own answer is the only reliable one.
+    """
+    from ada import Plate
+
+    plate = Plate.from_3d_points(name, points, t, **kwargs)
+    if desired_normal is None:
+        return plate
+    import numpy as _np
+
+    got = _np.asarray(plate.poly.normal, dtype=float)
+    want = _np.asarray(desired_normal, dtype=float)
+    if float(_np.dot(got, want)) < 0:
+        plate = Plate.from_3d_points(name, points, t, flip_normal=True, **kwargs)
+    return plate
+
+
 def _sense_against_face(sat_data, desired_normal, authored_sense: bool) -> bool:
     """The curved_shell sense flag: does ``desired_normal`` agree with the face?
 
@@ -136,8 +163,6 @@ def _sense_against_face(sat_data, desired_normal, authored_sense: bool) -> bool:
 
 
 def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fallback_d=None):
-    from ada import Plate
-
     base_name = plate_elem.attrib["name"]
     mat = parent.materials.get_by_name(plate_elem.attrib["material_ref"])
     t = thick_map.get(plate_elem.attrib.get("thickness_ref"))
@@ -176,10 +201,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                 merged_points = merge_coplanar_loops_by_edge_cancellation(face_point_sets)
                 if merged_points is not None:
                     try:
-                        yield Plate.from_3d_points(
+                        yield _plate_from_3d_points(
                             base_name,
                             merged_points,
                             t,
+                            desired_normal,
                             mat=mat,
                             metadata=dict(props=dict(gxml_face_refs=face_refs)),
                             parent=parent,
@@ -293,10 +319,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                                     name,
                                     mismatch,
                                 )
-                                yield Plate.from_3d_points(
+                                yield _plate_from_3d_points(
                                     name,
                                     _project_to_best_fit_plane(fallback_pts),
                                     t,
+                                    desired_normal,
                                     mat=mat,
                                     metadata=dict(props=dict(gxml_face_ref=face_ref)),
                                     parent=parent,
@@ -348,10 +375,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                 if fb and len(fb) >= 3:
                     try:
                         projected = _project_to_best_fit_plane(fb)
-                        yield Plate.from_3d_points(
+                        yield _plate_from_3d_points(
                             name,
                             projected,
                             t,
+                            desired_normal,
                             mat=mat,
                             metadata=dict(props=dict(gxml_face_ref=face_ref)),
                             parent=parent,
@@ -363,10 +391,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                 continue
 
             try:
-                yield Plate.from_3d_points(
+                yield _plate_from_3d_points(
                     name,
                     sat_data,
                     t,
+                    desired_normal,
                     mat=mat,
                     metadata=dict(props=dict(gxml_face_ref=face_ref)),
                     parent=parent,
@@ -387,10 +416,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
 
         name = base_name if i == 1 else f"{base_name}_{i:02d}"
         try:
-            yield Plate.from_3d_points(
+            yield _plate_from_3d_points(
                 name,
                 pts,
                 t,
+                desired_normal,
                 mat=mat,
                 metadata=dict(props=dict(gxml_polygon_index=i)),
                 parent=parent,

--- a/src/ada/cadit/gxml/read/helpers.py
+++ b/src/ada/cadit/gxml/read/helpers.py
@@ -168,7 +168,11 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                 # flat perimeter centroid, skip the PlateCurved
                 # path entirely and yield a Plate.from_3d_points
                 # at the correct world location instead.
-                if fallback_pts is not None and len(fallback_pts) >= 3:
+                if (
+                    fallback_pts is not None
+                    and len(fallback_pts) >= 3
+                    and Config().gxml_reject_deformed_curved_faces is True
+                ):
                     try:
                         import numpy as _np
 

--- a/src/ada/cadit/gxml/read/helpers.py
+++ b/src/ada/cadit/gxml/read/helpers.py
@@ -108,6 +108,33 @@ def _project_to_best_fit_plane(pts):
     return [tuple(p) for p in projected]
 
 
+def _sense_against_face(sat_data, desired_normal, authored_sense: bool) -> bool:
+    """The curved_shell sense flag: does ``desired_normal`` agree with the face?
+
+    Only used for a plate the source stated a normal for rather than a flag (a
+    ``flat_plate`` whose edges curve, so it reads as an advanced face and has to
+    leave as a ``curved_shell``). The face's own normal is its surface's,
+    flipped when the ACIS senses disagree — see ``get_face_same_sense``. Falls
+    back to the authored flag when there is nothing to compare.
+    """
+    import numpy as _np
+
+    from ada.geom import surfaces as _su
+
+    if desired_normal is None:
+        return authored_sense
+    geom = getattr(sat_data, "geometry", None)
+    if not isinstance(geom, _su.AdvancedFace) or not isinstance(geom.face_surface, _su.Plane):
+        return authored_sense
+    axis = _np.asarray(geom.face_surface.position.axis, dtype=float)
+    if not geom.same_sense:
+        axis = -axis
+    dot = float(_np.dot(_np.asarray(desired_normal, dtype=float), axis))
+    if abs(dot) < 1e-12:  # perpendicular: the comparison says nothing
+        return authored_sense
+    return dot > 0
+
+
 def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fallback_d=None):
     from ada import Plate
 
@@ -116,6 +143,27 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
     t = thick_map.get(plate_elem.attrib.get("thickness_ref"))
     if flat_fallback_d is None:
         flat_fallback_d = {}
+
+    # A curved shell has no single normal to state as a vector, so Genie
+    # orients it with a flag against its face's own surface normal. It is
+    # authored, and mostly false (4413 of 4746 in a hull export) — defaulting
+    # it to true on the way out draws the model inside-out.
+    sense_flag = plate_elem.find("./local_system/sense_flag")
+    sense = True
+    if sense_flag is not None:
+        sense = str(sense_flag.attrib.get("sense", "true")).strip().lower() != "false"
+    # A flat_plate states its normal outright instead. Those still reach here as
+    # PlateCurved when the face's edges curve (a flat face with a spline
+    # boundary is not a polygon), and they leave as a curved_shell, which has
+    # only the flag to say the same thing — so derive it rather than default it.
+    desired_normal = None
+    if sense_flag is None:
+        vec = plate_elem.find("./local_system/vector")
+        if vec is not None:
+            try:
+                desired_normal = tuple(float(vec.attrib[k]) for k in ("x", "y", "z"))
+            except (KeyError, ValueError):
+                desired_normal = None
 
     face_elems = list(plate_elem.findall(".//face"))
     if face_elems:
@@ -261,7 +309,12 @@ def yield_plate_elems_to_plate(plate_elem, parent, sat_ref_d, thick_map, flat_fa
                     sat_data,
                     t=t,
                     mat=mat,
-                    metadata=dict(props=dict(gxml_face_ref=face_ref)),
+                    metadata=dict(
+                        props=dict(
+                            gxml_face_ref=face_ref,
+                            gxml_sense_flag=_sense_against_face(sat_data, desired_normal, sense),
+                        )
+                    ),
                     parent=parent,
                 )
                 # Attach the planar fallback points (the SAT face's

--- a/src/ada/cadit/gxml/write/stream_xml.py
+++ b/src/ada/cadit/gxml/write/stream_xml.py
@@ -12,12 +12,14 @@ then each beam/plate ``<structure>`` is serialised one at a time and written,
 holding only one object's subtree at a time instead of the whole tree.
 
 The per-object elements are produced by the *exact* same builders the DOM
-writer uses (:func:`add_straight_beam`, :func:`add_plate_polygon`), so the
-output is geometry-identical — only the assembly strategy differs.
+writer uses (:func:`add_straight_beam`, :func:`add_plate_polygon` /
+:func:`add_plate_sat`), so the output is byte-identical — only the assembly
+strategy differs.
 
-Scope: the parametric (``embed_sat=False``) path only. The SAT-embedded path
-shares one cross-referenced CDATA body and is inherently whole-model, so it
-stays on :func:`write_xml`.
+``embed_sat`` composes with this: the ACIS body is one cross-referenced,
+imprinted whole-model blob and is necessarily built in memory in one piece, but
+the concept ``<structure>`` entries — the part that scales with model size —
+still stream.
 """
 
 from __future__ import annotations
@@ -26,6 +28,7 @@ import pathlib
 import xml.etree.ElementTree as ET
 from typing import Callable
 
+from ...sat.write.writer import part_to_sat_writer
 from .write_bcs import add_concept_constraints, add_fem_boundary_conditions
 from .write_equipments import add_equipments
 from .write_hinges import add_hinges
@@ -36,7 +39,13 @@ from .write_plates import (
     add_plate_curved_polygon,
     add_plate_polygon,
     add_plate_polygon_data,
+    add_plate_sat,
     thickness_name,
+)
+from .write_sat_embedded import (
+    embed_sat_geometry,
+    sat_to_base64_segments,
+    splice_cdata_segments,
 )
 from .write_sections import add_sections
 from .write_sets import add_sets
@@ -53,6 +62,7 @@ def write_xml_stream(
     xml_file,
     writer_postprocessor: Callable[[ET.Element, "object"], None] = None,
     merge_strategy=None,
+    embed_sat: bool = False,
 ) -> None:
     """Stream a Genie XML.
 
@@ -62,6 +72,12 @@ def write_xml_stream(
     object-free vectorized FEM-shell face engine
     (:func:`ada.fem.formats.mesh_faces.iter_faces`) instead — no Plate objects
     are ever materialised. Beams still come from the part's (bounded) beam set.
+
+    ``embed_sat`` writes the plates as references into an embedded ACIS body
+    instead of as polygons. The body is shared and imprinted across the whole
+    model, so it is necessarily built in memory in one piece — only the concept
+    ``<structure>`` entries stream. It is incompatible with ``merge_strategy``
+    (no Plate objects to build the body from); the caller checks that.
     """
     from ada import Beam, BeamTapered, Plate
 
@@ -69,6 +85,8 @@ def write_xml_stream(
         xml_file = pathlib.Path(xml_file)
 
     use_faces = merge_strategy is not None
+    if embed_sat and use_faces:
+        raise ValueError("write_xml_stream: embed_sat is incompatible with merge_strategy")
     if use_faces:
         # plate materials live on the FEM shell sections; register them so
         # add_materials emits them and the streamed face material_refs resolve.
@@ -76,6 +94,10 @@ def write_xml_stream(
 
     part.consolidate_sections()
     part.consolidate_materials()
+
+    # The ACIS body must exist before the plates stream: each <sheet> references
+    # its faces by the name the SAT writer minted for them.
+    sw = part_to_sat_writer(part) if embed_sat else None
 
     tree = ET.parse(_XML_TEMPLATE)
     root = tree.getroot()
@@ -120,7 +142,16 @@ def write_xml_stream(
     if writer_postprocessor:
         writer_postprocessor(root, part)
 
+    # <geometry> goes last, after <sets> — matching Genie's own export. A model
+    # with no plates has no ACIS body, so there is nothing to embed (and no
+    # plate will ask sw for a face name either).
+    segments = [] if sw is None or sw.is_empty else sat_to_base64_segments(sw.to_str())
+    if segments:
+        embed_sat_geometry(structure_domain, len(segments))
+
     scaffold = ET.tostring(root, encoding="unicode")
+    if segments:
+        scaffold = splice_cdata_segments(scaffold, segments)
     # ElementTree serialises a childless element as ``<tag />`` (with the space).
     marker = f"<{_MARKER} />"
     if marker not in scaffold:  # be liberal about the serialisation variant
@@ -132,7 +163,7 @@ def write_xml_stream(
         # Match the DOM writer byte-for-byte: tree.write(encoding="utf-8")
         # suppresses the XML declaration, so we emit none either.
         fh.write(head)
-        _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy)
+        _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy, sw)
         fh.write(tail)
 
 
@@ -168,7 +199,7 @@ def _register_shell_materials(part) -> None:
                 p.materials.add(mat)
 
 
-def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy) -> None:
+def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_strategy, sw=None) -> None:
     """Serialise one ``<structure>`` subtree at a time and write it out.
 
     Beams precede plates, matching the add_beams → add_plates order of the DOM
@@ -176,7 +207,8 @@ def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_
     written, and dropped, so peak memory is one object's element tree.
 
     Plates come from the part's Plate objects (``merge_strategy is None``) or,
-    for any strategy value, from the object-free vectorized face source.
+    for any strategy value, from the object-free vectorized face source. With
+    ``sw`` they are written as SAT face references instead of polygons.
     """
     import itertools
 
@@ -207,7 +239,7 @@ def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_
                 "(curved axis not supported by the Genie XML writer)"
             )
         tmp = ET.Element("structures")
-        add_straight_beam(beam, tmp)
+        add_straight_beam(beam, tmp, sw)
         for child in list(tmp):
             fh.write(ET.tostring(child, encoding="unicode"))
 
@@ -217,7 +249,10 @@ def _stream_structures(part, fh, thickness_map, Beam, BeamTapered, Plate, merge_
 
         for plate in part.get_all_physical_objects(by_type=Plate):
             tmp = ET.Element("structures")
-            add_plate_polygon(plate, thickness_map[plate.t], tmp)
+            if sw is not None:
+                add_plate_sat(plate, thickness_map[plate.t], tmp, sw)
+            else:
+                add_plate_polygon(plate, thickness_map[plate.t], tmp)
             for child in list(tmp):
                 fh.write(ET.tostring(child, encoding="unicode"))
         for plate in part.get_all_physical_objects(by_type=PlateCurved):

--- a/src/ada/cadit/gxml/write/write_beams.py
+++ b/src/ada/cadit/gxml/write/write_beams.py
@@ -9,7 +9,6 @@ from ada.api.spatial.eq_types import EquipRepr
 from ada.api.spatial.equipment import Equipment
 from ada.cadit.sat.write.writer import SatWriter
 from ada.config import get_logger
-from ada.sections.categories import BaseTypes
 
 from .write_utils import add_local_system
 
@@ -73,52 +72,47 @@ def add_straight_beam(beam: Beam, xml_root: ET.Element, sw: SatWriter = None):
     if beam.hinge2 is not None:
         ET.SubElement(straight_beam, "end2", {"hinge_ref": beam.hinge2.name})
 
-    # ---------------------------------------------------------------------
-    # Decide whether to write aligned_curve_offset (preferred) or constants
-    # ---------------------------------------------------------------------
-    force_constant_offsets = False  # set True for debugging if needed
+    add_curve_offset(beam, straight_beam)
 
-    curve_offset = ET.SubElement(straight_beam, "curve_offset")
+
+def add_curve_offset(beam: Beam, straight_beam: ET.Element) -> None:
+    """Write the beam's ``<curve_offset>``.
+
+    Genie rejects an empty ``<curve_offset/>`` ("Unable to build model from
+    element"), so the element is only created once it is known which child goes
+    in it. A beam with no offset still needs one: ``reparameterized_beam_curve_
+    offset`` names the same rule the exported journal sets as the default
+    (``GenieRules.BeamCreation.DefaultCurveOffset``, see gxml/utils.py).
+    """
     data = beam.offset_helper.curve_offset_local()
     (ox1, oy1, oz1) = data.end1
     (ox2, oy2, oz2) = data.end2
 
-    # 1) Varying offset: always explicit numeric
+    curve_offset = ET.Element("curve_offset")
+
     if data.is_varying:
+        # Ends differ: only explicit numerics can express that.
         lvo = ET.SubElement(curve_offset, "linear_varying_curve_offset", {"use_local_system": "true"})
         ET.SubElement(lvo, "offset_end1", {"x": f"{ox1:.12g}", "y": f"{oy1:.12g}", "z": f"{oz1:.12g}"})
         ET.SubElement(lvo, "offset_end2", {"x": f"{ox2:.12g}", "y": f"{oy2:.12g}", "z": f"{oz2:.12g}"})
-        return
-
-    # 2) Constant case: if justification requests FLUSH semantics, write aligned_curve_offset
-    #    IMPORTANT: do this BEFORE the "offset is zero" early-return.
-    if (not force_constant_offsets) and beam.justification in (
-        Justification.FLUSH_TOP,
-        Justification.FLUSH_BOTTOM,
-    ):
-
-        if beam.justification == Justification.FLUSH_TOP:
-            alignment = "flush_top"
-        elif beam.justification == Justification.FLUSH_BOTTOM:
-            alignment = "flush_bottom"
-        else:
-            # Legacy mapping (keep while you transition/verify)
-            # NOTE: Genie has no TPROFILE; your exporter writes unsymm I for T -> keep this legacy special-case.
-            alignment = "flush_bottom" if beam.section.type == BaseTypes.TPROFILE else "flush_top"
-
+    elif beam.justification in (Justification.FLUSH_TOP, Justification.FLUSH_BOTTOM):
+        # Flush is semantic — let Genie re-derive the numbers from the section,
+        # as its own exports do. Checked before the zero-offset case below:
+        # flush is meaningful even when the resolved offset is zero.
+        alignment = "flush_top" if beam.justification == Justification.FLUSH_TOP else "flush_bottom"
         ET.SubElement(curve_offset, "aligned_curve_offset", {"alignment": alignment, "constant_value": "0"})
-        return
+    elif ox1 == oy1 == oz1 == 0:
+        # No offset to state. The default rule, named explicitly.
+        ET.SubElement(curve_offset, "reparameterized_beam_curve_offset")
+    else:
+        cco = ET.SubElement(curve_offset, "constant_curve_offset", {"use_local_system": "true"})
+        ET.SubElement(
+            cco,
+            "constant_offset",
+            {"x": f"{float(ox1):.12g}", "y": f"{float(oy1):.12g}", "z": f"{float(oz1):.12g}"},
+        )
 
-    # 3) Constant numeric offset: only write if non-zero
-    if ox1 == oy1 == oz1 == 0:
-        return
-
-    cco = ET.SubElement(curve_offset, "constant_curve_offset", {"use_local_system": "true"})
-    ET.SubElement(
-        cco,
-        "constant_offset",
-        {"x": f"{float(ox1):.12g}", "y": f"{float(oy1):.12g}", "z": f"{float(oz1):.12g}"},
-    )
+    straight_beam.append(curve_offset)
 
 
 def add_curve_orientation(beam: Beam, straight_beam: ET.Element):

--- a/src/ada/cadit/gxml/write/write_beams.py
+++ b/src/ada/cadit/gxml/write/write_beams.py
@@ -38,10 +38,10 @@ def add_beams(root: ET.Element, part: Part, sw: SatWriter = None):
                 f"gxml-write: {type(beam).__name__} {beam.name!r} written as a straight chord beam "
                 "(curved axis not supported by the Genie XML writer)"
             )
-        add_straight_beam(beam, root)
+        add_straight_beam(beam, root, sw)
 
 
-def add_straight_beam(beam: Beam, xml_root: ET.Element):
+def add_straight_beam(beam: Beam, xml_root: ET.Element, sw: SatWriter = None):
     import numpy as np
 
     from ada import Placement
@@ -66,7 +66,7 @@ def add_straight_beam(beam: Beam, xml_root: ET.Element):
             up = ori_vectors[2]
 
     straight_beam.append(add_local_system(xvec, yvec, up))
-    straight_beam.append(add_segments(beam))
+    straight_beam.append(add_segments(beam, sw))
 
     if beam.hinge1 is not None:
         ET.SubElement(straight_beam, "end1", {"hinge_ref": beam.hinge1.name})
@@ -131,10 +131,8 @@ def add_curve_orientation(beam: Beam, straight_beam: ET.Element):
     ET.SubElement(local_system, "up_vector", {"x": str(beam.up[0]), "y": str(beam.up[1]), "z": str(beam.up[2])})
 
 
-def add_segments(beam: Beam):
-    import numpy as np
-
-    from ada import BeamTapered, Placement
+def add_segments(beam: Beam, sw: SatWriter = None):
+    from ada import BeamTapered
 
     segments = ET.Element("segments")
     props = dict(index="1", section_ref=beam.section.name, material_ref=beam.material.name)
@@ -144,21 +142,7 @@ def add_segments(beam: Beam):
     straight_segment = ET.SubElement(segments, "straight_segment", props)
 
     d = ["x", "y", "z"]
-    p1 = beam.n1.p
-    p2 = beam.n2.p
-    if beam.placement.is_identity() is False:
-        ident_place = Placement()
-        place_abs = beam.placement.get_absolute_placement(include_rotations=True)
-        place_abs_rot_mat = place_abs.rot_matrix
-        ident_rot_mat = ident_place.rot_matrix
-        # check if the 3x3 rotational np arrays are identical
-        if not np.allclose(place_abs_rot_mat, ident_rot_mat):
-            tra_vectors = place_abs.transform_array_from_other_place(np.asarray([p1, p2]), ident_place)
-            p1 = tra_vectors[0]
-            p2 = tra_vectors[1]
-        else:
-            p1 = place_abs.origin + p1
-            p2 = place_abs.origin + p2
+    p1, p2 = beam.axis_global()
 
     geom = ET.SubElement(straight_segment, "geometry")
     wire = ET.SubElement(geom, "wire")
@@ -168,10 +152,14 @@ def add_segments(beam: Beam):
         props.update(dict(end=str(i)))
         ET.SubElement(guide, "position", props)
 
-    ET.SubElement(wire, "sat_reference")
-
-    # TODO: add SAT embedded geometry and include the reference to the EDGE geometry here
-    # ET.SubElement(sat_ref, "edge_ref", dict(edge_ref=""))
+    sat_ref = ET.SubElement(wire, "sat_reference")
+    # Name the edges the beam's axis became in the embedded body. Left empty,
+    # Genie rebuilds the beam's ACIS wire itself on import, which on a large
+    # frame dominates load time. The axis is split wherever a plate crosses it,
+    # so a beam can reference several edges.
+    if sw is not None:
+        for edge_ref in sw.edge_map.get(beam.guid, []):
+            ET.SubElement(sat_ref, "edge", {"edge_ref": edge_ref})
 
     return segments
 

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ada.api.transforms import Placement
-
 from ...sat.write.writer import SatWriter
 
 if TYPE_CHECKING:
@@ -44,7 +42,11 @@ def add_plate_sat(plate: Plate, thck_name: str, structures_elem, sw: SatWriter):
     geometry = ET.SubElement(flat_plate, "geometry")
     sheet = ET.SubElement(geometry, "sheet")
     sat_reference = ET.SubElement(sheet, "sat_reference")
-    ET.SubElement(sat_reference, "face", {"face_ref": sw.face_map.get(plate.guid)})
+    # A plate resolves to several faces once the imprint pass splits it at the
+    # T-junctions with its neighbours, so every name in the map gets an element
+    # (a densely stiffened panel reaches ten).
+    for face_ref in sw.face_map.get(plate.guid, []):
+        ET.SubElement(sat_reference, "face", {"face_ref": face_ref})
 
 
 def add_plate_polygon_data(
@@ -106,15 +108,8 @@ def add_plate_curved_polygon(plate, thck_name: str, structures_elem: ET.Element)
 
 
 def add_plate_polygon(plate: Plate, thck_name: str, structures_elem: ET.Element):
-    abs_place = plate.placement.get_absolute_placement(include_rotations=True)
-    ident = Placement()  # identity place
-    outline_global = [
-        abs_place.transform_array_from_other_place(np.asarray([pt], dtype=float), ident, ignore_translation=False)[0]
-        for pt in plate.poly.points3d
-    ]
-    add_plate_polygon_data(
-        plate.name, outline_global, plate.poly.normal, thck_name, plate.material.name, structures_elem
-    )
+    outline_global, normal = plate.outline_global()
+    add_plate_polygon_data(plate.name, outline_global, normal, thck_name, plate.material.name, structures_elem)
 
 
 def add_plates(structure_domain: ET.Element, part: Part, sw: SatWriter):

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -77,13 +77,38 @@ def add_plate_polygon_data(
         ET.SubElement(polygon, "position", {"x": str(pt[0]), "y": str(pt[1]), "z": str(pt[2])})
 
 
+def add_curved_shell_sat(plate, thck_name: str, structures_elem: ET.Element, face_refs: list[str]):
+    """Emit a :class:`PlateCurved` as a ``<curved_shell>`` naming its SAT face.
+
+    The element Genie itself writes for a curved plate, and the only form that
+    carries the B-spline patch rather than an outline: the geometry lives in
+    the SAT blob and the XML just points at the face by name. Shaped after a
+    Genie-authored hull export, whose curved shells carry exactly this."""
+    structure = ET.SubElement(structures_elem, "structure")
+    curved_shell = ET.SubElement(
+        structure, "curved_shell", {"name": plate.name, "thickness_ref": thck_name, "material_ref": plate.material.name}
+    )
+    ET.SubElement(curved_shell, "segmentation")
+    ET.SubElement(curved_shell, "front")
+    ET.SubElement(curved_shell, "back")
+    local_sys = ET.SubElement(curved_shell, "local_system")
+    # A curved shell has no single normal to hand a <vector>; Genie orients it
+    # with a sense flag against the face's own surface normal instead.
+    ET.SubElement(local_sys, "sense_flag", {"sense": "true"})
+    geometry = ET.SubElement(curved_shell, "geometry")
+    sheet = ET.SubElement(geometry, "sheet")
+    sat_reference = ET.SubElement(sheet, "sat_reference")
+    for face_ref in face_refs:
+        ET.SubElement(sat_reference, "face", {"face_ref": face_ref})
+
+
 def add_plate_curved_polygon(plate, thck_name: str, structures_elem: ET.Element) -> bool:
     """Emit a :class:`PlateCurved` as a ``<flat_plate>`` boundary polygon.
 
-    Genie XML has no curved-plate element short of embedding the B-spline face
-    in a SAT blob, which the SAT writer can't author yet — so the curved face
-    degrades to its boundary polygon (position/extent-faithful, curvature
-    lost). Uses the reader-attached flat-fallback points when present (the SAT
+    The fallback for a curved face the SAT writer cannot author (see
+    :func:`add_curved_shell_sat` for the real path): the face degrades to its
+    boundary polygon, position- and extent-faithful with the curvature lost.
+    Uses the reader-attached flat-fallback points when present (the SAT
     loop-edge endpoints), else the face's boundary nodes. Returns False when no
     usable boundary can be derived, so the caller can log the drop."""
     pts = getattr(plate, "_flat_fallback_pts", None)
@@ -138,13 +163,15 @@ def add_plates(structure_domain: ET.Element, part: Part, sw: SatWriter):
     from ada.config import logger
 
     for plate in part.get_all_physical_objects(by_type=PlateCurved):
-        # Curved plates can't go through the SAT writer (no spline-face
-        # authoring) — degrade to the boundary polygon rather than silently
-        # dropping the plate (see add_plate_curved_polygon).
         if plate.t not in thickness:
             thickness[plate.t] = thickness_name(plate.t)
             tck_elem = ET.Element("thickness", {"name": thickness[plate.t], "default": "true"})
             tck_elem.append(ET.Element("constant_thickness", {"th": str(plate.t)}))
             thickness_elem.append(tck_elem)
-        if not add_plate_curved_polygon(plate, thickness[plate.t], structures_elem):
+
+        face_refs = sw.face_map.get(plate.guid, []) if sw is not None else []
+        if face_refs:
+            add_curved_shell_sat(plate, thickness[plate.t], structures_elem, face_refs)
+        elif not add_plate_curved_polygon(plate, thickness[plate.t], structures_elem):
+            # No SAT face and no usable boundary — nothing left to emit.
             logger.warning(f"gxml-write: PlateCurved {plate.name!r} has no usable boundary; dropped")

--- a/src/ada/cadit/gxml/write/write_plates.py
+++ b/src/ada/cadit/gxml/write/write_plates.py
@@ -93,8 +93,11 @@ def add_curved_shell_sat(plate, thck_name: str, structures_elem: ET.Element, fac
     ET.SubElement(curved_shell, "back")
     local_sys = ET.SubElement(curved_shell, "local_system")
     # A curved shell has no single normal to hand a <vector>; Genie orients it
-    # with a sense flag against the face's own surface normal instead.
-    ET.SubElement(local_sys, "sense_flag", {"sense": "true"})
+    # with a sense flag against the face's own surface normal instead. It is
+    # authored data — mostly false (4413 of 4746 in a hull export), so hardcoding
+    # true here drew all but a handful of the plates inside-out.
+    sense = plate.metadata.get("props", {}).get("gxml_sense_flag", True)
+    ET.SubElement(local_sys, "sense_flag", {"sense": "true" if sense else "false"})
     geometry = ET.SubElement(curved_shell, "geometry")
     sheet = ET.SubElement(geometry, "sheet")
     sat_reference = ET.SubElement(sheet, "sat_reference")

--- a/src/ada/cadit/gxml/write/write_sat_embedded.py
+++ b/src/ada/cadit/gxml/write/write_sat_embedded.py
@@ -1,26 +1,68 @@
+"""Embed an ACIS SAT body into a Genie XML as a zipped, base64 CDATA sequence.
+
+Genie stores the SAT under ``structure_domain/geometry`` as a
+``sat_embedded_sequence``: the body is zipped into a single ``b64temp.sat``
+member, the *compressed* bytes are cut into fixed-size segments, and each
+segment is base64-encoded on its own and wrapped in CDATA. Verified against a
+Genie-authored export, whose four segments decode to 1 MiB, 1 MiB, 1 MiB and a
+remainder.
+
+The text is spliced in as raw CDATA after the tree is serialised, because
+ElementTree has no CDATA node — assigning the base64 to ``.text`` would let it
+escape the payload instead.
+"""
+
 from __future__ import annotations
 
+import base64
 import xml.etree.ElementTree as ET
+import zipfile
+from io import BytesIO
+
+# Genie cuts the zipped body at exactly 1 MiB per segment.
+SEGMENT_BYTES = 1024 * 1024
+
+# The single member name inside the zip; the reader looks it up by this name
+# (see ada.cadit.gxml.sat_helpers.xml_elem_to_sat_text).
+ZIP_MEMBER = "b64temp.sat"
+
+_PLACEHOLDER = "__ADA_CDATA_SEGMENT_{}__"
 
 
-def embed_sat_geometry(root: ET.Element) -> None:
+def sat_to_base64_segments(sat_body: str) -> list[str]:
+    """Zip ``sat_body`` and return its base64 segments, in order.
+
+    Each segment encodes its own slice of the compressed stream, so a reader
+    concatenates the *decoded* bytes and unzips the result — it must not
+    concatenate the base64 text (every segment is padded independently).
+    """
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(ZIP_MEMBER, sat_body.encode("utf-8"))
+    compressed = buf.getvalue()
+
+    return [
+        base64.b64encode(compressed[i : i + SEGMENT_BYTES]).decode() for i in range(0, len(compressed), SEGMENT_BYTES)
+    ]
+
+
+def embed_sat_geometry(root: ET.Element, n_segments: int) -> None:
+    """Add ``<geometry><sat_embedded_sequence>`` with a placeholder per segment.
+
+    Call last: Genie writes ``geometry`` as the final child of
+    ``structure_domain``, after ``sets``.
+    """
     geom = ET.SubElement(root, "geometry")
-    sat_embedded = ET.SubElement(geom, "sat_embedded", dict(encoding="base64", compression="zip", tag_name="dnvscp"))
+    seq = ET.SubElement(geom, "sat_embedded_sequence", dict(encoding="base64", compression="zip", tag_name="dnvscp"))
+    for i in range(n_segments):
+        ET.SubElement(seq, "cdata_segment").text = _PLACEHOLDER.format(i)
 
-    # Temporary placeholder text for CDATA
-    sat_embedded.text = "__CDATA_PLACEHOLDER__"
 
-
-def create_sesam_sat_bytes(sat_body_str: str) -> bytes:
-    from datetime import datetime
-
-    date = datetime.now()
-    date_string = date.strftime("%d %a %b %d %H:%M:%S %Y")
-
-    header = f"""2000 0 1 0
-18 SESAM - gmGeometry 14 ACIS 30.0.1 NT {date_string}
-1000 9.9999999999999995e-07 1e-10\n"""
-
-    footer = "End-of-ACIS-data "
-
-    return bytes(header + sat_body_str + footer, encoding="utf8")
+def splice_cdata_segments(xml_str: str, segments: list[str]) -> str:
+    """Replace each placeholder with its real CDATA payload."""
+    for i, segment in enumerate(segments):
+        placeholder = _PLACEHOLDER.format(i)
+        if placeholder not in xml_str:
+            raise ValueError(f"CDATA placeholder {placeholder!r} missing from the serialised XML")
+        xml_str = xml_str.replace(placeholder, f"<![CDATA[{segment}]]>")
+    return xml_str

--- a/src/ada/cadit/gxml/write/write_sat_embedded.py
+++ b/src/ada/cadit/gxml/write/write_sat_embedded.py
@@ -26,6 +26,13 @@ SEGMENT_BYTES = 1024 * 1024
 # (see ada.cadit.gxml.sat_helpers.xml_elem_to_sat_text).
 ZIP_MEMBER = "b64temp.sat"
 
+# Stamp the member with the DOS epoch rather than the wall clock. zipfile
+# defaults to localtime(), which would make the same model write different bytes
+# from one run to the next — and, since DOS timestamps have two-second
+# resolution, would leave the output *intermittently* reproducible, which is
+# worse than never. Genie only reads the member's contents.
+ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+
 _PLACEHOLDER = "__ADA_CDATA_SEGMENT_{}__"
 
 
@@ -35,10 +42,15 @@ def sat_to_base64_segments(sat_body: str) -> list[str]:
     Each segment encodes its own slice of the compressed stream, so a reader
     concatenates the *decoded* bytes and unzips the result — it must not
     concatenate the base64 text (every segment is padded independently).
+
+    Byte-reproducible: the same body always gives the same segments.
     """
+    member = zipfile.ZipInfo(ZIP_MEMBER, date_time=ZIP_EPOCH)
+    member.compress_type = zipfile.ZIP_DEFLATED
+
     buf = BytesIO()
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zipf:
-        zipf.writestr(ZIP_MEMBER, sat_body.encode("utf-8"))
+        zipf.writestr(member, sat_body.encode("utf-8"))
     compressed = buf.getvalue()
 
     return [

--- a/src/ada/cadit/gxml/write/write_xml.py
+++ b/src/ada/cadit/gxml/write/write_xml.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import base64
 import pathlib
 import xml.etree.ElementTree as ET
-import zipfile
-from io import BytesIO
 from typing import TYPE_CHECKING, Callable
 
 from ...sat.write.writer import part_to_sat_writer
@@ -16,7 +13,11 @@ from .write_load_case import add_loads
 from .write_masses import add_masses
 from .write_materials import add_materials
 from .write_plates import add_plates
-from .write_sat_embedded import embed_sat_geometry
+from .write_sat_embedded import (
+    embed_sat_geometry,
+    sat_to_base64_segments,
+    splice_cdata_segments,
+)
 from .write_sections import add_sections
 from .write_sets import add_sets
 
@@ -46,11 +47,9 @@ def write_xml(part: Part, xml_file, embed_sat=False, writer_postprocessor: Calla
     add_materials(properties, part)
     add_hinges(properties, part)
 
-    # Add SAT geometry (maybe only applicable for plate geometry)
-    sw = None
-    if embed_sat:
-        sw = part_to_sat_writer(part)
-        embed_sat_geometry(structure_domain)
+    # Build the ACIS body up front: add_plates needs its plate -> FACE name map
+    # to emit each <sheet>'s <sat_reference>.
+    sw = part_to_sat_writer(part) if embed_sat else None
 
     # Add structural elements
     add_beams(structures_elem, part, sw)
@@ -69,23 +68,16 @@ def write_xml(part: Part, xml_file, embed_sat=False, writer_postprocessor: Calla
         writer_postprocessor(root, part)
 
     xml_file.parent.mkdir(exist_ok=True, parents=True)
-    if embed_sat:
-        # Compress the SAT data
-        sat_bytes = bytes(sw.to_str(), encoding="utf-8")
-        compressed_io = BytesIO()
-        with zipfile.ZipFile(compressed_io, mode="w", compression=zipfile.ZIP_DEFLATED) as zipf:
-            zipf.writestr("b64temp.sat", sat_bytes)
-        compressed_data = compressed_io.getvalue()
-
-        # Encode the compressed data in base64
-        encoded_data = base64.b64encode(compressed_data).decode()
-        xml_str = ET.tostring(tree.getroot(), encoding="unicode")
-        cdata_section = f"<![CDATA[{encoded_data}]]>"
-        xml_str = xml_str.replace("__CDATA_PLACEHOLDER__", cdata_section)
-
-        # Write the modified XML string to the file
-        with open(xml_file, "w", encoding="utf-8") as file:
-            file.write(xml_str)
-    else:
-        # Write the modified XML back to the file
+    # A model with no plates has no ACIS body, so there is nothing to embed.
+    if not embed_sat or sw.is_empty:
         tree.write(str(xml_file), encoding="utf-8")
+        return
+
+    # <geometry> goes last, after <sets>, matching Genie's own export.
+    segments = sat_to_base64_segments(sw.to_str())
+    embed_sat_geometry(structure_domain, len(segments))
+
+    xml_str = ET.tostring(tree.getroot(), encoding="unicode")
+    xml_str = splice_cdata_segments(xml_str, segments)
+    with open(xml_file, "w", encoding="utf-8") as file:
+        file.write(xml_str)

--- a/src/ada/cadit/ifc/write/geom/surfaces.py
+++ b/src/ada/cadit/ifc/write/geom/surfaces.py
@@ -231,6 +231,12 @@ def advanced_face(af: geo_su.AdvancedFace, f: ifcopenshell.file) -> ifcopenshell
     """Converts an AdvancedFace to an IFC representation"""
     if type(af.face_surface) in (geo_su.BSplineSurfaceWithKnots, geo_su.RationalBSplineSurfaceWithKnots):
         face_surface = bspline_surface_with_knots(af.face_surface, f)
+    elif isinstance(af.face_surface, geo_su.Plane):
+        # An advanced face can be flat: a plate cut with a curved edge has a
+        # plane surface and b-spline bounds. The surface being simple says
+        # nothing about the boundary, which is why the face is an AdvancedFace
+        # at all rather than a polygon.
+        face_surface = create_plane(af.face_surface, f)
     else:
         raise NotImplementedError(f"Unsupported face surface type: {type(af.face_surface)}")
 

--- a/src/ada/cadit/sat/exceptions.py
+++ b/src/ada/cadit/sat/exceptions.py
@@ -19,3 +19,13 @@ class ACISIncompleteCtrlPoints(Exception):
 
 class ACISUnsupportedCurveType(Exception):
     pass
+
+
+class ACISDegenerateEdge(Exception):
+    """An edge with no curve — ACIS marking a singularity, not a boundary.
+
+    Its two vertices are the same point and its box is that point, so it
+    contributes nothing to the face's boundary: where a spline patch collapses
+    to a point, the loop runs into the singularity and back out, and this is
+    the step between. A hull export carries 48, on 38 of its 5470 faces.
+    """

--- a/src/ada/cadit/sat/read/advanced_face.py
+++ b/src/ada/cadit/sat/read/advanced_face.py
@@ -124,9 +124,33 @@ def create_planar_face_from_sat(face_record: AcisRecord) -> geo_su.ClosedShell:
     return geo_su.ClosedShell([geo_su.FaceSurface(bounds, face_surface, same_sense=True)])
 
 
+def get_face_same_sense(face_record: AcisRecord) -> bool:
+    """Does the face's normal agree with its surface's natural one?
+
+    ACIS splits this across two records: the ``face`` carries a
+    forward/reversed sense, and a ``spline-surface`` carries one of its own,
+    so the face normal is the composition of the two. IFC's ``SameSense`` is
+    that composition, which is what the OCC builder and the IFC/STEP writers
+    already consume.
+
+    This used to be hardcoded True, which is a claim rather than a reading: a
+    Genie export writes ``reversed`` on 1248 of 4532 spline surfaces and on 112
+    plane faces, and every one of those came back with its normal flipped.
+    """
+    face_sense = face_record.chunks[11] if len(face_record.chunks) > 11 else "forward"
+    surface_record = face_record.sat_store.get(face_record.chunks[10])
+    # A plane-surface has no sense of its own (its normal is a vector it
+    # states outright); only a spline-surface carries one.
+    surface_sense = "forward"
+    if surface_record.type == "spline-surface" and len(surface_record.chunks) > 6:
+        if surface_record.chunks[6] in ("forward", "reversed"):
+            surface_sense = surface_record.chunks[6]
+    return (face_sense == "forward") == (surface_sense == "forward")
+
+
 def create_advanced_face_from_sat(face_record: AcisRecord) -> geo_su.AdvancedFace:
     """Creates an AdvancedFace from the SAT object data."""
-    same_sense = True
+    same_sense = get_face_same_sense(face_record)
     bounds = get_face_bound(face_record)
 
     face_surface = get_face_surface(face_record)

--- a/src/ada/cadit/sat/read/bsplinecurves.py
+++ b/src/ada/cadit/sat/read/bsplinecurves.py
@@ -478,13 +478,16 @@ def create_pcurve_2d_from_sat_record(pcurve_record: AcisRecord) -> geo_cu.Pcurve
     # 2D control points — collect 2-or-3-float rows up to expected count.
     cps: list[list[float]] = []
     weights: list[float] | None = []
+    after_cps = len(data_lines)
     for i in range(knot_end_idx, len(data_lines)):
         if len(cps) >= expected_n_poles:
+            after_cps = i
             break
         toks = data_lines[i].split()
         try:
             row = [float(t) for t in toks]
         except ValueError:
+            after_cps = i
             break
         if len(row) == 2:
             cps.append(row)
@@ -494,6 +497,7 @@ def create_pcurve_2d_from_sat_record(pcurve_record: AcisRecord) -> geo_cu.Pcurve
             if weights is not None:
                 weights.append(row[2])
         else:
+            after_cps = i
             break
     if len(cps) != expected_n_poles:
         logger.debug(
@@ -505,6 +509,19 @@ def create_pcurve_2d_from_sat_record(pcurve_record: AcisRecord) -> geo_cu.Pcurve
         )
         return None
 
+    # The lone real after the control points is the fit tolerance — how far the
+    # pcurve may sit from the true curve-on-surface (SAT v4.0 ch.5). Keep it:
+    # dropping it and writing 0 back out would assert an exactness the author
+    # never claimed. Genie writes 0.001 on roughly a quarter of its pcurves.
+    fit_tolerance = 0.0
+    if after_cps < len(data_lines):
+        toks = data_lines[after_cps].split()
+        if len(toks) == 1:
+            try:
+                fit_tolerance = float(toks[0])
+            except ValueError:
+                pass
+
     return geo_cu.Pcurve2dBSpline(
         degree=degree,
         control_points_2d=cps,
@@ -512,6 +529,7 @@ def create_pcurve_2d_from_sat_record(pcurve_record: AcisRecord) -> geo_cu.Pcurve
         knot_multiplicities=mults,
         weights=weights if (rational and weights) else None,
         closed=closed,
+        fit_tolerance=fit_tolerance,
     )
 
 

--- a/src/ada/cadit/sat/read/curves.py
+++ b/src/ada/cadit/sat/read/curves.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import Iterable
 
 from ada import Direction, Point
-from ada.cadit.sat.exceptions import ACISReferenceDataError, ACISUnsupportedCurveType
+from ada.cadit.sat.exceptions import (
+    ACISDegenerateEdge,
+    ACISReferenceDataError,
+    ACISUnsupportedCurveType,
+)
 from ada.cadit.sat.read.bsplinecurves import (
     create_bspline_curve_from_sat,
     create_pcurve_2d_from_sat_record,
@@ -118,7 +122,17 @@ def get_edge(coedge: AcisRecord) -> geo_cu.OrientedEdge:
     point_idx = 7
 
     edge = sat_store.get(coedge.chunks[edge_idx])
-    curve_record = sat_store.get(edge.chunks[curve_idx])
+    # An edge naming no curve is a degenerate one: ACIS marks a singularity on
+    # the surface that way, and its two vertices are the same point. Reading its
+    # `.type` was an AttributeError on None, which took the whole face down to a
+    # flat polygon (9 faces of a hull export). It bounds nothing, so the caller
+    # steps over it and the loop still closes.
+    curve_chunk = edge.chunks[curve_idx]
+    if not curve_chunk or curve_chunk == "$-1":
+        raise ACISDegenerateEdge(f"edge {edge.chunks[0]} names no curve")
+    curve_record = sat_store.get(curve_chunk)
+    if curve_record is None:
+        raise ACISDegenerateEdge(f"edge {edge.chunks[0]} names a curve that is not in the file")
     edge_direction = edge.chunks[12]
     coedge_direction = coedge.chunks[coedge_sense_idx]
     coedge_dir_bool = coedge_direction == "forward"
@@ -255,8 +269,23 @@ def get_edge(coedge: AcisRecord) -> geo_cu.OrientedEdge:
 
 
 def iter_loop_coedges(loop_record: AcisRecord) -> Iterable[geo_cu.OrientedEdge]:
-    """Iterates over the edges of the face."""
+    """Iterates over the edges of the face.
+
+    A degenerate coedge is stepped over rather than allowed to take the face
+    down with it: it stands for a point where the surface collapses, bounds
+    nothing, and the loop closes without it (the edge before it ends where the
+    edge after it starts). Skipping keeps the face's real geometry, where the
+    AttributeError it used to raise dropped the whole face to a flat polygon.
+    """
     sat_store = loop_record.sat_store
+
+    def _edge_or_none(coedge_record):
+        try:
+            return get_edge(coedge_record)
+        except ACISDegenerateEdge as ex:
+            logger.debug("skipping degenerate coedge %s: %s", coedge_record.chunks[0], ex)
+            return None
+
     # Coedge indices
     coedge_ref = 7
     coedge_start_id = loop_record.chunks[coedge_ref]
@@ -264,7 +293,9 @@ def iter_loop_coedges(loop_record: AcisRecord) -> Iterable[geo_cu.OrientedEdge]:
     next_coedge_idx = 6  # if coedge_first_direction == "forward" else 7
     coedge_next_id = coedge_first.chunks[next_coedge_idx]
 
-    yield get_edge(coedge_first)
+    edge = _edge_or_none(coedge_first)
+    if edge is not None:
+        yield edge
 
     max_iter = 100
     i = 0
@@ -272,7 +303,9 @@ def iter_loop_coedges(loop_record: AcisRecord) -> Iterable[geo_cu.OrientedEdge]:
     while next_coedge is True:
         coedge = sat_store.get(coedge_next_id)
 
-        yield get_edge(coedge)
+        edge = _edge_or_none(coedge)
+        if edge is not None:
+            yield edge
 
         coedge_next_id = coedge.chunks[next_coedge_idx]
         if coedge_next_id == coedge_start_id:

--- a/src/ada/cadit/sat/read/curves.py
+++ b/src/ada/cadit/sat/read/curves.py
@@ -44,6 +44,10 @@ def _reverse_pcurve_2d(pc: geo_cu.Pcurve2dBSpline) -> geo_cu.Pcurve2dBSpline:
         closed=pc.closed,
         # reversing changes the direction, not how well the curve fits
         fit_tolerance=pc.fit_tolerance,
+        # ...but the direction is exactly what the sense records, so it flips.
+        # Only the non-default ADA_PCURVE_REVERSE modes get here; "never" (the
+        # validated one) leaves the authored sense alone.
+        same_sense=not pc.same_sense,
     )
 
 
@@ -206,6 +210,12 @@ def get_edge(coedge: AcisRecord) -> geo_cu.OrientedEdge:
                             occ_edge_along_intcurve = edge_direction == coedge_direction
                             pcurve_along_intcurve = pcurve_sense == "forward"
                             do_reverse = occ_edge_along_intcurve != pcurve_along_intcurve
+                        # Keep the authored sense whatever the mode does to the
+                        # control points: it is not derivable from them (in a
+                        # Genie export it splits 13722/5184 with no correlation
+                        # to the knots or to the coedge), and the SAT writer
+                        # needs it to reproduce a face ACIS will accept.
+                        pcurve_geom.same_sense = pcurve_sense == "forward"
                         if do_reverse:
                             pcurve_geom = _reverse_pcurve_2d(pcurve_geom)
                 except Exception as ex:

--- a/src/ada/cadit/sat/read/curves.py
+++ b/src/ada/cadit/sat/read/curves.py
@@ -42,6 +42,8 @@ def _reverse_pcurve_2d(pc: geo_cu.Pcurve2dBSpline) -> geo_cu.Pcurve2dBSpline:
         knot_multiplicities=new_mults,
         weights=new_weights,
         closed=pc.closed,
+        # reversing changes the direction, not how well the curve fits
+        fit_tolerance=pc.fit_tolerance,
     )
 
 

--- a/src/ada/cadit/sat/store.py
+++ b/src/ada/cadit/sat/store.py
@@ -219,6 +219,37 @@ class SatReaderFactory:
             if sat_record.type == "face":
                 yield sat_record
 
+    def face_has_curved_edge(self, face_record: AcisRecord) -> bool:
+        """Does any of the face's edges run on something other than a line?
+
+        A planar face is only a polygon if its edges are straight. A flat plate
+        bounded by a b-spline or an arc cannot be carried by ``ada.Plate``, whose
+        outline is a point list — the edge would survive as a polyline, which
+        silently changes the plate's area and stops it sharing an edge with the
+        curved neighbour it was cut against.
+
+        Walks loop -> coedge ring -> edge -> curve. Chunk indices are the record
+        body offset by the leading id and type tokens.
+        """
+        loop = self.sat_store.get(face_record.chunks[7])
+        seen_loops = set()
+        while loop is not None and loop.type == "loop" and id(loop) not in seen_loops:
+            seen_loops.add(id(loop))
+            first = self.sat_store.get(loop.chunks[7])
+            coedge, seen = first, set()
+            while coedge is not None and coedge.type == "coedge" and id(coedge) not in seen:
+                seen.add(id(coedge))
+                edge = self.sat_store.get(coedge.chunks[9])
+                if edge is not None and edge.type == "edge":
+                    curve = self.sat_store.get(edge.chunks[11])
+                    if curve is not None and curve.type != "straight-curve":
+                        return True
+                coedge = self.sat_store.get(coedge.chunks[6])
+                if coedge is first:
+                    break
+            loop = self.sat_store.get(loop.chunks[6])
+        return False
+
     def iter_flat_plates(self) -> Iterable[tuple[str, list[tuple[float, float, float]]]]:
         for face_record in self.iter_faces():
             # face_surface = self.sat_store.get(face_record.chunks[10])
@@ -286,7 +317,15 @@ class SatReaderFactory:
         try:
             for face_record in self.iter_faces():
                 face_surface = self.sat_store.get(face_record.chunks[10])
-                if face_surface.type != "spline-surface":
+                if face_surface.type == "plane-surface":
+                    # A flat face is not necessarily a polygon. Take it as an
+                    # advanced face when any edge is curved, so the boundary
+                    # survives as the curves it is; leave a genuinely
+                    # straight-edged one to the flat path, where ada.Plate
+                    # represents it exactly and more cheaply.
+                    if not self.face_has_curved_edge(face_record):
+                        continue
+                elif face_surface.type != "spline-surface":
                     continue
                 attempted += 1
                 try:

--- a/src/ada/cadit/sat/write/from_imprint.py
+++ b/src/ada/cadit/sat/write/from_imprint.py
@@ -73,6 +73,12 @@ def imprint_to_sat_entities(
     coedges_on_edge: dict[int, list[tuple[se.CoEdge, np.ndarray, bool]]] = {}
     faces: list[se.Face] = []
 
+    # What each edge is bounded by — the loops and wires owning its coedges,
+    # by entity id (not id(), whose ordering would vary between runs). Two edges
+    # at a vertex are in the same manifold region when something owns both; see
+    # the VertEdgeAttribute pass at the end.
+    owners_of_edge: dict[int, set[int]] = {}
+
     # Which input plate each face came from. All the faces a plate was split
     # into lie on that plate's single plane, and Genie has them share one
     # plane-surface and carry one cached-plane attribute between them — exactly
@@ -137,6 +143,7 @@ def imprint_to_sat_entities(
                 if edge.coedge is None:
                     edge.coedge = coedge
                 coedges_on_edge.setdefault(edge_idx, []).append((coedge, np.asarray(f.normal, dtype=float), forward))
+                owners_of_edge.setdefault(edge_idx, set()).add(loop.id)
                 ring.append(coedge)
             entities += ring
 
@@ -174,6 +181,7 @@ def imprint_to_sat_entities(
             edge = edges[edge_idx]
             coedge = se.CoEdge(id_gen.next_id(), None, None, edge, wire, "forward")
             coedge_of_edge[edge_idx] = coedge
+            owners_of_edge.setdefault(edge_idx, set()).add(wire.id)
             if edge.coedge is None:
                 edge.coedge = coedge
 
@@ -241,11 +249,85 @@ def imprint_to_sat_entities(
     live_points = [v.point for v in live_vertices]
     live_curves = [e.straight_curve for e in live_edges]
 
+    attribs = _declare_nonmanifold_vertices(imprint, sw, vertices, edges, owners_of_edge, live_edges)
+
     # points/vertices/edges lead so their ids stay below the faces referencing
     # them; SatWriter.renumber reorders anyway, this only keeps output tidy.
     # `edges` stays index-aligned with imprint.edges (pruned entries included) so
     # curve_sources still resolves; only live ones are emitted.
-    return live_points + live_vertices + live_edges + live_curves + entities, faces, edges
+    return live_points + live_vertices + live_edges + live_curves + entities + attribs, faces, edges
+
+
+def _declare_nonmanifold_vertices(
+    imprint: PlanarImprint,
+    sw: SatWriter,
+    vertices: list[se.Vertex],
+    edges: list[se.Edge],
+    owners_of_edge: dict[int, set[int]],
+    live_edges: list[se.Edge],
+) -> list[se.SATEntity]:
+    """Give every vertex whose edges fall into several regions a VertEdgeAttribute.
+
+    A vertex normally just names one of its edges, and everything else there is
+    reachable from it. That breaks where a beam's axis leaves the plate it lies
+    on: the vertex on the plate boundary carries the plate's face edges AND the
+    wire edge for the free run, and no loop or wire owns both, so from either
+    one the other is unreachable — "vertex has edge in multiple groups".
+
+    Two edges are in the same region when something (a loop, or a wire) owns
+    both. Where that leaves more than one region, the vertex names no edge at
+    all and the attribute names one per region instead. Checked against Genie's
+    own export: this picks out exactly the vertices it attributes, no more.
+    """
+    live = {id(e) for e in live_edges}
+    edges_at_vertex: dict[int, list[int]] = {}
+    for edge_idx, edge in enumerate(edges):
+        if id(edge) not in live:
+            continue
+        e = imprint.edges[edge_idx]
+        for v in (e.start, e.end):
+            edges_at_vertex.setdefault(v, []).append(edge_idx)
+
+    attribs: list[se.SATEntity] = []
+    for vertex_idx, edge_idxs in edges_at_vertex.items():
+        regions = _regions_at(edge_idxs, owners_of_edge)
+        if len(regions) < 2:
+            continue
+        vertex = vertices[vertex_idx]
+        # one edge per region, lowest index first — the spec asks only for "an
+        # edge in each separable manifold region", so any member would do
+        reps = [edges[min(region)] for region in regions]
+        attrib = se.VertEdgeAttribute(sw.id_generator.next_id(), vertex, reps)
+        vertex.attrib = attrib
+        vertex.edge = None
+        attribs.append(attrib)
+    return attribs
+
+
+def _regions_at(edge_idxs: list[int], owners_of_edge: dict[int, set[int]]) -> list[list[int]]:
+    """Group a vertex's edges by what bounds them, ordered by lowest index."""
+    parent = {e: e for e in edge_idxs}
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    first_for_owner: dict[int, int] = {}
+    for edge_idx in edge_idxs:
+        for owner in sorted(owners_of_edge.get(edge_idx, ())):
+            if owner in first_for_owner:
+                ra, rb = find(first_for_owner[owner]), find(edge_idx)
+                if ra != rb:
+                    parent[ra] = rb
+            else:
+                first_for_owner[owner] = edge_idx
+
+    grouped: dict[int, list[int]] = {}
+    for edge_idx in edge_idxs:
+        grouped.setdefault(find(edge_idx), []).append(edge_idx)
+    return sorted(grouped.values(), key=min)
 
 
 def _loop_bbox(imprint: PlanarImprint, loop_edges) -> list[float]:

--- a/src/ada/cadit/sat/write/from_imprint.py
+++ b/src/ada/cadit/sat/write/from_imprint.py
@@ -67,9 +67,10 @@ def imprint_to_sat_entities(
         curves.append(curve)
 
     # --- faces, loops, coedges ----------------------------------------------
-    # Every coedge lying on a given edge, in creation order, so the partner
-    # rings can be closed once all faces are built.
-    coedges_on_edge: dict[int, list[se.CoEdge]] = {}
+    # Every coedge lying on a given edge, with the face normal and traversal
+    # direction its radial position about that edge is derived from, so the
+    # partner rings can be ordered once all the faces are built.
+    coedges_on_edge: dict[int, list[tuple[se.CoEdge, np.ndarray, bool]]] = {}
     faces: list[se.Face] = []
 
     # Which input plate each face came from. All the faces a plate was split
@@ -135,7 +136,7 @@ def imprint_to_sat_entities(
                 )
                 if edge.coedge is None:
                     edge.coedge = coedge
-                coedges_on_edge.setdefault(edge_idx, []).append(coedge)
+                coedges_on_edge.setdefault(edge_idx, []).append((coedge, np.asarray(f.normal, dtype=float), forward))
                 ring.append(coedge)
             entities += ring
 
@@ -210,11 +211,18 @@ def imprint_to_sat_entities(
     # writes it; an edge shared by N faces links its N coedges into a cycle. A
     # T-junction genuinely produces N > 2 (a deck split by a bulkhead gives the
     # imprint line three coedges).
-    for coedge_list in coedges_on_edge.values():
+    #
+    # The cycle has to run in radial order about the edge, or the model fails
+    # verification with "coedges out of order about edge" — ACIS reads the ring
+    # as the faces' angular order, which is what tells it which faces are
+    # neighbours around a non-manifold edge. Creation order says nothing about
+    # angle; it only ever looks right for N=2, where any cycle is sorted.
+    for edge_idx, coedge_list in coedges_on_edge.items():
         if len(coedge_list) < 2:
             continue
-        for i, coedge in enumerate(coedge_list):
-            coedge.partner = coedge_list[(i + 1) % len(coedge_list)]
+        ordered = _ordered_about_edge(imprint, edge_idx, coedge_list)
+        for i, coedge in enumerate(ordered):
+            coedge.partner = ordered[(i + 1) % len(ordered)]
 
     # --- prune topology that bounds nothing ---------------------------------
     # General Fuse can leave an edge on a face that no wire traverses (an
@@ -248,6 +256,46 @@ def _loop_bbox(imprint: PlanarImprint, loop_edges) -> list[float]:
         idx.add(e.start)
         idx.add(e.end)
     return _bbox_of(imprint, idx)
+
+
+def _ordered_about_edge(imprint: PlanarImprint, edge_idx: int, entries) -> list[se.CoEdge]:
+    """The coedges on an edge, counter-clockwise about it — the order ACIS wants.
+
+    A coedge's face lies to the left of the direction the coedge traverses the
+    edge, so ``normal x tangent`` points from the edge into that face. It is
+    perpendicular to the edge, and its angle about the edge axis is where that
+    face sits radially. Sorting on it reproduces the order Genie writes (checked
+    against its own export: every ring there is counter-clockwise about the
+    edge's own direction).
+    """
+    e = imprint.edges[edge_idx]
+    p0 = np.asarray(imprint.vertices[e.start], dtype=float)
+    p1 = np.asarray(imprint.vertices[e.end], dtype=float)
+    axis = p1 - p0
+    length = float(np.linalg.norm(axis))
+    if length < 1e-12:  # nothing to sort about
+        return [coedge for coedge, _, _ in entries]
+    axis = axis / length
+
+    # any pair of axes perpendicular to the edge; (ref, ortho, axis) is
+    # right-handed, so the angle below increases counter-clockwise about it
+    seed = np.array([1.0, 0.0, 0.0]) if abs(axis[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    ref = np.cross(axis, seed)
+    ref = ref / np.linalg.norm(ref)
+    ortho = np.cross(axis, ref)
+
+    def angle(entry) -> float:
+        _, normal, forward = entry
+        into_face = np.cross(normal, axis if forward else -axis)
+        norm = float(np.linalg.norm(into_face))
+        if norm < 1e-12:  # face degenerate along the edge; leave it put
+            return 0.0
+        into_face = into_face / norm
+        return float(np.arctan2(into_face @ ortho, into_face @ ref))
+
+    # stable, so coincident faces keep their creation order rather than swapping
+    # between runs
+    return [coedge for coedge, _, _ in sorted(entries, key=angle)]
 
 
 def _connected_edge_groups(imprint: PlanarImprint, edge_idxs) -> list[list[int]]:

--- a/src/ada/cadit/sat/write/from_imprint.py
+++ b/src/ada/cadit/sat/write/from_imprint.py
@@ -1,0 +1,231 @@
+"""Emit ACIS SAT entities from an imprinted planar complex.
+
+The per-plate builder (:mod:`ada.cadit.sat.write.write_plate`) gives each plate
+its own vertices and edges, so plates that touch stay topologically strangers.
+Genie's own SAT is *imprinted*: a deck crossed by a bulkhead is split into
+several faces, neighbours share one edge, and the coedges lying on that edge are
+linked in a ring. Genie rebuilds all of that on import when it isn't supplied —
+which is what makes importing a polygon-only XML take so long.
+
+This module turns the backend-neutral :class:`~ada.cad.PlanarImprint` (see
+``CadBackend.imprint_planar_faces``) into that shared topology directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+import ada
+from ada.cadit.sat.utils import make_ints_if_possible
+from ada.cadit.sat.write import sat_entities as se
+
+if TYPE_CHECKING:
+    from ada.cad import PlanarImprint
+    from ada.cadit.sat.write.writer import SatWriter
+
+
+def imprint_to_sat_entities(
+    imprint: PlanarImprint, sw: SatWriter
+) -> tuple[list[se.SATEntity], list[se.Face], list[se.Edge]]:
+    """Build every face of ``imprint`` under the writer's shared body/lump/shell.
+
+    Returns ``(entities, faces, edges)``, index-aligned with ``imprint.faces`` and
+    ``imprint.edges`` — the caller needs that alignment to resolve
+    ``PlanarImprint.sources`` / ``curve_sources`` into FACE and EDGE names.
+    ``sw.shell`` must already exist; the caller chains the faces and names them
+    (see :func:`part_to_sat_writer`).
+    """
+    id_gen = sw.id_generator
+    entities: list[se.SATEntity] = []
+
+    # --- shared points + vertices -------------------------------------------
+    # One SatPoint/Vertex per imprint vertex: this is the sharing. `edge` is
+    # backfilled below, from a coedge-carrying edge.
+    points = [se.SatPoint(id_gen.next_id(), ada.Point(*v)) for v in imprint.vertices]
+    vertices = [se.Vertex(id_gen.next_id(), None, p) for p in points]
+
+    # --- shared edges + curves ----------------------------------------------
+    edges: list[se.Edge] = []
+    curves: list[se.StraightCurve] = []
+    for e in imprint.edges:
+        p0, p1 = points[e.start].point, points[e.end].point
+        direction = ada.Direction(*(np.asarray(p1, dtype=float) - np.asarray(p0, dtype=float)))
+        curve = se.StraightCurve(id_gen.next_id(), p0, direction)
+        edges.append(
+            se.Edge(
+                id_gen.next_id(),
+                vertices[e.start],
+                vertices[e.end],
+                None,  # a coedge on this edge, filled in by the face pass
+                curve,
+                start_pt=p0,
+                end_pt=p1,
+            )
+        )
+        curves.append(curve)
+
+    # --- faces, loops, coedges ----------------------------------------------
+    # Every coedge lying on a given edge, in creation order, so the partner
+    # rings can be closed once all faces are built.
+    coedges_on_edge: dict[int, list[se.CoEdge]] = {}
+    faces: list[se.Face] = []
+
+    # Which input plate each face came from. All the faces a plate was split
+    # into lie on that plate's single plane, and Genie has them share one
+    # plane-surface and carry one cached-plane attribute between them — exactly
+    # one of each per plate, however many faces it split into.
+    face_source: dict[int, int] = {}
+    for src_idx, face_idxs in enumerate(imprint.sources):
+        for fi in face_idxs:
+            face_source.setdefault(fi, src_idx)
+    surface_of_source: dict[int, se.PlaneSurface] = {}
+    cached_sources: set[int] = set()
+
+    for face_idx, f in enumerate(imprint.faces):
+        normal = ada.Direction(*f.normal)
+        xdir = ada.Direction(*f.ref_direction)
+        src = face_source.get(face_idx)
+
+        surface = surface_of_source.get(src) if src is not None else None
+        if surface is None:
+            surface = se.PlaneSurface(id_gen.next_id(), ada.Point(*f.origin), normal, xdir)
+            entities.append(surface)
+            if src is not None:
+                surface_of_source[src] = surface
+
+        # One cached-plane attribute per plate, on the first face of it we emit.
+        cached_plane = None
+        if src is None or src not in cached_sources:
+            cached_plane = se.CachedPlaneAttribute(id_gen.next_id(), None, None, ada.Point(*f.origin), normal)
+            cached_sources.add(src)
+
+        # face, name attrib and cached-plane attrib reference each other, so
+        # build them with the links empty and wire them up once all exist.
+        # Named later by part_to_sat_writer, once the plate -> face assignment is known.
+        name_attrib = se.StringAttribName(id_gen.next_id(), "", None, cached_plane)
+        face = se.Face(id_gen.next_id(), None, sw.shell, name_attrib, surface)
+        name_attrib.entity = face
+        entities += [face, name_attrib]
+        if cached_plane is not None:
+            cached_plane.entity = face
+            cached_plane.name = name_attrib
+            entities.append(cached_plane)
+        faces.append(face)
+
+        face_loops: list[se.Loop] = []
+        for loop_edges in f.loops:
+            if not loop_edges:
+                continue
+            loop = se.Loop(id_gen.next_id(), None, _loop_bbox(imprint, loop_edges), face=face)
+            entities.append(loop)
+            face_loops.append(loop)
+
+            ring: list[se.CoEdge] = []
+            for edge_idx, forward in loop_edges:
+                edge = edges[edge_idx]
+                coedge = se.CoEdge(
+                    id_gen.next_id(),
+                    None,
+                    None,
+                    edge,
+                    loop,
+                    "forward" if forward else "reversed",
+                )
+                if edge.coedge is None:
+                    edge.coedge = coedge
+                coedges_on_edge.setdefault(edge_idx, []).append(coedge)
+                ring.append(coedge)
+            entities += ring
+
+            loop.coedge = ring[0]
+            n = len(ring)
+            for i, coedge in enumerate(ring):
+                coedge.next_coedge = ring[(i + 1) % n]
+                coedge.prev_coedge = ring[i - 1]
+
+        if not face_loops:
+            raise ValueError(f"imprint face {face_idx} has no loops")
+        face.loop = face_loops[0]
+        # holes hang off the outer loop's next_loop chain
+        for cur, nxt in zip(face_loops, face_loops[1:]):
+            cur.next_loop = nxt
+
+    # --- wire bodies for the edges that bound no face -----------------------
+    # A beam whose axis lies on no plate leaves an edge with no face around it.
+    # ACIS carries those as wire bodies hung off the shell's wire pointer; left
+    # out, the beam has nothing to reference and Genie rebuilds its geometry.
+    wires: list[se.Wire] = []
+    for edge_idx in imprint.free_edges:
+        edge = edges[edge_idx]
+        wire = se.Wire(id_gen.next_id(), None, sw.shell, _edge_bbox(imprint, edge_idx))
+        coedge = se.CoEdge(id_gen.next_id(), None, None, edge, wire, "forward")
+        # A lone coedge is its own next and previous — the degenerate ring.
+        coedge.next_coedge = coedge
+        coedge.prev_coedge = coedge
+        wire.coedge = coedge
+        if edge.coedge is None:
+            edge.coedge = coedge
+        entities += [wire, coedge]
+        wires.append(wire)
+
+    if wires:
+        sw.shell.wire = wires[0]
+        for cur, nxt in zip(wires, wires[1:]):
+            cur.next_wire = nxt
+
+    # --- partner rings ------------------------------------------------------
+    # ACIS reaches every coedge on an edge by following `next coedge on edge`
+    # (SAT v4.0 ch.5) as a circular list. An edge used once keeps $-1, as Genie
+    # writes it; an edge shared by N faces links its N coedges into a cycle. A
+    # T-junction genuinely produces N > 2 (a deck split by a bulkhead gives the
+    # imprint line three coedges).
+    for coedge_list in coedges_on_edge.values():
+        if len(coedge_list) < 2:
+            continue
+        for i, coedge in enumerate(coedge_list):
+            coedge.partner = coedge_list[(i + 1) % len(coedge_list)]
+
+    # --- prune topology that bounds nothing ---------------------------------
+    # General Fuse can leave an edge on a face that no wire traverses (an
+    # internal or degenerate edge, which BRepTools_WireExplorer skips). Such an
+    # edge has no coedge, so it must not be emitted: ACIS requires an edge to
+    # name one. Its vertices/points go too unless a live edge also uses them.
+    live_edges = [e for e in edges if e.coedge is not None]
+    edge_of_vertex: dict[int, se.Edge] = {}
+    for edge in live_edges:
+        edge_of_vertex.setdefault(id(edge.vertex_start), edge)
+        edge_of_vertex.setdefault(id(edge.vertex_end), edge)
+
+    live_vertices = [v for v in vertices if id(v) in edge_of_vertex]
+    for vertex in live_vertices:
+        vertex.edge = edge_of_vertex[id(vertex)]
+    live_points = [v.point for v in live_vertices]
+    live_curves = [e.straight_curve for e in live_edges]
+
+    # points/vertices/edges lead so their ids stay below the faces referencing
+    # them; SatWriter.renumber reorders anyway, this only keeps output tidy.
+    # `edges` stays index-aligned with imprint.edges (pruned entries included) so
+    # curve_sources still resolves; only live ones are emitted.
+    return live_points + live_vertices + live_edges + live_curves + entities, faces, edges
+
+
+def _loop_bbox(imprint: PlanarImprint, loop_edges) -> list[float]:
+    """Axis-aligned box of the loop's vertices, as ACIS's `T <lo> <hi>` wants."""
+    idx = set()
+    for edge_idx, _ in loop_edges:
+        e = imprint.edges[edge_idx]
+        idx.add(e.start)
+        idx.add(e.end)
+    return _bbox_of(imprint, idx)
+
+
+def _edge_bbox(imprint: PlanarImprint, edge_idx: int) -> list[float]:
+    e = imprint.edges[edge_idx]
+    return _bbox_of(imprint, {e.start, e.end})
+
+
+def _bbox_of(imprint: PlanarImprint, vertex_idx) -> list[float]:
+    pts = np.asarray([imprint.vertices[i] for i in vertex_idx], dtype=float)
+    return make_ints_if_possible([*np.min(pts, axis=0), *np.max(pts, axis=0)])

--- a/src/ada/cadit/sat/write/from_imprint.py
+++ b/src/ada/cadit/sat/write/from_imprint.py
@@ -156,18 +156,47 @@ def imprint_to_sat_entities(
     # A beam whose axis lies on no plate leaves an edge with no face around it.
     # ACIS carries those as wire bodies hung off the shell's wire pointer; left
     # out, the beam has nothing to reference and Genie rebuilds its geometry.
+    #
+    # One wire per CONNECTED GROUP of such edges, not one per edge: every edge
+    # meeting at a vertex has to sit in the same wire. Split across wires, ACIS
+    # sees the vertex as joining several groups and the model fails verification
+    # with "vertex has edge in multiple groups" (a frame of beams meeting at a
+    # corner puts up to five wires on that corner). Genie groups them the same
+    # way — verified against its own export, one wire per connected group.
     wires: list[se.Wire] = []
-    for edge_idx in imprint.free_edges:
-        edge = edges[edge_idx]
-        wire = se.Wire(id_gen.next_id(), None, sw.shell, _edge_bbox(imprint, edge_idx))
-        coedge = se.CoEdge(id_gen.next_id(), None, None, edge, wire, "forward")
-        # A lone coedge is its own next and previous — the degenerate ring.
-        coedge.next_coedge = coedge
-        coedge.prev_coedge = coedge
-        wire.coedge = coedge
-        if edge.coedge is None:
-            edge.coedge = coedge
-        entities += [wire, coedge]
+    for group in _connected_edge_groups(imprint, imprint.free_edges):
+        vertex_idx = {v for edge_idx in group for v in (imprint.edges[edge_idx].start, imprint.edges[edge_idx].end)}
+        wire = se.Wire(id_gen.next_id(), None, sw.shell, _bbox_of(imprint, vertex_idx))
+
+        coedge_of_edge: dict[int, se.CoEdge] = {}
+        for edge_idx in group:
+            edge = edges[edge_idx]
+            coedge = se.CoEdge(id_gen.next_id(), None, None, edge, wire, "forward")
+            coedge_of_edge[edge_idx] = coedge
+            if edge.coedge is None:
+                edge.coedge = coedge
+
+        # A wire coedge's `next`/`prev` are not a linear list: `next` is the
+        # following coedge around this coedge's END vertex and `prev` the one
+        # around its START vertex, so a branched wire stays walkable. Each
+        # vertex's coedges therefore form one closed ring — with a single edge
+        # at a loose end, that ring is the coedge itself.
+        at_vertex: dict[int, list[tuple[se.CoEdge, bool]]] = {}
+        for edge_idx in group:
+            e = imprint.edges[edge_idx]
+            at_vertex.setdefault(e.start, []).append((coedge_of_edge[edge_idx], False))
+            at_vertex.setdefault(e.end, []).append((coedge_of_edge[edge_idx], True))
+
+        for fan in at_vertex.values():
+            for i, (coedge, is_end) in enumerate(fan):
+                around = fan[(i + 1) % len(fan)][0]
+                if is_end:
+                    coedge.next_coedge = around
+                else:
+                    coedge.prev_coedge = around
+
+        wire.coedge = coedge_of_edge[group[0]]
+        entities += [wire, *coedge_of_edge.values()]
         wires.append(wire)
 
     if wires:
@@ -221,9 +250,42 @@ def _loop_bbox(imprint: PlanarImprint, loop_edges) -> list[float]:
     return _bbox_of(imprint, idx)
 
 
-def _edge_bbox(imprint: PlanarImprint, edge_idx: int) -> list[float]:
-    e = imprint.edges[edge_idx]
-    return _bbox_of(imprint, {e.start, e.end})
+def _connected_edge_groups(imprint: PlanarImprint, edge_idxs) -> list[list[int]]:
+    """Split ``edge_idxs`` into groups that touch, sharing a vertex.
+
+    Order is kept stable (groups by first appearance, edges by index) so the
+    same model always writes the same file.
+    """
+    parent: dict[int, int] = {}
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    edge_idxs = list(edge_idxs)
+    for edge_idx in edge_idxs:
+        parent[edge_idx] = edge_idx
+
+    first_at_vertex: dict[int, int] = {}
+    for edge_idx in edge_idxs:
+        e = imprint.edges[edge_idx]
+        for v in (e.start, e.end):
+            if v in first_at_vertex:
+                union(first_at_vertex[v], edge_idx)
+            else:
+                first_at_vertex[v] = edge_idx
+
+    groups: dict[int, list[int]] = {}
+    for edge_idx in edge_idxs:
+        groups.setdefault(find(edge_idx), []).append(edge_idx)
+    return list(groups.values())
 
 
 def _bbox_of(imprint: PlanarImprint, vertex_idx) -> list[float]:

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -190,6 +190,10 @@ class CoEdge(SATEntity):
     loop: Loop | Wire  # a coedge is owned by a loop, or by a wire when it bounds no face
     orientation: Literal["forward", "reversed"]
     partner: CoEdge = None
+    # The coedge's curve in its face's parameter space. Stays None on a planar
+    # face, whose edges need none; a coedge on a spline face is unusable without
+    # one (see PCurve).
+    pcurve: PCurve = None
 
     def to_string(self) -> str:
         # ACIS `coedge` record: $next_in_loop $prev_in_loop $next_coedge_on_edge
@@ -198,9 +202,10 @@ class CoEdge(SATEntity):
         # used by a single face leaves it $-1 (as Genie writes it); an edge shared
         # by two faces links the pair to each other.
         partner = -1 if self.partner is None else self.partner.id
+        pcurve = -1 if self.pcurve is None else self.pcurve.id
         return (
             f"-{self.id} coedge $-1 -1 -1 $-1 ${self.next_coedge.id} ${self.prev_coedge.id} "
-            f"${partner} ${self.edge.id} {self.orientation} ${self.loop.id} $-1 #"
+            f"${partner} ${self.edge.id} {self.orientation} ${self.loop.id} ${pcurve} #"
         )
 
 
@@ -214,6 +219,14 @@ class Edge(SATEntity):
     start_pt: ada.Point
     end_pt: ada.Point
     attrib_name: StringAttribName = None
+    # The curve's parameters at the two vertices. A straight-curve is
+    # parameterised by arc length from its start, so 0..length is right and is
+    # the default; nothing else is. On a circle it is the angle, on a b-spline
+    # the knot value, and guessing it from the endpoints is ambiguous — a closed
+    # curve passes through any two points twice. SAT records them on every edge,
+    # so pass the authored pair through rather than re-deriving it.
+    t_start: float = None
+    t_end: float = None
 
     def to_string(self) -> str:
         attrib_ref = "-1"
@@ -225,10 +238,13 @@ class Edge(SATEntity):
         lo = [min(a, b) for a, b in zip(self.start_pt, self.end_pt)]
         hi = [max(a, b) for a, b in zip(self.start_pt, self.end_pt)]
         bbox_str = " ".join(str(x) for x in make_ints_if_possible([*lo, *hi]))
-        vec = ada.Direction(self.end_pt - self.start_pt)
-        length = vec.get_length()
-        s1 = 0
-        s2 = make_ints_if_possible([length])[0]
+        if self.t_start is None or self.t_end is None:
+            vec = ada.Direction(self.end_pt - self.start_pt)
+            s1 = 0
+            s2 = make_ints_if_possible([vec.get_length()])[0]
+        else:
+            s1 = make_ints_if_possible([self.t_start])[0]
+            s2 = make_ints_if_possible([self.t_end])[0]
         return (
             f"-{self.id} edge ${attrib_ref} -1 -1 $-1 ${self.vertex_start.id} {s1} "
             f"${self.vertex_end.id} {s2} ${self.coedge.id} ${self.straight_curve.id} "
@@ -264,6 +280,21 @@ def _num(x: float) -> str:
     """A real, as ACIS writes them: repr, but integral values without the '.0'."""
     f = float(x)
     return str(int(f)) if f == int(f) and abs(f) < 1e15 else repr(f)
+
+
+def _lines(*segments: str) -> str:
+    """Join a subtype body's fields the way ACIS lays one out on disk.
+
+    The three records that carry a ``{ ... }`` body are not written on one line:
+    the header, the knot vector, each control point and each trailing field get
+    a line of their own, tab-indented, with a trailing space. That is what every
+    Genie export looks like, and it is not cosmetic — the reader is line-
+    oriented (``extract_data_lines`` collects lines until one carries a ``}``,
+    then indexes the knots and control points by line), so a body squeezed onto
+    one line reads back as no data at all. The single-line records (edge,
+    coedge, ellipse-curve, straight-curve) have no body and stay as they are.
+    """
+    return " \n\t".join(segments)
 
 
 def _acis_knots(knots: list[float], multiplicities: list[int], degree: int) -> str:
@@ -325,10 +356,14 @@ class SplineSurface(SATEntity):
                 w = weights[iu][iv] if weights is not None else 1.0
                 pts.append(f"{_num(p[0])} {_num(p[1])} {_num(p[2])} {_num(w)}")
 
-        return (
+        return _lines(
             f"{{ exactsur full nurbs {s.u_degree} {s.v_degree} both open open none none "
-            f"{len(s.u_knots)} {len(s.v_knots)} {u_knots} {v_knots} "
-            f"{' '.join(pts)} 0 0 0 0 0 0 0 F 1 F 0 F 1 F 0 }}"
+            f"{len(s.u_knots)} {len(s.v_knots)}",
+            u_knots,
+            v_knots,
+            *pts,
+            *(["0"] * 7),
+            "F 1 F 0 F 1 F 0 }",
         )
 
     def to_string(self) -> str:
@@ -419,17 +454,32 @@ class IntCurve(SATEntity):
 
         knots = _acis_knots(c.knots, c.knot_multiplicities, c.degree)
         if weights:
-            pts = " ".join(
-                f"{_num(p[0])} {_num(p[1])} {_num(p[2])} {_num(w)}" for p, w in zip(c.control_points_list, weights)
-            )
+            pts = [f"{_num(p[0])} {_num(p[1])} {_num(p[2])} {_num(w)}" for p, w in zip(c.control_points_list, weights)]
         else:
-            pts = " ".join(f"{_num(p[0])} {_num(p[1])} {_num(p[2])}" for p in c.control_points_list)
+            pts = [f"{_num(p[0])} {_num(p[1])} {_num(p[2])}" for p in c.control_points_list]
 
-        return (
+        # The two surface slots stay null: this curve is the spline, not an
+        # approximation of a curve on a surface. Genie's own exactcurs name the
+        # surface they lie on in the first slot; ours has none to name.
+        return _lines(
             f"-{self.id} intcurve-curve $-1 -1 -1 $-1 {self.sense} "
-            f"{{ exactcur full {'nurbs' if weights else 'nubs'} {c.degree} open {len(c.knots)} {knots} {pts} "
-            f"{_num(self.fit_tolerance)} null_surface null_surface nullbs nullbs -1 -1 I I 0 0 0 -1 "
-            f"none F F 1 F 0 }} I I #"
+            f"{{ exactcur full {'nurbs' if weights else 'nubs'} {c.degree} open {len(c.knots)}",
+            knots,
+            *pts,
+            _num(self.fit_tolerance),
+            "null_surface",
+            "null_surface",
+            "nullbs",
+            "nullbs",
+            "-1",
+            "-1",
+            "I I",
+            "0",
+            "0",
+            "0",
+            "",
+            "-1",
+            "none F F 1 F 0 } I I #",
         )
 
 
@@ -474,17 +524,20 @@ class PCurve(SATEntity):
 
     def to_string(self) -> str:
         pc = self.pcurve
-        pts = " ".join(f"{_num(u)} {_num(v)}" for u, v in pc.control_points_2d)
+        pts = [f"{_num(u)} {_num(v)}" for u, v in pc.control_points_2d]
         knots = _acis_knots(pc.knots, pc.knot_multiplicities, pc.degree)
         # `nubs`: a rational pcurve would be `nurbs` and carry weights. The
         # reader has never produced one, so refuse rather than drop the weights.
         if getattr(pc, "weights", None):
             raise NotImplementedError("rational pcurve (weights) is not supported yet")
-        return (
-            f"-{self.id} pcurve $-1 -1 -1 $-1 0 {self.sense} "
-            f"{{ exppc nubs {pc.degree} open {len(pc.knots)} {knots} {pts} "
-            f"{_num(pc.fit_tolerance)} -1 "
-            f"spline {self.surface.sense} {self.surface.subtype()} I I I I }} 0 0 #"
+        return _lines(
+            f"-{self.id} pcurve $-1 -1 -1 $-1 0 {self.sense} {{ exppc nubs {pc.degree} open {len(pc.knots)}",
+            knots,
+            *pts,
+            _num(pc.fit_tolerance),
+            "-1",
+            f"spline {self.surface.sense} {self.surface.subtype()} I I I I",
+            "} 0 0 #",
         )
 
 

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -388,6 +388,40 @@ class EllipseCurve(SATEntity):
         )
 
 
+@dataclass
+class IntCurve(SATEntity):
+    """A B-spline edge curve — ACIS ``intcurve-curve``, an ``exactcur`` int_cur.
+
+    "Exact" means the spline IS the curve, rather than an approximation of some
+    other construction: the ``null_surface``/``nullbs`` run says it lies on no
+    surface and needs no approximating data. Genie writes the same form for the
+    great majority of its edges (5134 of 6284 in a hull export; the rest are
+    ``lawintcur``, which encodes a procedural curve as a law expression and is
+    not synthesised here).
+
+    Non-rational only. Genie's exactcurs are all ``nubs``, and a rational curve
+    would need ``nurbs`` and per-point weights; writing one as nubs would drop
+    them silently and move the curve, so it raises instead.
+    """
+
+    curve: object  # geom.curves.BSplineCurveWithKnots
+    sense: Literal["forward", "reversed"] = "forward"
+    fit_tolerance: float = 0.0
+
+    def to_string(self) -> str:
+        c = self.curve
+        if getattr(c, "weights_data", None):
+            raise NotImplementedError(f"rational edge curve ({type(c).__name__}) cannot be written as an exactcur nubs")
+        knots = _acis_knots(c.knots, c.knot_multiplicities, c.degree)
+        pts = " ".join(f"{_num(p[0])} {_num(p[1])} {_num(p[2])}" for p in c.control_points_list)
+        return (
+            f"-{self.id} intcurve-curve $-1 -1 -1 $-1 {self.sense} "
+            f"{{ exactcur full nubs {c.degree} open {len(c.knots)} {knots} {pts} "
+            f"{_num(self.fit_tolerance)} null_surface null_surface nullbs nullbs -1 -1 I I 0 0 0 -1 "
+            f"none F F 1 F 0 }} I I #"
+        )
+
+
 def circle_param_of(circle, point) -> float:
     """The ACIS parameter of ``point`` on ``circle`` — its angle, in radians.
 

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -399,24 +399,35 @@ class IntCurve(SATEntity):
     ``lawintcur``, which encodes a procedural curve as a law expression and is
     not synthesised here).
 
-    Non-rational only. Genie's exactcurs are all ``nubs``, and a rational curve
-    would need ``nurbs`` and per-point weights; writing one as nubs would drop
-    them silently and move the curve, so it raises instead.
+    A rational curve is written ``nurbs``, with a weight after each control
+    point, the way a rational surface carries its weights. Genie's own exactcurs
+    are all ``nubs``, but its ``parcur`` records — a curve in the parameter space
+    of a surface — are rational, and reach here as a
+    ``RationalBSplineCurveWithKnots`` with real weights (the 1, cos(t/2), 1 of a
+    degree-2 arc). Writing one as nubs would drop them and move the curve.
     """
 
-    curve: object  # geom.curves.BSplineCurveWithKnots
+    curve: object  # geom.curves.BSplineCurveWithKnots | RationalBSplineCurveWithKnots
     sense: Literal["forward", "reversed"] = "forward"
     fit_tolerance: float = 0.0
 
     def to_string(self) -> str:
         c = self.curve
-        if getattr(c, "weights_data", None):
-            raise NotImplementedError(f"rational edge curve ({type(c).__name__}) cannot be written as an exactcur nubs")
+        weights = getattr(c, "weights_data", None)
+        if weights and len(weights) != len(c.control_points_list):
+            raise ValueError(f"{len(weights)} weights for {len(c.control_points_list)} control points")
+
         knots = _acis_knots(c.knots, c.knot_multiplicities, c.degree)
-        pts = " ".join(f"{_num(p[0])} {_num(p[1])} {_num(p[2])}" for p in c.control_points_list)
+        if weights:
+            pts = " ".join(
+                f"{_num(p[0])} {_num(p[1])} {_num(p[2])} {_num(w)}" for p, w in zip(c.control_points_list, weights)
+            )
+        else:
+            pts = " ".join(f"{_num(p[0])} {_num(p[1])} {_num(p[2])}" for p in c.control_points_list)
+
         return (
             f"-{self.id} intcurve-curve $-1 -1 -1 $-1 {self.sense} "
-            f"{{ exactcur full nubs {c.degree} open {len(c.knots)} {knots} {pts} "
+            f"{{ exactcur full {'nurbs' if weights else 'nubs'} {c.degree} open {len(c.knots)} {knots} {pts} "
             f"{_num(self.fit_tolerance)} null_surface null_surface nullbs nullbs -1 -1 I I 0 0 0 -1 "
             f"none F F 1 F 0 }} I I #"
         )

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -260,6 +260,112 @@ class PlaneSurface(SATEntity):
         return f"-{self.id} plane-surface $-1 -1 -1 $-1 {centroid_str} {normal_str} {xvec_str} forward_v I I I I #"
 
 
+def _num(x: float) -> str:
+    """A real, as ACIS writes them: repr, but integral values without the '.0'."""
+    f = float(x)
+    return str(int(f)) if f == int(f) and abs(f) < 1e15 else repr(f)
+
+
+def _acis_knots(knots: list[float], multiplicities: list[int], degree: int) -> str:
+    """``value mult`` pairs, in ACIS's knot convention.
+
+    IFC (and STEP) give a knot vector of ``n_ctrl + degree + 1`` entries. ACIS
+    stores ``n_ctrl + degree - 1``: it drops one knot from each end, so the end
+    multiplicities are one lower — degree rather than degree+1 for a clamped
+    curve. Checked against a Genie export: a degree-2 u with IFC mults [3, 3] is
+    written [2, 2], a degree-3 v with [4, 4] is written [3, 3], and its own
+    control-point count only comes out right under this reading
+    (``n_ctrl = sum(mults) - degree + 1``).
+    """
+    if len(knots) != len(multiplicities):
+        raise ValueError(f"{len(knots)} knots but {len(multiplicities)} multiplicities")
+    mults = list(multiplicities)
+    mults[0] -= 1
+    mults[-1] -= 1
+    if any(m < 1 for m in mults):
+        raise ValueError(f"knot multiplicities {multiplicities} too low for degree {degree}")
+    return " ".join(f"{_num(k)} {m}" for k, m in zip(knots, mults))
+
+
+@dataclass
+class SplineSurface(SATEntity):
+    """A NURBS patch — ACIS ``spline-surface``, an ``exactsur`` spl_sur.
+
+    Written to carry a :class:`~ada.geom.surfaces.RationalBSplineSurfaceWithKnots`
+    (what the SAT reader hands back for a Genie ``curved_shell``) unchanged, so a
+    curved plate survives a round trip instead of degrading to its boundary
+    polygon.
+
+    The non-data tokens are fixed exactly as Genie writes them — ``both open open
+    none none`` and the trailing ``0 0 0 0 0 0 0 F 1 F 0 F 1 F 0`` are identical
+    across every surface in a reference export, whatever the degree or grid.
+    """
+
+    surface: object  # RationalBSplineSurfaceWithKnots
+    sense: Literal["forward", "reversed"] = "forward"
+
+    def subtype(self) -> str:
+        """The ``{ ... }`` spl_sur body, also embedded inside a pcurve."""
+        s = self.surface
+        n_u = len(s.control_points_list)
+        n_v = len(s.control_points_list[0])
+
+        u_knots = _acis_knots(s.u_knots, s.u_multiplicities, s.u_degree)
+        v_knots = _acis_knots(s.v_knots, s.v_multiplicities, s.v_degree)
+
+        weights = getattr(s, "weights_data", None)
+        # Control points as `x y z w`, u varying fastest — the transpose of the
+        # [u][v] grid the geometry holds. Checked against a Genie export: its
+        # first run of points is n_u long and carries the 1, cos(t/2), 1 weights
+        # of a degree-2 rational arc, which is the u direction.
+        pts = []
+        for iv in range(n_v):
+            for iu in range(n_u):
+                p = s.control_points_list[iu][iv]
+                w = weights[iu][iv] if weights is not None else 1.0
+                pts.append(f"{_num(p[0])} {_num(p[1])} {_num(p[2])} {_num(w)}")
+
+        return (
+            f"{{ exactsur full nurbs {s.u_degree} {s.v_degree} both open open none none "
+            f"{len(s.u_knots)} {len(s.v_knots)} {u_knots} {v_knots} "
+            f"{' '.join(pts)} 0 0 0 0 0 0 0 F 1 F 0 F 1 F 0 }}"
+        )
+
+    def to_string(self) -> str:
+        return f"-{self.id} spline-surface $-1 -1 -1 $-1 {self.sense} {self.subtype()} I I I I #"
+
+
+@dataclass
+class PCurve(SATEntity):
+    """A coedge's curve in its face's parameter space — ACIS ``pcurve``/``exppc``.
+
+    A coedge on a spline face names one in the slot that stays ``$-1`` on a
+    planar face: without it ACIS has no 2D curve for the edge and the face is not
+    usable. The surface the curve lives on is embedded in the record; Genie emits
+    ``{ ref n }`` to share one between pcurves, which this does not do yet — the
+    surface is written out in full each time, which is larger but self-contained.
+    """
+
+    pcurve: object  # Pcurve2dBSpline
+    surface: SplineSurface
+    sense: Literal["forward", "reversed"] = "forward"
+
+    def to_string(self) -> str:
+        pc = self.pcurve
+        pts = " ".join(f"{_num(u)} {_num(v)}" for u, v in pc.control_points_2d)
+        knots = _acis_knots(pc.knots, pc.knot_multiplicities, pc.degree)
+        # `nubs`: a rational pcurve would be `nurbs` and carry weights. The
+        # reader has never produced one, so refuse rather than drop the weights.
+        if getattr(pc, "weights", None):
+            raise NotImplementedError("rational pcurve (weights) is not supported yet")
+        return (
+            f"-{self.id} pcurve $-1 -1 -1 $-1 0 {self.sense} "
+            f"{{ exppc nubs {pc.degree} open {len(pc.knots)} {knots} {pts} "
+            f"{_num(pc.fit_tolerance)} -1 "
+            f"spline {self.surface.sense} {self.surface.subtype()} I I I I }} 0 0 #"
+        )
+
+
 @dataclass
 class StringAttribName(SATEntity):
     name: str

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -44,10 +44,38 @@ class Shell(SATEntity):
     face: Face
     lump: Lump
     bbox: list[float]
+    wire: Wire = None
 
     def to_string(self) -> str:
+        # ACIS `shell` record: $next_shell $subshell $first_face $first_wire $lump.
+        # The wire pointer heads the chain of wire bodies — the edges that bound
+        # no face (a beam with no plate under its axis).
         bbox_str = " ".join(str(coord) for coord in self.bbox)
-        return f"-{self.id} shell $-1 -1 -1 $-1 $-1 $-1 ${self.face.id} $-1 ${self.lump.id} T {bbox_str} #"
+        face = -1 if self.face is None else self.face.id
+        wire = -1 if self.wire is None else self.wire.id
+        return f"-{self.id} shell $-1 -1 -1 $-1 $-1 $-1 ${face} ${wire} ${self.lump.id} T {bbox_str} #"
+
+
+@dataclass
+class Wire(SATEntity):
+    """A connected collection of edges that bound no face (SAT v4.0 ch.7).
+
+    Genie emits one per group of beams whose axes lie on no plate, hung off the
+    shell's wire pointer, so those beams still have ACIS geometry to reference.
+    """
+
+    coedge: CoEdge
+    shell: Shell
+    bbox: list[float]
+    next_wire: Wire = None
+
+    def to_string(self) -> str:
+        # $next_wire $first_coedge $body_or_shell $subshell <containment>
+        bbox_str = " ".join(str(coord) for coord in self.bbox)
+        next_wire = -1 if self.next_wire is None else self.next_wire.id
+        return (
+            f"-{self.id} wire $-1 -1 -1 $-1 ${next_wire} ${self.coedge.id} " f"${self.shell.id} $-1 out T {bbox_str} #"
+        )
 
 
 @dataclass
@@ -56,24 +84,45 @@ class Face(SATEntity):
     shell: Shell
     name: StringAttribName
     surface: PlaneSurface
+    next_face: Face = None
 
     def to_string(self) -> str:
-        return f"-{self.id} face ${self.name.id} -1 -1 $-1 $-1 ${self.loop.id} ${self.shell.id} $-1 ${self.surface.id} forward double out F F #"
+        # ACIS `face` record (SAT v4.0 spec, ch.6): after the common ENTITY prefix
+        # ($attrib -1 -1 $owner) come next_face_in_shell, first_loop, shell,
+        # subshell, surface. A shell holds ONE face pointer; the rest of its faces
+        # are reached by following next_face, so the chain must be linked.
+        next_face = -1 if self.next_face is None else self.next_face.id
+        return (
+            f"-{self.id} face ${self.name.id} -1 -1 $-1 ${next_face} ${self.loop.id} "
+            f"${self.shell.id} $-1 ${self.surface.id} forward double out F F #"
+        )
 
 
 @dataclass
 class Loop(SATEntity):
     coedge: CoEdge
     bbox: list[float]
+    face: Face = None
+    next_loop: Loop = None
     periphery_plane: PlaneSurface = None
 
     def to_string(self) -> str:
+        # ACIS `loop` record: $next_loop $first_coedge $face — the last field is
+        # the face this loop bounds, NOT a constant. It used to be hardcoded to
+        # `$3`, which only ever happened to be right for a single-plate model
+        # (whose face is entity 3); every loop of every other model pointed at
+        # the wrong entity.
         bbox_str = " ".join(str(coord) for coord in self.bbox)
         periphery = "unknown"
         if self.periphery_plane is not None:
             periphery = f"periphery ${self.periphery_plane.id} F"
-
-        return f"-{self.id} loop $-1 -1 -1 $-1 $-1 ${self.coedge.id} $3 T {bbox_str} {periphery} #"
+        face_ref = -1 if self.face is None else self.face.id
+        # A face points at its first loop only; any hole loops hang off
+        # next_loop (an imprint can enclose a region and produce them).
+        next_loop = -1 if self.next_loop is None else self.next_loop.id
+        return (
+            f"-{self.id} loop $-1 -1 -1 $-1 ${next_loop} ${self.coedge.id} ${face_ref} " f"T {bbox_str} {periphery} #"
+        )
 
 
 @dataclass
@@ -99,11 +148,21 @@ class CoEdge(SATEntity):
     next_coedge: CoEdge
     prev_coedge: CoEdge
     edge: Edge
-    loop: Loop
-    orientation: Literal["forward", "reverse"]
+    loop: Loop | Wire  # a coedge is owned by a loop, or by a wire when it bounds no face
+    orientation: Literal["forward", "reversed"]
+    partner: CoEdge = None
 
     def to_string(self) -> str:
-        return f"-{self.id} coedge $-1 -1 -1 $-1 ${self.next_coedge.id} ${self.prev_coedge.id} $-1 ${self.edge.id} {self.orientation} ${self.loop.id} $-1 #"
+        # ACIS `coedge` record: $next_in_loop $prev_in_loop $next_coedge_on_edge
+        # $edge <sense> $loop $pcurve. The third pointer is the partner ring: all
+        # coedges lying on the same edge form a circular list through it. An edge
+        # used by a single face leaves it $-1 (as Genie writes it); an edge shared
+        # by two faces links the pair to each other.
+        partner = -1 if self.partner is None else self.partner.id
+        return (
+            f"-{self.id} coedge $-1 -1 -1 $-1 ${self.next_coedge.id} ${self.prev_coedge.id} "
+            f"${partner} ${self.edge.id} {self.orientation} ${self.loop.id} $-1 #"
+        )
 
 
 @dataclass
@@ -121,14 +180,21 @@ class Edge(SATEntity):
         attrib_ref = "-1"
         if self.attrib_name:
             attrib_ref = self.attrib_name.id
-        start_str = " ".join([str(x) for x in make_ints_if_possible(self.start_pt)])
-        end_str = " ".join([str(x) for x in make_ints_if_possible(self.end_pt)])
-        # pos_str = f"{self.start_pt[0]} {self.start_pt[1]} {self.start_pt[2]} {self.end_pt[0]} {self.end_pt[1]} {self.end_pt[2]}"
+        # The trailing `T <box>` is a bounding box, so it must run min-corner then
+        # max-corner. Emitting start_pt/end_pt verbatim inverted the box for any
+        # edge running backwards along an axis.
+        lo = [min(a, b) for a, b in zip(self.start_pt, self.end_pt)]
+        hi = [max(a, b) for a, b in zip(self.start_pt, self.end_pt)]
+        bbox_str = " ".join(str(x) for x in make_ints_if_possible([*lo, *hi]))
         vec = ada.Direction(self.end_pt - self.start_pt)
         length = vec.get_length()
         s1 = 0
         s2 = make_ints_if_possible([length])[0]
-        return f"-{self.id} edge ${attrib_ref} -1 -1 $-1 ${self.vertex_start.id} {s1} ${self.vertex_end.id} {s2} ${self.coedge.id} ${self.straight_curve.id} forward @7 unknown T {start_str} {end_str} #"
+        return (
+            f"-{self.id} edge ${attrib_ref} -1 -1 $-1 ${self.vertex_start.id} {s1} "
+            f"${self.vertex_end.id} {s2} ${self.coedge.id} ${self.straight_curve.id} "
+            f"forward @7 unknown T {bbox_str} #"
+        )
 
 
 @dataclass

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -336,6 +336,83 @@ class SplineSurface(SATEntity):
 
 
 @dataclass
+class EllipseCurve(SATEntity):
+    """A circle or ellipse — ACIS ``ellipse-curve``.
+
+    The major axis is a *vector*: its direction is the circle's reference
+    direction and its length the major radius. ``ratio`` is minor/major, so 1 is
+    a circle — which is all a Genie hull export contains (every one of its
+    ellipse-curves has ratio 1).
+
+    ``t_start``/``t_end`` are the angular range in radians about the axis,
+    measured from the reference direction, and must ASCEND: ACIS writes the
+    range in the curve's own direction and lets each coedge's sense say which
+    way its loop runs it, so an edge traversed backwards still records an
+    ascending range. Checked against a Genie export — every edge there ascends,
+    and the range on the curve equals the edge's own (4171 of 4241; the rest are
+    arcs that were split, where both halves keep the range of the arc they came
+    from). They are trim data rather than a property of the circle, so the caller
+    supplies them (see :func:`circle_param_of`).
+    """
+
+    circle: object  # geom.curves.Circle | Ellipse
+    t_start: float
+    t_end: float
+
+    def __post_init__(self):
+        if self.t_end < self.t_start:
+            raise ValueError(
+                f"ellipse range must ascend, got ({self.t_start}, {self.t_end}) — "
+                "the coedge sense carries the direction, not the curve"
+            )
+
+    def to_string(self) -> str:
+        import numpy as np
+
+        c = self.circle
+        pos = c.position
+        radius = getattr(c, "radius", None)
+        if radius is None:  # an ellipse: semi_axis1 is the major radius
+            radius = c.semi_axis1
+            ratio = c.semi_axis2 / c.semi_axis1
+        else:
+            ratio = 1.0
+        major = np.asarray(pos.ref_direction, dtype=float) * float(radius)
+
+        centre = " ".join(_num(x) for x in pos.location)
+        normal = " ".join(_num(x) for x in pos.axis)
+        major_s = " ".join(_num(x) for x in major)
+        return (
+            f"-{self.id} ellipse-curve $-1 -1 -1 $-1 {centre} {normal} {major_s} "
+            f"{_num(ratio)} F {_num(self.t_start)} F {_num(self.t_end)} #"
+        )
+
+
+def circle_param_of(circle, point) -> float:
+    """The ACIS parameter of ``point`` on ``circle`` — its angle, in radians.
+
+    Measured about the circle's axis from its reference direction, the same
+    convention the edge's start/end parameters use. Wrapped to [0, 2*pi) so a
+    point just short of the reference direction reads as ~2*pi rather than a
+    small negative.
+    """
+    import numpy as np
+
+    pos = circle.position
+    centre = np.asarray(pos.location, dtype=float)
+    axis = np.asarray(pos.axis, dtype=float)
+    ref = np.asarray(pos.ref_direction, dtype=float)
+    axis = axis / np.linalg.norm(axis)
+    ref = ref - axis * float(ref @ axis)  # the reference need not be orthogonal
+    ref = ref / np.linalg.norm(ref)
+    other = np.cross(axis, ref)
+
+    v = np.asarray(point, dtype=float) - centre
+    angle = float(np.arctan2(v @ other, v @ ref))
+    return angle + 2.0 * np.pi if angle < 0 else angle
+
+
+@dataclass
 class PCurve(SATEntity):
     """A coedge's curve in its face's parameter space — ACIS ``pcurve``/``exppc``.
 

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -85,6 +85,11 @@ class Face(SATEntity):
     name: StringAttribName
     surface: PlaneSurface
     next_face: Face = None
+    # Whether the face's normal runs with its surface's or against it. A
+    # spline-surface carries a sense of its own and Genie puts the flip there,
+    # leaving every spline face forward; a plane-surface has none, so a plane
+    # face carries its own (reversed on 112 of a hull export's).
+    sense: Literal["forward", "reversed"] = "forward"
 
     def to_string(self) -> str:
         # ACIS `face` record (SAT v4.0 spec, ch.6): after the common ENTITY prefix
@@ -94,7 +99,7 @@ class Face(SATEntity):
         next_face = -1 if self.next_face is None else self.next_face.id
         return (
             f"-{self.id} face ${self.name.id} -1 -1 $-1 ${next_face} ${self.loop.id} "
-            f"${self.shell.id} $-1 ${self.surface.id} forward double out F F #"
+            f"${self.shell.id} $-1 ${self.surface.id} {self.sense} double out F F #"
         )
 
 

--- a/src/ada/cadit/sat/write/sat_entities.py
+++ b/src/ada/cadit/sat/write/sat_entities.py
@@ -129,9 +129,48 @@ class Loop(SATEntity):
 class Vertex(SATEntity):
     edge: Edge
     point: SatPoint
+    attrib: VertEdgeAttribute = None
 
     def to_string(self) -> str:
-        return f"-{self.id} vertex $-1 -1 -1 $-1 ${self.edge.id} ${self.point.id} #"
+        # A vertex names one of its edges — but only when that names the vertex
+        # unambiguously. Where its edges fall into separable regions there is no
+        # single right answer, so the pointer goes null and a VertEdgeAttribute
+        # names one edge per region instead (as Genie writes it).
+        attrib = -1 if self.attrib is None else self.attrib.id
+        edge = -1 if self.edge is None else self.edge.id
+        return f"-{self.id} vertex ${attrib} -1 -1 $-1 ${edge} ${self.point.id} #"
+
+
+@dataclass
+class VertEdgeAttribute(SATEntity):
+    """One edge pointer per separable manifold region at a non-manifold vertex.
+
+    SAT v4.0 ch.7 ``vertedge`` (ATTRIB_VERTEDGE : ATTRIB_SYS : ATTRIB): "Contains
+    a list of edge pointers ... At nonmanifold vertices, there should be a
+    pointer to an edge in each separable manifold region."
+
+    Where a beam's axis runs off the plate it lies on, the vertex at the plate
+    boundary carries both the plate's face edges and the wire edge for the free
+    run. Nothing joins those two regions, so ACIS cannot reach one from the
+    other and the model fails verification with "vertex has edge in multiple
+    groups" unless they are declared here.
+    """
+
+    vertex: Vertex
+    edges: list[Edge]
+
+    # Genie always writes four slots, padding with $-1, whatever the region
+    # count — matched rather than trimmed to len(edges), since this is an ACIS
+    # system attribute and its own exports are the only worked example.
+    slots: int = 4
+
+    def to_string(self) -> str:
+        slots = max(self.slots, len(self.edges))
+        refs = [f"${e.id}" for e in self.edges] + ["$-1"] * (slots - len(self.edges))
+        return (
+            f"-{self.id} vertedge-sys-attrib $-1 -1 $-1 $-1 ${self.vertex.id} "
+            f"1 1 1 1 1 1 1 1 1 1 1 1 0 1 0 1 1 1 {slots} {' '.join(refs)} #"
+        )
 
 
 @dataclass

--- a/src/ada/cadit/sat/write/write_curved_plate.py
+++ b/src/ada/cadit/sat/write/write_curved_plate.py
@@ -158,10 +158,67 @@ def _curve_entity(id_gen, curve, t_lo: float, t_hi: float) -> se.SATEntity:
     raise UnsupportedCurvedFace(f"no ACIS curve record for {type(curve).__name__}")
 
 
+def flat_plate_to_advanced_face(pl) -> geo_su.AdvancedFace:
+    """An :class:`~ada.Plate` as the advanced face it already is.
+
+    A flat plate is a plane face bounded by straight edges, which is what a
+    curved plate with a planar surface is too — Genie writes them identically,
+    down to sharing all four edges with the neighbours (2 coedges each). Putting
+    it through the same builder is what lets it share vertices and edges with
+    the curved faces around it; built on its own it leaves a coincident copy of
+    every corner, which ACIS rejects as "duplicate vertex".
+
+    The outline is wound counter-clockwise about the plate's normal, as ACIS
+    reads the material side off the winding, and the surface is stated with that
+    normal — so ``same_sense`` is true by construction.
+    """
+    from ada.cadit.sat.write.write_plate import outline_ccw_about
+
+    points3d, normal = pl.outline_global()
+    outline = outline_ccw_about(points3d, normal)
+
+    edges = []
+    for i, p_start in enumerate(outline):
+        p_end = outline[(i + 1) % len(outline)]
+        direction = np.asarray(p_end, dtype=float) - np.asarray(p_start, dtype=float)
+        line = geo_cu.Line(ada.Point(*p_start), ada.Direction(*direction))
+        edges.append(
+            geo_cu.OrientedEdge(
+                start=ada.Point(*p_start),
+                end=ada.Point(*p_end),
+                edge_element=geo_cu.EdgeCurve(
+                    start=ada.Point(*p_start), end=ada.Point(*p_end), edge_geometry=line, same_sense=True
+                ),
+                orientation=True,
+            )
+        )
+
+    centroid = ada.Point(*np.mean(np.asarray(outline, dtype=float), axis=0))
+    plane = geo_su.Plane(
+        position=geo_su.Axis2Placement3D(
+            location=centroid,
+            axis=ada.Direction(*normal),
+            ref_direction=ada.Direction(*pl.poly.xdir),
+        )
+    )
+    return geo_su.AdvancedFace(
+        bounds=[geo_su.FaceBound(bound=geo_cu.EdgeLoop(edge_list=edges), orientation=True)],
+        face_surface=plane,
+        same_sense=True,
+    )
+
+
 def curved_plate_to_sat_entities(
     pl: PlateCurved, face_name: str, sw: SatWriter, weld: TopologyWeld
 ) -> list[se.SATEntity]:
-    """Convert one :class:`~ada.api.plates.PlateCurved` into its ACIS face.
+    """Convert one :class:`~ada.api.plates.PlateCurved` into its ACIS face."""
+    return advanced_face_to_sat_entities(pl.geom.geometry, face_name, sw, weld)
+
+
+def advanced_face_to_sat_entities(
+    geom, face_name: str, sw: SatWriter, weld: TopologyWeld
+) -> list[se.SATEntity]:
+    """Convert one :class:`~ada.geom.surfaces.AdvancedFace` into its ACIS face.
 
     Vertices and edges come from ``weld``, so a face shares them with its
     neighbours instead of minting coincident copies (see :class:`TopologyWeld`).
@@ -177,7 +234,6 @@ def curved_plate_to_sat_entities(
     two vertices swap. Deriving it from the range keeps the edge record's range
     ascending, as ACIS reads it.
     """
-    geom = pl.geom.geometry
     if not isinstance(geom, geo_su.AdvancedFace):
         raise UnsupportedCurvedFace(f"{type(geom).__name__} is not an AdvancedFace")
     # The reader gives one bound per face — it does not surface hole loops (16
@@ -268,6 +324,12 @@ def curved_plate_to_sat_entities(
             if v.edge is None:
                 v.edge = edge
             face_vertices.append(v)
+
+        # Which way this loop runs the edge, asked of the edge rather than of
+        # our own parameters: a neighbour may have built it, and the sense has
+        # to be read against the record as written. For the face that built it
+        # this says exactly what `runs_backwards` did.
+        runs_backwards = _vkey(p_start, weld.nd) != _vkey(edge.start_pt, weld.nd)
 
         # A pcurve belongs to a spline face: it is the edge in that surface's
         # parameter space, and a plane has none to speak of. Genie agrees —

--- a/src/ada/cadit/sat/write/write_curved_plate.py
+++ b/src/ada/cadit/sat/write/write_curved_plate.py
@@ -215,9 +215,7 @@ def curved_plate_to_sat_entities(
     return advanced_face_to_sat_entities(pl.geom.geometry, face_name, sw, weld)
 
 
-def advanced_face_to_sat_entities(
-    geom, face_name: str, sw: SatWriter, weld: TopologyWeld
-) -> list[se.SATEntity]:
+def advanced_face_to_sat_entities(geom, face_name: str, sw: SatWriter, weld: TopologyWeld) -> list[se.SATEntity]:
     """Convert one :class:`~ada.geom.surfaces.AdvancedFace` into its ACIS face.
 
     Vertices and edges come from ``weld``, so a face shares them with its

--- a/src/ada/cadit/sat/write/write_curved_plate.py
+++ b/src/ada/cadit/sat/write/write_curved_plate.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+import ada
+from ada.cadit.sat.utils import make_ints_if_possible
+from ada.cadit.sat.write import sat_entities as se
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+
+if TYPE_CHECKING:
+    from ada.api.plates import PlateCurved
+    from ada.cadit.sat.write.writer import SatWriter
+
+
+class UnsupportedCurvedFace(NotImplementedError):
+    """The face uses geometry this writer cannot author yet.
+
+    Raised rather than approximated: a curved plate silently degraded to
+    something else is worse than one the caller can log and fall back on.
+    """
+
+
+def _surface_entity(id_gen, surface) -> se.SATEntity:
+    """The ACIS surface record for an AdvancedFace's ``face_surface``.
+
+    Both kinds occur under a Genie ``curved_shell``: the B-spline patch of a
+    genuinely curved plate, and a plain :class:`~ada.geom.surfaces.Plane` for
+    the flat faces whose *edges* curve (924 of 5453 in a hull export — a flat
+    plate with a spline boundary is not a polygon, so it reads as an advanced
+    face even though its surface is planar).
+    """
+    if isinstance(surface, geo_su.BSplineSurfaceWithKnots):
+        return se.SplineSurface(id_gen.next_id(), surface)
+    if isinstance(surface, geo_su.Plane):
+        pos = surface.position
+        return se.PlaneSurface(id_gen.next_id(), pos.location, pos.axis, pos.ref_direction)
+    raise UnsupportedCurvedFace(f"no ACIS surface record for {type(surface).__name__}")
+
+
+def _curve_entity(id_gen, curve, t_lo: float, t_hi: float) -> se.SATEntity:
+    """The ACIS curve record for an edge's ``edge_geometry``.
+
+    ``t_lo``/``t_hi`` are the edge's parameter range, already ascending; only
+    an ellipse needs them (its record carries the range, the other two do not).
+    """
+    if isinstance(curve, geo_cu.Line):
+        return se.StraightCurve(id_gen.next_id(), curve.pnt, curve.dir)
+    if isinstance(curve, (geo_cu.Circle, geo_cu.Ellipse)):
+        return se.EllipseCurve(id_gen.next_id(), curve, t_lo, t_hi)
+    if isinstance(curve, geo_cu.BSplineCurveWithKnots):
+        # Covers RationalBSplineCurveWithKnots too — IntCurve picks nurbs off
+        # the weights.
+        return se.IntCurve(id_gen.next_id(), curve)
+    raise UnsupportedCurvedFace(f"no ACIS curve record for {type(curve).__name__}")
+
+
+def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter) -> list[se.SATEntity]:
+    """Convert one :class:`~ada.api.plates.PlateCurved` into its ACIS face.
+
+    One independent face per plate: no shared topology, no partner ring. The
+    imprint path cannot take these — it splits *planar* outlines — so a curved
+    plate is emitted unfused whichever mode the writer runs in, and its coedges
+    leave the partner slot null the way Genie writes a face that stands alone.
+
+    Senses are reconstructed from the edge's parameter range rather than
+    guessed. Every edge in a Genie export is ``forward`` (18924 of 18924 in a
+    hull model) and its parameters ascend, so the loop's direction lives on the
+    coedge: the reader hands back ``t_start > t_end`` exactly when the loop runs
+    the edge against its curve, which is a ``reversed`` coedge and an edge whose
+    two vertices swap. Deriving it from the range keeps the edge record's range
+    ascending, as ACIS reads it.
+    """
+    geom = pl.geom.geometry
+    if not isinstance(geom, geo_su.AdvancedFace):
+        raise UnsupportedCurvedFace(f"{type(geom).__name__} is not an AdvancedFace")
+    # The reader gives one bound per face — it does not surface hole loops (16
+    # of a hull export's faces have one and lose it on the way in). Guard
+    # rather than emit the outer loop alone and call the plate round-tripped.
+    if len(geom.bounds) != 1:
+        raise UnsupportedCurvedFace(f"{len(geom.bounds)} bounds; only a single outer loop is supported")
+    bound = geom.bounds[0].bound
+    if not isinstance(bound, geo_cu.EdgeLoop):
+        raise UnsupportedCurvedFace(f"{type(bound).__name__} is not an EdgeLoop")
+    edge_list = bound.edge_list
+    if len(edge_list) < 2:
+        raise UnsupportedCurvedFace(f"{len(edge_list)} edges in the loop")
+
+    id_gen = sw.id_generator
+    entities: list[se.SATEntity] = []
+
+    surface = _surface_entity(id_gen, geom.face_surface)
+    entities.append(surface)
+
+    face_id = id_gen.next_id()
+    name = se.StringAttribName(id_gen.next_id(), face_name, face_id)
+    face = se.Face(face_id, None, sw.shell, name, surface)
+    name.entity = face
+    entities += [face, name]
+
+    loop = se.Loop(id_gen.next_id(), None, [0.0] * 6, face=face)
+    face.loop = loop
+    entities.append(loop)
+
+    # One vertex per distinct position on this face. Rounded because the two
+    # edges meeting at a corner carry the same point through separate reads and
+    # need not agree in the last bit; 1e-9 m is far below any modelling
+    # tolerance and far above that noise.
+    vertex_map: dict[tuple, se.Vertex] = {}
+
+    def vertex_at(p) -> se.Vertex:
+        key = tuple(round(float(c), 9) for c in p)
+        v = vertex_map.get(key)
+        if v is None:
+            sat_point = se.SatPoint(id_gen.next_id(), ada.Point(*p))
+            v = se.Vertex(id_gen.next_id(), None, sat_point)
+            vertex_map[key] = v
+            entities.extend([sat_point, v])
+        return v
+
+    coedges: list[se.CoEdge] = []
+    for oriented_edge in edge_list:
+        edge_curve = oriented_edge.edge_element
+        curve_geom = getattr(edge_curve, "edge_geometry", None)
+        if curve_geom is None:
+            raise UnsupportedCurvedFace("edge carries no curve geometry")
+
+        p_start, p_end = oriented_edge.start, oriented_edge.end
+
+        t_start, t_end = oriented_edge.t_start, oriented_edge.t_end
+        if t_start is None or t_end is None:
+            # Only a straight curve has a parameterisation we can rebuild
+            # unaided (arc length from the edge start); on a circle or a
+            # b-spline the range is not recoverable from the endpoints. Re-seat
+            # the line on the edge's own start so that 0..length — what Edge
+            # falls back to without parameters — is the range it means.
+            if not isinstance(curve_geom, geo_cu.Line):
+                raise UnsupportedCurvedFace(f"{type(curve_geom).__name__} edge without authored parameters")
+            curve_geom = geo_cu.Line(ada.Point(*p_start), ada.Direction(*(np.asarray(p_end) - np.asarray(p_start))))
+        runs_backwards = t_start is not None and t_end < t_start
+        if runs_backwards:
+            t_lo, t_hi = t_end, t_start
+            p_lo, p_hi = p_end, p_start
+        else:
+            t_lo, t_hi = t_start, t_end
+            p_lo, p_hi = p_start, p_end
+
+        curve = _curve_entity(id_gen, curve_geom, t_lo, t_hi)
+        entities.append(curve)
+
+        v_start, v_end = vertex_at(p_lo), vertex_at(p_hi)
+        edge = se.Edge(
+            id_gen.next_id(),
+            v_start,
+            v_end,
+            None,
+            curve,
+            start_pt=ada.Point(*p_lo),
+            end_pt=ada.Point(*p_hi),
+            t_start=t_lo,
+            t_end=t_hi,
+        )
+        entities.append(edge)
+        for v in (v_start, v_end):
+            if v.edge is None:
+                v.edge = edge
+
+        # A pcurve belongs to a spline face: it is the edge in that surface's
+        # parameter space, and a plane has none to speak of. Genie agrees —
+        # every coedge on a spline face carries one and no coedge on a plane
+        # face does.
+        pcurve = None
+        if oriented_edge.pcurve is not None and isinstance(surface, se.SplineSurface):
+            pcurve = se.PCurve(id_gen.next_id(), oriented_edge.pcurve, surface)
+            entities.append(pcurve)
+
+        coedge = se.CoEdge(
+            id_gen.next_id(),
+            None,
+            None,
+            edge,
+            loop,
+            "reversed" if runs_backwards else "forward",
+            pcurve=pcurve,
+        )
+        edge.coedge = coedge
+        entities.append(coedge)
+        coedges.append(coedge)
+
+    for i, coedge in enumerate(coedges):
+        coedge.next_coedge = coedges[(i + 1) % len(coedges)]
+        coedge.prev_coedge = coedges[i - 1]
+    loop.coedge = coedges[0]
+
+    pts = np.asarray([v.point.point for v in vertex_map.values()], dtype=float)
+    loop.bbox = make_ints_if_possible([*np.min(pts, axis=0), *np.max(pts, axis=0)])
+
+    return sorted(entities, key=lambda x: x.id)

--- a/src/ada/cadit/sat/write/write_curved_plate.py
+++ b/src/ada/cadit/sat/write/write_curved_plate.py
@@ -23,7 +23,7 @@ class UnsupportedCurvedFace(NotImplementedError):
     """
 
 
-def _surface_entity(id_gen, surface) -> se.SATEntity:
+def _surface_entity(id_gen, surface, same_sense: bool) -> tuple[se.SATEntity, str]:
     """The ACIS surface record for an AdvancedFace's ``face_surface``.
 
     Both kinds occur under a Genie ``curved_shell``: the B-spline patch of a
@@ -31,12 +31,21 @@ def _surface_entity(id_gen, surface) -> se.SATEntity:
     the flat faces whose *edges* curve (924 of 5453 in a hull export — a flat
     plate with a spline boundary is not a polygon, so it reads as an advanced
     face even though its surface is planar).
+
+    Returns the record and the sense the *face* should carry, because ACIS
+    splits the normal across the two and Genie puts it on whichever record can
+    hold it: a spline-surface has a sense of its own, so the face stays forward
+    and the surface flips; a plane-surface has none, so the face flips instead.
+    Either way the composition is ``same_sense``, which is what IFC models and
+    the rest of adapy already consumes.
     """
     if isinstance(surface, geo_su.BSplineSurfaceWithKnots):
-        return se.SplineSurface(id_gen.next_id(), surface)
+        sense = "forward" if same_sense else "reversed"
+        return se.SplineSurface(id_gen.next_id(), surface, sense=sense), "forward"
     if isinstance(surface, geo_su.Plane):
         pos = surface.position
-        return se.PlaneSurface(id_gen.next_id(), pos.location, pos.axis, pos.ref_direction)
+        record = se.PlaneSurface(id_gen.next_id(), pos.location, pos.axis, pos.ref_direction)
+        return record, ("forward" if same_sense else "reversed")
     raise UnsupportedCurvedFace(f"no ACIS surface record for {type(surface).__name__}")
 
 
@@ -91,12 +100,12 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
     id_gen = sw.id_generator
     entities: list[se.SATEntity] = []
 
-    surface = _surface_entity(id_gen, geom.face_surface)
+    surface, face_sense = _surface_entity(id_gen, geom.face_surface, geom.same_sense)
     entities.append(surface)
 
     face_id = id_gen.next_id()
     name = se.StringAttribName(id_gen.next_id(), face_name, face_id)
-    face = se.Face(face_id, None, sw.shell, name, surface)
+    face = se.Face(face_id, None, sw.shell, name, surface, sense=face_sense)
     name.entity = face
     entities += [face, name]
 
@@ -173,7 +182,16 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
         # face does.
         pcurve = None
         if oriented_edge.pcurve is not None and isinstance(surface, se.SplineSurface):
-            pcurve = se.PCurve(id_gen.next_id(), oriented_edge.pcurve, surface)
+            # The sense is authored, not derived: it says whether the 2D curve
+            # runs along its edge's 3D curve, and nothing in the knots or the
+            # coedge implies it. Defaulting it to forward is what ACIS rejects
+            # as "pcurve's range doesn't include coedge's range".
+            pcurve = se.PCurve(
+                id_gen.next_id(),
+                oriented_edge.pcurve,
+                surface,
+                sense="forward" if oriented_edge.pcurve.same_sense else "reversed",
+            )
             entities.append(pcurve)
 
         coedge = se.CoEdge(

--- a/src/ada/cadit/sat/write/write_curved_plate.py
+++ b/src/ada/cadit/sat/write/write_curved_plate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -21,6 +22,97 @@ class UnsupportedCurvedFace(NotImplementedError):
     Raised rather than approximated: a curved plate silently degraded to
     something else is worse than one the caller can log and fall back on.
     """
+
+
+def _vkey(p, nd: int) -> tuple:
+    return tuple(round(float(c), nd) for c in p)
+
+
+def _curve_key(curve, nd: int) -> tuple:
+    """A fingerprint that tells two curves between the same points apart.
+
+    Position alone is not enough to call two edges the same edge: two faces can
+    meet at a pair of vertices and still be bounded by different curves between
+    them (two arcs of a circle, most obviously).
+    """
+    if isinstance(curve, geo_cu.Line):
+        return ("line",)
+    if isinstance(curve, geo_cu.Circle):
+        return (
+            "circle",
+            round(float(curve.radius), nd),
+            _vkey(curve.position.location, nd),
+            _vkey(curve.position.axis, nd),
+        )
+    if isinstance(curve, geo_cu.Ellipse):
+        return (
+            "ellipse",
+            round(float(curve.semi_axis1), nd),
+            round(float(curve.semi_axis2), nd),
+            _vkey(curve.position.location, nd),
+            _vkey(curve.position.axis, nd),
+        )
+    if isinstance(curve, geo_cu.BSplineCurveWithKnots):
+        return ("bspline", curve.degree, tuple(_vkey(p, nd) for p in curve.control_points_list))
+    return ("?", type(curve).__name__, id(curve))
+
+
+class TopologyWeld:
+    """The vertices and edges shared by every curved face in the body.
+
+    A face built in isolation mints its own vertex at each corner, so two faces
+    meeting along an edge leave two coincident vertices and two coincident
+    edges in the same shell — which ACIS rejects as "duplicate vertex", once per
+    pair. Genie's own export shares them: 6159 vertices and 11627 edges for the
+    5470 faces where one-face-at-a-time produces 23186 of each.
+
+    The sharing is recoverable from what the reader hands over — welding by
+    position and curve gives 6111 vertices and 11573 edges, the difference being
+    the faces the reader could not convert. Faces are keyed on rounded
+    coordinates: two faces carry the same corner through separate reads and need
+    not agree in the last bit. 1e-7 m is far below any modelling tolerance and
+    far above that noise.
+    """
+
+    def __init__(self, id_gen, nd: int = 7):
+        self.id_gen = id_gen
+        self.nd = nd
+        self.entities: list[se.SATEntity] = []
+        self._vertices: dict[tuple, se.Vertex] = {}
+        self._edges: dict[tuple, se.Edge] = {}
+        # edge -> the coedges lying on it, with a vector pointing from the edge
+        # into each one's face (for the radial ordering ACIS wants)
+        self.coedges_on_edge: dict[int, list[tuple[se.CoEdge, np.ndarray]]] = defaultdict(list)
+        self.range_conflicts = 0
+
+    def vertex_at(self, p) -> se.Vertex:
+        key = _vkey(p, self.nd)
+        vertex = self._vertices.get(key)
+        if vertex is None:
+            sat_point = se.SatPoint(self.id_gen.next_id(), ada.Point(*p))
+            vertex = se.Vertex(self.id_gen.next_id(), None, sat_point)
+            self._vertices[key] = vertex
+            self.entities.extend([sat_point, vertex])
+        return vertex
+
+    def edge_key(self, p_lo, p_hi, curve_geom) -> tuple:
+        ka, kb = _vkey(p_lo, self.nd), _vkey(p_hi, self.nd)
+        return (min(ka, kb), max(ka, kb), _curve_key(curve_geom, self.nd))
+
+    def get_edge(self, key: tuple) -> se.Edge | None:
+        return self._edges.get(key)
+
+    def add_edge(self, key: tuple, edge: se.Edge, curve: se.SATEntity) -> None:
+        self._edges[key] = edge
+        self.entities.extend([curve, edge])
+
+    @property
+    def n_vertices(self) -> int:
+        return len(self._vertices)
+
+    @property
+    def n_edges(self) -> int:
+        return len(self._edges)
 
 
 def _surface_entity(id_gen, surface, same_sense: bool) -> tuple[se.SATEntity, str]:
@@ -66,13 +158,16 @@ def _curve_entity(id_gen, curve, t_lo: float, t_hi: float) -> se.SATEntity:
     raise UnsupportedCurvedFace(f"no ACIS curve record for {type(curve).__name__}")
 
 
-def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter) -> list[se.SATEntity]:
+def curved_plate_to_sat_entities(
+    pl: PlateCurved, face_name: str, sw: SatWriter, weld: TopologyWeld
+) -> list[se.SATEntity]:
     """Convert one :class:`~ada.api.plates.PlateCurved` into its ACIS face.
 
-    One independent face per plate: no shared topology, no partner ring. The
-    imprint path cannot take these — it splits *planar* outlines — so a curved
-    plate is emitted unfused whichever mode the writer runs in, and its coedges
-    leave the partner slot null the way Genie writes a face that stands alone.
+    Vertices and edges come from ``weld``, so a face shares them with its
+    neighbours instead of minting coincident copies (see :class:`TopologyWeld`).
+    The imprint path cannot take these — it splits *planar* outlines and has
+    nothing to say about a B-spline patch — so the sharing is recovered by
+    position and curve rather than by re-cutting the geometry.
 
     Senses are reconstructed from the edge's parameter range rather than
     guessed. Every edge in a Genie export is ``forward`` (18924 of 18924 in a
@@ -113,24 +208,11 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
     face.loop = loop
     entities.append(loop)
 
-    # One vertex per distinct position on this face. Rounded because the two
-    # edges meeting at a corner carry the same point through separate reads and
-    # need not agree in the last bit; 1e-9 m is far below any modelling
-    # tolerance and far above that noise.
-    vertex_map: dict[tuple, se.Vertex] = {}
-
-    def vertex_at(p) -> se.Vertex:
-        key = tuple(round(float(c), 9) for c in p)
-        v = vertex_map.get(key)
-        if v is None:
-            sat_point = se.SatPoint(id_gen.next_id(), ada.Point(*p))
-            v = se.Vertex(id_gen.next_id(), None, sat_point)
-            vertex_map[key] = v
-            entities.extend([sat_point, v])
-        return v
+    loop_points = [np.asarray(oe.start, dtype=float) for oe in edge_list]
 
     coedges: list[se.CoEdge] = []
-    for oriented_edge in edge_list:
+    face_vertices: list[se.Vertex] = []
+    for i, oriented_edge in enumerate(edge_list):
         edge_curve = oriented_edge.edge_element
         curve_geom = getattr(edge_curve, "edge_geometry", None)
         if curve_geom is None:
@@ -156,25 +238,36 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
             t_lo, t_hi = t_start, t_end
             p_lo, p_hi = p_start, p_end
 
-        curve = _curve_entity(id_gen, curve_geom, t_lo, t_hi)
-        entities.append(curve)
+        # The neighbour that already built this edge wrote the vertices, the
+        # curve and the range; only the coedge is ours.
+        key = weld.edge_key(p_lo, p_hi, curve_geom)
+        edge = weld.get_edge(key)
+        if edge is None:
+            curve = _curve_entity(id_gen, curve_geom, t_lo, t_hi)
+            v_start, v_end = weld.vertex_at(p_lo), weld.vertex_at(p_hi)
+            edge = se.Edge(
+                id_gen.next_id(),
+                v_start,
+                v_end,
+                None,
+                curve,
+                start_pt=ada.Point(*p_lo),
+                end_pt=ada.Point(*p_hi),
+                t_start=t_lo,
+                t_end=t_hi,
+            )
+            weld.add_edge(key, edge, curve)
+        elif t_lo is not None and edge.t_start is not None:
+            # Two faces on one edge must agree on where it starts and stops;
+            # they came from the same record, so this is a tolerance question
+            # rather than a real disagreement. Count it instead of picking one.
+            if abs(edge.t_start - t_lo) > 1e-6 or abs(edge.t_end - t_hi) > 1e-6:
+                weld.range_conflicts += 1
 
-        v_start, v_end = vertex_at(p_lo), vertex_at(p_hi)
-        edge = se.Edge(
-            id_gen.next_id(),
-            v_start,
-            v_end,
-            None,
-            curve,
-            start_pt=ada.Point(*p_lo),
-            end_pt=ada.Point(*p_hi),
-            t_start=t_lo,
-            t_end=t_hi,
-        )
-        entities.append(edge)
-        for v in (v_start, v_end):
+        for v in (edge.vertex_start, edge.vertex_end):
             if v.edge is None:
                 v.edge = edge
+            face_vertices.append(v)
 
         # A pcurve belongs to a spline face: it is the edge in that surface's
         # parameter space, and a plane has none to speak of. Genie agrees —
@@ -203,7 +296,11 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
             "reversed" if runs_backwards else "forward",
             pcurve=pcurve,
         )
-        edge.coedge = coedge
+        # An edge names ONE of its coedges; the others are reached round the
+        # partner ring, so the first face to claim it wins.
+        if edge.coedge is None:
+            edge.coedge = coedge
+        weld.coedges_on_edge[id(edge)].append((coedge, _into_face(p_lo, p_hi, loop_points)))
         entities.append(coedge)
         coedges.append(coedge)
 
@@ -212,7 +309,79 @@ def curved_plate_to_sat_entities(pl: PlateCurved, face_name: str, sw: SatWriter)
         coedge.prev_coedge = coedges[i - 1]
     loop.coedge = coedges[0]
 
-    pts = np.asarray([v.point.point for v in vertex_map.values()], dtype=float)
+    unique = {id(v): v for v in face_vertices}
+    pts = np.asarray([v.point.point for v in unique.values()], dtype=float)
     loop.bbox = make_ints_if_possible([*np.min(pts, axis=0), *np.max(pts, axis=0)])
 
     return sorted(entities, key=lambda x: x.id)
+
+
+def _into_face(p_lo, p_hi, loop_points: list[np.ndarray]) -> np.ndarray:
+    """A vector from the edge into the face it bounds, perpendicular to it.
+
+    Where an edge carries more than two coedges, ACIS wants them ordered by
+    where their faces sit radially about it, and this is what that angle is
+    measured on. The face's centroid stands in for the surface normal, which
+    would otherwise have to be evaluated on the patch; it only has to separate
+    the faces around the edge, and only 35 of a hull export's 11573 edges carry
+    more than two.
+    """
+    a = np.asarray(p_lo, dtype=float)
+    b = np.asarray(p_hi, dtype=float)
+    axis = b - a
+    length = float(np.linalg.norm(axis))
+    if length < 1e-12:
+        return np.zeros(3)
+    axis = axis / length
+    into = np.mean(np.asarray(loop_points, dtype=float), axis=0) - 0.5 * (a + b)
+    into = into - axis * float(into @ axis)
+    norm = float(np.linalg.norm(into))
+    return into / norm if norm > 1e-12 else np.zeros(3)
+
+
+def link_partner_rings(weld: TopologyWeld) -> None:
+    """Join the coedges lying on each edge into a ring, ordered about it.
+
+    An edge bounding one face leaves the slot null, as Genie writes it; two
+    faces link to each other. Beyond that ACIS wants them counter-clockwise
+    about the edge's own direction and says so ("coedges out of order about
+    edge") — the same rule the imprinted planar path sorts on.
+    """
+    for entries in weld.coedges_on_edge.values():
+        if len(entries) < 2:
+            continue
+        if len(entries) == 2:
+            # a 2-cycle reads the same either way round
+            ordered = [entries[0][0], entries[1][0]]
+        else:
+            ordered = _ordered_about_edge(entries)
+        for cur, nxt in zip(ordered, ordered[1:] + ordered[:1]):
+            cur.partner = nxt
+
+
+def _ordered_about_edge(entries) -> list[se.CoEdge]:
+    """The coedges on one edge, counter-clockwise about it."""
+    coedge = entries[0][0]
+    edge = coedge.edge
+    a = np.asarray(edge.start_pt, dtype=float)
+    b = np.asarray(edge.end_pt, dtype=float)
+    axis = b - a
+    length = float(np.linalg.norm(axis))
+    if length < 1e-12:
+        return [c for c, _ in entries]
+    axis = axis / length
+
+    # any pair perpendicular to the edge; (ref, ortho, axis) is right-handed, so
+    # the angle increases counter-clockwise about it
+    seed = np.array([1.0, 0.0, 0.0]) if abs(axis[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    ref = np.cross(axis, seed)
+    ref = ref / np.linalg.norm(ref)
+    ortho = np.cross(axis, ref)
+
+    def angle(entry) -> float:
+        _, into = entry
+        if float(np.linalg.norm(into)) < 1e-12:
+            return 0.0
+        return float(np.arctan2(into @ ortho, into @ ref))
+
+    return [c for c, _ in sorted(entries, key=angle)]

--- a/src/ada/cadit/sat/write/write_plate.py
+++ b/src/ada/cadit/sat/write/write_plate.py
@@ -14,135 +14,100 @@ if TYPE_CHECKING:
     from ada.cadit.sat.write.writer import SatWriter
 
 
-def plate_to_sat_entities(
-    pl: ada.Plate, face_name: str, geo_repr: GeomRepr, sw: SatWriter, use_dual_assembly=False
-) -> list[se.SATEntity]:
-    """Convert a Plate object to a SAT entities."""
+def outline_ccw_about(points3d, normal) -> list:
+    """The plate outline ordered counter-clockwise about ``normal``.
 
+    ACIS derives which side of a face is material from the loop winding relative
+    to the surface normal, so the two must agree. ``CurvePoly2d`` does not
+    guarantee that: it re-orders the outline during construction and can hand
+    back a loop wound *against* ``poly.normal`` (e.g. the 10x10 plate in
+    ``test_write_basic_plate_sat`` comes back clockwise). Comparing the loop's
+    own Newell normal to the declared one and flipping when they disagree keeps
+    the emitted face oriented the way Genie writes it.
+    """
+    pts = np.asarray(points3d, dtype=float)
+    newell = np.zeros(3)
+    for i in range(len(pts)):
+        a, b = pts[i], pts[(i + 1) % len(pts)]
+        newell += np.cross(a, b)
+    if float(np.dot(newell, np.asarray(normal, dtype=float))) < 0:
+        pts = pts[::-1]
+    return [tuple(p) for p in pts]
+
+
+def plate_to_sat_entities(pl: ada.Plate, face_name: str, geo_repr: GeomRepr, sw: SatWriter) -> list[se.SATEntity]:
+    """Convert one :class:`~ada.Plate` into the ACIS entities for its face.
+
+    The body/lump/shell are owned by the :class:`SatWriter` and shared by every
+    plate (see :func:`part_to_sat_writer`); this only builds the face and the
+    topology below it — loop, coedges, edges, vertices, points, curves — plus
+    the plane surface and the DNV name/cached-plane attributes Genie expects.
+    """
     if geo_repr != GeomRepr.SHELL:
         raise ValueError(f"Unsupported geometry representation: {geo_repr}")
 
-    pmin = np.min(pl.poly.points3d, axis=0)
-    pmax = np.max(pl.poly.points3d, axis=0)
-    sat_entities = []
-    bbox = [*pmin, *pmax]
-    bbox = make_ints_if_possible(bbox)
-    # Initialize strings for each component
-    # Create main entities using ID generator
-
     id_gen = sw.id_generator
-    bodies = sw.get_entities_by_type(se.Body)
 
-    if len(bodies) == 0:
-        body_id = id_gen.next_id()
-        lump_id = id_gen.next_id()
-        body = se.Body(body_id, lump_id, bbox)
-        sat_entities.append(body)
-    else:
-        body = bodies[0]
-        lump_id = id_gen.next_id()
-    # update body bbox
-    updated_body_bbox = [x for x in body.bbox]
-    for i, x in enumerate(bbox):
-        body_value = body.bbox[i]
-        local_value = bbox[i]
-        if i > 2:
-            if local_value > body_value:
-                updated_body_bbox[i] = local_value
-        else:
-            if local_value < body_value:
-                updated_body_bbox[i] = local_value
+    # Global coordinates: poly.points3d is in the plate's own frame, so a plate
+    # inside a placed Part would otherwise land at the wrong position.
+    points3d, normal = pl.outline_global()
+    bbox = make_ints_if_possible([*np.min(points3d, axis=0), *np.max(points3d, axis=0)])
+    # A plane-surface just needs any point on the plane for its origin; the mean
+    # of the outline is on it by construction, and for the rectangular plates
+    # Genie's reference files cover it is exactly the centroid they record.
+    centroid = ada.Point(*np.mean(points3d, axis=0))
 
-    body.bbox = updated_body_bbox
+    sat_entities: list[se.SATEntity] = []
 
-    shell_id = id_gen.next_id()
     face_id = id_gen.next_id()
-    lump = se.Lump(lump_id, shell_id, body, bbox)
-    sat_entities.append(lump)
-    shell = se.Shell(shell_id, face_id, lump, bbox)
-
     name_id = id_gen.next_id()
     loop_id = id_gen.next_id()
 
-    surface = se.PlaneSurface(id_gen.next_id(), pl.poly.get_centroid(), pl.poly.normal, pl.poly.xdir)
-    cache_plane_id = id_gen.next_id()
-    if use_dual_assembly:
-        fused_face_id = id_gen.next_id()
+    surface = se.PlaneSurface(id_gen.next_id(), centroid, normal, pl.poly.xdir)
+    cached_plane_attrib = se.CachedPlaneAttribute(id_gen.next_id(), face_id, name_id, centroid, normal)
+    string_attrib_name = se.StringAttribName(name_id, face_name, face_id, cached_plane_attrib)
 
-        posattr2_id = id_gen.next_id()
-        posattr1 = se.PositionAttribName(id_gen.next_id(), posattr2_id, fused_face_id, face_id, bbox, "ExactBoxHigh")
+    face = se.Face(face_id, loop_id, sw.shell, string_attrib_name, surface)
+    loop = se.Loop(loop_id, id_gen.next_id(), bbox, face=face)
 
-        posattr2 = se.PositionAttribName(posattr2_id, cache_plane_id, posattr1, face_id, bbox, "ExactBoxLow")
-        cached_plane_attrib = se.CachedPlaneAttribute(
-            cache_plane_id, face_id, posattr2.id, pl.poly.get_centroid(), pl.poly.normal
-        )
-        fused_face_att = se.FusedFaceAttribute(fused_face_id, name_id, posattr1, face_id)
-        string_attrib_name = se.StringAttribName(name_id, face_name, face_id, fused_face_att)
-        sat_entities += [posattr1, posattr2, fused_face_att]
-    else:
-        cached_plane_attrib = se.CachedPlaneAttribute(
-            id_gen.next_id(), face_id, name_id, pl.poly.get_centroid(), pl.poly.normal
-        )
-        string_attrib_name = se.StringAttribName(name_id, face_name, face_id, cached_plane_attrib)
+    outline = outline_ccw_about(points3d, normal)
+    n_seg = len(outline)
 
-    face = se.Face(face_id, loop_id, shell, string_attrib_name, surface)
-    if use_dual_assembly:
-        loop = se.Loop(loop_id, id_gen.next_id(), bbox, surface)
-    else:
-        loop = se.Loop(loop_id, id_gen.next_id(), bbox)
+    coedge_ids = [loop.coedge if i == 0 else id_gen.next_id() for i in range(n_seg)]
+
+    point_map = {}
+    for p in outline:
+        if tuple(p) not in point_map:
+            point_map[tuple(p)] = se.SatPoint(id_gen.next_id(), ada.Point(*p))
+
+    points = list(point_map.values())
+    vertex_map = {p.id: se.Vertex(id_gen.next_id(), None, p) for p in points}
+    vertices = list(vertex_map.values())
 
     edges = []
     coedges = []
     straight_curves = []
 
-    seg3d = pl.poly.segments3d
-
-    coedge_ids = []
-    for i, edge in enumerate(seg3d):
-        if i == 0:
-            coedge_id = loop.coedge
-        else:
-            coedge_id = id_gen.next_id()
-        coedge_ids.append(coedge_id)
-
-    point_map = {}
-
-    for segment in seg3d:
-        if tuple(segment.p1) not in point_map.keys():
-            point_map[tuple(segment.p1)] = se.SatPoint(id_gen.next_id(), segment.p1)
-        if tuple(segment.p2) not in point_map.keys():
-            point_map[tuple(segment.p2)] = se.SatPoint(id_gen.next_id(), segment.p2)
-
-    points = list(point_map.values())
-    vertex_map = {p.id: se.Vertex(id_gen.next_id(), None, p) for p in points}
-    vertices = list(vertex_map.values())
-    edge_seq = [(1, 2), (2, 3), (3, 4), (4, 1)]
-
-    for i, edge in enumerate(seg3d):
+    for i in range(n_seg):
+        start, end = outline[i], outline[(i + 1) % n_seg]
         coedge_id = coedge_ids[i]
-        if i == 0:
-            next_coedge_id = coedge_ids[(i + 1)]
-            prev_coedge_id = coedge_ids[-1]
-        elif i == len(seg3d) - 1:
-            next_coedge_id = coedge_ids[0]
-            prev_coedge_id = coedge_ids[(i - 1)]
-        else:
-            next_coedge_id = coedge_ids[(i + 1)]
-            prev_coedge_id = coedge_ids[(i - 1)]
+        next_coedge_id = coedge_ids[(i + 1) % n_seg]
+        prev_coedge_id = coedge_ids[i - 1]
 
-        # start
         edge_id = id_gen.next_id()
-        p1 = point_map.get(tuple(edge.p1))
+        p1 = point_map.get(tuple(start))
         if p1 is None:
-            raise ValueError(f"Point {edge.p1} not found in point_map")
+            raise ValueError(f"Point {start} not found in point_map")
         v1 = vertex_map.get(p1.id)
         if v1.edge is None:
             v1.edge = edge_id
-        p2 = point_map.get(tuple(edge.p2))
+        p2 = point_map.get(tuple(end))
         v2 = vertex_map.get(p2.id)
         if v2.edge is None:
             v2.edge = edge_id
-        straight_curve = se.StraightCurve(id_gen.next_id(), p1.point, edge.direction)
+
+        direction = ada.Direction(*(np.asarray(end, dtype=float) - np.asarray(start, dtype=float)))
+        straight_curve = se.StraightCurve(id_gen.next_id(), p1.point, direction)
         edge = se.Edge(
             edge_id,
             v1,
@@ -152,38 +117,12 @@ def plate_to_sat_entities(
             start_pt=p1.point,
             end_pt=p2.point,
         )
-        if use_dual_assembly:
-            edge_n = f"EDGE{sw.edge_name_id:08d}"
-            edge_str_id = id_gen.next_id()
-            length = ada.Direction(p1.point - p2.point).get_length()
-            fusedge = se.FusedEdgeAttribute(
-                id_gen.next_id(),
-                name=edge_str_id,
-                entity=edge,
-                edge_idx=i + 1,
-                edge_seq=edge_seq[i],
-                edge_length=length,
-            )
-            edge_string_att = se.StringAttribName(edge_str_id, edge_n, edge, attrib_ref=fusedge)
-            edge.attrib_name = edge_string_att
-            sat_entities.append(edge_string_att)
-            sat_entities.append(fusedge)
-            sw.edge_name_id += 1
-
-        coedge = se.CoEdge(coedge_id, prev_coedge_id, next_coedge_id, edge, loop, "forward")
-        coedges.append(coedge)
+        coedges.append(se.CoEdge(coedge_id, next_coedge_id, prev_coedge_id, edge, loop, "forward"))
         edges.append(edge)
         straight_curves.append(straight_curve)
 
     sat_entities += (
-        [
-            shell,
-            face,
-            loop,
-            string_attrib_name,
-            cached_plane_attrib,
-            surface,
-        ]
+        [face, loop, string_attrib_name, cached_plane_attrib, surface]
         + coedges
         + edges
         + vertices
@@ -191,14 +130,14 @@ def plate_to_sat_entities(
         + straight_curves
     )
 
+    # The builders above wire some references by id (they are minted before the
+    # target object exists); swap those for the objects now that all are built.
     sat_entity_map = {entity.id: entity for entity in sat_entities}
     for entity in sat_entities:
         for key, value in entity.__dict__.items():
             if key == "id" or "_idx" in key:
                 continue
-            if isinstance(value, int) and value in sat_entity_map.keys():
+            if isinstance(value, int) and value in sat_entity_map:
                 setattr(entity, key, sat_entity_map.get(value))
 
-    sorted_entities = sorted(sat_entities, key=lambda x: x.id)
-
-    return sorted_entities
+    return sorted(sat_entities, key=lambda x: x.id)

--- a/src/ada/cadit/sat/write/writer.py
+++ b/src/ada/cadit/sat/write/writer.py
@@ -10,6 +10,7 @@ from ada.cadit.sat.write import sat_entities as se
 from ada.cadit.sat.write.sat_entities import SATEntity
 from ada.cadit.sat.write.utils import IDGenerator
 from ada.cadit.sat.write.write_plate import plate_to_sat_entities
+from ada.config import logger
 
 if TYPE_CHECKING:
     from ada import Assembly, Part
@@ -20,46 +21,130 @@ HEADER_STR = """2000 0 1 0
 """
 
 
-def part_to_sat_writer(part: Part | Assembly) -> SatWriter:
+def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter:
+    """Build the ACIS SAT body for every :class:`~ada.Plate` under ``part``.
+
+    Every plate face lives in ONE body / lump / shell, matching what Genie
+    itself writes (verified against ``files/sat_files/flat_plate*_sesam_*.sat``).
+    A shell records a single face pointer, so the remaining faces are reached by
+    walking ``next_face`` — hence the chaining pass at the end.
+
+    With ``imprint`` (the default) the plates are mutually split and welded by
+    the CAD backend first, so touching plates share vertices and edges and a
+    plate crossed by its neighbours resolves to several faces — the form Genie
+    writes, and the one it otherwise has to reconstruct on import. Set it False
+    for the unfused one-face-per-plate body (no CAD backend needed).
+    """
     from ada import Plate
 
     sw = SatWriter(part)
 
-    # Beams (not implemented, because it's not strictly necessary to embed in ACIS in order to import beams into Genie)
-    # for bm in part.get_all_physical_objects(by_type=Beam):
-    #     pass
+    # Only plates become faces — Genie imports beams from the concept XML alone
+    # and its own SAT carries no beam bodies. Beams still take part in the
+    # imprint though (see _add_imprinted_plates).
+    plates = list(part.get_all_physical_objects(by_type=Plate))
+    if not plates:
+        # No faces means no body: a body/lump/shell with nothing in it is not a
+        # meaningful ACIS record, and `is_empty` lets the caller drop the whole
+        # <geometry> element (a beams-only model simply has no SAT).
+        return sw
 
-    # Plates
-    for face_id, pl in enumerate(part.get_all_physical_objects(by_type=Plate), start=1):
+    _, _, shell = sw.init_body(plates)
+
+    if imprint:
+        _add_imprinted_plates(sw, plates)
+    else:
+        _add_plates_unfused(sw, plates)
+
+    # A shell points at its first face only; link the rest into the chain.
+    faces = sw.get_entities_by_type(se.Face)
+    if faces:
+        shell.face = faces[0]
+        for cur, nxt in zip(faces, faces[1:]):
+            cur.next_face = nxt
+
+    sw.renumber()
+    return sw
+
+
+def _add_plates_unfused(sw: SatWriter, plates) -> None:
+    """One independent face per plate — no shared topology."""
+    for face_id, pl in enumerate(plates, start=1):
         face_name = f"FACE{face_id:08d}"
-        sw.face_map[pl.guid] = face_name
-        new_entities = plate_to_sat_entities(pl, face_name, GeomRepr.SHELL, sw)
-        for entity in new_entities:
+        sw.face_map[pl.guid] = [face_name]
+        for entity in plate_to_sat_entities(pl, face_name, GeomRepr.SHELL, sw):
             sw.add_entity(entity)
 
-    # re-arrange entities and make sure all body, lump, shell and face elements are before any further elements
-    bodies = sw.get_entities_by_type(se.Body)
-    lumps = sw.get_entities_by_type(se.Lump)
-    shells = sw.get_entities_by_type(se.Shell)
-    faces = sw.get_entities_by_type(se.Face)
-    new_id = 0
 
-    first_entities = list(chain(bodies, lumps, shells, faces))
-    for i, entity in enumerate(first_entities):
-        if isinstance(entity, se.Lump) and len(lumps) > 1:
-            next_entity = first_entities[i + 1]
-            if isinstance(next_entity, se.Lump):
-                entity.next_lump = next_entity
+def _add_imprinted_plates(sw: SatWriter, plates) -> None:
+    """Imprint the plates against each other and the beams, then emit the topology."""
+    from ada.cad import select_backend
+    from ada.cadit.sat.write.from_imprint import imprint_to_sat_entities
+    from ada.cadit.sat.write.write_plate import outline_ccw_about
 
-        entity.id = new_id
-        new_id += 1
-    for rest in sw.entities.values():
-        if type(rest) not in [se.Body, se.Lump, se.Shell, se.Face]:
-            rest.id = new_id
-            new_id += 1
-    # update map
-    sw.entities = {entity.id: entity for entity in sorted(sw.entities.values(), key=lambda x: x.id)}
-    return sw
+    # Global coordinates (a plate inside a placed Part would otherwise be
+    # imprinted at the wrong position), oriented counter-clockwise about the
+    # plate's own normal: the backend derives each face's plane from the polygon
+    # it is given, so feeding CurvePoly2d's raw (possibly clockwise) order would
+    # flip every face normal away from the plate's declared one.
+    outlines = [outline_ccw_about(*pl.outline_global()) for pl in plates]
+    beams, curves = _beam_axes(sw.part)
+
+    result = select_backend().imprint_planar_faces(outlines, imprint_curves=curves)
+
+    entities, faces, edges = imprint_to_sat_entities(result, sw)
+    for entity in entities:
+        sw.add_entity(entity)
+
+    for i, face in enumerate(faces, start=1):
+        face.name.name = f"FACE{i:08d}"
+
+    for pl, src in zip(plates, result.sources):
+        sw.face_map[pl.guid] = [faces[i].name.name for i in src]
+        if not src:
+            logger.warning(f"sat-write: plate {pl.name!r} produced no face in the imprint and is not referenced")
+
+    _name_beam_edges(sw, beams, edges, result.curve_sources)
+
+    logger.info(
+        f"sat-write: imprinted {len(plates)} plates against {len(curves)} beam axes -> "
+        f"{len(faces)} faces, {sum(len(v) for v in sw.edge_map.values())} named edges"
+    )
+
+
+def _name_beam_edges(sw: SatWriter, beams, edges, curve_sources) -> None:
+    """Name each beam's imprinted axis edges and record the beam -> EDGE map.
+
+    Without this a beam's ``<sat_reference/>`` is empty and Genie rebuilds that
+    beam's ACIS wire on import — on a large frame that dominates load time, far
+    more than the plates do. Genie's own exports name every edge a beam resolves
+    to and reference each one from the beam's ``<wire>``.
+    """
+    edge_name_of: dict[int, str] = {}
+    unresolved = 0
+    for beam, src in zip(beams, curve_sources or []):
+        names = []
+        for edge_idx in src:
+            edge = edges[edge_idx]
+            if edge.coedge is None:
+                continue  # pruned: bounds no face, so it is not in the body
+            name = edge_name_of.get(edge_idx)
+            if name is None:
+                name = f"EDGE{sw.edge_name_id:08d}"
+                sw.edge_name_id += 1
+                edge_name_of[edge_idx] = name
+                attrib = se.StringAttribName(sw.id_generator.next_id(), name, edge)
+                edge.attrib_name = attrib
+                sw.add_entity(attrib)
+            names.append(name)
+        if names:
+            sw.edge_map[beam.guid] = names
+        else:
+            unresolved += 1
+    if unresolved:
+        # A beam whose axis lies on no plate leaves no edge in the body (Genie
+        # emits those as standalone `wire` bodies, which we do not author yet).
+        logger.info(f"sat-write: {unresolved} beam(s) have no plate under their axis; left without a SAT edge")
 
 
 @dataclass
@@ -70,26 +155,61 @@ class SatWriter:
     header: str = HEADER_STR
     bbox: list[float] = field(default_factory=list)
     id_generator: IDGenerator = field(default_factory=IDGenerator)
-    face_map: dict[str, str] = field(default_factory=dict)  # face_name -> plate guid
+    # plate guid -> the FACE names that plate resolves to. A plate maps to
+    # several faces once the imprint pass splits it, so this is a list even
+    # though the un-imprinted writer only ever puts one name in it.
+    face_map: dict[str, list[str]] = field(default_factory=dict)
+    # beam guid -> the EDGE names its axis resolves to (imprinted path only).
+    # Empty for a beam whose axis lies on no plate.
+    edge_map: dict[str, list[str]] = field(default_factory=dict)
+
+    body: se.Body = None
+    lump: se.Lump = None
+    shell: se.Shell = None
 
     edge_name_id: int = 1
 
-    def __post_init__(self):
-        bboxes = []
-        for part in self.part.get_all_parts_in_assembly(include_self=True):
-            if len(part.nodes.nodes) == 0:
-                continue
-            bboxes.append(list(chain.from_iterable(zip(*part.nodes.bbox()))))
-        # Find the minimum values for the first 3 and the maximum values for the last 3
-        if len(bboxes) == 0:
-            raise ValueError("No nodes found in the part")
+    def init_body(self, plates) -> tuple[se.Body, se.Lump, se.Shell]:
+        """Create the single body/lump/shell that owns every face."""
+        self.bbox = _plates_bbox(plates)
+        body = se.Body(self.id_generator.next_id(), None, list(self.bbox))
+        lump = se.Lump(self.id_generator.next_id(), None, body, list(self.bbox))
+        shell = se.Shell(self.id_generator.next_id(), None, lump, list(self.bbox))
+        body.lump = lump
+        lump.shell = shell
+        self.body, self.lump, self.shell = body, lump, shell
+        for entity in (body, lump, shell):
+            self.add_entity(entity)
+        return body, lump, shell
 
-        bbox_min = [min([bbox[i] for bbox in bboxes]) for i in range(3)]
-        bbox_max = [max([bbox[i + 3] for bbox in bboxes]) for i in range(3)]
-        self.bbox = bbox_min + bbox_max
+    @property
+    def is_empty(self) -> bool:
+        """No faces to embed — the caller should omit ``<geometry>`` entirely."""
+        return not self.entities
 
     def add_entity(self, entity: SATEntity) -> None:
         self.entities[entity.id] = entity
+
+    def renumber(self) -> None:
+        """Re-index entities so body/lump/shell/face lead, then everything else.
+
+        Record ids are positional, so only their relative order matters to ACIS;
+        leading with the topology roots mirrors how Genie lays its files out and
+        keeps diffs against the reference files readable.
+        """
+        first = list(
+            chain(
+                self.get_entities_by_type(se.Body),
+                self.get_entities_by_type(se.Lump),
+                self.get_entities_by_type(se.Shell),
+                self.get_entities_by_type(se.Face),
+            )
+        )
+        leading = {id(e) for e in first}
+        rest = [e for e in self.entities.values() if id(e) not in leading]
+        for new_id, entity in enumerate(chain(first, rest)):
+            entity.id = new_id
+        self.entities = {e.id: e for e in sorted(self.entities.values(), key=lambda x: x.id)}
 
     def write(self, file_path: str | pathlib.Path) -> None:
         with open(file_path, "w") as f:
@@ -101,3 +221,48 @@ class SatWriter:
 
     def get_entities_by_type(self, by_type) -> list[SATEntity]:
         return list(filter(lambda x: type(x) is by_type, self.entities.values()))
+
+
+def _beam_axes(part) -> tuple[list, list[list[tuple[float, float, float]]]]:
+    """Every beam and its axis, as a 2-point polyline, to imprint onto the plates.
+
+    Returned index-aligned so the imprint's ``curve_sources`` maps straight back
+    to the beam that produced each edge.
+
+    A stiffener lying on a plate splits it along its axis; a member merely
+    crossing one drops a vertex on the boundary. This is where most of Genie's
+    face count comes from — its own export splits a 3.9 m panel carrying
+    stiffeners at 0.65 m spacing into 6 faces, one per bay.
+
+    Positioned exactly as :func:`~ada.cadit.gxml.write.write_beams.add_segments`
+    writes the beam's guide into the XML — full transform when the placement
+    rotates, translation only otherwise — so the imprinted edge lands on the
+    concept beam the ``<wire>`` will reference.
+    """
+    from ada import Beam
+
+    beams, axes = [], []
+    for bm in part.get_all_physical_objects(by_type=Beam):
+        p1, p2 = bm.axis_global()
+        a = tuple(float(c) for c in p1)
+        b = tuple(float(c) for c in p2)
+        if a != b:
+            beams.append(bm)
+            axes.append([a, b])
+    return beams, axes
+
+
+def _plates_bbox(plates) -> list[float]:
+    """[xmin, ymin, zmin, xmax, ymax, zmax] over every plate outline.
+
+    Genie sets the body/lump/shell box to the union of the plate extents; an
+    empty plate set degenerates to a zero box rather than failing.
+    """
+    import numpy as np
+
+    from ada.cadit.sat.utils import make_ints_if_possible
+
+    if not plates:
+        return [0.0] * 6
+    pts = np.concatenate([np.asarray(pl.poly.points3d, dtype=float) for pl in plates])
+    return make_ints_if_possible([*np.min(pts, axis=0), *np.max(pts, axis=0)])

--- a/src/ada/cadit/sat/write/writer.py
+++ b/src/ada/cadit/sat/write/writer.py
@@ -74,15 +74,109 @@ def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter
         else:
             _add_plates_unfused(sw, plates)
 
-    # A shell points at its first face only; link the rest into the chain.
-    faces = sw.get_entities_by_type(se.Face)
-    if faces:
-        shell.face = faces[0]
-        for cur, nxt in zip(faces, faces[1:]):
-            cur.next_face = nxt
+    _assign_faces_to_shells(sw, shell)
 
     sw.renumber()
     return sw
+
+
+def _face_components(faces: list[se.Face]) -> list[list[se.Face]]:
+    """Group faces into the connected sets they form.
+
+    Joined by a shared *vertex*, not merely a shared edge: Genie's own exports
+    put two plates meeting at a single corner in one lump
+    (``flat_plate_x2_sesam_10x10_shared_vertex.sat``) and two that touch nowhere
+    in two (``..._offset_no_shared.sat``). A vertex is the weaker claim and the
+    one that matches.
+    """
+    parent: dict[int, int] = {}
+
+    def find(x: int) -> int:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    # Keyed on where a vertex IS, not which object it is: the unfused path mints
+    # a vertex per face, so two plates meeting at a corner hold distinct objects
+    # at one position and would read as disconnected.
+    faces_at_vertex: dict[tuple, list[se.Face]] = {}
+    for face in faces:
+        find(id(face))
+        loop = face.loop
+        while loop is not None:
+            coedge = loop.coedge
+            seen = set()
+            while coedge is not None and id(coedge) not in seen:
+                seen.add(id(coedge))
+                edge = coedge.edge
+                if edge is not None:
+                    for vertex in (edge.vertex_start, edge.vertex_end):
+                        if vertex is not None:
+                            key = tuple(round(float(c), 7) for c in vertex.point.point)
+                            faces_at_vertex.setdefault(key, []).append(face)
+                coedge = coedge.next_coedge
+            loop = loop.next_loop
+
+    for sharing in faces_at_vertex.values():
+        for other in sharing[1:]:
+            union(id(sharing[0]), id(other))
+
+    grouped: dict[int, list[se.Face]] = {}
+    for face in faces:
+        grouped.setdefault(find(id(face)), []).append(face)
+    # ordered by the first face of each, so the layout is stable between runs
+    order = {id(f): i for i, f in enumerate(faces)}
+    return sorted(grouped.values(), key=lambda g: order[id(g[0])])
+
+
+def _assign_faces_to_shells(sw: SatWriter, shell: se.Shell) -> None:
+    """One lump and shell per connected set of faces, as Genie writes them.
+
+    A shell is a connected sheet, and ACIS says so — a shell holding faces that
+    cannot be reached from one another fails verification with "entities in
+    shell are not connected". A body carries the disjoint pieces as separate
+    lumps instead, chained off the body: a hull export splits its 5470 faces
+    into two lumps of 2910 and 2560.
+
+    Within a shell the faces chain through ``next_face``, since a shell records
+    only the first.
+    """
+    faces = sw.get_entities_by_type(se.Face)
+    if not faces:
+        return
+
+    components = _face_components(faces)
+    lumps: list[se.Lump] = []
+    for i, group in enumerate(components):
+        if i == 0:
+            lump, group_shell = sw.lump, shell
+        else:
+            lump = se.Lump(sw.id_generator.next_id(), None, sw.body, list(sw.bbox))
+            group_shell = se.Shell(sw.id_generator.next_id(), None, lump, list(sw.bbox))
+            lump.shell = group_shell
+            sw.add_entity(lump)
+            sw.add_entity(group_shell)
+        group_shell.face = group[0]
+        for face in group:
+            face.shell = group_shell
+            face.next_face = None
+        for cur, nxt in zip(group, group[1:]):
+            cur.next_face = nxt
+        lumps.append(lump)
+
+    for cur, nxt in zip(lumps, lumps[1:]):
+        cur.next_lump = nxt
+    sw.body.lump = lumps[0]
+
+    if len(lumps) > 1:
+        logger.info(f"sat-write: {len(faces)} faces form {len(lumps)} disconnected lumps")
 
 
 def _add_plates_unfused(sw: SatWriter, plates: list[Plate]) -> None:

--- a/src/ada/cadit/sat/write/writer.py
+++ b/src/ada/cadit/sat/write/writer.py
@@ -87,27 +87,34 @@ def _add_plates_unfused(sw: SatWriter, plates: list[Plate]) -> None:
 
 
 def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
-    """One independent spline (or curved-edged plane) face per curved plate.
+    """One spline (or curved-edged plane) face per curved plate, welded together.
 
     Numbered on from the planar faces so the two sets share one FACE namespace.
+    Neighbouring faces share their vertices and edges rather than minting
+    coincident copies — ACIS rejects those as "duplicate vertex" — and the
+    coedges on each shared edge are joined into a partner ring.
+
     A plate whose geometry this writer cannot author is skipped and logged
     rather than dropped silently — it leaves no entry in ``face_map``, so the
     gxml writer falls back to its boundary polygon for that plate alone.
     """
     from ada.cadit.sat.write.write_curved_plate import (
+        TopologyWeld,
         UnsupportedCurvedFace,
         curved_plate_to_sat_entities,
+        link_partner_rings,
     )
 
     if not curved:
         return
 
+    weld = TopologyWeld(sw.id_generator)
     face_id = len(sw.get_entities_by_type(se.Face)) + 1
     skipped = Counter()
     for pl in curved:
         face_name = f"FACE{face_id:08d}"
         try:
-            entities = curved_plate_to_sat_entities(pl, face_name, sw)
+            entities = curved_plate_to_sat_entities(pl, face_name, sw, weld)
         except UnsupportedCurvedFace as ex:
             skipped[str(ex)] += 1
             continue
@@ -116,6 +123,20 @@ def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
         sw.face_map[pl.guid] = [face_name]
         face_id += 1
 
+    link_partner_rings(weld)
+    for entity in weld.entities:
+        sw.add_entity(entity)
+
+    logger.info(
+        f"sat-write: {face_id - 1} curved faces share {weld.n_vertices} vertices and {weld.n_edges} edges"
+    )
+    if weld.range_conflicts:
+        # Two faces on one edge disagreeing about its parameter range means the
+        # weld joined edges that are not the same edge.
+        logger.warning(
+            f"sat-write: {weld.range_conflicts} shared edges disagree on their parameter range; "
+            "the welded topology may be wrong there"
+        )
     if skipped:
         total = sum(skipped.values())
         detail = "; ".join(f"{reason} ({n})" for reason, n in skipped.most_common(3))

--- a/src/ada/cadit/sat/write/writer.py
+++ b/src/ada/cadit/sat/write/writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+from collections import Counter
 from dataclasses import dataclass, field
 from itertools import chain
 from typing import TYPE_CHECKING
@@ -13,7 +14,8 @@ from ada.cadit.sat.write.write_plate import plate_to_sat_entities
 from ada.config import logger
 
 if TYPE_CHECKING:
-    from ada import Assembly, Part
+    from ada import Assembly, Part, Plate
+    from ada.api.plates import PlateCurved
 
 HEADER_STR = """2000 0 1 0
 18 SESAM - gmGeometry 14 ACIS 33.0.1 NT 24 Tue Jan 17 20:39:08 2023
@@ -34,8 +36,13 @@ def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter
     plate crossed by its neighbours resolves to several faces — the form Genie
     writes, and the one it otherwise has to reconstruct on import. Set it False
     for the unfused one-face-per-plate body (no CAD backend needed).
+
+    A :class:`~ada.api.plates.PlateCurved` becomes a spline face (or a plane
+    face with curved edges) and is always unfused: the imprint splits *planar*
+    outlines and has nothing to say about a B-spline patch.
     """
     from ada import Plate
+    from ada.api.plates import PlateCurved
 
     sw = SatWriter(part)
 
@@ -43,18 +50,21 @@ def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter
     # and its own SAT carries no beam bodies. Beams still take part in the
     # imprint though (see _add_imprinted_plates).
     plates = list(part.get_all_physical_objects(by_type=Plate))
-    if not plates:
+    curved = list(part.get_all_physical_objects(by_type=PlateCurved))
+    if not plates and not curved:
         # No faces means no body: a body/lump/shell with nothing in it is not a
         # meaningful ACIS record, and `is_empty` lets the caller drop the whole
         # <geometry> element (a beams-only model simply has no SAT).
         return sw
 
-    _, _, shell = sw.init_body(plates)
+    _, _, shell = sw.init_body(plates, curved)
 
-    if imprint:
-        _add_imprinted_plates(sw, plates)
-    else:
-        _add_plates_unfused(sw, plates)
+    if plates:
+        if imprint:
+            _add_imprinted_plates(sw, plates)
+        else:
+            _add_plates_unfused(sw, plates)
+    _add_curved_plates(sw, curved)
 
     # A shell points at its first face only; link the rest into the chain.
     faces = sw.get_entities_by_type(se.Face)
@@ -67,13 +77,49 @@ def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter
     return sw
 
 
-def _add_plates_unfused(sw: SatWriter, plates) -> None:
+def _add_plates_unfused(sw: SatWriter, plates: list[Plate]) -> None:
     """One independent face per plate — no shared topology."""
     for face_id, pl in enumerate(plates, start=1):
         face_name = f"FACE{face_id:08d}"
         sw.face_map[pl.guid] = [face_name]
         for entity in plate_to_sat_entities(pl, face_name, GeomRepr.SHELL, sw):
             sw.add_entity(entity)
+
+
+def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
+    """One independent spline (or curved-edged plane) face per curved plate.
+
+    Numbered on from the planar faces so the two sets share one FACE namespace.
+    A plate whose geometry this writer cannot author is skipped and logged
+    rather than dropped silently — it leaves no entry in ``face_map``, so the
+    gxml writer falls back to its boundary polygon for that plate alone.
+    """
+    from ada.cadit.sat.write.write_curved_plate import (
+        UnsupportedCurvedFace,
+        curved_plate_to_sat_entities,
+    )
+
+    if not curved:
+        return
+
+    face_id = len(sw.get_entities_by_type(se.Face)) + 1
+    skipped = Counter()
+    for pl in curved:
+        face_name = f"FACE{face_id:08d}"
+        try:
+            entities = curved_plate_to_sat_entities(pl, face_name, sw)
+        except UnsupportedCurvedFace as ex:
+            skipped[str(ex)] += 1
+            continue
+        for entity in entities:
+            sw.add_entity(entity)
+        sw.face_map[pl.guid] = [face_name]
+        face_id += 1
+
+    if skipped:
+        total = sum(skipped.values())
+        detail = "; ".join(f"{reason} ({n})" for reason, n in skipped.most_common(3))
+        logger.warning(f"sat-write: {total} of {len(curved)} curved plates are not authored as SAT faces: {detail}")
 
 
 def _add_imprinted_plates(sw: SatWriter, plates) -> None:
@@ -169,9 +215,9 @@ class SatWriter:
 
     edge_name_id: int = 1
 
-    def init_body(self, plates) -> tuple[se.Body, se.Lump, se.Shell]:
+    def init_body(self, plates: list[Plate], curved: list[PlateCurved]) -> tuple[se.Body, se.Lump, se.Shell]:
         """Create the single body/lump/shell that owns every face."""
-        self.bbox = _plates_bbox(plates)
+        self.bbox = _plates_bbox(plates, curved)
         body = se.Body(self.id_generator.next_id(), None, list(self.bbox))
         lump = se.Lump(self.id_generator.next_id(), None, body, list(self.bbox))
         shell = se.Shell(self.id_generator.next_id(), None, lump, list(self.bbox))
@@ -252,17 +298,21 @@ def _beam_axes(part) -> tuple[list, list[list[tuple[float, float, float]]]]:
     return beams, axes
 
 
-def _plates_bbox(plates) -> list[float]:
+def _plates_bbox(plates: list[Plate], curved: list[PlateCurved]) -> list[float]:
     """[xmin, ymin, zmin, xmax, ymax, zmax] over every plate outline.
 
     Genie sets the body/lump/shell box to the union of the plate extents; an
-    empty plate set degenerates to a zero box rather than failing.
+    empty plate set degenerates to a zero box rather than failing. A curved
+    plate has no ``poly``, so it contributes its boundary nodes instead — the
+    same loop-edge endpoints the face is built from.
     """
     import numpy as np
 
     from ada.cadit.sat.utils import make_ints_if_possible
 
-    if not plates:
+    groups = [np.asarray(pl.poly.points3d, dtype=float) for pl in plates]
+    groups += [np.asarray([n.p for n in pl.nodes], dtype=float) for pl in curved if pl.nodes]
+    if not groups:
         return [0.0] * 6
-    pts = np.concatenate([np.asarray(pl.poly.points3d, dtype=float) for pl in plates])
+    pts = np.concatenate(groups)
     return make_ints_if_possible([*np.min(pts, axis=0), *np.max(pts, axis=0)])

--- a/src/ada/cadit/sat/write/writer.py
+++ b/src/ada/cadit/sat/write/writer.py
@@ -59,12 +59,20 @@ def part_to_sat_writer(part: Part | Assembly, imprint: bool = True) -> SatWriter
 
     _, _, shell = sw.init_body(plates, curved)
 
-    if plates:
+    if curved:
+        # A body has one topology, and the imprint can only build a planar one.
+        # Where curved faces are present the flat plates join their weld
+        # instead, so the two share vertices and edges where they meet — built
+        # apart they leave a coincident copy of every shared corner, which ACIS
+        # rejects as "duplicate vertex". They forgo the imprint's splitting to
+        # get it; on a hull export that costs nothing (the imprint returns the
+        # 17 flat plates as 17 faces, having split none of them).
+        _add_curved_plates(sw, curved, plates)
+    elif plates:
         if imprint:
             _add_imprinted_plates(sw, plates)
         else:
             _add_plates_unfused(sw, plates)
-    _add_curved_plates(sw, curved)
 
     # A shell points at its first face only; link the rest into the chain.
     faces = sw.get_entities_by_type(se.Face)
@@ -86,13 +94,18 @@ def _add_plates_unfused(sw: SatWriter, plates: list[Plate]) -> None:
             sw.add_entity(entity)
 
 
-def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
-    """One spline (or curved-edged plane) face per curved plate, welded together.
+def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved], plates: list[Plate] = ()) -> None:
+    """One face per plate, curved and flat alike, welded into one topology.
 
-    Numbered on from the planar faces so the two sets share one FACE namespace.
     Neighbouring faces share their vertices and edges rather than minting
     coincident copies — ACIS rejects those as "duplicate vertex" — and the
     coedges on each shared edge are joined into a partner ring.
+
+    The curved plates go first: their edges carry the parameter range the file
+    authored, and a flat plate's straight edge has none to contribute, so
+    whichever builds an edge first decides its range. The other way round a
+    shared edge would be written 0..length and every curved face on it would
+    disagree.
 
     A plate whose geometry this writer cannot author is skipped and logged
     rather than dropped silently — it leaves no entry in ``face_map``, so the
@@ -101,7 +114,9 @@ def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
     from ada.cadit.sat.write.write_curved_plate import (
         TopologyWeld,
         UnsupportedCurvedFace,
+        advanced_face_to_sat_entities,
         curved_plate_to_sat_entities,
+        flat_plate_to_advanced_face,
         link_partner_rings,
     )
 
@@ -111,6 +126,14 @@ def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
     weld = TopologyWeld(sw.id_generator)
     face_id = len(sw.get_entities_by_type(se.Face)) + 1
     skipped = Counter()
+
+    def emit(pl, entities, face_name) -> None:
+        nonlocal face_id
+        for entity in entities:
+            sw.add_entity(entity)
+        sw.face_map[pl.guid] = [face_name]
+        face_id += 1
+
     for pl in curved:
         face_name = f"FACE{face_id:08d}"
         try:
@@ -118,17 +141,25 @@ def _add_curved_plates(sw: SatWriter, curved: list[PlateCurved]) -> None:
         except UnsupportedCurvedFace as ex:
             skipped[str(ex)] += 1
             continue
-        for entity in entities:
-            sw.add_entity(entity)
-        sw.face_map[pl.guid] = [face_name]
-        face_id += 1
+        emit(pl, entities, face_name)
+
+    for pl in plates:
+        face_name = f"FACE{face_id:08d}"
+        try:
+            face = flat_plate_to_advanced_face(pl)
+            entities = advanced_face_to_sat_entities(face, face_name, sw, weld)
+        except UnsupportedCurvedFace as ex:
+            skipped[f"flat plate: {ex}"] += 1
+            continue
+        emit(pl, entities, face_name)
 
     link_partner_rings(weld)
     for entity in weld.entities:
         sw.add_entity(entity)
 
     logger.info(
-        f"sat-write: {face_id - 1} curved faces share {weld.n_vertices} vertices and {weld.n_edges} edges"
+        f"sat-write: {face_id - 1} faces ({len(curved)} curved, {len(plates)} flat) share "
+        f"{weld.n_vertices} vertices and {weld.n_edges} edges"
     )
     if weld.range_conflicts:
         # Two faces on one edge disagreeing about its parameter range means the

--- a/src/ada/config.py
+++ b/src/ada/config.py
@@ -145,7 +145,18 @@ class Config:
                 # It is a heuristic over the *control points*, which for a
                 # b-spline need not lie near the surface, so it can fire on a
                 # face that is perfectly good. Off means trust the peel.
-                ConfigEntry("reject_deformed_curved_faces", bool, True),
+                #
+                # Off by default: it was a fallback from when the reader could
+                # not yet take these faces and imports crashed, and it now costs
+                # more than it saves. A face it flattens keeps its corners and
+                # loses its curved edges, so it no longer shares an edge with
+                # the curved neighbours it was cut from — on a hull export it
+                # flattened 119 good faces, and the SAT writer then wrote 24
+                # non-manifold vertices and split one shell into six islands
+                # that ACIS rejects. With it off the same model welds into the
+                # two connected lumps Genie itself writes. Kept as an escape
+                # hatch pending confidence that nothing needs it.
+                ConfigEntry("reject_deformed_curved_faces", bool, False),
             ],
         ),
         ConfigSection(

--- a/src/ada/config.py
+++ b/src/ada/config.py
@@ -139,6 +139,13 @@ class Config:
                 # Eliminates the rotated-flat fallback for these faces;
                 # sacrifices the original ACIS surface parameterisation.
                 ConfigEntry("curved_fallback_via_fill", bool, True),
+                # Reject a peeled surface whose centre lands outside the flat
+                # boundary's box, or which is parameterised over a much larger
+                # patch than that boundary, and use the flat points instead.
+                # It is a heuristic over the *control points*, which for a
+                # b-spline need not lie near the surface, so it can fire on a
+                # face that is perfectly good. Off means trust the peel.
+                ConfigEntry("reject_deformed_curved_faces", bool, True),
             ],
         ),
         ConfigSection(

--- a/src/ada/geom/curves.py
+++ b/src/ada/geom/curves.py
@@ -483,6 +483,13 @@ class Pcurve2dBSpline:
 
     Control points are 2D ``[u, v]`` pairs. Optional ``weights`` makes
     the curve rational; ``None`` means non-rational.
+
+    ``fit_tolerance`` is how closely the curve approximates the true
+    curve-on-surface, as the author measured it (ACIS ``exppc`` carries
+    it; SAT v4.0 ch.5 calls it "Fit tolerance"). ``0.0`` asserts the
+    pcurve is exact, so it is a claim rather than a neutral default —
+    keep the authored value when there is one instead of re-asserting
+    exactness a reprojection cannot support.
     """
 
     degree: int
@@ -491,6 +498,7 @@ class Pcurve2dBSpline:
     knot_multiplicities: list[int]
     weights: list[float] | None = None
     closed: bool = False
+    fit_tolerance: float = 0.0
 
 
 @dataclass(slots=True)

--- a/src/ada/geom/curves.py
+++ b/src/ada/geom/curves.py
@@ -490,6 +490,14 @@ class Pcurve2dBSpline:
     pcurve is exact, so it is a claim rather than a neutral default —
     keep the authored value when there is one instead of re-asserting
     exactness a reprojection cannot support.
+
+    ``same_sense`` is the ACIS ``pcurve`` record's own forward/reversed
+    flag: whether this 2D curve runs along its edge's 3D curve or
+    against it. It is authored data and not derivable from the rest —
+    in a Genie export it splits 13722/5184 with no correlation to the
+    knots — so a reader that drops it leaves the writer defaulting to
+    forward, and ACIS then rejects the face with "pcurve's range doesn't
+    include coedge's range" on every one it got wrong.
     """
 
     degree: int
@@ -499,6 +507,7 @@ class Pcurve2dBSpline:
     weights: list[float] | None = None
     closed: bool = False
     fit_tolerance: float = 0.0
+    same_sense: bool = True
 
 
 @dataclass(slots=True)

--- a/src/ada/occ/backend.py
+++ b/src/ada/occ/backend.py
@@ -14,7 +14,7 @@ from ada.cad import Containment
 if TYPE_CHECKING:
     import numpy as np
 
-    from ada.cad import Mesh, ShapeHandle
+    from ada.cad import Mesh, PlanarImprint, ShapeHandle
     from ada.geom import Geometry
     from ada.geom.booleans import BoolOpEnum
     from ada.geom.direction import Direction
@@ -662,6 +662,212 @@ class OccBackend:
             if amap.FindFromIndex(i).Size() == 1:
                 out.append(amap.FindKey(i))
         return out
+
+    def imprint_planar_faces(
+        self,
+        outlines: "list[list[tuple[float, float, float]]]",
+        imprint_curves: "list[list[tuple[float, float, float]]] | None" = None,
+        tolerance: float = 1e-6,
+    ) -> "PlanarImprint":
+        # General Fuse (BOPAlgo_Builder, same kernel as non_manifold_merge) splits
+        # every outline against the others and welds coincident topology, so a
+        # deck crossed by a bulkhead comes back as two faces sharing the bulkhead
+        # line as ONE edge. Unlike non_manifold_merge this keeps the Modified()
+        # history, which is what maps an input outline to the faces it became.
+        #
+        # `imprint_curves` (e.g. beam axes) join the fuse as wire arguments: a
+        # stiffener lying on a plate splits it along its axis, and one merely
+        # crossing it drops a vertex on the boundary. That is where most of
+        # Genie's face count comes from — a 3.9 m panel with stiffeners every
+        # 0.65 m arrives as 6 faces, not 1.
+        #
+        # The whole model is imprinted and extracted in this single call: the
+        # abstraction boundary must not land inside a per-face/per-edge loop, so
+        # everything below stays kernel-side and only plain data is returned.
+        from OCC.Core.BOPAlgo import BOPAlgo_Builder
+        from OCC.Core.BRep import BRep_Tool
+        from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
+        from OCC.Core.BRepBuilderAPI import (
+            BRepBuilderAPI_MakeEdge,
+            BRepBuilderAPI_MakeFace,
+            BRepBuilderAPI_MakePolygon,
+        )
+        from OCC.Core.BRepTools import BRepTools_WireExplorer, breptools
+        from OCC.Core.GeomAbs import GeomAbs_Plane
+        from OCC.Core.gp import gp_Pnt
+        from OCC.Core.TopAbs import (
+            TopAbs_EDGE,
+            TopAbs_FACE,
+            TopAbs_FORWARD,
+            TopAbs_REVERSED,
+            TopAbs_VERTEX,
+            TopAbs_WIRE,
+        )
+        from OCC.Core.TopExp import TopExp_Explorer, topexp
+        from OCC.Core.TopoDS import topods
+        from OCC.Core.TopTools import (
+            TopTools_IndexedDataMapOfShapeListOfShape,
+            TopTools_IndexedMapOfShape,
+        )
+
+        from ada.cad import ImprintedEdge, ImprintedFace, PlanarImprint
+
+        def _pnt(p):
+            c = list(p)
+            return gp_Pnt(float(c[0]), float(c[1]), float(c[2]))
+
+        def _mkface(pts):
+            poly = BRepBuilderAPI_MakePolygon()
+            for p in pts:
+                poly.Add(_pnt(p))
+            poly.Close()
+            return BRepBuilderAPI_MakeFace(poly.Wire(), True).Face()
+
+        def _mkedges(pts):
+            # One TopoDS_Edge per segment rather than a wire: BOPAlgo's history is
+            # per-argument, and edges give a direct Modified(edge) -> split edges
+            # map, which is what resolves a beam axis to the edges it became.
+            out = []
+            for a, b in zip(pts, pts[1:]):
+                pa, pb = _pnt(a), _pnt(b)
+                if pa.Distance(pb) <= max(tolerance, 1e-12):
+                    continue  # a zero-length segment would fail the edge build
+                out.append(BRepBuilderAPI_MakeEdge(pa, pb).Edge())
+            return out
+
+        inputs = [_mkface(o) for o in outlines]
+        if not inputs:
+            return PlanarImprint(vertices=[], edges=[], faces=[], sources=[], curve_sources=[])
+
+        # per curve, the argument edges it contributed
+        curve_edges = [_mkedges(c) for c in (imprint_curves or [])]
+        cutters = [e for edges_ in curve_edges for e in edges_]
+
+        if len(inputs) + len(cutters) < 2:
+            # General Fuse needs at least two arguments (it raises
+            # TooFewArguments otherwise). A lone outline has nothing to imprint
+            # against, so it passes straight through.
+            builder = None
+            res = inputs[0]
+        else:
+            builder = BOPAlgo_Builder()
+            for shape in inputs + cutters:
+                builder.AddArgument(shape)
+            if tolerance and tolerance > 0:
+                builder.SetFuzzyValue(tolerance)
+            builder.SetRunParallel(True)
+            builder.Perform()
+            if builder.HasErrors():
+                raise RuntimeError("imprint_planar_faces: BOPAlgo_Builder reported errors")
+            res = builder.Shape()
+
+        # Index every unique sub-shape. The map's hasher keys on TShape+Location
+        # and ignores orientation, so a FORWARD and a REVERSED use of the same
+        # edge collapse to one index — which is exactly the sharing we want.
+        #
+        # Index the whole result, faces and free edges alike: an imprint curve
+        # with no face under it survives as a free edge, and the caller still
+        # needs geometry for it (ACIS carries those as wire bodies). Which is
+        # which is reported via free_edges.
+        fmap, vmap, emap = (TopTools_IndexedMapOfShape() for _ in range(3))
+        topexp.MapShapes(res, TopAbs_FACE, fmap)
+        topexp.MapShapes(res, TopAbs_VERTEX, vmap)
+        topexp.MapShapes(res, TopAbs_EDGE, emap)
+
+        edge_faces = TopTools_IndexedDataMapOfShapeListOfShape()
+        topexp.MapShapesAndAncestors(res, TopAbs_EDGE, TopAbs_FACE, edge_faces)
+        free_edges = []
+        for i in range(1, emap.Size() + 1):
+            e = emap.FindKey(i)
+            if not edge_faces.Contains(e) or edge_faces.FindFromKey(e).Size() == 0:
+                free_edges.append(i - 1)
+
+        vertices = []
+        for i in range(1, vmap.Size() + 1):
+            p = BRep_Tool.Pnt(topods.Vertex(vmap.FindKey(i)))
+            vertices.append((p.X(), p.Y(), p.Z()))
+
+        edges = []
+        for i in range(1, emap.Size() + 1):
+            e = topods.Edge(emap.FindKey(i)).Oriented(TopAbs_FORWARD)
+            v0 = topexp.FirstVertex(e, True)
+            v1 = topexp.LastVertex(e, True)
+            edges.append(ImprintedEdge(start=vmap.FindIndex(v0) - 1, end=vmap.FindIndex(v1) - 1))
+
+        faces = []
+        for i in range(1, fmap.Size() + 1):
+            f = topods.Face(fmap.FindKey(i))
+            surf = BRepAdaptor_Surface(f, True)
+            if surf.GetType() != GeomAbs_Plane:
+                raise ValueError("imprint_planar_faces: result contains a non-planar face")
+            pln = surf.Plane()
+            loc, ax, xd = pln.Location(), pln.Axis().Direction(), pln.XAxis().Direction()
+            normal = (ax.X(), ax.Y(), ax.Z())
+            # A REVERSED face's true outward normal is the opposite of its
+            # surface's; flipping here keeps every loop below wound
+            # counter-clockwise about the normal we report.
+            if f.Orientation() == TopAbs_REVERSED:
+                normal = (-normal[0], -normal[1], -normal[2])
+
+            outer = breptools.OuterWire(f)
+            wires = []
+            wexp = TopExp_Explorer(f, TopAbs_WIRE)
+            while wexp.More():
+                wires.append(topods.Wire(wexp.Current()))
+                wexp.Next()
+            wires.sort(key=lambda w: 0 if w.IsSame(outer) else 1)  # outer loop first
+
+            loops = []
+            for w in wires:
+                loop = []
+                we = BRepTools_WireExplorer(w, f)
+                while we.More():
+                    edge = we.Current()
+                    loop.append((emap.FindIndex(edge) - 1, edge.Orientation() == TopAbs_FORWARD))
+                    we.Next()
+                loops.append(loop)
+            faces.append(
+                ImprintedFace(
+                    origin=(loc.X(), loc.Y(), loc.Z()),
+                    normal=normal,
+                    ref_direction=(xd.X(), xd.Y(), xd.Z()),
+                    loops=loops,
+                )
+            )
+
+        def _history(shape, index_map):
+            """The result sub-shapes ``shape`` became, as indices into ``index_map``.
+
+            Only ones present in the map count: an imprint curve with no plate
+            under it survives as a free edge, which bounds no face and is
+            deliberately absent from the map (and from the emitted body).
+            """
+            if builder is None:
+                return [index_map.FindIndex(shape) - 1] if index_map.Contains(shape) else []
+            mods = builder.Modified(shape)
+            if mods is not None and mods.Size() > 0:
+                return [index_map.FindIndex(s) - 1 for s in mods if index_map.Contains(s)]
+            if not builder.IsDeleted(shape) and index_map.Contains(shape):
+                return [index_map.FindIndex(shape) - 1]  # untouched: passes through as itself
+            return []
+
+        sources = [_history(f, fmap) for f in inputs]
+
+        curve_sources = []
+        for edges_ in curve_edges:
+            got = []
+            for e in edges_:
+                got.extend(i for i in _history(e, emap) if i not in got)
+            curve_sources.append(got)
+
+        return PlanarImprint(
+            vertices=vertices,
+            edges=edges,
+            faces=faces,
+            sources=sources,
+            curve_sources=curve_sources,
+            free_edges=free_edges,
+        )
 
     def point_in_solid(self, solid: ShapeHandle, point, tolerance: float = 1e-6) -> "Containment":
         from OCC.Core.BRepClass3d import BRepClass3d_SolidClassifier

--- a/tests/core/cadit/gxml/test_read_plate_normal.py
+++ b/tests/core/cadit/gxml/test_read_plate_normal.py
@@ -1,0 +1,53 @@
+"""A plate faces the way its XML says it does, not the way its points wind.
+
+A ``flat_plate`` states its normal outright as a ``<vector>``. The reader used
+to ignore it and let ``Plate.from_3d_points`` derive one from the point order —
+and the two disagree about half the time, because the points come off the SAT
+face's loop, whose winding is its own business. The plate then went back out
+facing the other way, which Genie draws inside-out.
+"""
+
+import numpy as np
+import pytest
+
+from ada.cadit.gxml.read.helpers import _plate_from_3d_points
+
+# a unit square wound counter-clockwise about +z
+SQUARE = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
+
+
+def _normal(points, desired):
+    return np.asarray(_plate_from_3d_points("pl", points, 0.01, desired).poly.normal, dtype=float)
+
+
+class TestOrientation:
+    @pytest.mark.parametrize("desired", [(0.0, 0.0, 1.0), (0.0, 0.0, -1.0)])
+    def test_the_plate_faces_the_way_it_was_asked_to(self, desired):
+        assert np.dot(_normal(SQUARE, desired), desired) > 0
+
+    @pytest.mark.parametrize("desired", [(0.0, 0.0, 1.0), (0.0, 0.0, -1.0)])
+    def test_the_point_winding_does_not_decide_it(self, desired):
+        """Both windings of the same square must land on the same normal."""
+        forward = _normal(SQUARE, desired)
+        backward = _normal(list(reversed(SQUARE)), desired)
+        assert np.dot(forward, backward) > 0
+        assert np.dot(forward, desired) > 0
+
+    def test_no_normal_asked_for_leaves_it_alone(self):
+        """Without a <vector> there is nothing to honour; keep the old behaviour."""
+        from ada import Plate
+
+        expected = Plate.from_3d_points("pl", SQUARE, 0.01).poly.normal
+        got = _plate_from_3d_points("pl", SQUARE, 0.01, None).poly.normal
+        assert np.allclose(np.asarray(got, dtype=float), np.asarray(expected, dtype=float))
+
+    def test_a_normal_it_already_agrees_with_is_not_flipped(self):
+        from ada import Plate
+
+        natural = np.asarray(Plate.from_3d_points("pl", SQUARE, 0.01).poly.normal, dtype=float)
+        assert np.allclose(_normal(SQUARE, tuple(natural)), natural)
+
+    def test_an_off_axis_normal_still_decides(self):
+        """The test only needs the sign of the dot product, not an exact match."""
+        assert _normal(SQUARE, (0.1, 0.2, -0.97))[2] < 0
+        assert _normal(SQUARE, (0.1, 0.2, 0.97))[2] > 0

--- a/tests/core/cadit/gxml/test_sesam_read_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_read_xml.py
@@ -35,3 +35,21 @@ def test_sesam_xml(example_files, tmp_path, monkeypatch):
     assert surfaces["Plane"] > 0, surfaces
 
     a.to_ifc(tmp_path / "sesam_test.ifc", validate=True)
+
+
+def test_deformed_face_rejection_can_be_turned_off(example_files, monkeypatch):
+    """The guard is a heuristic over control points, so it must be escapable.
+
+    A b-spline's control points need not lie near the surface, so a patch can be
+    called "stretched" on a face that is perfectly good — and the cost of a false
+    positive is silent: the plate keeps its position and loses its boundary.
+    """
+    xml_file = (example_files / "fem_files/sesam/curved_plates.xml").resolve().absolute()
+    monkeypatch.setenv("ADA_GXML_IMPORT_ADVANCED_FACES", "true")
+    monkeypatch.setenv("ADA_GXML_REJECT_DEFORMED_CURVED_FACES", "false")
+
+    a = ada.from_genie_xml(xml_file)
+    objects = list(a.get_all_subparts()[0].get_all_physical_objects())
+
+    # the two the guard rejects are kept as advanced faces instead
+    assert Counter(type(o).__name__ for o in objects) == {"PlateCurved": 9}

--- a/tests/core/cadit/gxml/test_sesam_read_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_read_xml.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import ada
 
 
@@ -11,9 +13,25 @@ def test_sesam_xml(example_files, tmp_path, monkeypatch):
     p = a.get_all_subparts()[0]
     objects = list(p.get_all_physical_objects())
 
-    # The fixture has 3 curved_shell elements. elev3 (4 flat split faces) is
-    # merged into 1 Plate, elev4 is a single PlateCurved, and elev5 is a
-    # PlateCurved plus 3 leftover flat faces.
-    assert len(objects) == 6
+    # The fixture has 3 curved_shell elements over 9 SAT faces. Every one of
+    # those faces is bounded by at least one intcurve — including the four with
+    # a PLANE surface — so all nine come in as PlateCurved.
+    #
+    # Those four used to merge into a single flat Plate: flat surface, so the
+    # reader took the polygon path and their b-spline edges survived only as
+    # polylines. That merge was cheaper but not what the file says, and a plate
+    # whose edge has been straightened no longer shares that edge with the
+    # curved face it was cut against.
+    assert len(objects) == 9
+    kinds = Counter(type(o).__name__ for o in objects)
+    # two still fall back to a flat Plate, caught by the stretched-surface guard
+    # rather than by having straight edges
+    assert kinds == {"PlateCurved": 7, "Plate": 2}, kinds
+
+    from ada.api.plates import PlateCurved
+
+    surfaces = Counter(type(o.geom.geometry.face_surface).__name__ for o in objects if isinstance(o, PlateCurved))
+    # the flat-surfaced ones are carried as advanced faces for their edges' sake
+    assert surfaces["Plane"] > 0, surfaces
 
     a.to_ifc(tmp_path / "sesam_test.ifc", validate=True)

--- a/tests/core/cadit/gxml/test_sesam_read_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_read_xml.py
@@ -24,9 +24,12 @@ def test_sesam_xml(example_files, tmp_path, monkeypatch):
     # curved face it was cut against.
     assert len(objects) == 9
     kinds = Counter(type(o).__name__ for o in objects)
-    # two still fall back to a flat Plate, caught by the stretched-surface guard
-    # rather than by having straight edges
-    assert kinds == {"PlateCurved": 7, "Plate": 2}, kinds
+    # Two of these used to fall back to a flat Plate on the stretched-surface
+    # guard, which is now off by default: it fires on the control points, which
+    # for a b-spline need not lie near the surface, so it flattened faces that
+    # were perfectly good — and a flattened face no longer shares an edge with
+    # the curved one it was cut against (see reject_deformed_curved_faces).
+    assert kinds == {"PlateCurved": 9}, kinds
 
     from ada.api.plates import PlateCurved
 

--- a/tests/core/cadit/gxml/test_sesam_write_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_write_xml.py
@@ -178,6 +178,18 @@ class TestEmbeddedSat:
         assert all(len(d) == SEGMENT_BYTES for d in decoded[:-1])
         assert 0 < len(decoded[-1]) <= SEGMENT_BYTES
 
+    def test_the_same_body_always_zips_to_the_same_bytes(self):
+        """zipfile stamps members with localtime() unless told otherwise.
+
+        That made the embedded SAT differ between two writes of the same model —
+        and, because DOS timestamps have two-second resolution, only sometimes,
+        which is worse than always: it turned the streaming-vs-DOM comparison
+        into a rare flake rather than an honest failure.
+        """
+        from ada.cadit.gxml.write.write_sat_embedded import sat_to_base64_segments
+
+        assert sat_to_base64_segments("body") == sat_to_base64_segments("body")
+
     def test_multi_segment_body_round_trips(self, tmp_path):
         """A body larger than one segment must reassemble exactly."""
         import base64

--- a/tests/core/cadit/gxml/test_sesam_write_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_write_xml.py
@@ -107,10 +107,208 @@ def test_streaming_xml_from_fem_byte_identical(fem_files, tmp_path):
     assert dom.read_bytes() == stream.read_bytes()
 
 
-def test_create_sesam_xml_with_plate(tmp_path):
-    pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1)
-    a = ada.Assembly("a") / pl
-    a.to_genie_xml(tmp_path / "plate.xml", embed_sat=True)
+class TestEmbeddedSat:
+    """Genie stores the ACIS body under structure_domain/geometry as a
+    sat_embedded_sequence: zipped to one b64temp.sat member, the compressed
+    bytes cut into segments, each segment base64'd on its own inside CDATA.
+    Shapes asserted here were read off a Genie-authored export."""
+
+    @staticmethod
+    def _model():
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)
+        bulk = ada.Plate.from_3d_points("bulk", [(0, 5, 0), (10, 5, 0), (10, 5, 5), (0, 5, 5)], 0.01)
+        return ada.Assembly("a") / (ada.Part("p") / [deck, bulk])
+
+    def test_embed_sat_is_the_default(self, tmp_path):
+        """Without SAT, Genie rebuilds every plate's ACIS on import — the thing
+        that made a large model take minutes to open."""
+        out = self._model().to_genie_xml(tmp_path / "plate.xml")
+        raw = out.read_text()
+        assert "<sat_embedded_sequence" in raw
+        assert "<polygons>" not in raw
+
+    def test_geometry_is_the_last_child_of_structure_domain(self, tmp_path):
+        out = self._model().to_genie_xml(tmp_path / "plate.xml")
+        sd = ET.parse(str(out)).getroot().find("./model/structure_domain")
+        assert [c.tag for c in sd][-1] == "geometry"
+
+    def test_sequence_attributes_and_cdata(self, tmp_path):
+        out = self._model().to_genie_xml(tmp_path / "plate.xml")
+        seq = ET.parse(str(out)).getroot().find(".//geometry/sat_embedded_sequence")
+        assert seq.attrib == {"encoding": "base64", "compression": "zip", "tag_name": "dnvscp"}
+        assert len(seq.findall("cdata_segment")) >= 1
+        raw = out.read_text()
+        assert "<cdata_segment><![CDATA[" in raw
+        assert "__ADA_CDATA_SEGMENT" not in raw  # every placeholder spliced
+
+    def test_sat_reads_back_out_of_the_xml(self, tmp_path):
+        from ada.cadit.gxml.sat_helpers import get_sat_text_from_xml
+
+        out = self._model().to_genie_xml(tmp_path / "plate.xml")
+        sat = get_sat_text_from_xml(out)
+        assert sat.startswith("2000 0 1 0")
+        assert sat.rstrip().endswith("End-of-ACIS-data")
+
+    def test_plate_references_every_face_it_was_split_into(self, tmp_path):
+        """The bulkhead cuts the deck in two, so the deck's sheet must name both
+        halves — Genie writes up to 10 faces for one plate on a real model."""
+        out = self._model().to_genie_xml(tmp_path / "plate.xml")
+        refs = {
+            fp.get("name"): [f.get("face_ref") for f in fp.iterfind(".//sat_reference/face")]
+            for fp in ET.parse(str(out)).getroot().iterfind(".//structure/flat_plate")
+        }
+        assert len(refs["deck"]) == 2
+        assert len(refs["bulk"]) == 1
+        assert not set(refs["deck"]) & set(refs["bulk"])  # no face claimed twice
+
+    def test_segments_split_the_zipped_body_at_1mib(self):
+        """Each segment is base64 of its own 1 MiB slice of the *compressed*
+        stream, so a reader must join the decoded bytes, not the base64 text."""
+        import base64
+
+        from ada.cadit.gxml.write.write_sat_embedded import (
+            SEGMENT_BYTES,
+            sat_to_base64_segments,
+        )
+
+        segments = sat_to_base64_segments("x" * (6 * SEGMENT_BYTES))  # compresses small
+        assert len(segments) >= 1
+        decoded = [base64.b64decode(s) for s in segments]
+        assert all(len(d) == SEGMENT_BYTES for d in decoded[:-1])
+        assert 0 < len(decoded[-1]) <= SEGMENT_BYTES
+
+    def test_multi_segment_body_round_trips(self, tmp_path):
+        """A body larger than one segment must reassemble exactly."""
+        import base64
+        import io
+        import zipfile
+
+        from ada.cadit.gxml.write.write_sat_embedded import (
+            SEGMENT_BYTES,
+            ZIP_MEMBER,
+            sat_to_base64_segments,
+        )
+
+        # incompressible payload, so the zip is comfortably over one segment
+        body = base64.b64encode(np.random.default_rng(0).bytes(3 * SEGMENT_BYTES)).decode()
+        segments = sat_to_base64_segments(body)
+        assert len(segments) > 1
+
+        blob = b"".join(base64.b64decode(s) for s in segments)
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            assert zf.namelist() == [ZIP_MEMBER]
+            assert zf.read(ZIP_MEMBER).decode() == body
+
+    def test_beams_only_model_omits_geometry(self, tmp_path):
+        """No plates means no ACIS body — emitting an empty one is not valid."""
+        a = ada.Assembly("a") / (ada.Part("p") / ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE200"))
+        out = a.to_genie_xml(tmp_path / "beams.xml")
+        assert ET.parse(str(out)).getroot().find(".//geometry/sat_embedded_sequence") is None
+
+
+class TestBeamSatReference:
+    """A beam's <wire> must name the SAT edges its axis became.
+
+    Left empty, Genie rebuilds every beam's ACIS wire on import. On a large
+    frame that is the single dominant import cost — far more than the plates —
+    so an empty reference here is a performance bug, not a cosmetic one.
+    """
+
+    @staticmethod
+    def _model():
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (3.9, 0, 0), (3.9, 1.3, 0), (0, 1.3, 0)], 0.01)
+        # crosses the stiffeners at y=0.65, so each stiffener axis splits in two
+        bulk = ada.Plate.from_3d_points("bulk", [(0, 0.65, 0), (3.9, 0.65, 0), (3.9, 0.65, 1.0), (0, 0.65, 1.0)], 0.01)
+        stiff = [ada.Beam(f"st{i}", (x, 0, 0), (x, 1.3, 0), "HP180x8") for i, x in enumerate([1.3, 2.6])]
+        return ada.Assembly("a") / (ada.Part("p") / ([deck, bulk] + stiff))
+
+    def _refs(self, out):
+        return {
+            sb.get("name"): [e.get("edge_ref") for e in sb.iterfind(".//wire/sat_reference/edge")]
+            for sb in ET.parse(str(out)).getroot().iterfind(".//structure/straight_beam")
+        }
+
+    def test_beam_references_every_edge_its_axis_became(self, tmp_path):
+        refs = self._refs(self._model().to_genie_xml(tmp_path / "b.xml"))
+        assert len(refs["st0"]) == 2  # split by the bulkhead
+        assert len(refs["st1"]) == 2
+        assert not set(refs["st0"]) & set(refs["st1"])  # no edge claimed twice
+
+    def test_every_edge_ref_resolves_to_a_named_sat_edge(self, tmp_path):
+        import re
+
+        from ada.cadit.gxml.sat_helpers import get_sat_text_from_xml
+
+        out = self._model().to_genie_xml(tmp_path / "b.xml")
+        named = set(re.findall(r"@12 (EDGE\d{8}) #", get_sat_text_from_xml(out)))
+        referenced = {r for v in self._refs(out).values() for r in v}
+        assert referenced and referenced <= named
+        assert named == referenced  # and no EDGE is named without being referenced
+
+    def test_beam_with_no_plate_under_it_gets_a_wire_body(self, tmp_path):
+        """Its axis bounds no face, so it cannot hang off a loop — ACIS carries
+        it as a wire body off the shell instead. Without one the beam has no
+        geometry to reference and Genie rebuilds it."""
+        from tests.core.cadit.sat.sat_topology import parse, ref_errors
+
+        from ada.cadit.gxml.sat_helpers import get_sat_text_from_xml
+
+        a = self._model()
+        a.parts["p"].add_beam(ada.Beam("floating", (0, 0, 9), (1, 0, 9), "IPE200"))
+        out = a.to_genie_xml(tmp_path / "b.xml")
+
+        refs = self._refs(out)
+        assert len(refs["floating"]) == 1
+        assert len(refs["st0"]) == 2  # the plate-bound beams are unaffected
+
+        sat = get_sat_text_from_xml(out)
+        assert ref_errors(sat) == []
+        ents = parse(sat)
+        wires = [i for i, (t, _) in ents.items() if t == "wire"]
+        assert len(wires) == 1
+        # the shell must actually point at it (field[7]), or it is unreachable
+        shell = next(f for t, f in ents.values() if t == "shell")
+        assert shell[7] == f"${wires[0]}"
+
+    def test_no_sat_means_no_edge_refs(self, tmp_path):
+        out = self._model().to_genie_xml(tmp_path / "b.xml", embed_sat=False)
+        assert all(v == [] for v in self._refs(out).values())
+
+
+class TestGenieXmlFlags:
+    @staticmethod
+    def _model():
+        pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1)
+        return ada.Assembly("a") / (ada.Part("p") / pl)
+
+    def test_streaming_matches_dom_with_sat(self, tmp_path):
+        dom, stream = tmp_path / "dom.xml", tmp_path / "stream.xml"
+        self._model().to_genie_xml(dom, embed_sat=True)
+        self._model().to_genie_xml(stream, embed_sat=True, streaming=True)
+        assert dom.read_bytes() == stream.read_bytes()
+
+    def test_embed_sat_with_merge_strategy_raises(self, tmp_path):
+        """Contradictory: the SAT body is built from Plate objects, which the
+        merge_strategy face source never materialises. It used to silently drop
+        merge_strategy (DOM path) or embed_sat (streaming path)."""
+        with pytest.raises(ValueError, match="incompatible with merge_strategy"):
+            self._model().to_genie_xml(tmp_path / "x.xml", embed_sat=True, streaming=True, merge_strategy="coplanar")
+
+    def test_merge_strategy_without_streaming_raises(self, tmp_path):
+        """merge_strategy is only honoured on the streaming path; it used to be
+        accepted and ignored."""
+        with pytest.raises(ValueError, match="only honoured on the streaming path"):
+            self._model().to_genie_xml(tmp_path / "x.xml", merge_strategy="coplanar")
+
+    def test_merge_strategy_alone_falls_back_to_polygons(self, tmp_path):
+        out = self._model().to_genie_xml(tmp_path / "x.xml", streaming=True, merge_strategy="coplanar")
+        assert "<sat_embedded_sequence" not in out.read_text()
+
+    def test_embed_sat_false_writes_polygons(self, tmp_path):
+        out = self._model().to_genie_xml(tmp_path / "x.xml", embed_sat=False)
+        raw = out.read_text()
+        assert "<polygons>" in raw
+        assert "<sat_embedded_sequence" not in raw
 
 
 def test_create_groups_split_across_parts(tmp_path):

--- a/tests/core/cadit/gxml/test_sesam_write_xml.py
+++ b/tests/core/cadit/gxml/test_sesam_write_xml.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import ada
+from ada.api.beams.justification import Justification
 from ada.api.spatial.eq_types import EquipRepr
 
 
@@ -270,9 +271,112 @@ class TestBeamSatReference:
         shell = next(f for t, f in ents.values() if t == "shell")
         assert shell[7] == f"${wires[0]}"
 
+    def test_touching_free_beams_share_one_wire(self, tmp_path):
+        """Edges meeting at a vertex must all sit in the SAME wire.
+
+        One wire per edge puts that vertex in as many groups as there are edges
+        on it, and the model fails ACIS verification with "vertex has edge in
+        multiple groups". Genie groups them per connected run; so do we.
+        """
+        from tests.core.cadit.sat.sat_topology import parse, ref_errors, wire_groups
+
+        from ada.cadit.gxml.sat_helpers import get_sat_text_from_xml
+
+        a = self._model()
+        # a closed frame away from any plate, plus a spur off one corner: two
+        # runs that never touch each other -> two wires, whatever the edge count
+        corners = [(0, 0, 9), (4, 0, 9), (4, 4, 9), (0, 4, 9)]
+        for i in range(4):
+            a.parts["p"].add_beam(ada.Beam(f"fr{i}", corners[i], corners[(i + 1) % 4], "IPE200"))
+        a.parts["p"].add_beam(ada.Beam("spur", (4, 4, 9), (6, 6, 9), "IPE200"))
+        a.parts["p"].add_beam(ada.Beam("lonely", (0, 0, 20), (1, 0, 20), "IPE200"))
+
+        sat = get_sat_text_from_xml(a.to_genie_xml(tmp_path / "b.xml"))
+        assert ref_errors(sat) == []
+
+        groups = wire_groups(sat)
+        assert groups["wires"] == 2  # the 5-beam run, and the lonely one
+        assert groups["wires_per_component"] == {1: 2}
+        assert groups["vertices_in_multiple_wires"] == 0
+        # every vertex's coedges form one closed ring, including the loose ends
+        assert groups["fans_that_are_closed_rings"] == groups["fans"]
+
+        ents = parse(sat)
+        shell = next(f for t, f in ents.values() if t == "shell")
+        wires = [i for i, (t, _) in ents.items() if t == "wire"]
+        assert shell[7] == f"${wires[0]}"  # the chain still hangs off the shell
+
     def test_no_sat_means_no_edge_refs(self, tmp_path):
         out = self._model().to_genie_xml(tmp_path / "b.xml", embed_sat=False)
         assert all(v == [] for v in self._refs(out).values())
+
+
+class TestCurveOffset:
+    """Every <curve_offset> needs a child.
+
+    Genie rejects a bare <curve_offset/> outright ("Unable to build model from
+    element"), losing the beam. The default Justification.NA with no
+    eccentricity is the overwhelmingly common case, so an empty element there
+    takes out most of a model's beams at once.
+    """
+
+    @staticmethod
+    def _offsets(out):
+        return {
+            sb.get("name"): [c.tag for c in sb.find("curve_offset")]
+            for sb in ET.parse(str(out)).getroot().iterfind(".//structure/straight_beam")
+        }
+
+    def _write(self, tmp_path, beam):
+        a = ada.Assembly("a") / (ada.Part("p") / beam)
+        return self._offsets(a.to_genie_xml(tmp_path / "b.xml"))
+
+    def test_default_beam_states_the_default_rule(self, tmp_path):
+        """No offset and no flush intent still has to name a rule."""
+        offsets = self._write(tmp_path, ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300"))
+        assert offsets["bm"] == ["reparameterized_beam_curve_offset"]
+
+    @pytest.mark.parametrize(
+        "justification, expected",
+        [
+            (Justification.NA, "reparameterized_beam_curve_offset"),
+            (Justification.UNSET, "reparameterized_beam_curve_offset"),
+            (Justification.TOS, "constant_curve_offset"),
+            (Justification.FLUSH_TOP, "aligned_curve_offset"),
+            (Justification.FLUSH_BOTTOM, "aligned_curve_offset"),
+        ],
+    )
+    def test_every_justification_writes_exactly_one_child(self, tmp_path, justification, expected):
+        beam = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300", justification=justification)
+        assert self._write(tmp_path, beam)["bm"] == [expected]
+
+    def test_varying_eccentricity_is_written_numerically(self, tmp_path):
+        beam = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300", e1=(0, 0, 0.1))
+        assert self._write(tmp_path, beam)["bm"] == ["linear_varying_curve_offset"]
+
+    def test_flush_alignment_matches_the_justification(self, tmp_path):
+        for just, alignment in ((Justification.FLUSH_TOP, "flush_top"), (Justification.FLUSH_BOTTOM, "flush_bottom")):
+            beam = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300", justification=just)
+            a = ada.Assembly("a") / (ada.Part("p") / beam)
+            out = a.to_genie_xml(tmp_path / f"{alignment}.xml")
+            el = ET.parse(str(out)).getroot().find(".//straight_beam/curve_offset/aligned_curve_offset")
+            assert el.get("alignment") == alignment
+
+    def test_no_beam_is_written_with_an_empty_curve_offset(self, tmp_path):
+        """The whole point, over a mixed model."""
+        beams = [
+            ada.Beam("default", (0, 0, 0), (1, 0, 0), "IPE300"),
+            ada.Beam("flush", (0, 1, 0), (1, 1, 0), "IPE300", justification=Justification.FLUSH_TOP),
+            ada.Beam("ecc", (0, 2, 0), (1, 2, 0), "IPE300", e1=(0, 0, 0.1)),
+            ada.Beam("tos", (0, 3, 0), (1, 3, 0), "IPE300", justification=Justification.TOS),
+        ]
+        a = ada.Assembly("a") / (ada.Part("p") / beams)
+        out = a.to_genie_xml(tmp_path / "b.xml")
+        offsets = self._offsets(out)
+        assert len(offsets) == 4
+        assert all(len(v) == 1 for v in offsets.values()), offsets
+        assert "<curve_offset/>" not in out.read_text()
+        assert "<curve_offset />" not in out.read_text()
 
 
 class TestGenieXmlFlags:

--- a/tests/core/cadit/sat/sat_topology.py
+++ b/tests/core/cadit/sat/sat_topology.py
@@ -163,6 +163,93 @@ def wire_groups(text: str) -> dict:
     }
 
 
+def partner_rings(text: str) -> dict:
+    """Every edge's partner ring, and whether it runs in radial order.
+
+    ACIS reads the ring of coedges on an edge as the angular order of the faces
+    around it, so it has to be sorted; otherwise the model fails verification
+    with "coedges out of order about edge". A coedge's face lies to the left of
+    the direction it traverses the edge, so ``normal x tangent`` points from the
+    edge into the face and its angle about the edge places that face radially.
+
+    Returns ``{ring size: {"sorted_ccw": n, "sorted_cw": n, "unsorted": n}}``.
+    Only sizes >= 2 appear; a 2-ring is trivially sorted whatever the order, so
+    only 3+ tells you anything. Genie writes every ring counter-clockwise about
+    the edge's own direction.
+    """
+    import math
+
+    ents = parse(text)
+    coedges = {i: f for i, (t, f) in ents.items() if t == "coedge"}
+    loops = {i: f for i, (t, f) in ents.items() if t == "loop"}
+
+    def vec(fields, i):
+        return tuple(float(x) for x in fields[i : i + 3])
+
+    def cross(a, b):
+        return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
+    def unit(v):
+        n = math.sqrt(sum(x * x for x in v))
+        return None if n < 1e-12 else tuple(x / n for x in v)
+
+    on_edge: dict[int, list[int]] = {}
+    for cid, f in coedges.items():
+        if _ref(f[9]) in loops:  # face coedges; wire coedges carry no partner
+            on_edge.setdefault(_ref(f[7]), []).append(cid)
+
+    def face_normal(cid):
+        face = ents[_ref(loops[_ref(coedges[cid][9])][6])][1]
+        n = vec(ents[_ref(face[8])][1], 7)
+        return tuple(-x for x in n) if face[9] == "reversed" else n
+
+    out: dict[int, Counter] = {}
+    for eid, cids in on_edge.items():
+        if len(cids) < 2:
+            continue
+        axis = unit(vec(ents[_ref(ents[eid][1][9])][1], 7))
+        if axis is None:
+            continue
+        seed = (1.0, 0.0, 0.0) if abs(axis[0]) < 0.9 else (0.0, 1.0, 0.0)
+        ref = unit(cross(axis, seed))
+        ortho = cross(axis, ref)
+
+        def angle(cid):
+            tangent = axis if coedges[cid][8] == "forward" else tuple(-x for x in axis)
+            into = unit(cross(face_normal(cid), tangent))
+            if into is None:
+                return None
+            return math.atan2(sum(a * b for a, b in zip(into, ortho)), sum(a * b for a, b in zip(into, ref)))
+
+        ring, cur = [], cids[0]
+        for _ in range(len(cids) + 1):
+            ring.append(cur)
+            nxt = _ref(coedges[cur][6])
+            if nxt is None or nxt == cids[0]:
+                break
+            cur = nxt
+        bucket = out.setdefault(len(cids), Counter())
+        if set(ring) != set(cids):
+            bucket["ring_broken"] += 1
+            continue
+        angles = [angle(c) for c in ring]
+        if any(a is None for a in angles):
+            bucket["degenerate"] += 1
+            continue
+
+        def wraps_once(seq):
+            steps = [(seq[(i + 1) % len(seq)] - seq[i]) % (2 * math.pi) for i in range(len(seq))]
+            return all(s > 1e-9 for s in steps) and abs(sum(steps) - 2 * math.pi) < 1e-6
+
+        if wraps_once(angles):
+            bucket["sorted_ccw"] += 1
+        elif wraps_once(angles[::-1]):
+            bucket["sorted_cw"] += 1
+        else:
+            bucket["unsorted"] += 1
+    return {k: dict(v) for k, v in sorted(out.items())}
+
+
 def digest(text: str) -> dict:
     """Numbering-independent shape of the body.
 

--- a/tests/core/cadit/sat/sat_topology.py
+++ b/tests/core/cadit/sat/sat_topology.py
@@ -26,6 +26,7 @@ _EXPECTED = {
     "coedge": {4: ("coedge",), 5: ("coedge",), 6: ("coedge",), 7: ("edge",), 9: ("loop", "wire")},
     "edge": {4: ("vertex",), 6: ("vertex",), 8: ("coedge",), 9: ("straight-curve",)},
     "vertex": {4: ("edge",), 5: ("point",)},
+    "wire": {4: ("wire",), 5: ("coedge",), 6: ("body", "shell"), 7: ("subshell",)},
 }
 
 
@@ -63,6 +64,103 @@ def ref_errors(text: str) -> list[str]:
             elif ents[target][0] not in expected:
                 errors.append(f"-{idx} {etype}: field[{fi}]={fields[fi]} is {ents[target][0]!r}, expected {expected}")
     return errors
+
+
+def wire_groups(text: str) -> dict:
+    """How the wire (face-less) edges are grouped, and whether that is legal.
+
+    ACIS wants every edge meeting at a vertex reachable within one group, so a
+    connected run of edges has to live in a single wire; spread over several,
+    the model fails verification with "vertex has edge in multiple groups".
+
+    A wire coedge's ``next``/``prev`` are not a linear list — ``next`` is the
+    following coedge around its END vertex and ``prev`` the one around its START
+    vertex — so the coedges at each vertex form one closed ring, which is what
+    keeps a branched wire walkable. Reports:
+
+    ``wires``                      how many wire records
+    ``free_edges``                 edges carried by a wire rather than a loop
+    ``components``                 connected runs of those edges (shared vertex)
+    ``wires_per_component``        {wires spanned: how many components} — must be {1: n}
+    ``vertices_in_multiple_wires`` the failure itself; must be 0
+    ``fans`` / ``fans_that_are_closed_rings``   must be equal
+    """
+    ents = parse(text)
+    wires = {i for i, (t, _) in ents.items() if t == "wire"}
+    coedges = {i: f for i, (t, f) in ents.items() if t == "coedge"}
+    edges = {i: f for i, (t, f) in ents.items() if t == "edge"}
+    mine = {i: f for i, f in coedges.items() if _ref(f[9]) in wires}
+
+    def ends(cid):
+        """(start, end) vertex of the coedge's edge, in the coedge's own sense."""
+        e = edges[_ref(mine[cid][7])]
+        a, b = _ref(e[4]), _ref(e[6])
+        return (a, b) if mine[cid][8] == "forward" else (b, a)
+
+    def around(cid, v):
+        """The next coedge around vertex ``v``."""
+        start, end = ends(cid)
+        if v == end:
+            return _ref(mine[cid][4])  # next
+        if v == start:
+            return _ref(mine[cid][5])  # prev
+        return None
+
+    wire_of_edge = {_ref(f[7]): _ref(f[9]) for f in mine.values()}
+
+    parent = {e: e for e in wire_of_edge}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    seen_at = {}
+    for e in wire_of_edge:
+        for v in (_ref(edges[e][4]), _ref(edges[e][6])):
+            if v in seen_at:
+                ra, rb = find(seen_at[v]), find(e)
+                if ra != rb:
+                    parent[ra] = rb
+            else:
+                seen_at[v] = e
+    comps = {}
+    for e in wire_of_edge:
+        comps.setdefault(find(e), []).append(e)
+
+    fans = {}
+    for cid in mine:
+        start, end = ends(cid)
+        for v in {start, end}:
+            fans.setdefault(v, []).append(cid)
+
+    closed = 0
+    for v, cids in fans.items():
+        first, cur, walked = cids[0], cids[0], []
+        for _ in range(len(cids) + 1):
+            walked.append(cur)
+            cur = around(cur, v)
+            if cur is None or cur == first:
+                break
+        if cur == first and set(walked) == set(cids):
+            closed += 1
+
+    wires_at_vertex = {}
+    for e, w in wire_of_edge.items():
+        for v in (_ref(edges[e][4]), _ref(edges[e][6])):
+            wires_at_vertex.setdefault(v, set()).add(w)
+
+    return {
+        "wires": len(wires),
+        "free_edges": len(wire_of_edge),
+        "components": len(comps),
+        "component_sizes": dict(sorted(Counter(len(c) for c in comps.values()).items())),
+        "wires_per_component": dict(sorted(Counter(len({wire_of_edge[e] for e in c}) for c in comps.values()).items())),
+        "vertices_in_multiple_wires": sum(1 for w in wires_at_vertex.values() if len(w) > 1),
+        "fans": len(fans),
+        "fans_that_are_closed_rings": closed,
+    }
 
 
 def digest(text: str) -> dict:

--- a/tests/core/cadit/sat/sat_topology.py
+++ b/tests/core/cadit/sat/sat_topology.py
@@ -1,0 +1,147 @@
+"""Read a SESAM/ACIS SAT body back as topology, for asserting on writer output.
+
+Entity numbering is positional and carries no meaning, so comparing writer output
+to a Genie reference line-by-line asserts the wrong thing — it breaks on any
+re-ordering while missing genuinely corrupt cross-references. These helpers walk
+the record graph instead: :func:`ref_errors` checks every pointer resolves to the
+right kind of entity, and :func:`digest` reports the body's shape (counts, each
+face's boundary loop, sharing) independent of numbering.
+
+Field layouts are per the ACIS SAT v4.0 spec: all records open with the ENTITY
+prefix ``$attrib -1 -1 $owner`` at [0:4], then the entity's own fields at [4:].
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+# field index -> the entity type(s) that pointer must resolve to
+_EXPECTED = {
+    "body": {4: ("lump",), 5: ("wire",), 6: ("transform",)},
+    "lump": {4: ("lump",), 5: ("shell",), 6: ("body",)},
+    "shell": {4: ("shell",), 5: ("subshell",), 6: ("face",), 7: ("wire",), 8: ("lump",)},
+    "face": {4: ("face",), 5: ("loop",), 6: ("shell",), 8: ("plane-surface", "spline-surface")},
+    "loop": {4: ("loop",), 5: ("coedge",), 6: ("face",)},
+    "coedge": {4: ("coedge",), 5: ("coedge",), 6: ("coedge",), 7: ("edge",), 9: ("loop", "wire")},
+    "edge": {4: ("vertex",), 6: ("vertex",), 8: ("coedge",), 9: ("straight-curve",)},
+    "vertex": {4: ("edge",), 5: ("point",)},
+}
+
+
+def parse(text: str) -> dict[int, tuple[str, list[str]]]:
+    """{record index: (entity type, fields after the type token)}."""
+    out = {}
+    for line in text.splitlines():
+        m = re.match(r"^-(\d+)\s+(\S+)\s*(.*)$", line.strip())
+        if m:
+            out[int(m.group(1))] = (m.group(2), m.group(3).split())
+    return out
+
+
+def _ref(token: str) -> int | None:
+    """The record a ``$n`` pointer names, or None for ``$-1`` / a non-pointer."""
+    if not token.startswith("$"):
+        return None
+    idx = int(token[1:])
+    return None if idx < 0 else idx
+
+
+def ref_errors(text: str) -> list[str]:
+    """Every pointer that dangles or resolves to the wrong entity type."""
+    ents = parse(text)
+    errors = []
+    for idx, (etype, fields) in ents.items():
+        for fi, expected in _EXPECTED.get(etype, {}).items():
+            if fi >= len(fields):
+                continue
+            target = _ref(fields[fi])
+            if target is None:
+                continue
+            if target not in ents:
+                errors.append(f"-{idx} {etype}: field[{fi}]={fields[fi]} dangles")
+            elif ents[target][0] not in expected:
+                errors.append(f"-{idx} {etype}: field[{fi}]={fields[fi]} is {ents[target][0]!r}, expected {expected}")
+    return errors
+
+
+def digest(text: str) -> dict:
+    """Numbering-independent shape of the body.
+
+    Walks shell -> face chain -> loop -> coedge ring, reporting each face's
+    boundary as ordered points, its surface normal, and whether the loop winds
+    counter-clockwise about that normal (``winding_dots`` > 0 — the two must
+    agree or the face's material side is inverted).
+    """
+    ents = parse(text)
+    counts = Counter(etype for etype, _ in ents.values())
+
+    def point_of(vertex_idx: int) -> tuple[float, float, float]:
+        point_idx = _ref(ents[vertex_idx][1][5])
+        coords = ents[point_idx][1][4:7]
+        return tuple(round(float(c), 9) for c in coords)
+
+    body = next(i for i, (t, _) in ents.items() if t == "body")
+    lump = _ref(ents[body][1][4])
+    shell = _ref(ents[lump][1][5])
+
+    boundaries, normals, dots = [], [], []
+    face = _ref(ents[shell][1][6])
+    seen = set()
+    while face is not None and face not in seen:
+        seen.add(face)
+        fields = ents[face][1]
+
+        loop = _ref(fields[5])
+        first = _ref(ents[loop][1][5])
+        pts, coedge = [], first
+        while True:
+            cfields = ents[coedge][1]
+            efields = ents[_ref(cfields[7])][1]
+            start, end = point_of(_ref(efields[4])), point_of(_ref(efields[6]))
+            pts.append(end if cfields[8] == "reversed" else start)
+            coedge = _ref(cfields[4])
+            if coedge == first or coedge is None:
+                break
+        boundaries.append(pts)
+
+        sfields = ents[_ref(fields[8])][1]
+        normal = tuple(round(float(c), 6) for c in sfields[7:10])
+        normals.append(normal)
+        dots.append(round(sum(a * b for a, b in zip(_newell(pts), normal)), 6))
+
+        face = _ref(fields[4])
+
+    return {
+        "counts": dict(counts),
+        "faces_walked": len(boundaries),
+        "boundaries": boundaries,
+        "normals": normals,
+        "winding_dots": dots,
+        "coedges_with_partner": sum(1 for t, f in ents.values() if t == "coedge" and _ref(f[6]) is not None),
+    }
+
+
+def _newell(pts) -> tuple[float, float, float]:
+    """Unit normal of a closed polygon, robust to non-convexity."""
+    nx = ny = nz = 0.0
+    for i, a in enumerate(pts):
+        b = pts[(i + 1) % len(pts)]
+        nx += (a[1] - b[1]) * (a[2] + b[2])
+        ny += (a[2] - b[2]) * (a[0] + b[0])
+        nz += (a[0] - b[0]) * (a[1] + b[1])
+    mag = (nx * nx + ny * ny + nz * nz) ** 0.5 or 1.0
+    return (nx / mag, ny / mag, nz / mag)
+
+
+def loop_as_cycle(pts) -> list:
+    """A boundary loop normalised so equivalent loops compare equal.
+
+    Two SAT writers can start the same loop at a different vertex; rotating to
+    the lexicographically smallest start makes that irrelevant while keeping the
+    traversal direction significant (which orientation depends on).
+    """
+    if not pts:
+        return []
+    start = min(range(len(pts)), key=lambda i: pts[i])
+    return [pts[(start + i) % len(pts)] for i in range(len(pts))]

--- a/tests/core/cadit/sat/test_read_face_sense.py
+++ b/tests/core/cadit/sat/test_read_face_sense.py
@@ -1,0 +1,69 @@
+"""The face normal, read off a SAT file rather than assumed.
+
+ACIS splits it across two records: the ``face`` carries a forward/reversed
+sense and a ``spline-surface`` carries one of its own, so the normal is the
+composition. The reader used to hardcode ``same_sense = True``, which is a
+claim rather than a reading — a Genie export writes ``reversed`` on 1248 of
+4532 spline surfaces and on 112 plane faces, and every one came back flipped.
+"""
+
+import pathlib
+
+import pytest
+
+from ada.cadit.sat.read.advanced_face import get_face_same_sense
+from ada.cadit.sat.store import SatReaderFactory
+
+HEADER = "2000 0 1 0\n18 SESAM - gmGeometry 14 ACIS 33.0.1 NT 24 Tue Jan 17 20:39:08 2023\n1000 1e-06 1e-10\n"
+
+# a face, its loop, one plane-surface, and the minimum below it to resolve
+_PLANE_MODEL = """-0 body $-1 -1 -1 $-1 $1 $-1 $-1 T 0 0 0 1 1 0 #
+-1 lump $-1 -1 -1 $-1 $-1 $2 $0 T 0 0 0 1 1 0 #
+-2 shell $-1 -1 -1 $-1 $-1 $-1 $3 $-1 $1 T 0 0 0 1 1 0 #
+-3 face $-1 -1 -1 $-1 $-1 $4 $2 $-1 $5 {face_sense} double out F F #
+-4 loop $-1 -1 -1 $-1 $-1 $-1 $3 T 0 0 0 1 1 0 unknown #
+-5 plane-surface $-1 -1 -1 $-1 0 0 0 0 0 1 1 0 0 forward_v I I I I #
+End-of-ACIS-data"""
+
+_SPLINE_MODEL = """-0 body $-1 -1 -1 $-1 $1 $-1 $-1 T 0 0 0 1 1 0 #
+-1 lump $-1 -1 -1 $-1 $-1 $2 $0 T 0 0 0 1 1 0 #
+-2 shell $-1 -1 -1 $-1 $-1 $-1 $3 $-1 $1 T 0 0 0 1 1 0 #
+-3 face $-1 -1 -1 $-1 $-1 $4 $2 $-1 $5 {face_sense} double out F F #
+-4 loop $-1 -1 -1 $-1 $-1 $-1 $3 T 0 0 0 1 1 0 unknown #
+-5 spline-surface $-1 -1 -1 $-1 {surf_sense} {{ exactsur full nurbs 1 1 both open open none none 2 2 \n\t0 1 1 1 \n\t0 1 1 1 \n\t0 0 0 1 \n\t1 0 0 1 \n\t0 1 0 1 \n\t1 1 0 1 \n\t0 \n\t0 \n\t0 \n\t0 \n\t0 \n\t0 \n\t0 \n\tF 1 F 0 F 1 F 0 }} I I I I #
+End-of-ACIS-data"""
+
+
+def _face_record(tmp_path: pathlib.Path, text: str, name: str):
+    path = tmp_path / f"{name}.sat"
+    path.write_text(HEADER + text)
+    rf = SatReaderFactory(path)
+    return next(iter(rf.iter_faces()))
+
+
+class TestPlaneFace:
+    """A plane-surface has no sense of its own; the face carries it."""
+
+    @pytest.mark.parametrize("face_sense,expected", [("forward", True), ("reversed", False)])
+    def test_the_face_sense_is_the_answer(self, tmp_path, face_sense, expected):
+        rec = _face_record(tmp_path, _PLANE_MODEL.format(face_sense=face_sense), face_sense)
+        assert get_face_same_sense(rec) is expected
+
+
+class TestSplineFace:
+    """Both records carry a sense; the normal is the composition."""
+
+    @pytest.mark.parametrize(
+        "face_sense,surf_sense,expected",
+        [
+            ("forward", "forward", True),
+            ("forward", "reversed", False),
+            ("reversed", "forward", False),
+            # two flips cancel
+            ("reversed", "reversed", True),
+        ],
+    )
+    def test_the_senses_compose(self, tmp_path, face_sense, surf_sense, expected):
+        text = _SPLINE_MODEL.format(face_sense=face_sense, surf_sense=surf_sense)
+        rec = _face_record(tmp_path, text, f"{face_sense}_{surf_sense}")
+        assert get_face_same_sense(rec) is expected

--- a/tests/core/cadit/sat/test_write_curved_plate.py
+++ b/tests/core/cadit/sat/test_write_curved_plate.py
@@ -14,7 +14,9 @@ from ada.cadit.sat.write import sat_entities as se
 from ada.cadit.sat.write.write_curved_plate import (
     TopologyWeld,
     UnsupportedCurvedFace,
+    advanced_face_to_sat_entities,
     curved_plate_to_sat_entities,
+    flat_plate_to_advanced_face,
     link_partner_rings,
 )
 from ada.cadit.sat.write.writer import SatWriter
@@ -384,6 +386,115 @@ class TestWeld:
         p1, p2 = (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)
         line = geo_cu.Line(Point(*p1), (1.0, 0.0, 0.0))
         assert weld.edge_key(p1, p2, line) == weld.edge_key(p2, p1, line)
+
+
+class TestFlatPlatesJoinTheWeld:
+    """A flat plate meeting a curved one must share its corners with it.
+
+    Built apart they leave a coincident copy of every shared corner, which ACIS
+    rejects as "duplicate vertex" — 54 positions on a hull export, every one of
+    them a flat plate meeting a curved face. Genie shares all four edges of such
+    a face with its neighbours.
+    """
+
+    @staticmethod
+    def _flat_plate(x0, x1, normal=(0.0, 0.0, 1.0)):
+        """A unit square facing ``normal``.
+
+        The normal is pinned because CurvePoly2d picks its own: these points
+        come back facing -z, and two faces facing opposite ways run a shared
+        edge the SAME way, which is correct and not what these tests are about.
+        """
+        import ada
+
+        pts = [(x0, 0.0, 0.0), (x1, 0.0, 0.0), (x1, 1.0, 0.0), (x0, 1.0, 0.0)]
+        pl = ada.Plate.from_3d_points(f"flat{x0}", pts, 0.01)
+        if np.dot(np.asarray(pl.poly.normal, dtype=float), np.asarray(normal, dtype=float)) < 0:
+            pl = ada.Plate.from_3d_points(f"flat{x0}", pts, 0.01, flip_normal=True)
+        return pl
+
+    def test_a_flat_plate_becomes_a_plane_face_with_a_loop(self):
+        face = flat_plate_to_advanced_face(self._flat_plate(0.0, 1.0))
+        assert isinstance(face, geo_su.AdvancedFace)
+        assert isinstance(face.face_surface, geo_su.Plane)
+        assert len(face.bounds) == 1
+        assert len(face.bounds[0].bound.edge_list) == 4
+
+    def test_the_surface_states_the_plates_own_normal(self):
+        pl = self._flat_plate(0.0, 1.0)
+        face = flat_plate_to_advanced_face(pl)
+        axis = np.asarray(face.face_surface.position.axis, dtype=float)
+        assert np.dot(axis, np.asarray(pl.poly.normal, dtype=float)) > 0
+        # stated with the plate's normal, so the face agrees with it
+        assert face.same_sense is True
+
+    def test_a_flat_plate_shares_the_curved_faces_corners(self):
+        """The whole point: one vertex where they meet, not two."""
+        pl_curved = _plate(name="curved")  # the unit square at x in [0, 1]
+        pl_flat = self._flat_plate(1.0, 2.0)  # meets it along x = 1
+
+        sw = _writer(pl_curved)
+        weld = TopologyWeld(sw.id_generator)
+        ents = curved_plate_to_sat_entities(pl_curved, "FACE00000001", sw, weld)
+        ents += advanced_face_to_sat_entities(flat_plate_to_advanced_face(pl_flat), "FACE00000002", sw, weld)
+        link_partner_rings(weld)
+        ents += weld.entities
+
+        assert weld.n_vertices == 6, "the two shared corners were duplicated"
+        pts = [tuple(round(float(c), 7) for c in p.point) for p in _by_type(ents, se.SatPoint)]
+        assert len(pts) == len(set(pts))
+
+    def test_a_flat_plate_shares_the_curved_faces_edge(self):
+        pl_curved = _plate(name="curved")
+        pl_flat = self._flat_plate(1.0, 2.0)
+
+        sw = _writer(pl_curved)
+        weld = TopologyWeld(sw.id_generator)
+        curved_plate_to_sat_entities(pl_curved, "FACE00000001", sw, weld)
+        advanced_face_to_sat_entities(flat_plate_to_advanced_face(pl_flat), "FACE00000002", sw, weld)
+        link_partner_rings(weld)
+
+        assert weld.n_edges == 7, "the shared edge was written twice"
+        shared = [e for e in weld.coedges_on_edge.values() if len(e) == 2]
+        assert len(shared) == 1
+        (ca, _), (cb, _) = shared[0]
+        assert ca.partner is cb and cb.partner is ca
+        # both faces face +z, so they run the edge between them opposite ways
+        assert {ca.orientation, cb.orientation} == {"forward", "reversed"}
+
+    def test_two_faces_facing_opposite_ways_run_the_edge_the_same_way(self):
+        """The sense follows the winding, and the winding follows the normal.
+
+        Not a curiosity: the flat plate above comes out of CurvePoly2d facing
+        -z unless asked otherwise, and then both coedges reading `forward` is
+        the correct answer rather than a bug.
+        """
+        pl_curved = _plate(name="curved")  # faces +z
+        pl_flat = self._flat_plate(1.0, 2.0, normal=(0.0, 0.0, -1.0))
+
+        sw = _writer(pl_curved)
+        weld = TopologyWeld(sw.id_generator)
+        curved_plate_to_sat_entities(pl_curved, "FACE00000001", sw, weld)
+        advanced_face_to_sat_entities(flat_plate_to_advanced_face(pl_flat), "FACE00000002", sw, weld)
+
+        shared = [e for e in weld.coedges_on_edge.values() if len(e) == 2]
+        assert len(shared) == 1
+        (ca, _), (cb, _) = shared[0]
+        assert ca.orientation == cb.orientation
+
+    def test_the_curved_faces_parameter_range_survives_the_sharing(self):
+        """A straight edge has no range to contribute; the curved face's stands."""
+        pl_curved = _plate(name="curved")
+        pl_flat = self._flat_plate(1.0, 2.0)
+
+        sw = _writer(pl_curved)
+        weld = TopologyWeld(sw.id_generator)
+        curved_plate_to_sat_entities(pl_curved, "FACE00000001", sw, weld)
+        advanced_face_to_sat_entities(flat_plate_to_advanced_face(pl_flat), "FACE00000002", sw, weld)
+
+        assert weld.range_conflicts == 0
+        for edge in _by_type(weld.entities, se.Edge):
+            assert edge.t_start is None or edge.t_start < edge.t_end
 
 
 class TestRefusals:

--- a/tests/core/cadit/sat/test_write_curved_plate.py
+++ b/tests/core/cadit/sat/test_write_curved_plate.py
@@ -12,8 +12,10 @@ import pytest
 from ada.api.plates import PlateCurved
 from ada.cadit.sat.write import sat_entities as se
 from ada.cadit.sat.write.write_curved_plate import (
+    TopologyWeld,
     UnsupportedCurvedFace,
     curved_plate_to_sat_entities,
+    link_partner_rings,
 )
 from ada.cadit.sat.write.writer import SatWriter
 from ada.geom import Geometry
@@ -104,6 +106,14 @@ def _writer(pl) -> SatWriter:
     return sw
 
 
+def _build(pl, face_name="FACE00000001"):
+    """Build one face, with a weld of its own — the single-plate case."""
+    sw = _writer(pl)
+    weld = TopologyWeld(sw.id_generator)
+    entities = curved_plate_to_sat_entities(pl, face_name, sw, weld)
+    return entities + weld.entities
+
+
 def _by_type(entities, cls):
     return [e for e in entities if type(e) is cls]
 
@@ -111,7 +121,7 @@ def _by_type(entities, cls):
 class TestTopology:
     def test_one_face_one_loop_and_a_closed_coedge_ring(self):
         pl = _plate()
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
 
         assert len(_by_type(ents, se.Face)) == 1
         assert len(_by_type(ents, se.Loop)) == 1
@@ -130,14 +140,14 @@ class TestTopology:
     def test_a_shared_corner_is_one_vertex(self):
         """Four edges, four corners — not eight."""
         pl = _plate()
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert len(_by_type(ents, se.Vertex)) == 4
         assert len(_by_type(ents, se.SatPoint)) == 4
 
     def test_the_face_is_named_and_owned_by_the_shell(self):
         pl = _plate()
         sw = _writer(pl)
-        ents = curved_plate_to_sat_entities(pl, "FACE00000042", sw)
+        ents = curved_plate_to_sat_entities(pl, "FACE00000042", sw, TopologyWeld(sw.id_generator))
         face = _by_type(ents, se.Face)[0]
         assert face.name.name == "FACE00000042"
         assert face.shell is sw.shell
@@ -145,7 +155,7 @@ class TestTopology:
 
     def test_every_vertex_names_an_edge(self):
         pl = _plate()
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         for v in _by_type(ents, se.Vertex):
             assert v.edge is not None
 
@@ -168,7 +178,7 @@ class TestSenses:
 
     def test_a_descending_range_becomes_a_reversed_coedge(self):
         pl = _plate(self._face_with_backwards_edge())
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         senses = [c.orientation for c in _by_type(ents, se.CoEdge)]
         assert senses.count("reversed") == 1
         assert senses.count("forward") == 3
@@ -176,14 +186,14 @@ class TestSenses:
     def test_the_edge_range_still_ascends(self):
         """ACIS reads an edge forward along its curve, so t must ascend."""
         pl = _plate(self._face_with_backwards_edge())
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         for edge in _by_type(ents, se.Edge):
             assert edge.t_start < edge.t_end
             assert " forward " in edge.to_string()
 
     def test_a_reversed_edge_swaps_its_vertices(self):
         pl = _plate(self._face_with_backwards_edge())
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         reversed_coedge = next(c for c in _by_type(ents, se.CoEdge) if c.orientation == "reversed")
         edge = reversed_coedge.edge
         # the loop runs (1,0,0) -> (1,1,0); the edge is written the other way
@@ -195,21 +205,21 @@ class TestSurfacesAndPCurves:
     def test_a_plane_surfaced_face_carries_no_pcurve(self):
         """A flat face with curved edges: Genie gives its coedges no pcurve."""
         pl = _plate(_square_face(surface=_plane_surface(), pcurve=_pcurve()))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert len(_by_type(ents, se.PlaneSurface)) == 1
         assert _by_type(ents, se.PCurve) == []
         assert all(c.pcurve is None for c in _by_type(ents, se.CoEdge))
 
     def test_a_spline_face_carries_one_pcurve_per_coedge(self):
         pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve()))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert len(_by_type(ents, se.SplineSurface)) == 1
         assert len(_by_type(ents, se.PCurve)) == 4
         assert all(c.pcurve is not None for c in _by_type(ents, se.CoEdge))
 
     def test_the_pcurve_names_the_face_surface(self):
         pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve()))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         surface = _by_type(ents, se.SplineSurface)[0]
         for pc in _by_type(ents, se.PCurve):
             assert pc.surface is surface
@@ -226,20 +236,20 @@ class TestNormals:
     def test_a_spline_face_puts_the_flip_on_the_surface(self):
         """A spline-surface has a sense of its own, so the face stays forward."""
         pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(), same_sense=False))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert _by_type(ents, se.SplineSurface)[0].sense == "reversed"
         assert _by_type(ents, se.Face)[0].sense == "forward"
 
     def test_a_plane_face_puts_the_flip_on_the_face(self):
         """A plane-surface has no sense to carry it."""
         pl = _plate(_square_face(surface=_plane_surface(), same_sense=False))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert _by_type(ents, se.Face)[0].sense == "reversed"
 
     def test_an_agreeing_face_is_forward_either_way(self):
         for surface in (_spline_surface(), _plane_surface()):
             pl = _plate(_square_face(surface=surface, pcurve=_pcurve(), same_sense=True))
-            ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+            ents = _build(pl)
             assert _by_type(ents, se.Face)[0].sense == "forward"
             splines = _by_type(ents, se.SplineSurface)
             if splines:
@@ -247,7 +257,7 @@ class TestNormals:
 
     def test_the_face_sense_reaches_the_record(self):
         pl = _plate(_square_face(surface=_plane_surface(), same_sense=False))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         assert " reversed double out " in _by_type(ents, se.Face)[0].to_string()
 
 
@@ -262,14 +272,14 @@ class TestPCurveSense:
 
     def test_a_reversed_pcurve_is_written_reversed(self):
         pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(same_sense=False)))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         pcurves = _by_type(ents, se.PCurve)
         assert pcurves and all(pc.sense == "reversed" for pc in pcurves)
         assert all(" 0 reversed { exppc " in pc.to_string() for pc in pcurves)
 
     def test_a_forward_pcurve_is_written_forward(self):
         pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(same_sense=True)))
-        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        ents = _build(pl)
         pcurves = _by_type(ents, se.PCurve)
         assert pcurves and all(pc.sense == "forward" for pc in pcurves)
 
@@ -281,6 +291,101 @@ class TestPCurveSense:
         assert _reverse_pcurve_2d(_pcurve(same_sense=False)).same_sense is True
 
 
+class TestWeld:
+    """Neighbouring faces share their vertices and edges.
+
+    A face built alone mints its own vertex at each corner, so two faces meeting
+    along an edge leave coincident copies in the same shell — ACIS calls that
+    "duplicate vertex". Genie's export shares them: 6159 vertices for the 5470
+    faces where one-face-at-a-time gives 23186.
+    """
+
+    @staticmethod
+    def _two_squares():
+        """Two unit squares meeting along the x=1 edge."""
+
+        def square(x0, x1):
+            c = [(x0, 0.0, 0.0), (x1, 0.0, 0.0), (x1, 1.0, 0.0), (x0, 1.0, 0.0)]
+            edges = [_line_edge(c[i], c[(i + 1) % 4]) for i in range(4)]
+            return geo_su.AdvancedFace(
+                bounds=[geo_su.FaceBound(bound=geo_cu.EdgeLoop(edge_list=edges), orientation=True)],
+                face_surface=_plane_surface(),
+            )
+
+        return _plate(square(0.0, 1.0), name="a"), _plate(square(1.0, 2.0), name="b")
+
+    def _build_both(self):
+        pl_a, pl_b = self._two_squares()
+        sw = _writer(pl_a)
+        weld = TopologyWeld(sw.id_generator)
+        ents = curved_plate_to_sat_entities(pl_a, "FACE00000001", sw, weld)
+        ents += curved_plate_to_sat_entities(pl_b, "FACE00000002", sw, weld)
+        link_partner_rings(weld)
+        return ents + weld.entities, weld
+
+    def test_the_shared_corners_are_one_vertex_each(self):
+        ents, weld = self._build_both()
+        # 6 distinct corners across the two squares, not 8
+        assert weld.n_vertices == 6
+        assert len(_by_type(ents, se.Vertex)) == 6
+        assert len(_by_type(ents, se.SatPoint)) == 6
+
+    def test_no_two_points_are_coincident(self):
+        ents, _ = self._build_both()
+        pts = [tuple(round(float(c), 7) for c in p.point) for p in _by_type(ents, se.SatPoint)]
+        assert len(pts) == len(set(pts))
+
+    def test_the_shared_edge_is_one_record(self):
+        ents, weld = self._build_both()
+        # 7 edges: 3 on each square plus the one they share, not 8
+        assert weld.n_edges == 7
+        assert len(_by_type(ents, se.Edge)) == 7
+
+    def test_the_shared_edge_carries_two_coedges_that_partner_each_other(self):
+        ents, weld = self._build_both()
+        shared = [e for e in weld.coedges_on_edge.values() if len(e) == 2]
+        assert len(shared) == 1
+        (ca, _), (cb, _) = shared[0]
+        assert ca.partner is cb
+        assert cb.partner is ca
+        assert ca.edge is cb.edge
+
+    def test_an_edge_bounding_one_face_has_no_partner(self):
+        ents, weld = self._build_both()
+        for entries in weld.coedges_on_edge.values():
+            if len(entries) == 1:
+                assert entries[0][0].partner is None
+
+    def test_every_coedge_still_belongs_to_its_own_loop(self):
+        """Sharing an edge must not merge the two faces' loops."""
+        ents, _ = self._build_both()
+        loops = _by_type(ents, se.Loop)
+        assert len(loops) == 2
+        for loop in loops:
+            n, cur = 0, loop.coedge
+            while True:
+                assert cur.loop is loop
+                cur = cur.next_coedge
+                n += 1
+                if cur is loop.coedge or n > 8:
+                    break
+            assert n == 4
+
+    def test_a_differing_curve_between_the_same_points_is_not_the_same_edge(self):
+        """Two arcs can join one pair of vertices; position alone cannot tell."""
+        weld = TopologyWeld(_writer(_plate()).id_generator)
+        p1, p2 = (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)
+        line = geo_cu.Line(Point(*p1), (1.0, 0.0, 0.0))
+        circle = geo_cu.Circle(_plane_surface().position, 1.0)
+        assert weld.edge_key(p1, p2, line) != weld.edge_key(p1, p2, circle)
+
+    def test_the_key_ignores_which_way_the_edge_is_given(self):
+        weld = TopologyWeld(_writer(_plate()).id_generator)
+        p1, p2 = (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)
+        line = geo_cu.Line(Point(*p1), (1.0, 0.0, 0.0))
+        assert weld.edge_key(p1, p2, line) == weld.edge_key(p2, p1, line)
+
+
 class TestRefusals:
     """Refuse rather than approximate — the caller falls back to a polygon."""
 
@@ -289,14 +394,14 @@ class TestRefusals:
         face.bounds.append(face.bounds[0])
         pl = _plate(face)
         with pytest.raises(UnsupportedCurvedFace, match="bounds"):
-            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+            _build(pl)
 
     def test_an_unknown_surface_is_refused(self):
         face = _square_face()
         face.face_surface = geo_su.CylindricalSurface(position=_plane_surface().position, radius=1.0)
         pl = _plate(face)
         with pytest.raises(UnsupportedCurvedFace, match="CylindricalSurface"):
-            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+            _build(pl)
 
     def test_a_circle_without_parameters_is_refused(self):
         """A circle passes through two points twice; the range is not derivable."""
@@ -307,7 +412,7 @@ class TestRefusals:
         oe.t_start = oe.t_end = None
         pl = _plate(face)
         with pytest.raises(UnsupportedCurvedFace, match="without authored parameters"):
-            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+            _build(pl)
 
 
 class TestWiring:

--- a/tests/core/cadit/sat/test_write_curved_plate.py
+++ b/tests/core/cadit/sat/test_write_curved_plate.py
@@ -1,0 +1,289 @@
+"""The curved-plate SAT builder: one face per PlateCurved, senses and all.
+
+The senses are the interesting part. A Genie export writes every edge
+``forward`` with an ascending parameter range and lets the coedge carry the
+loop's direction, so the writer has to put the direction back where it came
+from — the reader hands it back as a ``t_start > t_end`` range instead.
+"""
+
+import numpy as np
+import pytest
+
+from ada.api.plates import PlateCurved
+from ada.cadit.sat.write import sat_entities as se
+from ada.cadit.sat.write.write_curved_plate import (
+    UnsupportedCurvedFace,
+    curved_plate_to_sat_entities,
+)
+from ada.cadit.sat.write.writer import SatWriter
+from ada.geom import Geometry
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+from ada.geom.placement import Axis2Placement3D
+from ada.geom.points import Point
+
+
+def _plane_surface():
+    return geo_su.Plane(
+        position=Axis2Placement3D(
+            location=Point(0.0, 0.0, 0.0),
+            axis=(0.0, 0.0, 1.0),
+            ref_direction=(1.0, 0.0, 0.0),
+        )
+    )
+
+
+def _spline_surface():
+    pts = [[(float(iu), float(iv), 0.0) for iv in range(4)] for iu in range(3)]
+    return geo_su.RationalBSplineSurfaceWithKnots(
+        u_degree=2,
+        v_degree=3,
+        control_points_list=pts,
+        surface_form=geo_su.BSplineSurfaceForm.UNSPECIFIED,
+        u_closed=False,
+        v_closed=False,
+        self_intersect=False,
+        u_multiplicities=[3, 3],
+        v_multiplicities=[4, 4],
+        u_knots=[0.0, 1.0],
+        v_knots=[0.0, 1.0],
+        knot_spec=geo_cu.KnotType.UNSPECIFIED,
+        weights_data=[[1.0] * 4 for _ in range(3)],
+    )
+
+
+def _pcurve():
+    return geo_cu.Pcurve2dBSpline(
+        degree=1,
+        control_points_2d=[[0.0, 0.0], [1.0, 0.0]],
+        knots=[0.0, 1.0],
+        knot_multiplicities=[2, 2],
+    )
+
+
+def _line_edge(p1, p2, t_start=None, t_end=None, pcurve=None):
+    """An oriented edge on a straight curve running p1 -> p2."""
+    d = np.asarray(p2, dtype=float) - np.asarray(p1, dtype=float)
+    length = float(np.linalg.norm(d))
+    line = geo_cu.Line(Point(*p1), tuple(d / length))
+    ec = geo_cu.EdgeCurve(start=Point(*p1), end=Point(*p2), edge_geometry=line, same_sense=True)
+    if t_start is None:
+        t_start, t_end = 0.0, length
+    return geo_cu.OrientedEdge(
+        start=Point(*p1),
+        end=Point(*p2),
+        edge_element=ec,
+        orientation=True,
+        pcurve=pcurve,
+        t_start=t_start,
+        t_end=t_end,
+    )
+
+
+def _square_face(surface=None, pcurve=None):
+    corners = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
+    edges = [_line_edge(corners[i], corners[(i + 1) % 4], pcurve=pcurve) for i in range(4)]
+    return geo_su.AdvancedFace(
+        bounds=[geo_su.FaceBound(bound=geo_cu.EdgeLoop(edge_list=edges), orientation=True)],
+        face_surface=surface if surface is not None else _plane_surface(),
+    )
+
+
+def _plate(face=None, name="pl1") -> PlateCurved:
+    from ada.visit.colors import Color
+
+    geom = Geometry(1, face if face is not None else _square_face(), Color(0.5, 0.5, 0.5))
+    return PlateCurved(name, geom, t=0.01)
+
+
+def _writer(pl) -> SatWriter:
+    sw = SatWriter(None)
+    sw.init_body([], [pl])
+    return sw
+
+
+def _by_type(entities, cls):
+    return [e for e in entities if type(e) is cls]
+
+
+class TestTopology:
+    def test_one_face_one_loop_and_a_closed_coedge_ring(self):
+        pl = _plate()
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+
+        assert len(_by_type(ents, se.Face)) == 1
+        assert len(_by_type(ents, se.Loop)) == 1
+        coedges = _by_type(ents, se.CoEdge)
+        assert len(coedges) == 4
+
+        # walk the ring: it must come back to the start having seen all four
+        seen, cur = [], coedges[0]
+        for _ in range(len(coedges)):
+            seen.append(cur)
+            assert cur.next_coedge.prev_coedge is cur
+            cur = cur.next_coedge
+        assert cur is coedges[0]
+        assert len(set(id(c) for c in seen)) == 4
+
+    def test_a_shared_corner_is_one_vertex(self):
+        """Four edges, four corners — not eight."""
+        pl = _plate()
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert len(_by_type(ents, se.Vertex)) == 4
+        assert len(_by_type(ents, se.SatPoint)) == 4
+
+    def test_the_face_is_named_and_owned_by_the_shell(self):
+        pl = _plate()
+        sw = _writer(pl)
+        ents = curved_plate_to_sat_entities(pl, "FACE00000042", sw)
+        face = _by_type(ents, se.Face)[0]
+        assert face.name.name == "FACE00000042"
+        assert face.shell is sw.shell
+        assert face.loop.face is face
+
+    def test_every_vertex_names_an_edge(self):
+        pl = _plate()
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        for v in _by_type(ents, se.Vertex):
+            assert v.edge is not None
+
+
+class TestSenses:
+    """The loop's direction lives on the coedge; the edge always runs forward."""
+
+    @staticmethod
+    def _face_with_backwards_edge():
+        # a loop whose second edge the reader handed back reversed: it runs
+        # (1,0,0) -> (1,1,0) but its curve is parameterised the other way, so
+        # t_start > t_end
+        corners = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
+        edges = [_line_edge(corners[i], corners[(i + 1) % 4]) for i in range(4)]
+        edges[1] = _line_edge((1.0, 0.0, 0.0), (1.0, 1.0, 0.0), t_start=1.0, t_end=0.0)
+        return geo_su.AdvancedFace(
+            bounds=[geo_su.FaceBound(bound=geo_cu.EdgeLoop(edge_list=edges), orientation=True)],
+            face_surface=_plane_surface(),
+        )
+
+    def test_a_descending_range_becomes_a_reversed_coedge(self):
+        pl = _plate(self._face_with_backwards_edge())
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        senses = [c.orientation for c in _by_type(ents, se.CoEdge)]
+        assert senses.count("reversed") == 1
+        assert senses.count("forward") == 3
+
+    def test_the_edge_range_still_ascends(self):
+        """ACIS reads an edge forward along its curve, so t must ascend."""
+        pl = _plate(self._face_with_backwards_edge())
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        for edge in _by_type(ents, se.Edge):
+            assert edge.t_start < edge.t_end
+            assert " forward " in edge.to_string()
+
+    def test_a_reversed_edge_swaps_its_vertices(self):
+        pl = _plate(self._face_with_backwards_edge())
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        reversed_coedge = next(c for c in _by_type(ents, se.CoEdge) if c.orientation == "reversed")
+        edge = reversed_coedge.edge
+        # the loop runs (1,0,0) -> (1,1,0); the edge is written the other way
+        assert tuple(edge.vertex_start.point.point) == (1.0, 1.0, 0.0)
+        assert tuple(edge.vertex_end.point.point) == (1.0, 0.0, 0.0)
+
+
+class TestSurfacesAndPCurves:
+    def test_a_plane_surfaced_face_carries_no_pcurve(self):
+        """A flat face with curved edges: Genie gives its coedges no pcurve."""
+        pl = _plate(_square_face(surface=_plane_surface(), pcurve=_pcurve()))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert len(_by_type(ents, se.PlaneSurface)) == 1
+        assert _by_type(ents, se.PCurve) == []
+        assert all(c.pcurve is None for c in _by_type(ents, se.CoEdge))
+
+    def test_a_spline_face_carries_one_pcurve_per_coedge(self):
+        pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve()))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert len(_by_type(ents, se.SplineSurface)) == 1
+        assert len(_by_type(ents, se.PCurve)) == 4
+        assert all(c.pcurve is not None for c in _by_type(ents, se.CoEdge))
+
+    def test_the_pcurve_names_the_face_surface(self):
+        pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve()))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        surface = _by_type(ents, se.SplineSurface)[0]
+        for pc in _by_type(ents, se.PCurve):
+            assert pc.surface is surface
+
+
+class TestRefusals:
+    """Refuse rather than approximate — the caller falls back to a polygon."""
+
+    def test_a_face_with_a_hole_is_refused(self):
+        face = _square_face()
+        face.bounds.append(face.bounds[0])
+        pl = _plate(face)
+        with pytest.raises(UnsupportedCurvedFace, match="bounds"):
+            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+
+    def test_an_unknown_surface_is_refused(self):
+        face = _square_face()
+        face.face_surface = geo_su.CylindricalSurface(position=_plane_surface().position, radius=1.0)
+        pl = _plate(face)
+        with pytest.raises(UnsupportedCurvedFace, match="CylindricalSurface"):
+            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+
+    def test_a_circle_without_parameters_is_refused(self):
+        """A circle passes through two points twice; the range is not derivable."""
+        circle = geo_cu.Circle(_plane_surface().position, 1.0)
+        face = _square_face()
+        oe = face.bounds[0].bound.edge_list[0]
+        oe.edge_element.edge_geometry = circle
+        oe.t_start = oe.t_end = None
+        pl = _plate(face)
+        with pytest.raises(UnsupportedCurvedFace, match="without authored parameters"):
+            curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+
+
+class TestWiring:
+    def test_part_to_sat_writer_gives_every_curved_plate_a_face(self):
+        import ada
+        from ada.cadit.sat.write.writer import part_to_sat_writer
+
+        p = ada.Part("p")
+        for i in range(3):
+            p.add_plate(_plate(name=f"cp{i}"))
+        a = ada.Assembly("a") / p
+
+        sw = part_to_sat_writer(a, imprint=False)
+        assert len(sw.get_entities_by_type(se.Face)) == 3
+        # each plate resolves to a face, and the names do not collide
+        names = [sw.face_map[pl.guid][0] for pl in p.get_all_physical_objects(by_type=PlateCurved)]
+        assert sorted(names) == ["FACE00000001", "FACE00000002", "FACE00000003"]
+
+    def test_a_curved_only_model_still_gets_a_body(self):
+        """The early-out used to key on flat plates alone."""
+        import ada
+        from ada.cadit.sat.write.writer import part_to_sat_writer
+
+        p = ada.Part("p")
+        p.add_plate(_plate())
+        a = ada.Assembly("a") / p
+
+        sw = part_to_sat_writer(a, imprint=False)
+        assert not sw.is_empty
+        assert len(sw.get_entities_by_type(se.Body)) == 1
+        assert sw.shell.face is not None
+
+    def test_the_shell_chains_every_face(self):
+        import ada
+        from ada.cadit.sat.write.writer import part_to_sat_writer
+
+        p = ada.Part("p")
+        for i in range(4):
+            p.add_plate(_plate(name=f"cp{i}"))
+        a = ada.Assembly("a") / p
+
+        sw = part_to_sat_writer(a, imprint=False)
+        seen, face = 0, sw.shell.face
+        while face is not None:
+            seen += 1
+            face = face.next_face
+        assert seen == 4

--- a/tests/core/cadit/sat/test_write_curved_plate.py
+++ b/tests/core/cadit/sat/test_write_curved_plate.py
@@ -52,12 +52,13 @@ def _spline_surface():
     )
 
 
-def _pcurve():
+def _pcurve(same_sense=True):
     return geo_cu.Pcurve2dBSpline(
         degree=1,
         control_points_2d=[[0.0, 0.0], [1.0, 0.0]],
         knots=[0.0, 1.0],
         knot_multiplicities=[2, 2],
+        same_sense=same_sense,
     )
 
 
@@ -80,12 +81,13 @@ def _line_edge(p1, p2, t_start=None, t_end=None, pcurve=None):
     )
 
 
-def _square_face(surface=None, pcurve=None):
+def _square_face(surface=None, pcurve=None, same_sense=True):
     corners = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]
     edges = [_line_edge(corners[i], corners[(i + 1) % 4], pcurve=pcurve) for i in range(4)]
     return geo_su.AdvancedFace(
         bounds=[geo_su.FaceBound(bound=geo_cu.EdgeLoop(edge_list=edges), orientation=True)],
         face_surface=surface if surface is not None else _plane_surface(),
+        same_sense=same_sense,
     )
 
 
@@ -211,6 +213,72 @@ class TestSurfacesAndPCurves:
         surface = _by_type(ents, se.SplineSurface)[0]
         for pc in _by_type(ents, se.PCurve):
             assert pc.surface is surface
+
+
+class TestNormals:
+    """ACIS splits the face normal across two records; Genie picks by surface.
+
+    Every one of these was written `forward` unconditionally at first, which
+    flipped 1248 spline surfaces and 112 plane faces of a hull export and had
+    Genie draw the model inside-out.
+    """
+
+    def test_a_spline_face_puts_the_flip_on_the_surface(self):
+        """A spline-surface has a sense of its own, so the face stays forward."""
+        pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(), same_sense=False))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert _by_type(ents, se.SplineSurface)[0].sense == "reversed"
+        assert _by_type(ents, se.Face)[0].sense == "forward"
+
+    def test_a_plane_face_puts_the_flip_on_the_face(self):
+        """A plane-surface has no sense to carry it."""
+        pl = _plate(_square_face(surface=_plane_surface(), same_sense=False))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert _by_type(ents, se.Face)[0].sense == "reversed"
+
+    def test_an_agreeing_face_is_forward_either_way(self):
+        for surface in (_spline_surface(), _plane_surface()):
+            pl = _plate(_square_face(surface=surface, pcurve=_pcurve(), same_sense=True))
+            ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+            assert _by_type(ents, se.Face)[0].sense == "forward"
+            splines = _by_type(ents, se.SplineSurface)
+            if splines:
+                assert splines[0].sense == "forward"
+
+    def test_the_face_sense_reaches_the_record(self):
+        pl = _plate(_square_face(surface=_plane_surface(), same_sense=False))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        assert " reversed double out " in _by_type(ents, se.Face)[0].to_string()
+
+
+class TestPCurveSense:
+    """The pcurve's sense is authored data, not a default.
+
+    It says whether the 2D curve runs along its edge's 3D curve, and nothing in
+    the knots or the coedge implies it — a Genie export splits 13722/5184 with
+    no correlation to either. Writing `forward` on all of them is what ACIS
+    rejects as "pcurve's range doesn't include coedge's range".
+    """
+
+    def test_a_reversed_pcurve_is_written_reversed(self):
+        pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(same_sense=False)))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        pcurves = _by_type(ents, se.PCurve)
+        assert pcurves and all(pc.sense == "reversed" for pc in pcurves)
+        assert all(" 0 reversed { exppc " in pc.to_string() for pc in pcurves)
+
+    def test_a_forward_pcurve_is_written_forward(self):
+        pl = _plate(_square_face(surface=_spline_surface(), pcurve=_pcurve(same_sense=True)))
+        ents = curved_plate_to_sat_entities(pl, "FACE00000001", _writer(pl))
+        pcurves = _by_type(ents, se.PCurve)
+        assert pcurves and all(pc.sense == "forward" for pc in pcurves)
+
+    def test_reversing_a_pcurve_flips_its_sense(self):
+        """Reversal inverts the direction, which is what the sense records."""
+        from ada.cadit.sat.read.curves import _reverse_pcurve_2d
+
+        assert _reverse_pcurve_2d(_pcurve(same_sense=True)).same_sense is False
+        assert _reverse_pcurve_2d(_pcurve(same_sense=False)).same_sense is True
 
 
 class TestRefusals:

--- a/tests/core/cadit/sat/test_write_spline_surface.py
+++ b/tests/core/cadit/sat/test_write_spline_surface.py
@@ -11,7 +11,13 @@ import re
 
 import pytest
 
-from ada.cadit.sat.write.sat_entities import PCurve, SplineSurface, _acis_knots
+from ada.cadit.sat.write.sat_entities import (
+    EllipseCurve,
+    PCurve,
+    SplineSurface,
+    _acis_knots,
+    circle_param_of,
+)
 from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
@@ -130,6 +136,65 @@ class TestPCurve:
         pc.weights = [1.0, 0.9]
         with pytest.raises(NotImplementedError, match="rational pcurve"):
             PCurve(2, pc, SplineSurface(1, _surface())).to_string()
+
+
+class TestEllipseCurve:
+    @staticmethod
+    def _circle(radius=3.5):
+        from ada import Direction, Point
+        from ada.geom.placement import Axis2Placement3D
+
+        pos = Axis2Placement3D(
+            location=Point(-89.3, -31.0, 3.5),
+            axis=Direction(0.0, 0.0, 1.0),
+            ref_direction=Direction(1.0, 0.0, 0.0),
+        )
+        return geo_cu.Circle(pos, radius)
+
+    def test_record_matches_genie(self):
+        rec = EllipseCurve(1, self._circle(), 0.0, 0.3926990816987237).to_string()
+        # centre, unit normal, major axis as a VECTOR of length radius, ratio 1
+        assert rec == ("-1 ellipse-curve $-1 -1 -1 $-1 -89.3 -31 3.5 0 0 1 3.5 0 0 1 F 0 F 0.3926990816987237 #")
+
+    def test_major_axis_carries_the_radius(self):
+        assert " 3.5 0 0 1 F " in EllipseCurve(1, self._circle(3.5), 0.0, 1.0).to_string()
+        assert " 7 0 0 1 F " in EllipseCurve(1, self._circle(7.0), 0.0, 1.0).to_string()
+
+    def test_a_descending_range_is_refused(self):
+        """The coedge sense carries direction; the curve's range always ascends."""
+        with pytest.raises(ValueError, match="must ascend"):
+            EllipseCurve(1, self._circle(), 0.3926990816987237, 0.0)
+
+
+class TestCircleParamOf:
+    """The angle convention: about the axis, from the reference direction."""
+
+    @staticmethod
+    def _circle():
+        from ada import Direction, Point
+        from ada.geom.placement import Axis2Placement3D
+
+        pos = Axis2Placement3D(
+            location=Point(0.0, 0.0, 0.0),
+            axis=Direction(0.0, 0.0, 1.0),
+            ref_direction=Direction(1.0, 0.0, 0.0),
+        )
+        return geo_cu.Circle(pos, 2.0)
+
+    def test_reference_direction_is_zero(self):
+        assert circle_param_of(self._circle(), (2.0, 0.0, 0.0)) == pytest.approx(0.0)
+
+    def test_quarter_turn(self):
+        import math
+
+        assert circle_param_of(self._circle(), (0.0, 2.0, 0.0)) == pytest.approx(math.pi / 2)
+
+    def test_wraps_rather_than_going_negative(self):
+        import math
+
+        # just short of the reference direction reads as ~2pi, not a small negative
+        p = circle_param_of(self._circle(), (2.0, -1e-9, 0.0))
+        assert p > math.pi, f"expected a wrap to ~2pi, got {p}"
 
 
 def test_fit_tolerance_survives_a_pcurve_reversal():

--- a/tests/core/cadit/sat/test_write_spline_surface.py
+++ b/tests/core/cadit/sat/test_write_spline_surface.py
@@ -208,10 +208,18 @@ class TestIntCurve:
     def test_fit_tolerance_is_written(self):
         assert " 3 0 0 0.001 null_surface" in IntCurve(1, self._bspline(), fit_tolerance=0.001).to_string()
 
-    def test_rational_curve_refuses_rather_than_dropping_weights(self):
-        """nubs has nowhere to put a weight; writing one anyway moves the curve."""
-        with pytest.raises(NotImplementedError, match="rational edge curve"):
-            IntCurve(1, self._bspline(rational=True)).to_string()
+    def test_a_rational_curve_is_written_nurbs_with_its_weights(self):
+        """Genie's parcur edges are rational; nubs has nowhere to put a weight."""
+        rec = IntCurve(1, self._bspline(rational=True)).to_string()
+        assert "{ exactcur full nurbs 3 open 2 0 3 2.33 3 " in rec
+        # x y z w per control point, in order
+        assert " 0 0 0 1 1 1 0 0.9 2 1 0 0.9 3 0 0 1 " in rec
+
+    def test_mismatched_weights_raise(self):
+        c = self._bspline(rational=True)
+        c.weights_data = [1.0, 0.9]
+        with pytest.raises(ValueError, match="weights for"):
+            IntCurve(1, c).to_string()
 
 
 class TestCircleParamOf:

--- a/tests/core/cadit/sat/test_write_spline_surface.py
+++ b/tests/core/cadit/sat/test_write_spline_surface.py
@@ -1,0 +1,146 @@
+"""Encoders for the curved-plate SAT records, pinned against a Genie export.
+
+The reference strings here are lifted verbatim from a Genie-authored hull model
+(``spline-surface`` -36315 and one of its coedge pcurves) and reduced to a small
+patch. They are ground truth for what Genie itself emits: the two conventions
+that matter — the knot vector and the control-point order — are both invisible
+in a self-consistent round trip and only show up against a real file.
+"""
+
+import re
+
+import pytest
+
+from ada.cadit.sat.write.sat_entities import PCurve, SplineSurface, _acis_knots
+from ada.geom import curves as geo_cu
+from ada.geom import surfaces as geo_su
+
+
+def _surface(u_degree=2, v_degree=3):
+    """A 3x4 rational patch, the shape a Genie hull plate uses."""
+    pts = [[(float(iu), float(iv), 0.0) for iv in range(4)] for iu in range(3)]
+    return geo_su.RationalBSplineSurfaceWithKnots(
+        u_degree=u_degree,
+        v_degree=v_degree,
+        control_points_list=pts,
+        surface_form=geo_su.BSplineSurfaceForm.UNSPECIFIED,
+        u_closed=False,
+        v_closed=False,
+        self_intersect=False,
+        u_multiplicities=[u_degree + 1, u_degree + 1],
+        v_multiplicities=[v_degree + 1, v_degree + 1],
+        u_knots=[0.0, 1.0],
+        v_knots=[0.0, 1.0],
+        knot_spec=geo_cu.KnotType.UNSPECIFIED,
+        weights_data=[[1.0] * 4 for _ in range(3)],
+    )
+
+
+class TestAcisKnots:
+    """ACIS stores one fewer knot at each end than IFC does."""
+
+    def test_end_multiplicities_drop_by_one(self):
+        # IFC gives n + degree + 1 knots; ACIS wants n + degree - 1
+        assert _acis_knots([0.0, 1.0], [3, 3], 2) == "0 2 1 2"
+        assert _acis_knots([0.0, 1.0], [4, 4], 3) == "0 3 1 3"
+
+    def test_interior_knots_are_untouched(self):
+        assert _acis_knots([0.0, 0.5, 1.0], [3, 1, 3], 2) == "0 2 0.5 1 1 2"
+
+    def test_control_point_count_reconciles(self):
+        """ACIS derives n_ctrl = sum(mults) - degree + 1; that must give 3."""
+        emitted = _acis_knots([0.0, 1.0], [3, 3], 2)
+        mults = [int(x) for x in emitted.split()[1::2]]
+        assert sum(mults) - 2 + 1 == 3
+
+    def test_multiplicity_too_low_for_the_degree_raises(self):
+        with pytest.raises(ValueError, match="too low"):
+            _acis_knots([0.0, 1.0], [1, 1], 2)
+
+    def test_mismatched_knots_and_multiplicities_raise(self):
+        with pytest.raises(ValueError, match="multiplicities"):
+            _acis_knots([0.0, 0.5, 1.0], [3, 3], 2)
+
+
+class TestSplineSurface:
+    def test_header_and_shape_match_genie(self):
+        body = SplineSurface(1, _surface()).subtype()
+        assert body.startswith("{ exactsur full nurbs 2 3 both open open none none 2 2 ")
+        assert body.endswith("0 0 0 0 0 0 0 F 1 F 0 F 1 F 0 }")
+        # 3x4 control points, each `x y z w`
+        assert len(re.findall(r"\d+ \d+ \d+ 1", body)) >= 12
+
+    def test_control_points_run_u_fastest(self):
+        """The grid is [u][v]; ACIS writes the transpose.
+
+        Genie's first run of points is n_u long — identifiable because it
+        carries the 1, cos(t/2), 1 weights of a degree-2 rational arc.
+        """
+        s = _surface()
+        # tag each control point with its (u, v) via x=u, y=v
+        s.control_points_list = [[(float(iu), float(iv), 0.0) for iv in range(4)] for iu in range(3)]
+        body = SplineSurface(1, s).subtype()
+        pts = re.findall(r"(\d+) (\d+) 0 1", body)
+        assert len(pts) == 12
+        # first three points share v=0 and step through u
+        assert [p[0] for p in pts[:3]] == ["0", "1", "2"]
+        assert {p[1] for p in pts[:3]} == {"0"}
+
+    def test_sense_is_written(self):
+        assert " reversed { exactsur" in SplineSurface(1, _surface(), sense="reversed").to_string()
+        assert " forward { exactsur" in SplineSurface(1, _surface()).to_string()
+
+    def test_record_is_a_spline_surface(self):
+        rec = SplineSurface(7, _surface()).to_string()
+        assert rec.startswith("-7 spline-surface $-1 -1 -1 $-1 ")
+        assert rec.endswith("I I I I #")
+
+
+class TestPCurve:
+    @staticmethod
+    def _pcurve(fit_tolerance=0.0):
+        return geo_cu.Pcurve2dBSpline(
+            degree=1,
+            control_points_2d=[[0.0, -4.0], [0.5, -4.0]],
+            knots=[0.0, 0.5],
+            knot_multiplicities=[2, 2],
+            fit_tolerance=fit_tolerance,
+        )
+
+    def test_exppc_head_matches_genie(self):
+        rec = PCurve(2, self._pcurve(), SplineSurface(1, _surface())).to_string()
+        assert rec.startswith("-2 pcurve $-1 -1 -1 $-1 0 forward { exppc nubs 1 open 2 ")
+        # degree-1 knots: IFC [2, 2] -> ACIS [1, 1]
+        assert "{ exppc nubs 1 open 2 0 1 0.5 1 0 -4 0.5 -4 " in rec
+        assert rec.endswith("I I I I } 0 0 #")
+
+    def test_fit_tolerance_is_written_not_assumed(self):
+        """0 claims the pcurve is exact; Genie says 0.001 on a quarter of them."""
+        assert " 0.5 -4 0.001 -1 spline " in PCurve(2, self._pcurve(0.001), SplineSurface(1, _surface())).to_string()
+        assert " 0.5 -4 0 -1 spline " in PCurve(2, self._pcurve(0.0), SplineSurface(1, _surface())).to_string()
+
+    def test_the_surface_is_embedded(self):
+        """A pcurve is meaningless without the surface its uv space belongs to."""
+        surf = SplineSurface(1, _surface(), sense="reversed")
+        rec = PCurve(2, self._pcurve(), surf).to_string()
+        assert "spline reversed { exactsur full nurbs 2 3 " in rec
+
+    def test_rational_pcurve_refuses_rather_than_dropping_weights(self):
+        pc = self._pcurve()
+        pc.weights = [1.0, 0.9]
+        with pytest.raises(NotImplementedError, match="rational pcurve"):
+            PCurve(2, pc, SplineSurface(1, _surface())).to_string()
+
+
+def test_fit_tolerance_survives_a_pcurve_reversal():
+    """Reversing changes direction, not how well the curve fits."""
+    from ada.cadit.sat.read.curves import _reverse_pcurve_2d
+
+    pc = geo_cu.Pcurve2dBSpline(
+        degree=1,
+        control_points_2d=[[0.0, 0.0], [1.0, 0.0]],
+        knots=[0.0, 1.0],
+        knot_multiplicities=[2, 2],
+        fit_tolerance=0.001,
+    )
+    assert _reverse_pcurve_2d(pc).fit_tolerance == 0.001

--- a/tests/core/cadit/sat/test_write_spline_surface.py
+++ b/tests/core/cadit/sat/test_write_spline_surface.py
@@ -23,6 +23,16 @@ from ada.geom import curves as geo_cu
 from ada.geom import surfaces as geo_su
 
 
+def _flat(record: str) -> str:
+    """The record's tokens, with the physical line breaks collapsed.
+
+    A subtype body is written across lines (see :func:`_lines`); assertions
+    about the *data* say so on the token stream, and the layout itself is
+    pinned separately in :class:`TestLineLayout`.
+    """
+    return " ".join(record.split())
+
+
 def _surface(u_degree=2, v_degree=3):
     """A 3x4 rational patch, the shape a Genie hull plate uses."""
     pts = [[(float(iu), float(iv), 0.0) for iv in range(4)] for iu in range(3)]
@@ -71,7 +81,7 @@ class TestAcisKnots:
 
 class TestSplineSurface:
     def test_header_and_shape_match_genie(self):
-        body = SplineSurface(1, _surface()).subtype()
+        body = _flat(SplineSurface(1, _surface()).subtype())
         assert body.startswith("{ exactsur full nurbs 2 3 both open open none none 2 2 ")
         assert body.endswith("0 0 0 0 0 0 0 F 1 F 0 F 1 F 0 }")
         # 3x4 control points, each `x y z w`
@@ -115,7 +125,7 @@ class TestPCurve:
         )
 
     def test_exppc_head_matches_genie(self):
-        rec = PCurve(2, self._pcurve(), SplineSurface(1, _surface())).to_string()
+        rec = _flat(PCurve(2, self._pcurve(), SplineSurface(1, _surface())).to_string())
         assert rec.startswith("-2 pcurve $-1 -1 -1 $-1 0 forward { exppc nubs 1 open 2 ")
         # degree-1 knots: IFC [2, 2] -> ACIS [1, 1]
         assert "{ exppc nubs 1 open 2 0 1 0.5 1 0 -4 0.5 -4 " in rec
@@ -123,13 +133,15 @@ class TestPCurve:
 
     def test_fit_tolerance_is_written_not_assumed(self):
         """0 claims the pcurve is exact; Genie says 0.001 on a quarter of them."""
-        assert " 0.5 -4 0.001 -1 spline " in PCurve(2, self._pcurve(0.001), SplineSurface(1, _surface())).to_string()
-        assert " 0.5 -4 0 -1 spline " in PCurve(2, self._pcurve(0.0), SplineSurface(1, _surface())).to_string()
+        assert " 0.5 -4 0.001 -1 spline " in _flat(
+            PCurve(2, self._pcurve(0.001), SplineSurface(1, _surface())).to_string()
+        )
+        assert " 0.5 -4 0 -1 spline " in _flat(PCurve(2, self._pcurve(0.0), SplineSurface(1, _surface())).to_string())
 
     def test_the_surface_is_embedded(self):
         """A pcurve is meaningless without the surface its uv space belongs to."""
         surf = SplineSurface(1, _surface(), sense="reversed")
-        rec = PCurve(2, self._pcurve(), surf).to_string()
+        rec = _flat(PCurve(2, self._pcurve(), surf).to_string())
         assert "spline reversed { exactsur full nurbs 2 3 " in rec
 
     def test_rational_pcurve_refuses_rather_than_dropping_weights(self):
@@ -186,7 +198,7 @@ class TestIntCurve:
         return geo_cu.BSplineCurveWithKnots(**kw)
 
     def test_record_matches_genie(self):
-        rec = IntCurve(1, self._bspline()).to_string()
+        rec = _flat(IntCurve(1, self._bspline()).to_string())
         # degree 3, IFC mults [4, 4] -> ACIS [3, 3], then 4 control points
         assert rec.startswith(
             "-1 intcurve-curve $-1 -1 -1 $-1 forward { exactcur full nubs 3 open 2 0 3 2.33 3 "
@@ -197,7 +209,7 @@ class TestIntCurve:
 
     def test_control_point_count_follows_the_knots(self):
         """ACIS reads n_ctrl back as sum(mults) - degree + 1; it must give 4."""
-        rec = IntCurve(1, self._bspline()).to_string()
+        rec = _flat(IntCurve(1, self._bspline()).to_string())
         mults = [3, 3]  # what _acis_knots emits for [4, 4] at degree 3
         assert sum(mults) - 3 + 1 == 4
         assert rec.count(" 0 0 0 1 1 0 2 1 0 3 0 0 ") == 1
@@ -206,11 +218,11 @@ class TestIntCurve:
         assert " reversed { exactcur" in IntCurve(1, self._bspline(), sense="reversed").to_string()
 
     def test_fit_tolerance_is_written(self):
-        assert " 3 0 0 0.001 null_surface" in IntCurve(1, self._bspline(), fit_tolerance=0.001).to_string()
+        assert " 3 0 0 0.001 null_surface" in _flat(IntCurve(1, self._bspline(), fit_tolerance=0.001).to_string())
 
     def test_a_rational_curve_is_written_nurbs_with_its_weights(self):
         """Genie's parcur edges are rational; nubs has nowhere to put a weight."""
-        rec = IntCurve(1, self._bspline(rational=True)).to_string()
+        rec = _flat(IntCurve(1, self._bspline(rational=True)).to_string())
         assert "{ exactcur full nurbs 3 open 2 0 3 2.33 3 " in rec
         # x y z w per control point, in order
         assert " 0 0 0 1 1 1 0 0.9 2 1 0 0.9 3 0 0 1 " in rec
@@ -220,6 +232,58 @@ class TestIntCurve:
         c.weights_data = [1.0, 0.9]
         with pytest.raises(ValueError, match="weights for"):
             IntCurve(1, c).to_string()
+
+
+class TestLineLayout:
+    """A subtype body is written across lines, the way ACIS lays one out.
+
+    Not cosmetic: the reader is line-oriented — ``extract_data_lines`` collects
+    lines until one carries a ``}``, then indexes the knots and control points
+    by line. Squeezed onto one line the whole body reads back as no data, and
+    every curved face in a file we wrote fails to import (with an IndexError
+    off the empty line list). These records went out one-line until the hull
+    round trip caught it, because a token-stream comparison against Genie's
+    file cannot see a newline.
+    """
+
+    @staticmethod
+    def _cont(record: str) -> list[str]:
+        return record.splitlines()[1:]
+
+    def test_spline_surface_breaks_after_the_header(self):
+        rec = SplineSurface(1, _surface()).to_string()
+        first = rec.splitlines()[0]
+        assert first.endswith("none none 2 2 ")
+        assert " exactsur " in first
+
+    def test_one_control_point_per_line(self):
+        rec = IntCurve(1, TestIntCurve._bspline()).to_string()
+        lines = rec.splitlines()
+        # header, knots, then one line per control point
+        assert lines[1] == "\t0 3 2.33 3 "
+        assert [ln.strip() for ln in lines[2:6]] == ["0 0 0", "1 1 0", "2 1 0", "3 0 0"]
+
+    def test_continuation_lines_are_tab_indented(self):
+        for rec in (
+            SplineSurface(1, _surface()).to_string(),
+            IntCurve(1, TestIntCurve._bspline()).to_string(),
+            PCurve(2, TestPCurve._pcurve(), SplineSurface(1, _surface())).to_string(),
+        ):
+            assert len(rec.splitlines()) > 1
+            for line in self._cont(rec):
+                assert line.startswith("\t"), f"{line!r} is not indented"
+
+    def test_the_reader_can_take_the_curve_back(self):
+        """The round trip the one-line layout silently broke."""
+        from ada.cadit.sat.read.bsplinecurves import extract_data_lines
+
+        rec = IntCurve(1, TestIntCurve._bspline()).to_string()
+        body = rec[rec.index("{") + 1 :]  # the reader is handed the body, brace consumed
+        data_lines = extract_data_lines(body)
+        assert data_lines, "the reader sees no data lines at all"
+        assert data_lines[0].split()[0] == "exactcur"
+        # the header, the knots, one line per control point, the fit tolerance
+        assert len(data_lines) >= 7
 
 
 class TestCircleParamOf:

--- a/tests/core/cadit/sat/test_write_spline_surface.py
+++ b/tests/core/cadit/sat/test_write_spline_surface.py
@@ -13,6 +13,7 @@ import pytest
 
 from ada.cadit.sat.write.sat_entities import (
     EllipseCurve,
+    IntCurve,
     PCurve,
     SplineSurface,
     _acis_knots,
@@ -164,6 +165,53 @@ class TestEllipseCurve:
         """The coedge sense carries direction; the curve's range always ascends."""
         with pytest.raises(ValueError, match="must ascend"):
             EllipseCurve(1, self._circle(), 0.3926990816987237, 0.0)
+
+
+class TestIntCurve:
+    @staticmethod
+    def _bspline(rational=False):
+        pts = [(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (2.0, 1.0, 0.0), (3.0, 0.0, 0.0)]
+        kw = dict(
+            degree=3,
+            control_points_list=pts,
+            curve_form=geo_cu.BSplineCurveFormEnum.UNSPECIFIED,
+            closed_curve=False,
+            self_intersect=False,
+            knot_multiplicities=[4, 4],
+            knots=[0.0, 2.33],
+            knot_spec=geo_cu.KnotType.UNSPECIFIED,
+        )
+        if rational:
+            return geo_cu.RationalBSplineCurveWithKnots(**kw, weights_data=[1.0, 0.9, 0.9, 1.0])
+        return geo_cu.BSplineCurveWithKnots(**kw)
+
+    def test_record_matches_genie(self):
+        rec = IntCurve(1, self._bspline()).to_string()
+        # degree 3, IFC mults [4, 4] -> ACIS [3, 3], then 4 control points
+        assert rec.startswith(
+            "-1 intcurve-curve $-1 -1 -1 $-1 forward { exactcur full nubs 3 open 2 0 3 2.33 3 "
+            "0 0 0 1 1 0 2 1 0 3 0 0 0 "
+        )
+        # lies on no surface, and needs no approximating data
+        assert "null_surface null_surface nullbs nullbs -1 -1 I I 0 0 0 -1 none F F 1 F 0 } I I #" in rec
+
+    def test_control_point_count_follows_the_knots(self):
+        """ACIS reads n_ctrl back as sum(mults) - degree + 1; it must give 4."""
+        rec = IntCurve(1, self._bspline()).to_string()
+        mults = [3, 3]  # what _acis_knots emits for [4, 4] at degree 3
+        assert sum(mults) - 3 + 1 == 4
+        assert rec.count(" 0 0 0 1 1 0 2 1 0 3 0 0 ") == 1
+
+    def test_sense_is_written(self):
+        assert " reversed { exactcur" in IntCurve(1, self._bspline(), sense="reversed").to_string()
+
+    def test_fit_tolerance_is_written(self):
+        assert " 3 0 0 0.001 null_surface" in IntCurve(1, self._bspline(), fit_tolerance=0.001).to_string()
+
+    def test_rational_curve_refuses_rather_than_dropping_weights(self):
+        """nubs has nowhere to put a weight; writing one anyway moves the curve."""
+        with pytest.raises(NotImplementedError, match="rational edge curve"):
+            IntCurve(1, self._bspline(rational=True)).to_string()
 
 
 class TestCircleParamOf:

--- a/tests/core/cadit/sat/test_write_write_basic_sat.py
+++ b/tests/core/cadit/sat/test_write_write_basic_sat.py
@@ -4,7 +4,7 @@ each case compares topology (via :mod:`sat_topology`) rather than raw lines —
 record numbering is positional and carries no meaning."""
 
 import pytest
-from tests.core.cadit.sat.sat_topology import digest, loop_as_cycle, ref_errors
+from tests.core.cadit.sat.sat_topology import digest, loop_as_cycle, parse, ref_errors
 
 import ada
 from ada.cadit.sat.write import sat_entities as se
@@ -186,6 +186,50 @@ class TestImprint:
         rings = partner_rings(part_to_sat_writer(a).to_str())
         assert rings[3] == {"sorted_ccw": 1}
         assert all(set(v) == {"sorted_ccw"} for v in rings.values()), rings
+
+    def test_beam_leaving_its_plate_declares_the_nonmanifold_vertex(self):
+        """Where a beam's axis runs off the plate, the boundary vertex is split.
+
+        It carries the plate's face edges AND the wire edge for the free run,
+        and nothing owns both, so neither is reachable from the other:
+        "vertex has edge in multiple groups". SAT v4.0 ch.7 `vertedge` wants an
+        edge pointer per separable region there, and the vertex itself to name
+        none — a single pointer could only ever reach one of the two.
+        """
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)
+        # starts on the deck, ends past its edge
+        bm = ada.Beam("bm", (5, 5, 0), (15, 5, 0), "IPE200")
+        a = ada.Assembly("t") / (ada.Part("p") / [deck, bm])
+
+        sat = part_to_sat_writer(a).to_str()
+        assert ref_errors(sat) == []
+
+        ents = parse(sat)
+        attribs = [(i, f) for i, (t, f) in ents.items() if t == "vertedge-sys-attrib"]
+        assert len(attribs) == 1, "the vertex where the axis crosses the deck edge"
+
+        aid, fields = attribs[0]
+        owner = int(fields[4][1:])
+        assert ents[owner][0] == "vertex"
+        # the vertex hands off to the attribute rather than naming one edge
+        assert ents[owner][1][0] == f"${aid}"
+        assert ents[owner][1][4] == "$-1"
+
+        # payload: a count, then that many edge pointers, the real ones first
+        payload = fields[5 + 18 :]
+        assert payload[0] == "4"
+        listed = [p for p in payload[1:] if p != "#"]
+        assert len(listed) == 4
+        named = [int(p[1:]) for p in listed if p != "$-1"]
+        assert len(named) == 2, "one edge per region: the deck's, and the free run's"
+        assert all(ents[e][0] == "edge" for e in named)
+
+    def test_a_plain_plate_has_no_vertedge_attribs(self):
+        """Nothing non-manifold about it — the attribute must not appear."""
+        a = ada.Assembly() / _plate_10x10(t=0.1)
+        sat = part_to_sat_writer(a).to_str()
+        assert "vertedge" not in sat
+        assert all(f[4] != "$-1" for t, f in parse(sat).values() if t == "vertex")
 
     def test_unfused_leaves_plates_unshared(self):
         """imprint=False keeps the old one-face-per-plate body (no CAD backend)."""

--- a/tests/core/cadit/sat/test_write_write_basic_sat.py
+++ b/tests/core/cadit/sat/test_write_write_basic_sat.py
@@ -52,8 +52,16 @@ def test_every_loop_points_at_its_own_face():
     assert ref_errors(sat) == []  # a wrong face pointer resolves to a non-face
 
 
-def test_all_faces_share_one_body_lump_shell():
-    """Genie puts every plate face in ONE body/lump/shell, chained via next_face."""
+def test_disconnected_plates_get_a_lump_each():
+    """A shell is a connected sheet; Genie carries disjoint pieces as lumps.
+
+    This used to assert one lump for every plate whatever their arrangement,
+    generalised from the reference files where the plates touch. The one where
+    they don't says otherwise — ``flat_plate_x2_sesam_10x10_offset_no_shared.sat``
+    is 2 faces in 2 lumps — and a shell holding faces that cannot be reached
+    from one another fails ACIS verification with "entities in shell are not
+    connected".
+    """
     plates = [_plate_10x10(f"pl{i}", origin=(0, 0, 2 * i)) for i in range(4)]
     a = ada.Assembly() / plates
 
@@ -61,10 +69,30 @@ def test_all_faces_share_one_body_lump_shell():
     sat = sw.to_str()
     d = digest(sat)
 
-    assert d["counts"]["body"] == d["counts"]["lump"] == d["counts"]["shell"] == 1
+    assert d["counts"]["body"] == 1
+    assert d["counts"]["lump"] == d["counts"]["shell"] == 4
     assert d["counts"]["face"] == 4
-    # all four reachable by walking the chain from the shell's single face pointer
-    assert d["faces_walked"] == 4
+    assert ref_errors(sat) == []
+
+
+def test_plates_sharing_a_vertex_stay_in_one_lump():
+    """Genie's ``flat_plate_x2_sesam_10x10_shared_vertex.sat`` is 2 faces, 1 lump.
+
+    A corner is enough — the pieces are reachable from each other, so they are
+    one connected sheet even though they share no edge.
+    """
+    a = ada.Assembly() / (
+        _plate_10x10("pl"),
+        _plate_10x10("pl2", origin=(10, 10, 0)),
+    )
+
+    sw = part_to_sat_writer(a, imprint=False)
+    sat = sw.to_str()
+    d = digest(sat)
+
+    assert d["counts"]["face"] == 2
+    assert d["counts"]["lump"] == d["counts"]["shell"] == 1
+    assert d["faces_walked"] == 2
     assert ref_errors(sat) == []
 
 

--- a/tests/core/cadit/sat/test_write_write_basic_sat.py
+++ b/tests/core/cadit/sat/test_write_write_basic_sat.py
@@ -148,6 +148,45 @@ class TestImprint:
         assert d["counts"]["vertex"] == 8  # welded, not 4+4
         assert all(x > 0 for x in d["winding_dots"])
 
+    def test_partner_ring_runs_in_radial_order(self):
+        """The ring on an edge is the faces' angular order, so it must be sorted.
+
+        Two plates crossing put FOUR faces on the intersection line — the case
+        that exposes this, since a ring of two is sorted whatever the order and
+        one of three is at worst reversed. Unordered, the model fails
+        verification with "coedges out of order about edge".
+        """
+        from tests.core.cadit.sat.sat_topology import partner_rings
+
+        horiz = ada.Plate.from_3d_points("h", [(0, -5, 0), (10, -5, 0), (10, 5, 0), (0, 5, 0)], 0.01)
+        vert = ada.Plate.from_3d_points("v", [(0, 0, -5), (10, 0, -5), (10, 0, 5), (0, 0, 5)], 0.01)
+        a = ada.Assembly("t") / (ada.Part("p") / [horiz, vert])
+
+        sw = part_to_sat_writer(a)
+        sat = sw.to_str()
+        assert ref_errors(sat) == []
+
+        # each plate is cut in two by the other
+        assert len(sw.face_map[horiz.guid]) == 2
+        assert len(sw.face_map[vert.guid]) == 2
+
+        rings = partner_rings(sat)
+        assert 4 in rings, f"expected an edge carrying four coedges, got {rings}"
+        assert rings[4] == {"sorted_ccw": 1}
+        # and nothing anywhere in the body is out of order
+        assert all(set(v) == {"sorted_ccw"} for v in rings.values()), rings
+
+    def test_t_junction_partner_ring_is_ordered(self):
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)
+        bulk = ada.Plate.from_3d_points("bulk", [(0, 5, 0), (10, 5, 0), (10, 5, 5), (0, 5, 5)], 0.01)
+        a = ada.Assembly("t") / (ada.Part("p") / [deck, bulk])
+
+        from tests.core.cadit.sat.sat_topology import partner_rings
+
+        rings = partner_rings(part_to_sat_writer(a).to_str())
+        assert rings[3] == {"sorted_ccw": 1}
+        assert all(set(v) == {"sorted_ccw"} for v in rings.values()), rings
+
     def test_unfused_leaves_plates_unshared(self):
         """imprint=False keeps the old one-face-per-plate body (no CAD backend)."""
         deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)

--- a/tests/core/cadit/sat/test_write_write_basic_sat.py
+++ b/tests/core/cadit/sat/test_write_write_basic_sat.py
@@ -1,53 +1,160 @@
+"""SAT writer tests, asserted against the Genie-authored reference bodies in
+``files/sat_files``. Those files are ground truth for what Genie itself emits, so
+each case compares topology (via :mod:`sat_topology`) rather than raw lines —
+record numbering is positional and carries no meaning."""
+
+import pytest
+from tests.core.cadit.sat.sat_topology import digest, loop_as_cycle, ref_errors
+
 import ada
 from ada.cadit.sat.write import sat_entities as se
 from ada.cadit.sat.write.writer import part_to_sat_writer
 
 
-def test_write_basic_plate_sat(example_files, tmp_path):
-    reference_file = example_files / "sat_files/flat_plate_sesam_10x10.sat"
-
-    pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1)
-    a = ada.Assembly() / pl
-
-    sw = part_to_sat_writer(a)
-    faces = sw.get_entities_by_type(se.Face)
-    assert len(faces) == 1
-    sat_str = sw.to_str()
-
-    # Make sure the top-level lines are the same
-    for line_a, line_b in zip(sat_str.splitlines(), reference_file.read_text().splitlines()):
-        if "gmGeometry" in line_a:
-            continue
-        if "coedge" in line_a or "edge" in line_a or "vertex" in line_a or "point" in line_a:
-            break
-        assert line_a == line_b
+def _plate_10x10(name="pl", origin=None, t=0.01):
+    return ada.Plate(name, [(0, 0), (10, 0), (10, 10), (0, 10)], t, origin=origin)
 
 
-def test_write_basic_plates_offset_shared_vertex():
-    pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.01)
-    pl2 = ada.Plate("pl2", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.01, origin=(10, 10, 0))
+def test_write_basic_plate_sat(example_files):
+    """A single plate must reproduce the Genie reference body."""
+    reference = (example_files / "sat_files/flat_plate_sesam_10x10.sat").read_text()
 
-    a = ada.Assembly() / (pl, pl2)
-    sw = part_to_sat_writer(a)
-    faces = sw.get_entities_by_type(se.Face)
-    assert len(faces) == 2
+    a = ada.Assembly() / _plate_10x10(t=0.1)
+    sat = part_to_sat_writer(a).to_str()
 
+    assert ref_errors(sat) == []
 
-def test_write_basic_plates_offset_shared_edge():
-    pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.01)
-    pl2 = ada.Plate("pl2", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.01, origin=(10, 5, 0))
-
-    a = ada.Assembly() / (pl, pl2)
-    sw = part_to_sat_writer(a)
-    faces = sw.get_entities_by_type(se.Face)
-    assert len(faces) == 2
+    ours, theirs = digest(sat), digest(reference)
+    assert ours["faces_walked"] == theirs["faces_walked"] == 1
+    for key in ("body", "lump", "shell", "face", "loop", "edge", "vertex", "point", "coedge"):
+        assert ours["counts"][key] == theirs["counts"][key], key
+    assert ours["normals"] == theirs["normals"] == [(0.0, 0.0, 1.0)]
+    assert loop_as_cycle(ours["boundaries"][0]) == loop_as_cycle(theirs["boundaries"][0])
 
 
-def test_write_basic_plates_offset_no_shared():
-    pl = ada.Plate("pl", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1)
-    pl2 = ada.Plate("pl2", [(0, 0), (10, 0), (10, 10), (0, 10)], 0.1, origin=(0, 0, 2))
+def test_plate_loop_winds_with_its_normal():
+    """The loop must wind counter-clockwise about the face normal.
 
-    a = ada.Assembly() / (pl, pl2)
-    sw = part_to_sat_writer(a)
-    faces = sw.get_entities_by_type(se.Face)
-    assert len(faces) == 2
+    CurvePoly2d hands back an outline wound *against* ``poly.normal``, so writing
+    ``segments3d`` straight out inverts which side of the face is material.
+    """
+    a = ada.Assembly() / _plate_10x10(t=0.1)
+    d = digest(part_to_sat_writer(a).to_str())
+    assert d["winding_dots"] == [1.0]
+
+
+def test_every_loop_points_at_its_own_face():
+    """Regression: the loop's face pointer was hardcoded to ``$3``, which is only
+    ever right for a single-plate body (whose face happens to be entity 3)."""
+    a = ada.Assembly() / (_plate_10x10("pl"), _plate_10x10("pl2", origin=(0, 0, 2)))
+    sat = part_to_sat_writer(a, imprint=False).to_str()
+
+    assert ref_errors(sat) == []  # a wrong face pointer resolves to a non-face
+
+
+def test_all_faces_share_one_body_lump_shell():
+    """Genie puts every plate face in ONE body/lump/shell, chained via next_face."""
+    plates = [_plate_10x10(f"pl{i}", origin=(0, 0, 2 * i)) for i in range(4)]
+    a = ada.Assembly() / plates
+
+    sw = part_to_sat_writer(a, imprint=False)
+    sat = sw.to_str()
+    d = digest(sat)
+
+    assert d["counts"]["body"] == d["counts"]["lump"] == d["counts"]["shell"] == 1
+    assert d["counts"]["face"] == 4
+    # all four reachable by walking the chain from the shell's single face pointer
+    assert d["faces_walked"] == 4
+    assert ref_errors(sat) == []
+
+
+@pytest.mark.parametrize("imprint", [False, True])
+def test_plate_in_a_placed_part_lands_in_global_coords(imprint):
+    """Regression: poly.points3d is in the plate's own frame, and the SAT body
+    used to emit it verbatim — so a plate inside a placed Part was written at
+    the wrong position while the polygon writer placed it correctly."""
+    pl = ada.Plate("pl", [(0, 0), (1, 0), (1, 1), (0, 1)], 0.01)
+    part = ada.Part("offset")
+    part.placement = ada.Placement(origin=(100, 0, 0))
+    a = ada.Assembly("a") / (part / pl)
+
+    d = digest(part_to_sat_writer(a, imprint=imprint).to_str())
+    xs = [p[0] for p in d["boundaries"][0]]
+    assert min(xs) == 100.0 and max(xs) == 101.0
+
+
+@pytest.mark.parametrize("imprint", [False, True])
+def test_write_basic_plates_offset_no_shared(imprint):
+    a = ada.Assembly() / (_plate_10x10("pl", t=0.1), _plate_10x10("pl2", origin=(0, 0, 2), t=0.1))
+    sw = part_to_sat_writer(a, imprint=imprint)
+    assert len(sw.get_entities_by_type(se.Face)) == 2
+    assert ref_errors(sw.to_str()) == []
+
+
+class TestImprint:
+    """The imprinted body must match what Genie produces for the same plates."""
+
+    def test_shared_vertex_matches_reference(self, example_files):
+        reference = (example_files / "sat_files/flat_plate_x2_sesam_10x10_shared_vertex.sat").read_text()
+        a = ada.Assembly() / (_plate_10x10("pl"), _plate_10x10("pl2", origin=(10, 10, 0)))
+
+        ours, theirs = digest(part_to_sat_writer(a).to_str()), digest(reference)
+        # touching at one corner: that vertex is shared, so 7 not 8
+        for key in ("face", "edge", "vertex", "point", "coedge"):
+            assert ours["counts"][key] == theirs["counts"][key], key
+        assert ours["counts"]["vertex"] == 7
+        assert ours["coedges_with_partner"] == theirs["coedges_with_partner"] == 0
+
+    def test_shared_edge_matches_reference(self, example_files):
+        reference = (example_files / "sat_files/flat_plate_x2_sesam_10x10_offset_shared_edge.sat").read_text()
+        a = ada.Assembly() / (_plate_10x10("pl"), _plate_10x10("pl2", origin=(10, 5, 0)))
+
+        sat = part_to_sat_writer(a).to_str()
+        assert ref_errors(sat) == []
+
+        ours, theirs = digest(sat), digest(reference)
+        # Genie splits both plates' facing edges at the overlap ends: 9 edges and
+        # 8 vertices for what would otherwise be 8 and 8.
+        for key in ("face", "edge", "vertex", "point", "coedge"):
+            assert ours["counts"][key] == theirs["counts"][key], key
+        assert ours["counts"]["edge"] == 9
+        # the one genuinely shared edge pairs two coedges through the partner ring
+        assert ours["coedges_with_partner"] == theirs["coedges_with_partner"] == 2
+        assert ours["normals"] == theirs["normals"]
+        assert all(d > 0 for d in ours["winding_dots"])
+
+        ours_loops = sorted(loop_as_cycle(b) for b in ours["boundaries"])
+        theirs_loops = sorted(loop_as_cycle(b) for b in theirs["boundaries"])
+        assert ours_loops == theirs_loops
+
+    def test_t_junction_splits_the_crossed_plate(self):
+        """A deck crossed by a bulkhead: the deck becomes two faces, and the
+        imprint line is ONE edge carrying three coedges in a partner ring."""
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)
+        bulk = ada.Plate.from_3d_points("bulk", [(0, 5, 0), (10, 5, 0), (10, 5, 5), (0, 5, 5)], 0.01)
+        a = ada.Assembly("t") / (ada.Part("p") / [deck, bulk])
+
+        sw = part_to_sat_writer(a)
+        sat = sw.to_str()
+        d = digest(sat)
+
+        assert ref_errors(sat) == []
+        assert d["counts"]["face"] == 3
+        assert d["faces_walked"] == 3
+        assert len(sw.face_map[deck.guid]) == 2  # split
+        assert len(sw.face_map[bulk.guid]) == 1
+        # 3 faces meet along the imprint line -> a 3-cycle, not a pair
+        assert d["coedges_with_partner"] == 3
+        assert d["counts"]["vertex"] == 8  # welded, not 4+4
+        assert all(x > 0 for x in d["winding_dots"])
+
+    def test_unfused_leaves_plates_unshared(self):
+        """imprint=False keeps the old one-face-per-plate body (no CAD backend)."""
+        deck = ada.Plate.from_3d_points("deck", [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)], 0.01)
+        bulk = ada.Plate.from_3d_points("bulk", [(0, 5, 0), (10, 5, 0), (10, 5, 5), (0, 5, 5)], 0.01)
+        a = ada.Assembly("t") / (ada.Part("p") / [deck, bulk])
+
+        d = digest(part_to_sat_writer(a, imprint=False).to_str())
+        assert d["counts"]["face"] == 2
+        assert d["counts"]["vertex"] == 8  # 4 + 4, none welded
+        assert d["coedges_with_partner"] == 0


### PR DESCRIPTION
Opening a generated Genie XML took minutes. The XML contained **no ACIS at all**: `to_genie_xml` defaulted `embed_sat=False`, so every plate went out as a bare `<polygons>` and every beam with an empty `<sat_reference/>`, leaving Genie to reconstruct — and imprint — the whole model's ACIS itself.

Measured on a large stiffened-panel frame, importing into GenieRuntime V9.2 with an identical `startup.js`:

| XML | Genie import |
|---|---|
| polygons (the old default) | **>556s**, killed unfinished at 9.3 min |
| SAT, plates only | **1564.5s** |
| **SAT, plates + beams (this PR)** | **34.4s** |
| a Genie-authored export of the same model, for reference | 36.8s |

The **beams**, not the plates, were the dominant cost — supplying only plate geometry left it at 26 minutes.

## Writer correctness

All verified against the Genie-authored reference bodies already in `files/sat_files/`.

- **`Loop` hardcoded `$3` as its owning face.** That's only ever right for a single-plate body (whose face happens to be entity 3) — which is exactly what the one existing test covered — so every loop of every real model pointed at the wrong entity.
- One lump+shell **per plate**; Genie puts every connected sheet in one lump (see *Curved plates* below for the correction to this).
- `face.next_face` was never linked, so only the first face was reachable from the shell's single face pointer.
- The coedge partner ring (`next coedge on edge`) was always `$-1`, so nothing knew two faces met at an edge.
- The edge's trailing `T <box>` is a **bounding box** but was emitted as start/end, inverting it for any edge running backwards along an axis.
- Loops wound **against** their own surface normal — `CurvePoly2d` hands back an outline wound against `poly.normal`, which inverts the face's material side.
- The SAT body **ignored `Part` placements entirely** (a plate in a part at x=100 was written at x=0) while the polygon writer honoured them. `Plate.outline_global()` / `Beam.axis_global()` now back both paths so they can't drift apart again.

## Imprinting

Genie's SAT is imprinted, and reproducing that is what makes it loadable as-is: plates are split by their neighbours **and by the beam axes lying on them** (a 3.9 m panel stiffened at 0.65 m arrives as 6 faces, not 1).

Added a backend-neutral `CadBackend.imprint_planar_faces` — General Fuse + `Modified()` history, one call per model, since the abstraction boundary must not land inside a per-face loop — and drove the writer from its result. Every beam now names the edges its axis became, and a beam with no plate under it gets a wire body rather than nothing.

Against a Genie-authored export of the same model, every plate and beam resolves to exactly the same number of faces/edges, with identical distributions.

Implemented for `OccBackend` here; the adacpp counterpart is Krande/adacpp#38 (needed for the pyodide path, where pythonocc doesn't exist). Without it, `AdacppBackend.imprint_planar_faces` raises a clear error pointing at `ADAPY_CAD_BACKEND=occ`.

## Curved plates

A `PlateCurved` reached the SAT writer and was ignored, so a curved plate had no face to reference and degraded to its boundary polygon — position-faithful, curvature gone. It now becomes a real spline face, leaving as the `<curved_shell>` Genie itself writes, with the records that hang under one: `spline-surface`, `pcurve`, `ellipse-curve` and `intcurve-curve`.

Neighbouring faces are welded into one topology, sharing vertices and edges rather than minting coincident copies, and the coedges on each shared edge form a partner ring. Flat plates join the same weld where curved faces are present, since a body has one topology and the imprint can only build a planar one.

**Every bug found here was the same shape: data the file authored, dropped on the way in, then defaulted on the way out.** The reader discarded the pcurve sense, the surface sense, the face sense, the `curved_shell` sense flag and the `flat_plate` normal vector, and the writer wrote `forward` / `true` for each. None is derivable — a pcurve's sense splits 13722/5184 in a reference export with no correlation to its knots or its coedge — so ACIS rejected every face it got wrong ("pcurve's range doesn't include coedge's range") and drew the rest inside-out.

Two reader fixes reach beyond SAT. `AdvancedFace.same_sense` was hardcoded `True`, which the OCC builder and the IFC/STEP writers all consume, so 1248 spline surfaces and 112 plane faces came back flipped in **every** export format. And a `flat_plate`'s normal was taken from its point winding rather than from the `<vector>` it states.

`reject_deformed_curved_faces` is now **off by default**: it was a fallback from when the reader could not yet take these faces, and it fires on control points, which for a b-spline need not lie near the surface. It flattened 119 good faces of a reference export, and a flattened face keeps its corners while losing its curved edges, so it can no longer weld to the neighbours it was cut from.

Verified by reading a Genie-authored hull export and comparing our records to its own, face by face, joined through the plate name:

| | ours | reference |
|---|---|---|
| faces compared, differing fields | 4743, **0** | — |
| lumps / shells | 2 / 2 | 2 / 2 |
| connected components | 2 | 2 |
| coincident vertices | 0 | 0 |
| non-manifold vertices | 0 | 0 |

Genie's verification of the round-tripped model is clean; its only remaining note ("2 disjoint model parts") is one the original raises too.

## Also

- `<geometry>` is written as Genie writes it: a `sat_embedded_sequence` of base64'd 1 MiB slices of the zipped body, in CDATA, last under `structure_domain`. Each slice is padded independently, so a reader must join the *decoded bytes*, not the base64 text.
- **`embed_sat` now defaults on.** It can't be produced with `merge_strategy`, which sources plates from the FEM face engine without ever materialising the `Plate` objects the body is built from — so the default resolves to off there, and asking for both explicitly now **raises** instead of silently dropping one. `merge_strategy` outside the streaming path was likewise accepted and ignored; that raises too.
- `embed_sat` composes with `streaming=True` (byte-identical to the DOM writer); it used to be silently discarded.
- Dropped `create_sesam_sat_bytes`: dead code, and its date format emitted the day-of-month where ACIS wants a string-length prefix.
- A subtype body is written across lines, as ACIS lays one out. Not cosmetic: the reader is line-oriented, so a body squeezed onto one line reads back as no data at all.

## Testing

1359 tests pass. The SAT tests assert against the Genie reference bodies **by topology rather than by line** — record numbering is positional and carries no meaning, so the old comparison broke on any reordering while missing genuinely corrupt references. `tests/core/cadit/sat/sat_topology.py` walks the record graph: every pointer must resolve to the right kind of entity, and the body's shape (counts, each face's boundary loop, winding vs. normal, sharing) is compared independent of numbering.

The reference bodies also settled two questions and corrected a test that had generalised from them: `flat_plate_x2_sesam_10x10_offset_no_shared.sat` is 2 faces in **2** lumps, and `..._shared_vertex.sat` is 2 faces in **1** — so a shell is a connected sheet, and a shared corner is enough to make one.

The pre-existing `test_ada_ext_codegen` failure is an unrelated em-dash encoding issue that also fails on a clean tree.

## Known gaps

- A pcurve inlines the surface it lies on where Genie emits `{ ref n }` to share one, so a curved-plate body is ~35 MB against the reference's ~25 MB. Size, not correctness — but since import speed is the point, it is the one worth closing next.
- 48 degenerate edges (an edge with no curve, ACIS marking a singularity) on 38 of a reference export's 5470 faces: 39 sit in inner loops the reader does not walk, and 9 leave their face with a single-edge outer loop, which the writer declines and the gxml writer falls back to a polygon for.
- Genie shares curves between collinear edges and names vertices; the XML references neither.
