### PR TITLE
feat: discover tessellation tracks from adacpp and publish them to the API

### DIFF
--- a/.forgejo/workflows/build.yaml
+++ b/.forgejo/workflows/build.yaml
@@ -403,12 +403,22 @@ jobs:
               .
           else
             echo "Full viewer build (FULL=$FULL)"
-            # Default to the repo-pinned base when the secret is unset, so the
-            # version lives in ONE place (matches deploy/Dockerfile.viewer) and
-            # a cleared secret can't fall back to a stale emscripten-3.1.58
-            # base. Override via the secret only to point at a different
-            # registry/tag (>=0.9.0 = pyodide_2025_0 / emscripten 4.0.9).
-            ADACPP_BASE_IMAGE="${ADACPP_BASE_IMAGE:-ghcr.io/krande/adacpp-wasm-base:0.13.2}"
+            # Default to the repo-pinned base when the secret is unset. READ the pin out
+            # of deploy/Dockerfile.viewer rather than restating it: this line used to
+            # carry its own literal with a "matches deploy/Dockerfile.viewer" comment,
+            # and it drifted to 0.13.2 while the Dockerfile said 0.14.0 — so the hosted
+            # viewer shipped on a base two releases old, and bumping the Dockerfile
+            # changed nothing. Now the version genuinely lives in ONE place.
+            # Override via the secret only to point at a different registry/tag
+            # (>=0.9.0 = pyodide_2025_0 / emscripten 4.0.9).
+            if [ -z "$ADACPP_BASE_IMAGE" ]; then
+              ADACPP_BASE_IMAGE="$(sed -n 's/^ARG ADACPP_BASE_IMAGE=//p' deploy/Dockerfile.viewer)"
+            fi
+            if [ -z "$ADACPP_BASE_IMAGE" ]; then
+              echo "::error::could not read the ADACPP_BASE_IMAGE pin from deploy/Dockerfile.viewer"
+              exit 1
+            fi
+            echo "adacpp wasm base: ${ADACPP_BASE_IMAGE}"
             # Pull the base ahead of the viewer build so a missing tag
             # fails loudly here, not buried in BuildKit output.
             docker pull "${ADACPP_BASE_IMAGE}"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,7 +25,10 @@ jobs:
               cache: true
               environments: lint
 
-          - run: pixi run lint
+          # NOT `pixi run lint`: that is black + `ruff check --fix` + isort, which all MUTATE the
+          # runner's checkout and exit 0 — so this job reformatted a throwaway copy and passed
+          # unconditionally. lint-check reports instead of rewriting.
+          - run: pixi run lint-check
 
     test:
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -39,11 +39,7 @@ permissions:
 # adapy repo read access) for the GITHUB_TOKEN pull below to resolve it.
 env:
   # 0.9.0: pyodide_2025_0 ABI (emscripten 4.0.9) + OCCT symbol isolation.
-  # MUST stay >=0.9.0 — older bases ship an emscripten 3.1.58 wheel that
-  # micropip refuses against pyodide 0.29.4 ("Wheel was built with Emscripten
-  # v3.1.58 but Pyodide was built with v4.0.9"). Keep in sync with the
-  # ADACPP_BASE_IMAGE default in deploy/Dockerfile.viewer.
-  ADACPP_WASM_BASE: ghcr.io/krande/adacpp-wasm-base:0.13.2
+  # (The adacpp wasm base version is NOT pinned here — see the viewer build step.)
 
 jobs:
   viewer:
@@ -78,9 +74,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # ADACPP_BASE_IMAGE is deliberately NOT passed: the pin is the ARG default in
+          # deploy/Dockerfile.viewer, and an unpassed build-arg lets that default stand.
+          # This used to restate the version as ADACPP_WASM_BASE, which drifted to 0.13.2
+          # while the Dockerfile said 0.14.0 — and a passed build-arg WINS over the ARG
+          # default, so the stale value is what shipped and bumping the Dockerfile did
+          # nothing. Pass this arg only to build against something other than the pin.
           build-args: |
             IMAGE_TAG=${{ steps.meta.outputs.version }}
-            ADACPP_BASE_IMAGE=${{ env.ADACPP_WASM_BASE }}
           cache-from: type=gha,scope=viewer
           cache-to: type=gha,mode=max,scope=viewer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,5 +10,9 @@ If you have pixi installed there is now experimental support.
 
 To lint with pixi do this: `pixi run lint`
 
+That rewrites your files in place. To see what CI will say without changing anything, run
+`pixi run lint-check` — same tools and config in check mode. It is the exact command the lint job
+runs, so a green `lint-check` locally means a green lint job.
+
 if pixi is not installed, you can find the isort, black and ruff versions in the `pyproject.toml` file,
 and install them yourself and use the tools however you like.

--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -12,7 +12,7 @@
 # CI passes the full image reference as a build-arg so this Dockerfile
 # stays registry-agnostic. Pin a different adacpp by pointing the
 # build-arg at a different version tag.
-ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.13.2
+ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.14.0
 FROM ${ADACPP_BASE_IMAGE} AS adacpp-wheel
 
 # Stage 0b: build the pure-python adapy wheel for pyodide. The browser

--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -9,10 +9,21 @@
 # adacpp's own publish-wasm-base workflow and runs only on adacpp
 # releases.
 #
-# CI passes the full image reference as a build-arg so this Dockerfile
-# stays registry-agnostic. Pin a different adacpp by pointing the
-# build-arg at a different version tag.
-ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.14.0
+# THIS LINE IS THE PIN — the single source of the adacpp wasm base version.
+# Both CI systems derive it from here (github publish-image.yaml lets this
+# default stand; forgejo build.yaml seds it out to pre-pull); override the
+# build-arg only to point at a different registry/tag.
+#
+# It did not used to be. Both workflows restated the version as their own
+# literal with a "keep in sync with deploy/Dockerfile.viewer" comment, and both
+# drifted to 0.13.2 while this line said 0.14.0 — and since a passed build-arg
+# overrides an ARG default, THEIR value is what shipped. Bumping this line alone
+# changed nothing about the built image. Hence: derived, not restated.
+#
+# MUST stay >=0.9.0 — older bases ship an emscripten 3.1.58 wheel that micropip
+# refuses against pyodide 0.29.4 ("Wheel was built with Emscripten v3.1.58 but
+# Pyodide was built with v4.0.9").
+ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.15.0
 FROM ${ADACPP_BASE_IMAGE} AS adacpp-wheel
 
 # Stage 0b: build the pure-python adapy wheel for pyodide. The browser

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -8,6 +8,20 @@
 # meaningfully shrink things.
 #
 # Rebuild marker (bump to re-pull the ADACPP_BRANCH overlay fresh):
+#   2026-07-14a — adacpp feat/tess-track-watertight @ f19e626: selectable tessellation tracks +
+#   boundary pinning ON by default. Boundary vertices are now emitted at their SHARED-EDGE point
+#   instead of each face's own surface.point(uv) re-projection, so the two faces of an edge land on
+#   the same position and the per-solid weld stitches the seam. Halves shared-edge cracks (ventilator
+#   19,067 -> 9,880 open edges, non-manifold 12 -> 9) for ~3% time, with the triangle count UNCHANGED
+#   and the crane GLB 0.7% SMALLER (pinned verts actually weld); no geometry lost (crane solids
+#   7291=7291, dropped faces 78=78). This is what OCC/gmsh/truck all do — OCC's BRepMesh takes the
+#   boundary node's 3D straight from the shared edge curve and never evaluates the face surface
+#   there. Disable with pin_boundary=false if a byte-compatible mesh is needed.
+#   Also: TessTrack/Libtess2Opts abstraction (default libtess2 output byte-identical when pinning is
+#   off), stream_step_to_glb gains a `pipeline` arg, ADA_TESS_DIAG per-face UV-residual diagnostic.
+#   NOT watertight yet — ~8.8k residual edges remain on the UV-grid path (53/305 ventilator faces),
+#   which needs the CDT track.
+#
 #   2026-07-13f — adacpp feat/lazy-shape-store @ 5a84825: cone semi-angle plane-angle-unit fix. A
 #   CONICAL_SURFACE stores its semi-angle in the model's declared plane-angle unit (frequently DEGREE);
 #   the reader was reading it as radians, so a 45-degree cone became a 45-radian cone that tessellated

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -8,38 +8,15 @@
 # meaningfully shrink things.
 #
 # Rebuild marker (bump to re-pull the ADACPP_BRANCH overlay fresh):
-#   2026-07-14b — adacpp feat/tess-track-watertight @ a359782: adds the `cdt` track (vendored
-#   detria constrained Delaunay). Trim loops become constraint edges and the curvature grid becomes
-#   interior Steiner points — one boundary-first path with no UV-grid fast path, which is what OCC
-#   and truck do. Ventilator: boundary edges 19,067 -> 432 (-98%), non-manifold 12 -> 0, and 4% FEWER
-#   triangles (the grid path was never cheap, it was wrong). Costs ~+30%, so it is OPT-IN and NOT
-#   reachable from the worker yet — the pipeline token isn't threaded through adapy's converter.
-#   What this worker DOES pick up is the 2026-07-14a default change: boundary pinning ON.
+#   2026-07-15 — overlay retired. Everything the previous markers were previewing (selectable
+#   tessellation tracks, boundary pinning ON by default, the watertight `cdt` track) shipped in
+#   ada-cpp 0.14.0, which pixi.toml now pins. The worker takes it from conda.
 #
-#   2026-07-14a — adacpp feat/tess-track-watertight @ f19e626: selectable tessellation tracks +
-#   boundary pinning ON by default. Boundary vertices are now emitted at their SHARED-EDGE point
-#   instead of each face's own surface.point(uv) re-projection, so the two faces of an edge land on
-#   the same position and the per-solid weld stitches the seam. Halves shared-edge cracks (ventilator
-#   19,067 -> 9,880 open edges, non-manifold 12 -> 9) for ~3% time, with the triangle count UNCHANGED
-#   and the crane GLB 0.7% SMALLER (pinned verts actually weld); no geometry lost (crane solids
-#   7291=7291, dropped faces 78=78). This is what OCC/gmsh/truck all do — OCC's BRepMesh takes the
-#   boundary node's 3D straight from the shared edge curve and never evaluates the face surface
-#   there. Disable with pin_boundary=false if a byte-compatible mesh is needed.
-#   Also: TessTrack/Libtess2Opts abstraction (default libtess2 output byte-identical when pinning is
-#   off), stream_step_to_glb gains a `pipeline` arg, ADA_TESS_DIAG per-face UV-residual diagnostic.
-#   NOT watertight yet — ~8.8k residual edges remain on the UV-grid path (53/305 ventilator faces),
-#   which needs the CDT track.
-#
-#   2026-07-13f — adacpp feat/lazy-shape-store @ 5a84825: cone semi-angle plane-angle-unit fix. A
-#   CONICAL_SURFACE stores its semi-angle in the model's declared plane-angle unit (frequently DEGREE);
-#   the reader was reading it as radians, so a 45-degree cone became a 45-radian cone that tessellated
-#   to nothing and was silently dropped — nearly every conical face on degree-unit assemblies. Now
-#   collects CONVERSION_BASED_UNIT records and scales the semi-angle to radians. Also carries the
-#   curved-surface fidelity fixes (curved trim on near-rectangular B-spline faces; scale-invariant
-#   angular refinement so cylinders/holes aren't faceted into prisms/squares), opt-in per-face
-#   clickable regions (face_ranges_node via ADA_STREAM_TESS_FACE_REGIONS), the linear-extrusion face
-#   fix, dropped-face health counter, IFC linear placement + opening voids, the bogus-SI-prefix guard
-#   (empty tanks), GLB-spill RAM buffering, tri-count logging, parent malloc_trim.
+#   NOTE: unsetting this file's default is NOT enough to stop the overlay — it is driven by the
+#   forgejo repo variable ADACPP_BRANCH (Settings -> Actions -> Variables). While that variable
+#   names a branch, the overlay is built and put on PYTHONPATH AHEAD of the conda ada-cpp, so the
+#   worker silently runs the branch build and the pinned 0.14.0 is never exercised. Clear the
+#   variable when a preview is no longer wanted.
 
 ARG PIXI_VERSION=0.68.0
 # CI passes --build-arg IMAGE_TAG=sha-XXXXXXX so the worker can publish

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -33,7 +33,7 @@ ARG IMAGE_TAG=dev
 # The feat/lazy-shape-store overlay HEAD carries: the z=0 face-set plane-fit (IfcFacetedBrep /
 # Triangulated- + PolygonalFaceSet no longer render as a flat sheet), parallel native IFC→GLB,
 # a B-spline-weighted LPT cost estimate + per-solid audit instrumentation (spearman_est_ms/tris),
-# the NAUO-gate fix for the crane STEP→GLB regression, and a moderate 4 MB malloc mmap/trim that
+# the NAUO-gate fix for the large-assembly STEP→GLB regression, and a moderate 4 MB malloc mmap/trim that
 # trims streaming-tessellation peak RSS.
 ARG ADACPP_BRANCH=""
 

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -8,6 +8,14 @@
 # meaningfully shrink things.
 #
 # Rebuild marker (bump to re-pull the ADACPP_BRANCH overlay fresh):
+#   2026-07-14b — adacpp feat/tess-track-watertight @ a359782: adds the `cdt` track (vendored
+#   detria constrained Delaunay). Trim loops become constraint edges and the curvature grid becomes
+#   interior Steiner points — one boundary-first path with no UV-grid fast path, which is what OCC
+#   and truck do. Ventilator: boundary edges 19,067 -> 432 (-98%), non-manifold 12 -> 0, and 4% FEWER
+#   triangles (the grid path was never cheap, it was wrong). Costs ~+30%, so it is OPT-IN and NOT
+#   reachable from the worker yet — the pipeline token isn't threaded through adapy's converter.
+#   What this worker DOES pick up is the 2026-07-14a default change: boundary pinning ON.
+#
 #   2026-07-14a — adacpp feat/tess-track-watertight @ f19e626: selectable tessellation tracks +
 #   boundary pinning ON by default. Boundary vertices are now emitted at their SHARED-EDGE point
 #   instead of each face's own surface.point(uv) re-projection, so the two faces of an edge land on

--- a/pixi.lock
+++ b/pixi.lock
@@ -7546,7 +7546,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8175,7 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -8573,7 +8573,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -8785,7 +8785,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -9414,7 +9414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -9812,7 +9812,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10294,7 +10294,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -10576,7 +10576,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -10769,7 +10769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -11838,7 +11838,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -12172,7 +12172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -12396,7 +12396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -12545,28 +12545,28 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
-  sha256: f318624b5719d043c163d2c143d30207eee785ef8d79e74cb71306a72ffb21c9
-  md5: 0aeb22e47b67f51891c129760a1f4577
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
+  sha256: a7683c0208017b94b8780bff12133a3b89bc52dc036899edb82f86c42e8be69d
+  md5: 96893f1a2f70d970288c7ec737a14f10
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - libstdcxx >=14
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
   - occt >=7.9.3,<7.9.4.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - python_abi 3.12.* *_cp312
   - libzlib >=1.3.2,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.14.0,<0.14.1.0a0
-  size: 15232426
-  timestamp: 1784106132379
+    - ada-cpp >=0.15.0,<0.15.1.0a0
+  size: 15237002
+  timestamp: 1784110658298
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -21770,27 +21770,27 @@ packages:
   purls: []
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
-  sha256: abe480c24af86bddb9576fab34f01e5c7bbeaf11db095bb9d28c187b4746f3cf
-  md5: 819701876caff5b96cea51962299d55a
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
+  sha256: 999d1766f9d1100c03fe66c54411c8fbf7738cbc2b8487ef8437024d31075d62
+  md5: 01e7b38936a2bac19ecd6948946a4084
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - libcxx >=19
   - __osx >=11.0
+  - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
-  - python_abi 3.12.* *_cp312
   - libzlib >=1.3.2,<2.0a0
+  - occt >=7.9.3,<7.9.4.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.14.0,<0.14.1.0a0
-  size: 13072631
-  timestamp: 1784106243422
+    - ada-cpp >=0.15.0,<0.15.1.0a0
+  size: 13081434
+  timestamp: 1784110690753
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -25536,28 +25536,28 @@ packages:
     - _openmp_mutex >=4.5
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
-  sha256: 2065252a9a40e91fa53d540c07f7b143fdbb0192995e85cc148f97251035476c
-  md5: d1e7ca2ba72c141e63ab966e68f4799e
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
+  sha256: 0b3a6e823ec786bc95f4fee34fb64ebce0c2df3d526d9a483310b2c3f46efa8c
+  md5: e5f16f62d0c3c4e38584f70977bb169f
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   - python_abi 3.12.* *_cp312
+  - rocksdb >=10.6.2,<10.7.0a0
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
   - libzlib >=1.3.2,<2.0a0
+  - occt >=7.9.3,<7.9.4.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.14.0,<0.14.1.0a0
-  size: 9537495
-  timestamp: 1784106164800
+    - ada-cpp >=0.15.0,<0.15.1.0a0
+  size: 9542481
+  timestamp: 1784110682170
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.lock
+++ b/pixi.lock
@@ -7546,7 +7546,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.13.2-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8175,7 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.13.2-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -8573,7 +8573,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.13.2-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -8785,7 +8785,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.13.2-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -9414,7 +9414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.13.2-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -9812,7 +9812,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.13.2-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10294,7 +10294,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.13.2-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -10576,7 +10576,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.13.2-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -10769,7 +10769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.13.2-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -11838,7 +11838,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.13.2-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -12172,7 +12172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.13.2-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -12396,7 +12396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.13.2-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -12545,18 +12545,18 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.13.2-py312h29cc896_0.conda
-  sha256: da1996d24720ae22ec100cb6b374e916def6ab657b779ea0321a6f987ed805e9
-  md5: b5c69e459885f4a59d4ea4e9ae4b4ba4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.14.0-py312h29cc896_0.conda
+  sha256: f318624b5719d043c163d2c143d30207eee785ef8d79e74cb71306a72ffb21c9
+  md5: 0aeb22e47b67f51891c129760a1f4577
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - occt >=7.9.3,<7.9.4.0a0
   - rocksdb >=10.6.2,<10.7.0a0
   - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   - python_abi 3.12.* *_cp312
   - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
@@ -12564,9 +12564,9 @@ packages:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.13.2,<0.13.3.0a0
-  size: 15113688
-  timestamp: 1784010838343
+    - ada-cpp >=0.14.0,<0.14.1.0a0
+  size: 15232426
+  timestamp: 1784106132379
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -21770,27 +21770,27 @@ packages:
   purls: []
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.13.2-py312h9b4feea_0.conda
-  sha256: e5014b519ce045edd6ce938f4189d6e6f6e8c7b7ab716d6c96cc49c62980024d
-  md5: f64ba5baae803eb729e3fb5f14b45df6
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.14.0-py312h9b4feea_0.conda
+  sha256: abe480c24af86bddb9576fab34f01e5c7bbeaf11db095bb9d28c187b4746f3cf
+  md5: 819701876caff5b96cea51962299d55a
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - __osx >=11.0
   - libcxx >=19
-  - occt >=7.9.3,<7.9.4.0a0
+  - __osx >=11.0
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - occt >=7.9.3,<7.9.4.0a0
   - python_abi 3.12.* *_cp312
+  - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.13.2,<0.13.3.0a0
-  size: 12969239
-  timestamp: 1784010906061
+    - ada-cpp >=0.14.0,<0.14.1.0a0
+  size: 13072631
+  timestamp: 1784106243422
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -25536,28 +25536,28 @@ packages:
     - _openmp_mutex >=4.5
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.13.2-py312h710a262_0.conda
-  sha256: dddc9d4ecec5c7a59b162e0e078e86deda4740b898288c2a6a46aa744ef229a5
-  md5: 9c7d42d31657d1d48273201929dc56c7
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.14.0-py312h710a262_0.conda
+  sha256: 2065252a9a40e91fa53d540c07f7b143fdbb0192995e85cc148f97251035476c
+  md5: d1e7ca2ba72c141e63ab966e68f4799e
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
   - occt >=7.9.3,<7.9.4.0a0
+  - python_abi 3.12.* *_cp312
   - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
   purls:
   - pkg:pypi/ada-cpp?source=compressed-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.13.2,<0.13.3.0a0
-  size: 9441692
-  timestamp: 1784010869805
+    - ada-cpp >=0.14.0,<0.14.1.0a0
+  size: 9537495
+  timestamp: 1784106164800
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.toml
+++ b/pixi.toml
@@ -146,7 +146,7 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # for every other path (IFC/XML/FEM, occ-builtin fallback). Shares occt 7.9.3 with
 # pyocc (see above) so both coexist in one env.
 [feature.adacpp-runtime.dependencies]
-ada-cpp = "0.13.2.*"
+ada-cpp = "0.14.0.*"
 
 # ada-cpp CAD backend (AdacppBackend) — native CPython build of the
 # wasm-capable kernel. Brings its own occt 7.9.3 + gmsh + ifcopenshell,
@@ -161,8 +161,11 @@ ada-cpp = "0.13.2.*"
 # cap, and the cgroup-aware concurrency clamp — adapy's pcurve/parity paths here require it.
 # 0.13 adds the pure-C++ IFC reader/writer + zero-copy NGEOM streams (lazy ShapeStore), the cone
 # semi-angle plane-angle-unit drop fix, and tessellation perf work; adapy's native import/stream
-# paths graduate off the branch overlay onto this release.
-ada-cpp = "0.13.2.*"
+# paths graduate off the branch overlay onto this release. 0.14 adds tess_tracks() — the track
+# vocabulary adacpp declares and ada.cad.registry discovers — plus boundary pinning on by default
+# and the watertight `cdt` track. REQUIRED, not merely nice: the discovery tests skip outright
+# against an older ada-cpp, so a lower pin makes them silently vacuous.
+ada-cpp = "0.14.0.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/pixi.toml
+++ b/pixi.toml
@@ -292,7 +292,7 @@ asyncpg = "*"
 psutil = "*"
 croniter = "*"
 # parallel gzip: derived outputs (obj/stl/step/ifc/xml/glb) are gzipped at-rest, and
-# single-threaded zlib at level 9 was ~85% of the crane STEP->obj job wall. pigz emits
+# single-threaded zlib at level 9 was ~85% of the large-assembly STEP->obj job wall. pigz emits
 # a standard gzip stream (Content-Encoding: gzip) across all cores — see storage._gzip_file.
 pigz = "*"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,14 @@ channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64"]
 
 [feature.lint.tasks]
-lint = "black . --config pyproject.toml && ruff check . --fix && isort ."
+# Local dev: rewrite the tree in place. Exclusions are config-driven (pyproject's [tool.black] via
+# .gitignore, [tool.ruff] exclude, [tool.isort] skip), so these are safe to point at ".".
+lint = { cmd = "black . --config pyproject.toml && ruff check . --fix && isort .", description = "Format + lint Python in place" }
+# The CI gate — NOT `lint`. black, `ruff check --fix` and isort all MUTATE and exit 0, so a lint job
+# running `lint` reformats the runner's throwaway checkout and passes unconditionally: it cannot
+# fail, whatever the PR contains. Same tools, same config, same order — check mode reports instead
+# of rewriting.
+lint-check = { cmd = "black . --check --config pyproject.toml && ruff check . && isort . --check-only", description = "CI gate: fail on any unformatted/unlinted Python" }
 flat = { cmd = "python src/flatbuffers/update_flatbuffers.py && pixi run lint", cwd = "./" }
 
 json-code-gen-py = { cmd = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -153,7 +153,7 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # for every other path (IFC/XML/FEM, occ-builtin fallback). Shares occt 7.9.3 with
 # pyocc (see above) so both coexist in one env.
 [feature.adacpp-runtime.dependencies]
-ada-cpp = "0.14.0.*"
+ada-cpp = "0.15.0.*"
 
 # ada-cpp CAD backend (AdacppBackend) — native CPython build of the
 # wasm-capable kernel. Brings its own occt 7.9.3 + gmsh + ifcopenshell,
@@ -171,8 +171,9 @@ ada-cpp = "0.14.0.*"
 # paths graduate off the branch overlay onto this release. 0.14 adds tess_tracks() — the track
 # vocabulary adacpp declares and ada.cad.registry discovers — plus boundary pinning on by default
 # and the watertight `cdt` track. REQUIRED, not merely nice: the discovery tests skip outright
-# against an older ada-cpp, so a lower pin makes them silently vacuous.
-ada-cpp = "0.14.0.*"
+# against an older ada-cpp, so a lower pin makes them silently vacuous. 0.15 adds
+# imprint_planar_faces plus win-64 build and cad-API-generator encoding fixes.
+ada-cpp = "0.15.0.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/src/ada/cad/registry.py
+++ b/src/ada/cad/registry.py
@@ -32,41 +32,96 @@ from functools import lru_cache
 DEFAULT_STREAM_TESS_DEFLECTION = 2.0
 DEFAULT_STREAM_TESS_ANGULAR_DEG = 10.0
 
-# Angular density mode. OFF (default): ``angular_deg`` is a fixed global ceiling for every curved
-# surface (explicit-global-angle mode, backward compatible). ON: the ceiling is applied ADAPTIVELY
-# per surface — a model-relative reference (``model_scale``, the model bbox diagonal) lets tiny
-# curved features (bolts/pins in a large assembly, whose facets are sub-pixel) coarsen while large
-# visible surfaces keep the fine angle. The relaxation itself lives in adacpp (angle_step); adapy
-# only decides the mode and supplies ``model_scale``. Toggle with ADA_STREAM_TESS_ADAPTIVE.
+# Angular density mode. OFF: ``angular_deg`` is a fixed global ceiling for every curved surface
+# (explicit-global-angle mode, backward compatible). ON: the ceiling is applied ADAPTIVELY per
+# surface — a model-relative reference (``model_scale``, the model bbox diagonal) lets tiny curved
+# features (bolts/pins in a large assembly, whose facets are sub-pixel) coarsen while large visible
+# surfaces keep the fine angle. The relaxation itself lives in adacpp (angle_step); adapy only
+# decides the mode and supplies ``model_scale``. Toggle with ADA_STREAM_TESS_ADAPTIVE.
+#
+# The default DIFFERS BY CALL PATH, deliberately — pass it explicitly via ``stream_tess_adaptive(default=)``:
+#   * OFF for the per-object stream path (BatchTessellator): a library API whose mesh density must
+#     not shift under callers who never asked for adaptive.
+#   * ON for the whole-file native converters (STEP->GLB / ->OBJ / ->STL): dense curved assemblies
+#     over-tessellate at a fixed fine angle, and these are the transfer-size- and timeout-sensitive
+#     products (the crane's 107M-tri OBJ/STL blew the 5-min timeout).
 DEFAULT_STREAM_TESS_ADAPTIVE = False
+DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE = True
+
+# One falsy spelling for every ADA_STREAM_TESS_* boolean. Note "" is FALSY: an explicitly-empty env
+# var means "off", not "on" (before this was centralised, scene_from_step_stream omitted "" from its
+# set and so read an explicit ADA_STREAM_TESS_ADAPTIVE="" as ON while every other path read it OFF).
+_TESS_ENV_FALSY = frozenset({"0", "false", "no", "off", ""})
+
+
+def _tess_env_flag(name: str, default: bool) -> bool:
+    """Read an ADA_STREAM_TESS_* boolean: unset => ``default``, else any non-falsy spelling => True."""
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    return v.strip().lower() not in _TESS_ENV_FALSY
 
 
 def stream_tess_defaults() -> tuple[float, float]:
-    """(deflection, angular_deg) for the NGEOM stream path: env override else the corpus default."""
+    """(deflection, angular_deg) for the NGEOM stream path: env override else the corpus default.
+
+    The single source of these two numbers — every stream/native tessellation entry point reads them
+    through here so one nominal config can't mean different densities on different call paths.
+    """
     defl = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", str(DEFAULT_STREAM_TESS_DEFLECTION)))
     ang = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
     return defl, ang
 
 
-def stream_tess_adaptive() -> bool:
-    """Whether adaptive per-surface angular density is enabled (env override else the default OFF)."""
-    v = os.environ.get("ADA_STREAM_TESS_ADAPTIVE")
-    if v is None:
-        return DEFAULT_STREAM_TESS_ADAPTIVE
-    return v.strip().lower() not in {"0", "false", "no", "off", ""}
+def stream_tess_adaptive(default: bool = DEFAULT_STREAM_TESS_ADAPTIVE) -> bool:
+    """Whether adaptive per-surface angular density is enabled (env override else ``default``).
+
+    ``default`` is the caller's mode when ADA_STREAM_TESS_ADAPTIVE is unset — it differs by call
+    path on purpose (see DEFAULT_STREAM_TESS_ADAPTIVE / _NATIVE), so state it rather than relying on
+    this signature's default.
+    """
+    return _tess_env_flag("ADA_STREAM_TESS_ADAPTIVE", default)
 
 
-def stream_tess_model_scale() -> float:
-    """The model reference scale (world units) for adaptive density on the object stream path, or
-    0.0 (off). Adaptive is meaningful only with a model scale, so this returns 0 unless adaptive is
-    enabled AND a scale is supplied via ADA_STREAM_TESS_MODEL_SCALE (the caller sets it once per
-    model — the native STEP->GLB path estimates its own; see ada.cadit.step.model_scale)."""
-    if not stream_tess_adaptive():
-        return 0.0
+def stream_tess_face_regions() -> bool:
+    """Whether to emit per-face clickable regions (face_ranges_node<m> in scenes[0].extras).
+
+    Opt-in (ADA_STREAM_TESS_FACE_REGIONS=1): it bloats the GLB and forces serial face tessellation.
+    """
+    return _tess_env_flag("ADA_STREAM_TESS_FACE_REGIONS", False)
+
+
+def stream_tess_strict() -> bool:
+    """Whether a NGEOM->OCC tessellation fallback should raise instead of silently degrading
+    (ADA_STREAM_TESS_STRICT=1) — enforces 100% stream-kernel coverage."""
+    return _tess_env_flag("ADA_STREAM_TESS_STRICT", False)
+
+
+def stream_tess_model_scale_env() -> float:
+    """The raw ADA_STREAM_TESS_MODEL_SCALE (world units), 0.0 if unset/invalid — NO adaptive gating.
+
+    For consumers *downstream* of the adaptive decision: the parent estimates the scale once per
+    model and exports it, so its presence is itself the adaptive signal. A pool worker must not
+    re-gate on ADA_STREAM_TESS_ADAPTIVE — it may not have inherited it, and re-gating would silently
+    return 0.0 (fixed-angle) in every worker while the parent believed adaptive was on.
+    Use ``stream_tess_model_scale`` when *you* are the one deciding.
+    """
     try:
         return float(os.environ.get("ADA_STREAM_TESS_MODEL_SCALE", "0") or 0.0)
     except ValueError:
         return 0.0
+
+
+def stream_tess_model_scale(default: bool = DEFAULT_STREAM_TESS_ADAPTIVE) -> float:
+    """The model reference scale (world units) for adaptive density, or 0.0 (off).
+
+    Adaptive is meaningful only with a model scale, so this returns 0 unless adaptive is enabled
+    (env else ``default``) AND a scale is supplied via ADA_STREAM_TESS_MODEL_SCALE (the caller sets
+    it once per model — the native STEP->GLB path estimates its own; see ada.cadit.step.model_scale).
+    """
+    if not stream_tess_adaptive(default=default):
+        return 0.0
+    return stream_tess_model_scale_env()
 
 
 class CadBackendName(str, Enum):

--- a/src/ada/cad/registry.py
+++ b/src/ada/cad/registry.py
@@ -44,7 +44,7 @@ DEFAULT_STREAM_TESS_ANGULAR_DEG = 10.0
 #     not shift under callers who never asked for adaptive.
 #   * ON for the whole-file native converters (STEP->GLB / ->OBJ / ->STL): dense curved assemblies
 #     over-tessellate at a fixed fine angle, and these are the transfer-size- and timeout-sensitive
-#     products (the crane's 107M-tri OBJ/STL blew the 5-min timeout).
+#     products (the reference assembly's 107M-tri OBJ/STL blew the 5-min timeout).
 DEFAULT_STREAM_TESS_ADAPTIVE = False
 DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE = True
 

--- a/src/ada/cad/registry.py
+++ b/src/ada/cad/registry.py
@@ -283,7 +283,10 @@ class CadConfig:
     or pass to a factory function (e.g. ``stream_step_to_glb(..., cad_config=cfg)`` or
     ``ada.from_step(..., cad_config=cfg)``)."""
 
-    path: TessellationPath = TessellationPath.OCC
+    # Either a legacy TessellationPath member or any discovered track name (see
+    # available_tess_tracks). The enum cannot name a track added after it was written, so a plain
+    # string is the forward-compatible spelling: CadConfig(path="adacpp:cdt").
+    path: TessellationPath | str = TessellationPath.OCC
     deflection: float = DEFAULT_STREAM_TESS_DEFLECTION
     angular_deg: float = DEFAULT_STREAM_TESS_ANGULAR_DEG
     simplify: bool = False  # meshopt cleanup (step2glb merge parity); adacpp paths only
@@ -291,6 +294,12 @@ class CadConfig:
     # fallback for out-of-scope files — the most memory-efficient + robust default. Override per
     # config to force a specific reader.
     step_reader: StepReader = StepReader.AUTO
+
+    @property
+    def track(self) -> TessTrack | None:
+        """The resolved track for ``path`` (enum member or discovered name), or None if unavailable."""
+        name = self.path.value if isinstance(self.path, TessellationPath) else str(self.path)
+        return tess_track_by_name(name)
 
     @classmethod
     def default(cls) -> "CadConfig":
@@ -301,19 +310,28 @@ class CadConfig:
         return cls(path=TessellationPath.OCC)
 
     def validate(self) -> None:
-        if self.path not in available_paths():
+        # Discovered tracks are the authority; the legacy enum list is only a fallback for members
+        # that predate discovery in an env without adacpp.
+        if self.track is None and self.path not in available_paths():
+            name = self.path.value if isinstance(self.path, TessellationPath) else str(self.path)
             raise ValueError(
-                f"tessellation path {self.path.value!r} is not available in this environment; "
-                f"available: {[p.value for p in available_paths()]}"
+                f"tessellation path {name!r} is not available in this environment; "
+                f"available: {[t.name for t in available_tess_tracks()]}"
             )
         # Accept a bare string for ergonomics, but it must be a known reader.
         StepReader(self.step_reader)
 
     def env(self) -> dict[str, str]:
         """The streaming-export env vars this config maps to (read by the conversion worker)."""
-        e = {"ADAPY_CAD_BACKEND": self.path.backend.value}
-        if self.path.pipeline is not None:
-            e["ADA_STREAM_TESS_PIPELINE"] = self.path.pipeline
+        track = self.track
+        if track is None:  # unavailable/unknown: fall back to the legacy enum's own view
+            backend = self.path.backend if isinstance(self.path, TessellationPath) else CadBackendName.OCC
+            pipeline = self.path.pipeline if isinstance(self.path, TessellationPath) else None
+        else:
+            backend, pipeline = track.backend, track.pipeline
+        e = {"ADAPY_CAD_BACKEND": backend.value}
+        if pipeline is not None:
+            e["ADA_STREAM_TESS_PIPELINE"] = pipeline
             e["ADA_STREAM_TESS_DEFLECTION"] = repr(self.deflection)
             e["ADA_STREAM_TESS_ANGULAR"] = repr(self.angular_deg)
             if self.simplify:

--- a/src/ada/cad/registry.py
+++ b/src/ada/cad/registry.py
@@ -129,12 +129,92 @@ class CadBackendName(str, Enum):
     ADACPP = "adacpp"  # the adacpp extension (NGEOM / libtess2 + linked OCCT/CGAL/ifc kernels)
 
 
-class TessellationPath(str, Enum):
-    """A selectable (backend, tessellation-algorithm) pair.
+@dataclass(frozen=True)
+class TessTrack:
+    """One selectable tessellation track: a (backend, algorithm) pair plus how to describe it.
 
-    ``OCC`` is pythonocc's BRepMesh; the ``ADACPP_*`` paths map to adacpp ``tessellate_stream``
-    pipelines (``libtess2`` is the OCC-free boundary CDT; ``occ``/``cgal``/``hybrid`` use adacpp's
-    linked OCCT / ifcopenshell-taxonomy kernels)."""
+    **adapy does not own this vocabulary.** adapy declares only its OWN track (pythonocc's
+    BRepMesh); every adacpp track is DISCOVERED from ``adacpp.cad.tess_tracks()``, which reports
+    what that build actually compiled. Adding a track is therefore a change in adacpp alone — nothing
+    here, in the converter, or in the frontend enumerates track names.
+    """
+
+    name: str  # stable token, e.g. "occ" or "adacpp:cdt"
+    label: str  # human-readable, for a dropdown
+    description: str  # one line, for a tooltip
+    watertight: bool  # does it close shared-edge seams?
+    backend: CadBackendName
+    pipeline: str | None  # the adacpp `pipeline` arg; None => pythonocc BRepMesh
+    is_default: bool = False
+
+
+# adapy's own track. This is the ONE we are entitled to hardcode: it is pythonocc's BRepMesh, which
+# adapy owns and adacpp knows nothing about.
+_OCC_TRACK = TessTrack(
+    name="occ",
+    label="OCC BRepMesh (pythonocc)",
+    description="pythonocc's BRepMesh. adapy's built-in tessellator; no adacpp required.",
+    watertight=False,
+    backend=CadBackendName.OCC,
+    pipeline=None,
+)
+
+
+def _adacpp_tracks() -> list[TessTrack]:
+    """Tracks declared BY adacpp, for this build. Empty when adacpp isn't importable.
+
+    Tolerates an older adacpp with no ``tess_tracks`` binding by falling back to the pipeline names
+    that predate the self-declaration, so a mixed install degrades instead of losing every track.
+    """
+    if not _module_available("adacpp"):
+        return []
+    try:
+        import adacpp
+    except Exception:  # noqa: BLE001 - a broken adacpp must not take the registry down
+        return []
+    decl = getattr(adacpp.cad, "tess_tracks", None)
+    if decl is None:
+        return [
+            TessTrack(f"adacpp:{n}", f"adacpp {n}", "", False, CadBackendName.ADACPP, n)
+            for n in ("libtess2", "occ", "cgal", "hybrid")
+        ]
+    out: list[TessTrack] = []
+    for t in decl():
+        name = t["name"]
+        out.append(
+            TessTrack(
+                name=f"adacpp:{name}",
+                label=t.get("label") or name,
+                description=t.get("description") or "",
+                watertight=bool(t.get("watertight")),
+                backend=CadBackendName.ADACPP,
+                pipeline=name,
+                is_default=bool(t.get("default")),
+            )
+        )
+    return out
+
+
+def available_tess_tracks() -> list[TessTrack]:
+    """Every tessellation track usable in THIS environment: adapy's own + whatever adacpp declares.
+
+    This is the single source of truth for the vocabulary. Publish it; don't re-list it.
+    """
+    tracks = [_OCC_TRACK] if backend_available(CadBackendName.OCC) else []
+    return tracks + _adacpp_tracks()
+
+
+def tess_track_by_name(name: str) -> TessTrack | None:
+    return next((t for t in available_tess_tracks() if t.name == name), None)
+
+
+class TessellationPath(str, Enum):
+    """LEGACY, kept for back-compat with existing configs and callers.
+
+    Prefer :func:`available_tess_tracks` — it is discovered from adacpp rather than enumerated here,
+    so it sees tracks (``adacpp:cdt``, ...) that this enum predates and will never grow. A
+    ``CadConfig.path`` accepts either an enum member or any discovered track name.
+    """
 
     OCC = "occ"
     ADACPP_LIBTESS2 = "adacpp:libtess2"

--- a/src/ada/cadit/ifc/native_ifc_to_glb.py
+++ b/src/ada/cadit/ifc/native_ifc_to_glb.py
@@ -15,7 +15,6 @@ ANGULAR`` env as the STEP native path.
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -41,19 +40,20 @@ def native_ifc_to_glb(
 ) -> dict:
     """Convert ``ifc_path`` to a GLB at ``glb_path`` with the native adacpp IFC pipeline.
 
-    ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` (2.0) /
-    ``ADA_STREAM_TESS_ANGULAR`` (20.0) env, matching the streaming path. ``meshopt`` (default on) bakes
+    ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` /
+    ``ADA_STREAM_TESS_ANGULAR`` env via ``ada.cad.registry.stream_tess_defaults`` (the single source
+    of the corpus defaults), matching the streaming path. ``meshopt`` (default on) bakes
     ``EXT_meshopt_compression`` inline in the C++ writer. Returns ``{solids, total, skipped}``. Raises
     if adacpp is unavailable or the conversion fails (the converter falls back per its fallback chain).
     """
     import adacpp
 
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    if deflection is None or angular_deg is None:
+        from ada.cad.registry import stream_tess_defaults
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
 
     if on_progress is not None:
         on_progress("adacpp-native-ifc", 0.1)

--- a/src/ada/cadit/ngeom/serialize.py
+++ b/src/ada/cadit/ngeom/serialize.py
@@ -231,7 +231,7 @@ class _Encoder:
     # below ``_BULK_MIN`` keep the per-scalar path. Crucially, the *per-face* tiny index lists
     # (a face's 1-2 bounds, an edge-loop's handful of edge refs) are joined inline at the call site
     # rather than via these helpers — on a B-rep model that path runs millions of times and the
-    # helper's call+guard overhead was measured to slightly *regress* the crane (the bulk win only
+    # helper's call+guard overhead was measured to slightly *regress* the large reference assembly (the bulk win only
     # materializes on genuinely large arrays / NURBS-heavy geometry).
     @staticmethod
     def _f64_raw(xs) -> bytes:

--- a/src/ada/cadit/sat/read/faces.py
+++ b/src/ada/cadit/sat/read/faces.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from ada.cadit.sat.exceptions import ACISInsufficientPointsError
 from ada.cadit.sat.read.sat_entities import AcisRecord
-from ada.config import logger
+from ada.config import Config, logger
 from ada.core.vector_utils import remove_near_collinear_points
 
 if TYPE_CHECKING:
@@ -134,7 +134,71 @@ class PlateFactory:
         if coedge_first_direction == "reversed":
             points.reverse()
 
+        # Curved boundary edges (intcurve/ellipse) otherwise collapse to the chord between their two
+        # corners — a deck plate meeting a curved hull skin renders straight while the skin beside it
+        # curves (measured on OP1_v1007_hullskin FACE00004482: a 0.072 m bulge flattened out of a
+        # 1.4 m plate). Splice the sampled curve into the FINISHED corner polygon, between the two
+        # corners that edge joins. Done here, after the corner sequence is complete, precisely because
+        # `edges` is NOT in geometric chain order — the loop above works by collecting far-endpoints
+        # and deduping, not by walking the chain, so there is no "insert before edge i" position to
+        # write into. A straight-only loop splices nothing and keeps its exact historic point list.
+        if Config().sat_plate_curved_edges:
+            points = self._splice_curved_edges(points, edges)
+
         return points
+
+    def _splice_curved_edges(self, points: list[tuple[float]], edges: list[AcisRecord]) -> list[tuple[float]]:
+        """Insert each curved edge's sampled interior between the two corners it joins.
+
+        Purely additive: every original corner stays, in its original order. An edge whose two
+        corners aren't adjacent in `points` (or which we couldn't sample) is skipped and keeps its
+        chord — so the worst case is exactly today's output.
+        """
+        curved = self._curved_edge_interiors(edges)
+        if not curved:
+            return points
+
+        pts = list(points)
+        for i, coedge in enumerate(edges):
+            interior = curved.get(i)
+            if not interior:
+                continue
+            p1, p2 = self.get_points_from_edge(coedge)
+            near, far = (p1, p2) if str(coedge.chunks[-4]) == "forward" else (p2, p1)
+            n = len(pts)
+            for k in range(n):
+                a, b = pts[k], pts[(k + 1) % n]
+                if a == near and b == far:
+                    pts[k + 1 : k + 1] = interior
+                    break
+                if a == far and b == near:
+                    pts[k + 1 : k + 1] = list(reversed(interior))
+                    break
+            else:
+                logger.debug(f"curved edge {i}: corners not adjacent in the outline; keeping its chord")
+        return pts
+
+    def _curved_edge_interiors(self, edges: list[AcisRecord]) -> dict[int, list[tuple[float, float, float]]]:
+        """{edge index -> interior points, ordered near->far along the coedge's own direction}.
+
+        Best-effort by design: any edge we can't read or sample simply isn't in the dict, and the
+        caller keeps today's chord for it. A curved boundary that silently stays straight is the bug
+        we're fixing; a curved boundary that fails to sample is only as bad as the status quo.
+        """
+        from ada.cadit.sat.read.plate_edge_curves import edge_interior_points
+
+        out: dict[int, list[tuple[float, float, float]]] = {}
+        for i, coedge in enumerate(edges):
+            try:
+                p1, p2 = self.get_points_from_edge(coedge)
+                near, far = (p1, p2) if str(coedge.chunks[-4]) == "forward" else (p2, p1)
+                pts = edge_interior_points(coedge, self.sat_store, near, far)
+            except Exception as exc:  # noqa: BLE001 - never let a curve read drop a whole plate
+                logger.debug(f"curved edge sample failed on coedge {i}: {exc}")
+                continue
+            if pts:
+                out[i] = pts
+        return out
 
     def get_edges(self, face_data_list: list[str]) -> list[AcisRecord]:
         loop = self._get_primary_loop(face_data_list)

--- a/src/ada/cadit/sat/read/plate_edge_curves.py
+++ b/src/ada/cadit/sat/read/plate_edge_curves.py
@@ -1,0 +1,190 @@
+"""Discretize a flat plate's CURVED boundary edges into extra outline points.
+
+WHY THIS EXISTS (and why it is a stopgap, not the right answer)
+--------------------------------------------------------------
+``PlateFactory.get_points`` walks a SAT face's coedges and keeps only the edge
+ENDPOINTS. Whatever the edge's curve does between its two vertices is discarded,
+so a plate whose boundary follows a spline (e.g. a deck plate meeting a curved
+hull skin) comes out as a straight chord between its corners. Measured on
+``OP1_v1007_hullskin.xml`` face ``FACE00004482``: 4 coedges — 1 straight, 2
+``intcurve``, 1 ``ellipse`` — collapsed to a 4-point polygon.
+
+The loss is doubled by the target type: ``CurvePoly2d`` (the ``Plate`` outline) is
+documented as *"a closed curve defined by a list of 2d points represented by line
+and arc segments"* and its API is ``segments() -> list[LineSegment | ArcSegment]``.
+There is no B-spline segment, so even a perfectly-read spline edge has nowhere to
+live on a ``Plate``.
+
+So this module does the cheap thing: SAMPLE the curve and emit the samples as
+extra straight-segment outline points. The plate then visually follows the curve.
+
+WHAT THIS DOES NOT FIX. The samples are ours, not the neighbouring face's. The
+adjacent ``curved_shell`` keeps its real spline (it goes through ``AdvancedFace``),
+so the two faces still do not share edge points and the seam is still not
+watertight — it just looks right. A real fix is B-spline edge support in ``Plate``
+/ ``CurvePoly2d``, or routing curved-boundary flat plates through ``AdvancedFace``
+like the curved shells. See dap ``plan/v3/notes_plate_bspline_edges.md``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ada.config import logger
+
+# Samples per curved edge. A straight-ish edge collapses back to its chord in
+# remove_near_collinear_points (tol 1e-8*scale^2), so over-sampling a nearly
+# straight edge costs nothing; under-sampling a tight one is visible.
+DEFAULT_CURVE_SAMPLES = 24
+# Ring resolution for ellipse/circle sampling before clipping to the edge's arc.
+_ELLIPSE_RING_SAMPLES = 2048
+
+
+def _de_boor(x: float, knots, cp, deg: int):
+    """Evaluate a B-spline at parameter x (de Boor). numpy only — scipy is NOT a core dep.
+
+    `cp` may carry a 4th homogeneous component (rational weights); the caller divides through.
+    """
+    # Knot span: last index k with knots[k] <= x < knots[k+1], clamped to the valid range.
+    k = int(np.searchsorted(knots, x, side="right") - 1)
+    k = max(deg, min(k, len(cp) - 1))
+    d = [cp[j + k - deg].copy() for j in range(deg + 1)]
+    for r in range(1, deg + 1):
+        for j in range(deg, r - 1, -1):
+            lo = knots[j + k - deg]
+            hi = knots[j + 1 + k - r]
+            den = hi - lo
+            a = 0.0 if den == 0 else (x - lo) / den
+            d[j] = (1.0 - a) * d[j - 1] + a * d[j]
+    return d[deg]
+
+
+def _bspline_points(curve, n: int) -> list[tuple[float, float, float]] | None:
+    """Sample a BSplineCurveWithKnots at n params across its knot span."""
+    try:
+        cp = np.asarray([list(p)[:3] for p in curve.control_points_list], dtype=float)
+        # SAT/IFC store knots + multiplicities separately; de Boor wants them expanded.
+        knots = np.repeat(np.asarray(curve.knots, dtype=float), np.asarray(curve.knot_multiplicities, dtype=int))
+        deg = int(curve.degree)
+        if deg < 1 or len(cp) <= deg or len(knots) != len(cp) + deg + 1:
+            # Malformed (or a form we don't model) — fall back to the chord.
+            return None
+        # Rational curves: weight the control points, then divide through after evaluation.
+        w = getattr(curve, "weights_data", None) or getattr(curve, "weights", None)
+        if w is not None and len(w) == len(cp):
+            wa = np.asarray(w, dtype=float).reshape(-1, 1)
+            cp = np.hstack([cp * wa, wa])
+        lo, hi = float(knots[deg]), float(knots[len(knots) - deg - 1])
+        if not np.isfinite([lo, hi]).all() or hi <= lo:
+            return None
+        out = []
+        for x in np.linspace(lo, hi, n):
+            p = _de_boor(float(x), knots, cp, deg)
+            if p.shape[0] == 4:  # rational: de-homogenize
+                if p[3] == 0:
+                    return None
+                p = p[:3] / p[3]
+            out.append(tuple(float(v) for v in p[:3]))
+        arr = np.asarray(out)
+        if not np.isfinite(arr).all():
+            return None
+        return out
+    except Exception as exc:  # noqa: BLE001 - a curve we can't sample falls back to the chord
+        logger.debug(f"bspline sample failed: {exc}")
+        return None
+
+
+def _ellipse_points(curve, n: int) -> list[tuple[float, float, float]] | None:
+    """Sample a full Ellipse/Circle. Trimming to the edge happens in _clip_to_endpoints."""
+    try:
+        c = np.asarray(list(curve.position.location)[:3], dtype=float)
+        z = np.asarray(list(curve.position.axis)[:3], dtype=float)
+        x = np.asarray(list(curve.position.ref_direction)[:3], dtype=float)
+        x = x / np.linalg.norm(x)
+        z = z / np.linalg.norm(z)
+        y = np.cross(z, x)
+        ra = float(getattr(curve, "semi_axis1", getattr(curve, "radius", 0.0)))
+        rb = float(getattr(curve, "semi_axis2", getattr(curve, "radius", 0.0)))
+        if ra <= 0 or rb <= 0:
+            return None
+        # Sample the FULL ring densely, not n*4: the edge is usually a small arc of it (measured:
+        # a 1.46 m edge spanning ~5 of 96 ring samples), so ring density must be high enough that
+        # the clipped arc still carries ~n points. 2048 vectorised points is free.
+        t = np.linspace(0.0, 2.0 * np.pi, _ELLIPSE_RING_SAMPLES, endpoint=False)
+        pts = c + np.outer(ra * np.cos(t), x) + np.outer(rb * np.sin(t), y)
+        return [tuple(float(v) for v in p) for p in pts]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"ellipse sample failed: {exc}")
+        return None
+
+
+def _clip_to_endpoints(pts, a, b, n: int, closed: bool) -> list[tuple[float, float, float]]:
+    """Keep the run of `pts` from vertex a to vertex b, thinned to ~n interior points.
+
+    The curve records span the FULL basis curve (a documented ACIS trait: pcurves span the whole
+    curve and are trimmed by projecting the vertices), so a sampled curve generally overshoots the
+    edge. Snap to the closest sample to each vertex and keep the span between them.
+
+    `closed` matters and is not cosmetic. For an ellipse/circle the sample ring wraps, and the edge
+    is the SHORTER of the two arcs. For an open B-spline there is no wrap: indices must be sliced,
+    never taken modulo — doing so walks off the end of the curve and back to its start, which
+    inserts a jump straight across the plate (measured: a 1.79 m step on a 1.4 m plate, perimeter
+    8.86 m instead of ~5 m, and the resulting bow-tie polygon collapsed under the collinear pruner).
+    """
+    arr = np.asarray(pts, dtype=float)
+    ia = int(np.argmin(np.linalg.norm(arr - np.asarray(a, dtype=float), axis=1)))
+    ib = int(np.argmin(np.linalg.norm(arr - np.asarray(b, dtype=float), axis=1)))
+    if ia == ib:
+        return []
+    m = len(arr)
+
+    def arclen(idx):
+        return float(np.linalg.norm(np.diff(arr[idx], axis=0), axis=1).sum())
+
+    if closed:
+        fwd = [(ia + k) % m for k in range((ib - ia) % m + 1)]
+        bwd = [(ia - k) % m for k in range((ia - ib) % m + 1)]
+        idx = fwd if arclen(fwd) <= arclen(bwd) else bwd
+    else:
+        idx = list(range(ia, ib + 1)) if ia < ib else list(range(ia, ib - 1, -1))
+    if len(idx) <= 2:
+        return []
+    # Drop the endpoints (the caller already has the exact vertices) and thin to ~n.
+    inner = idx[1:-1]
+    if len(inner) > n:
+        sel = np.linspace(0, len(inner) - 1, n).round().astype(int)
+        inner = [inner[i] for i in sorted(set(sel.tolist()))]
+    return [tuple(float(v) for v in arr[i]) for i in inner]
+
+
+def edge_interior_points(coedge, sat_store, a, b, n: int = DEFAULT_CURVE_SAMPLES) -> list[tuple[float, float, float]]:
+    """Interior 3D points along `coedge`'s curve, ordered from vertex `a` to vertex `b`.
+
+    Returns [] for straight edges, unreadable curves, or anything we can't sample —
+    the caller then keeps today's chord, so this can only add detail, never lose a plate.
+    """
+    # Local import: ada.cadit.sat.read.curves imports from this package's siblings.
+    from ada.cadit.sat.read.curves import get_edge
+
+    try:
+        oe = get_edge(coedge)
+    except Exception as exc:  # noqa: BLE001 - unreadable curve => keep the chord
+        logger.debug(f"edge_interior_points: get_edge failed: {exc}")
+        return []
+    curve = getattr(oe, "edge_element", None) or getattr(oe, "edge_geometry", None) or oe
+    curve = getattr(curve, "edge_geometry", curve)
+
+    from ada.geom.curves import BSplineCurveWithKnots, Circle, Ellipse, Line
+
+    if isinstance(curve, Line):
+        return []
+    pts = None
+    closed = False
+    if isinstance(curve, BSplineCurveWithKnots):
+        pts = _bspline_points(curve, max(n * 4, 32))  # open: sampled across the knot span
+    elif isinstance(curve, (Ellipse, Circle)):
+        pts = _ellipse_points(curve, n)
+        closed = True  # sampled as a full ring; the edge is an arc of it
+    if not pts:
+        return []
+    return _clip_to_endpoints(pts, a, b, n, closed)

--- a/src/ada/cadit/step/model_scale.py
+++ b/src/ada/cadit/step/model_scale.py
@@ -3,7 +3,7 @@
 The adaptive angular density (see ``ada.cad.registry.stream_tess_adaptive``) relaxes the fine
 angular ceiling for curved surfaces small *relative to the model*. That needs a model length
 scale. A raw min/max bounding box is unusable: CAD STEP files routinely carry a handful of
-far-flung reference/construction points (the crane spans ±500 m of stray points yet its real
+far-flung reference/construction points (the large reference assembly spans ±500 m of stray points yet its real
 geometry is ~13-45 m), which inflate the diagonal ~30x and would coarsen every surface.
 
 So we use an OUTLIER-ROBUST estimate: sample CARTESIAN_POINT coordinates and take ~2x the 99th

--- a/src/ada/cadit/step/native_ifc_to_step.py
+++ b/src/ada/cadit/step/native_ifc_to_step.py
@@ -10,7 +10,6 @@ when adacpp lacks the verb).
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -36,12 +35,12 @@ def native_ifc_to_step(
     Returns the losslessness audit dict; raises if adacpp is unavailable or no solid converted."""
     import adacpp
 
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    if deflection is None or angular_deg is None:
+        from ada.cad.registry import stream_tess_defaults
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
     if on_progress is not None:
         on_progress("adacpp-native-ifc2step", 0.1)
     stats = adacpp.cad.stream_ifc_to_step(str(ifc_path), str(out_path), deflection=deflection, angular_deg=angular_deg)

--- a/src/ada/cadit/step/native_step_to_glb.py
+++ b/src/ada/cadit/step/native_step_to_glb.py
@@ -19,7 +19,6 @@ streaming path on the crane (same products, placements, triangle counts, names, 
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -46,8 +45,9 @@ def native_step_to_glb(
 ) -> dict:
     """Convert ``step_path`` to a GLB at ``glb_path`` with the native adacpp pipeline.
 
-    ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` (2.0) /
-    ``ADA_STREAM_TESS_ANGULAR`` (20.0) env, matching the streaming path. ``num_threads`` 0 = auto
+    ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` /
+    ``ADA_STREAM_TESS_ANGULAR`` env via ``ada.cad.registry.stream_tess_defaults`` (the single source
+    of the corpus defaults), matching the streaming path. ``num_threads`` 0 = auto
     (hardware concurrency). ``meshopt`` (default on) bakes ``EXT_meshopt_compression`` inline in the
     C++ writer — no Python re-pack of the (potentially GB-scale) GLB, and the worker's compress_glb
     detects the already-packed GLB and skips it (gzip-at-rest still applies on upload). Returns a
@@ -56,20 +56,23 @@ def native_step_to_glb(
     """
     import adacpp
 
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    from ada.cad.registry import (
+        DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE,
+        stream_tess_adaptive,
+        stream_tess_defaults,
+    )
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+    if deflection is None or angular_deg is None:
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
 
     # Adaptive per-surface angular density is ON BY DEFAULT for STEP->GLB: large curved CAD
     # assemblies (crane: 7291 solids, thousands of sub-cm bolts/pins) over-tessellate at a fixed
     # fine angle, and the GLB is the transfer-size-sensitive product. We estimate a model reference
     # scale so adacpp coarsens tiny features while keeping large surfaces fine. ADA_STREAM_TESS_
     # ADAPTIVE=0/false forces the fixed-angle path (model_scale 0 => angular_deg governs everything).
-    adaptive_env = os.environ.get("ADA_STREAM_TESS_ADAPTIVE")
-    adaptive = True if adaptive_env is None else adaptive_env.strip().lower() not in {"0", "false", "no", "off", ""}
+    adaptive = stream_tess_adaptive(default=DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE)
     model_scale = 0.0
     if adaptive:
         from ada.cadit.step.model_scale import estimate_step_model_scale
@@ -104,9 +107,9 @@ def native_step_to_glb(
     # Opt-in per-face clickable regions (scenes[0].extras face_ranges_node<m>): ADA_STREAM_TESS_FACE_REGIONS=1.
     # Off by default — it bloats the GLB and forces serial face tessellation. Only forward to an adacpp
     # build whose binding accepts it (older extensions would raise on the unknown kwarg).
-    fr_env = os.environ.get("ADA_STREAM_TESS_FACE_REGIONS")
-    face_regions = fr_env is not None and fr_env.strip().lower() not in {"0", "false", "no", "off", ""}
-    if face_regions and "face_regions" in (adacpp.cad.stream_step_to_glb.__doc__ or ""):
+    from ada.cad.registry import stream_tess_face_regions
+
+    if stream_tess_face_regions() and "face_regions" in (adacpp.cad.stream_step_to_glb.__doc__ or ""):
         glb_kwargs["face_regions"] = True
     n = adacpp.cad.stream_step_to_glb(str(step_path), str(glb_path), **glb_kwargs)
     if n < 0:

--- a/src/ada/cadit/step/native_step_to_glb.py
+++ b/src/ada/cadit/step/native_step_to_glb.py
@@ -6,7 +6,7 @@ and in-process: a Part-21 reader (offset index + per-statement pread, bounded me
 resolve -> libtess2 tessellation across a C++ thread pool -> a merge-by-colour GLB writer with on-disk
 spill. No Python reader, no pickle, no worker pool, no GIL.
 
-On the crane (778 MB, 7291 solids, 26 M tris) this is ~2.9x faster than the Python 6-worker path at
+On the large reference assembly (778 MB, 7291 solids, 26 M tris) this is ~2.9x faster than the Python 6-worker path at
 ~20% lower peak memory, in one process. It honours the same ``ADA_STREAM_TESS_DEFLECTION`` /
 ``ADA_STREAM_TESS_ANGULAR`` env as the streaming path so deflection options carry over.
 
@@ -14,7 +14,7 @@ The native GLB carries the full viewer picking contract: merge-by-colour materia
 ``draw_ranges_node<matidx>`` and a per-instance, product-named ``id_hierarchy`` in
 ``scenes[0].extras``, plus an ``ADA_EXT_data`` extension. Each placement is individually pickable and
 the assembly tree is reconstructed from the reader's instance paths — validated 1:1 with the Python
-streaming path on the crane (same products, placements, triangle counts, names, and full tree).
+streaming path on the large reference assembly (same products, placements, triangle counts, names, and full tree).
 """
 
 from __future__ import annotations
@@ -68,7 +68,7 @@ def native_step_to_glb(
         angular_deg = _ang if angular_deg is None else angular_deg
 
     # Adaptive per-surface angular density is ON BY DEFAULT for STEP->GLB: large curved CAD
-    # assemblies (crane: 7291 solids, thousands of sub-cm bolts/pins) over-tessellate at a fixed
+    # assemblies (reference assembly: 7291 solids, thousands of sub-cm bolts/pins) over-tessellate at a fixed
     # fine angle, and the GLB is the transfer-size-sensitive product. We estimate a model reference
     # scale so adacpp coarsens tiny features while keeping large surfaces fine. ADA_STREAM_TESS_
     # ADAPTIVE=0/false forces the fixed-angle path (model_scale 0 => angular_deg governs everything).
@@ -85,7 +85,7 @@ def native_step_to_glb(
         # 3.2 GB-capped pod oversubscribes the CPUs AND bloats glibc's per-thread malloc arenas past
         # the RSS watchdog (observed: 3.12 GB peak → reaped at 31 s). Bound it to the streaming path's
         # cgroup-aware allotment (reads ADA_STEP_STREAM_WORKERS, else the cgroup cpu.max quota → cpu-1,
-        # capped at 3) — the same allotment libtess2 runs the crane under at ~1 GB. Falls back to the
+        # capped at 3) — the same allotment libtess2 runs the reference assembly under at ~1 GB. Falls back to the
         # C++ auto-pick only if that helper can't be imported.
         try:
             from ada.visit.scene_handling.scene_from_step_stream import _stream_workers
@@ -127,7 +127,7 @@ def native_step_to_glb(
     )
     if on_progress is not None:
         on_progress("ready", 1.0)
-    # Native coverage is 100% on the crane (all surface types + BREP_WITH_VOIDS resolved); the binding
+    # Native coverage is 100% on the reference assembly (all surface types + BREP_WITH_VOIDS resolved); the binding
     # returns solids actually written, so skipped is reported 0 here. (A future binding return of the
     # total-root count would let this report exact skips.)
     return {"solids": n, "total": n, "skipped": 0}

--- a/src/ada/cadit/step/native_step_to_ifc.py
+++ b/src/ada/cadit/step/native_step_to_ifc.py
@@ -16,7 +16,6 @@ assembly path (navigable hierarchy in IFC viewers).
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -52,12 +51,12 @@ def native_step_to_ifc(
     """
     import adacpp
 
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    if deflection is None or angular_deg is None:
+        from ada.cad.registry import stream_tess_defaults
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
     if num_threads <= 0:
         # Bound to the cgroup-aware allotment (not the node's core count) so we don't oversubscribe a
         # CPU-capped pod — same rule as the native GLB/mesh paths.

--- a/src/ada/cadit/step/native_step_to_ifc.py
+++ b/src/ada/cadit/step/native_step_to_ifc.py
@@ -9,7 +9,7 @@ the writer parallelizes across the cgroup-aware thread allotment. Peak memory is
 worker. The per-solid Python ``stream_step_to_ifc`` stays as the fallback when adacpp lacks the verb.
 
 Output is ifcopenshell.validate-clean (IFC4X3_ADD2) across flat + instanced models — verified on
-fixtures, 469826 (1308 solids) and the instanced crane (proxy/header GlobalIds are disjoint). The
+fixtures, 469826 (1308 solids) and the instanced reference assembly (proxy/header GlobalIds are disjoint). The
 file declares its real length unit (mm files → MILLIMETRE) and names instanced proxies by their
 assembly path (navigable hierarchy in IFC viewers).
 """

--- a/src/ada/cadit/step/native_step_to_mesh.py
+++ b/src/ada/cadit/step/native_step_to_mesh.py
@@ -10,7 +10,7 @@ Python ``stream_step_to_mesh`` on giant-solid / FEM-export STEP (469826: 72s nat
 Coordinates are scaled to metres (the adapy / viewer unit convention, same as the native GLB path).
 
 OBJ output welds vertices (each instance's unique tessellated verts written once + indexed faces),
-~2.3x smaller than per-triangle unshared verts (crane 8.25 GB -> 3.53 GB) — the file size drove the
+~2.3x smaller than per-triangle unshared verts (reference assembly 8.25 GB -> 3.53 GB) — the file size drove the
 write + gzip-at-rest + upload time that dominated STEP->obj in the capped worker pod.
 """
 
@@ -72,7 +72,7 @@ def native_step_to_mesh(
 
     # Adaptive per-surface density is ON BY DEFAULT for STEP->OBJ/STL too (same rationale as
     # STEP->GLB: dense curved assemblies over-tessellate, and the text OBJ/STL are the largest,
-    # slowest products — the crane's 107M-tri OBJ/STL blew the 5-min timeout). ADA_STREAM_TESS_
+    # slowest products — the reference assembly's 107M-tri OBJ/STL blew the 5-min timeout). ADA_STREAM_TESS_
     # ADAPTIVE=0/false forces the fixed-angle path.
     adaptive = stream_tess_adaptive(default=DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE)
     model_scale = 0.0

--- a/src/ada/cadit/step/native_step_to_mesh.py
+++ b/src/ada/cadit/step/native_step_to_mesh.py
@@ -16,7 +16,6 @@ write + gzip-at-rest + upload time that dominated STEP->obj in the capped worker
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -42,20 +41,25 @@ def native_step_to_mesh(
     on_progress=None,
 ) -> int:
     """Convert ``step_path`` to ``out_path`` as ``fmt`` ('stl' | 'obj') with the native adacpp mesh
-    pipeline. ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` (2.0) /
-    ``ADA_STREAM_TESS_ANGULAR`` (20.0) env. ``num_threads`` 0 = the cgroup-aware streaming allotment.
+    pipeline. ``deflection`` / ``angular_deg`` default to the ``ADA_STREAM_TESS_DEFLECTION`` /
+    ``ADA_STREAM_TESS_ANGULAR`` env via ``ada.cad.registry.stream_tess_defaults``. ``num_threads``
+    0 = the cgroup-aware streaming allotment.
     Returns the triangle count; raises if adacpp is unavailable or the conversion fails."""
     import adacpp
 
     fmt = fmt.lower().lstrip(".")
     if fmt not in ("stl", "obj"):
         raise ValueError(f"native_step_to_mesh: unsupported format {fmt!r}")
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    from ada.cad.registry import (
+        DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE,
+        stream_tess_adaptive,
+        stream_tess_defaults,
+    )
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+    if deflection is None or angular_deg is None:
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
     if num_threads <= 0:
         # Mirror the native GLB path: bound threads to the cgroup-aware allotment, not the node's
         # core count, so we don't oversubscribe a CPU-capped pod or bloat per-thread malloc arenas.
@@ -70,8 +74,7 @@ def native_step_to_mesh(
     # STEP->GLB: dense curved assemblies over-tessellate, and the text OBJ/STL are the largest,
     # slowest products — the crane's 107M-tri OBJ/STL blew the 5-min timeout). ADA_STREAM_TESS_
     # ADAPTIVE=0/false forces the fixed-angle path.
-    adaptive_env = os.environ.get("ADA_STREAM_TESS_ADAPTIVE")
-    adaptive = True if adaptive_env is None else adaptive_env.strip().lower() not in {"0", "false", "no", "off", ""}
+    adaptive = stream_tess_adaptive(default=DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE)
     model_scale = 0.0
     if adaptive:
         from ada.cadit.step.model_scale import estimate_step_model_scale

--- a/src/ada/cadit/step/native_step_to_step.py
+++ b/src/ada/cadit/step/native_step_to_step.py
@@ -9,7 +9,6 @@ per-solid Python ``Ap242StreamWriter`` stays as the fallback when adacpp lacks t
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 from ada.config import logger
@@ -37,12 +36,12 @@ def native_step_to_step(
     adacpp is unavailable or no solid converted."""
     import adacpp
 
-    if deflection is None:
-        deflection = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-    if angular_deg is None:
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+    if deflection is None or angular_deg is None:
+        from ada.cad.registry import stream_tess_defaults
 
-        angular_deg = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+        _defl, _ang = stream_tess_defaults()
+        deflection = _defl if deflection is None else deflection
+        angular_deg = _ang if angular_deg is None else angular_deg
     if num_threads <= 0:
         try:
             from ada.visit.scene_handling.scene_from_step_stream import _stream_workers

--- a/src/ada/cadit/step/read/native_reader.py
+++ b/src/ada/cadit/step/read/native_reader.py
@@ -8,8 +8,8 @@ per-representation mixed-unit scaling), and assembly instance paths match the Py
 
 The C++ side emits one NGEOM root per solid plus a parallel ``StepRootMeta`` (id / has_color / color /
 transforms / instance_paths); this rebuilds each as a ``Geometry``. NOTE ``stream_step_to_ngeom``
-currently full-parses the file (not memory-bounded) — fine for small/medium models; large files (the
-crane) need the streaming GLB path until the ngeom emitter is made streaming too.
+currently full-parses the file (not memory-bounded) — fine for small/medium models; large files (a
+multi-GB reference assembly) need the streaming GLB path until the ngeom emitter is made streaming too.
 """
 
 from __future__ import annotations

--- a/src/ada/cadit/step/read/stream_reader.py
+++ b/src/ada/cadit/step/read/stream_reader.py
@@ -731,7 +731,7 @@ def detect_step_length_unit_scale(filepath) -> float:
     (logged at warning in the latter case).
 
     Scanned with chunked ``os.pread`` rather than a whole-file mmap: ``LENGTH_UNIT``
-    routinely sits at the very END of the DATA section (e.g. ~99.7% into a 778 MB crane
+    routinely sits at the very END of the DATA section (e.g. ~99.7% into a 778 MB reference
     assembly), so an ``mmap.find`` would fault the entire file into RSS — a ~700 MB+
     transient spike right in the middle of the streaming reader's setup. pread keeps the
     pages in the reclaimable OS page cache, off this process's VmRSS."""

--- a/src/ada/cadit/step/write/ap242_stream.py
+++ b/src/ada/cadit/step/write/ap242_stream.py
@@ -728,7 +728,6 @@ class Ap242StreamWriter:
         triples already carrying the active instance transform ``self._tf``; ``tri_
         indices`` an (M,3) list of int triples. Returns ``(None, None)`` if adacpp is
         unavailable or the solid yields no triangles."""
-        import os
 
         try:
             from ada.cad import active_backend
@@ -738,10 +737,9 @@ class Ap242StreamWriter:
         fn = getattr(backend, "tessellate_stream", None)
         if fn is None:
             return None, None
-        defl = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-        from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+        from ada.cad.registry import stream_tess_defaults
 
-        ang = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+        defl, ang = stream_tess_defaults()
         try:
             mesh = fn([("0", g)], pipeline="libtess2", deflection=defl, angular_deg=ang)
         except Exception as exc:  # noqa: BLE001 - tessellation can't cover this solid

--- a/src/ada/cadit/step/write/stream_step_to_step.py
+++ b/src/ada/cadit/step/write/stream_step_to_step.py
@@ -1,6 +1,6 @@
 """Streaming STEP → STEP (AP242) re-export — per-solid, no full Assembly.
 
-Large CAD STEP assemblies (the multi-GB crane) OOM-kill / time out through the
+Large CAD STEP assemblies (a multi-GB reference assembly) OOM-kill / time out through the
 full-OCC ``ada.from_step`` → ``to_stp`` path: OCC builds the whole compound + an
 XCAF document in memory before writing. This streams instead — the native NGEOM
 reader yields one ``ada.geom.Geometry`` per solid (analytic B-rep incl. B-spline

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import pathlib
@@ -44,6 +45,7 @@ from .converter import (
     is_fea_artefact_source,
     is_fea_result_key,
     is_supported_source,
+    merge_option_into,
     supported_targets_for,
 )
 from .handlers import dispatch
@@ -403,10 +405,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return []
         workers = _worker_registry["workers"]
         merged: dict[str, set[str]] = {}
-        # from → target → option-name → option-dict. Per-job knob schemas are unioned across workers:
-        # for an enum option (e.g. step_glb_pipeline) the enum VALUES are unioned, so an engine that
-        # only some worker pool can run still appears in the list. (Pair with capability routing so the
-        # job lands on a pool that actually advertises that engine — see queue source-ext routing.)
+        # from → target → option-name → option-dict. Per-job knob schemas are unioned across workers
+        # by merge_option_into: enum VALUES, each enum_by list, and the per-value label/runtime maps
+        # all union, so an engine only one pool can run still appears — fully described — in the list.
+        # (Pair with capability routing so the job lands on a pool that actually advertises that
+        # engine — see queue source-ext routing.)
         merged_opts: dict[str, dict[str, dict[str, dict]]] = {}
         now = time.time()
         for w in workers:
@@ -440,9 +443,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         slot = merged_opts.setdefault(frm, {}).setdefault(target, {})
                         cur = slot.get(opt["name"])
                         if cur is None:
-                            slot[opt["name"]] = dict(opt)
-                        elif isinstance(opt.get("enum"), list) and isinstance(cur.get("enum"), list):
-                            cur["enum"] = cur["enum"] + [v for v in opt["enum"] if v not in cur["enum"]]
+                            slot[opt["name"]] = copy.deepcopy(opt)
+                        else:
+                            merge_option_into(cur, opt)
         return [
             {
                 "from": frm,

--- a/src/ada/comms/rest/auth.py
+++ b/src/ada/comms/rest/auth.py
@@ -1,7 +1,7 @@
 """OIDC JWT verification for the hosted REST viewer.
 
 Provider-agnostic: a single implementation serves both Authentik
-(homelab) and Azure AD direct (enterprise). Both expose a
+(self-hosted) and Azure AD direct (enterprise). Both expose a
 ``.well-known/openid-configuration`` discovery doc and a JWKS
 endpoint, so configuration is purely env-driven (issuer, client_id,
 audience, admin_group).

--- a/src/ada/comms/rest/config.py
+++ b/src/ada/comms/rest/config.py
@@ -47,7 +47,7 @@ class QueueConfig:
 class AuthConfig:
     """Provider-agnostic OIDC settings.
 
-    One implementation handles both Authentik (homelab) and Azure AD
+    One implementation handles both Authentik (self-hosted) and Azure AD
     direct (enterprise) — both expose a `.well-known/openid-configuration`
     discovery doc and a JWKS endpoint.
 

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -890,7 +890,49 @@ _STEP_GLB_PIPELINE_ADACPP_HYBRID = "adacpp-hybrid"
 # default; it degrades gracefully to libtess2 if adacpp's native entry point is missing or the
 # conversion raises.
 _STEP_GLB_PIPELINE_ADACPP_NATIVE = "adacpp-native"
-_STEP_GLB_PIPELINES = (
+
+
+def _pipeline_to_track_name(pipe: str) -> str | None:
+    """`step_glb_pipeline` token -> discovered track name, or None for the OCC-builtin path.
+
+    The inverse of _tess_token_to_pipeline. Both directions are derived from discovery, so a track
+    added in adacpp resolves end-to-end (dropdown -> pipeline token -> CadConfig -> env) with no
+    change here. The four historic identities are pinned so existing configs and audit rows keep
+    meaning what they meant.
+    """
+    from ada.cad.registry import available_tess_tracks
+
+    historic = {
+        _STEP_GLB_PIPELINE_LIBTESS2: "adacpp:libtess2",
+        _STEP_GLB_PIPELINE_ADACPP_OCC: "adacpp:occ",
+        _STEP_GLB_PIPELINE_ADACPP_CGAL: "adacpp:cgal",
+        _STEP_GLB_PIPELINE_ADACPP_HYBRID: "adacpp:hybrid",
+    }
+    if pipe in historic:
+        return historic[pipe]
+    if pipe.startswith("adacpp-"):
+        cand = f"adacpp:{pipe[len('adacpp-'):]}"
+        if any(t.name == cand for t in available_tess_tracks()):
+            return cand
+    return None  # occ-builtin / adacpp-native / unknown → not a stream CadConfig
+
+
+def _adacpp_stream_pipelines() -> tuple[str, ...]:
+    """Every `step_glb_pipeline` token backed by a DISCOVERED adacpp track (adacpp-native excluded:
+    it is a whole-file code path, not a tessellator)."""
+    from ada.cad.registry import CadBackendName, available_tess_tracks
+
+    out = []
+    for t in available_tess_tracks():
+        if t.backend is not CadBackendName.ADACPP:
+            continue
+        tok = _tess_token_to_pipeline(t.name)
+        if tok not in out:
+            out.append(tok)
+    return tuple(out)
+
+
+_STEP_GLB_PIPELINES_STATIC = (
     _STEP_GLB_PIPELINE_LIBTESS2,
     _STEP_GLB_PIPELINE_OCC,
     _STEP_GLB_PIPELINE_ADACPP_OCC,
@@ -898,6 +940,18 @@ _STEP_GLB_PIPELINES = (
     _STEP_GLB_PIPELINE_ADACPP_HYBRID,
     _STEP_GLB_PIPELINE_ADACPP_NATIVE,
 )
+
+
+def _step_glb_pipelines() -> tuple[str, ...]:
+    """The accepted `step_glb_pipeline` vocabulary: adapy's own tokens + every discovered adacpp
+    track. Derived, so a new track is accepted without touching this module."""
+    out = list(_STEP_GLB_PIPELINES_STATIC)
+    for tok in _adacpp_stream_pipelines():
+        if tok not in out:
+            out.append(tok)
+    return tuple(out)
+
+
 _STEP_GLB_PIPELINE_DEFAULT = _STEP_GLB_PIPELINE_ADACPP_NATIVE
 # Where the native path degrades to when adacpp is absent or a conversion raises. Kept separate from
 # the default so the native branch's fallback is never circular.
@@ -928,19 +982,14 @@ def available_step_glb_pipelines() -> tuple[str, ...]:
         # the import check spuriously reports False at worker-startup advert time. find_spec is resolved
         # at call time against sys.path and isn't poisoned by an earlier import; the worker's runtime
         # fallback (native → libtess2 → occ-builtin) still covers a pool that turns out not to run it.
-        runnable.update(
-            {
-                _STEP_GLB_PIPELINE_LIBTESS2,
-                _STEP_GLB_PIPELINE_ADACPP_OCC,
-                _STEP_GLB_PIPELINE_ADACPP_CGAL,
-                _STEP_GLB_PIPELINE_ADACPP_HYBRID,
-                _STEP_GLB_PIPELINE_ADACPP_NATIVE,
-            }
-        )
+        # Discovered, not listed: adacpp reports which tracks IT compiled, so a build without the
+        # taxonomy kernels (or with a new one) advertises the truth rather than this module's guess.
+        runnable.update(_adacpp_stream_pipelines())
+        runnable.add(_STEP_GLB_PIPELINE_ADACPP_NATIVE)  # a whole-file code path, not a track
     if _have("OCP") or _have("OCC"):
         runnable.add(_STEP_GLB_PIPELINE_OCC)
-    avail = tuple(p for p in _STEP_GLB_PIPELINES if p in runnable)
-    return avail or _STEP_GLB_PIPELINES
+    avail = tuple(p for p in _step_glb_pipelines() if p in runnable)
+    return avail or _step_glb_pipelines()
 
 
 # Non-STEP →GLB engine toggle (xml / ifc / sat / fem / obj / stl → glb via to_gltf's
@@ -1005,31 +1054,90 @@ _GLB_SERIALIZER_LABELS = {
 # in-browser pipeline and gates them on client capability (wasmSupport).
 _GLB_CLIENT_SERIALIZERS = frozenset({_GLB_SERIALIZER_WASM})
 
-_GLB_TESS_LABELS = {
-    "native": "Native (libtess2)",
+# Labels adapy OWNS: its own serializer-pinned token and the two in-browser engines, none of which
+# adacpp knows about. Every adacpp track's label + description comes from the track itself
+# (_glb_tess_label / _glb_tess_description), so a new track arrives fully described.
+_GLB_TESS_OWN_LABELS = {
+    "native": "Native (libtess2)",  # the cpp serializer's pinned tessellator
+    # client-side (wasm serializer) engines:
+    "wasm-native": "Native (WASM module)",
+    "pyodide": "Pyodide (wasm wheels)",
+    # legacy tokens, still resolvable for stored configs / older SPA builds:
     "pyocc": "PythonOCC (OCC)",
     "adacpp-occ": "adacpp OCC",
     "cgal": "adacpp CGAL",
     "ifc-hybrid": "ifcOpenShell hybrid",
-    "occ": "OCC streaming reader",
-    # client-side (wasm serializer) engines:
-    "wasm-native": "Native (WASM module)",
-    "pyodide": "Pyodide (wasm wheels)",
 }
+
+
+def _glb_tess_label(tok: str) -> str:
+    """Human label for a tessellator token. Discovered tracks describe themselves."""
+    from ada.cad.registry import tess_track_by_name
+
+    track = tess_track_by_name(_LEGACY_TESS_ALIASES.get(tok, tok))
+    if track is not None:
+        return track.label
+    return _GLB_TESS_OWN_LABELS.get(tok, tok)
+
+
+def _glb_tess_description(tok: str) -> str:
+    """One-line tooltip for a tessellator token, from the track's own declaration ('' if it has
+    none). This is why a track can explain its own cost/benefit in the UI without adapy knowing
+    anything about it."""
+    from ada.cad.registry import tess_track_by_name
+
+    track = tess_track_by_name(_LEGACY_TESS_ALIASES.get(tok, tok))
+    return track.description if track is not None else ""
+
 
 # Per (serializer, source-family) the tessellator tokens offered. ``step`` =
 # STEP/STP sources (own streaming reader + OCC reader); ``generic`` = every
 # other →GLB source (ifc / xml / sat / fem / obj / stl) driven by to_gltf's
 # BatchTessellator. The lists ARE the enum_by mapping the frontend uses to
 # repopulate the tessellator dropdown when the serializer changes.
-_GLB_SERIALIZER_TESS = {
-    (_GLB_SERIALIZER_CPP, "step"): ["native"],
-    (_GLB_SERIALIZER_CPP, "generic"): ["native"],
-    (_GLB_SERIALIZER_PYTHON, "step"): ["native", "pyocc", "adacpp-occ", "cgal", "ifc-hybrid", "occ"],
-    (_GLB_SERIALIZER_PYTHON, "generic"): ["native", "pyocc", "adacpp-occ", "cgal", "ifc-hybrid"],
-    (_GLB_SERIALIZER_WASM, "step"): ["wasm-native", "pyodide"],
-    (_GLB_SERIALIZER_WASM, "generic"): ["wasm-native", "pyodide"],
+# LEGACY tessellator tokens -> discovered track name. The python serializer's vocabulary used to be
+# this list; it is now DISCOVERED (see _python_tess_tokens), which is the only reason `adacpp:cdt`
+# can reach the UI at all — a hand-written list cannot grow a track added later in adacpp. These
+# aliases keep stored configs, the admin panel and older SPA builds resolving.
+_LEGACY_TESS_ALIASES = {
+    "native": "adacpp:libtess2",
+    "pyocc": "occ",
+    "occ": "occ",
+    "adacpp-occ": "adacpp:occ",
+    "cgal": "adacpp:cgal",
+    "ifc-hybrid": "adacpp:hybrid",
 }
+
+
+def _python_tess_tokens(fam: str) -> list[str]:
+    """The `python` serializer's tessellator tokens — DISCOVERED from adacpp, not enumerated here.
+
+    Adding a track in adacpp makes it appear in this dropdown with no change in adapy. The order puts
+    the declared default first (the dropdown's default is enum_by[...][0]).
+    """
+    from ada.cad.registry import available_tess_tracks
+
+    tracks = available_tess_tracks()
+    ranked = sorted(tracks, key=lambda t: (not t.is_default, t.backend.value != "adacpp", t.name))
+    return [t.name for t in ranked]
+
+
+def _glb_serializer_tess(serializer: str, fam: str) -> list[str] | None:
+    """Tessellator tokens for a (serializer, family), or None if that pair isn't offered.
+
+    `cpp` pins its own tessellator and `wasm` runs in-browser engines adacpp doesn't know about, so
+    both stay declared here — they are adapy's own. Only the `python` serializer, which is the one
+    that actually dispatches to adacpp, is discovered.
+    """
+    if serializer == _GLB_SERIALIZER_CPP:
+        return ["native"]
+    if serializer == _GLB_SERIALIZER_WASM:
+        return ["wasm-native", "pyodide"]
+    if serializer == _GLB_SERIALIZER_PYTHON:
+        return _python_tess_tokens(fam)
+    return None
+
+
 # Serializer ordering per family (default is the first entry). cpp is the
 # default server path for both; the client serializer comes last.
 _GLB_SERIALIZER_ORDER = (
@@ -1038,23 +1146,34 @@ _GLB_SERIALIZER_ORDER = (
     _GLB_SERIALIZER_WASM,
 )
 
+
 # tessellator token → effective engine knob, reusing the existing pipeline
 # identities so there is exactly one definition of each engine.
-_TESS_TO_STEP_PIPELINE = {
-    "native": _STEP_GLB_PIPELINE_LIBTESS2,
-    "pyocc": _STEP_GLB_PIPELINE_OCC,
-    "occ": _STEP_GLB_PIPELINE_OCC,
-    "adacpp-occ": _STEP_GLB_PIPELINE_ADACPP_OCC,
-    "cgal": _STEP_GLB_PIPELINE_ADACPP_CGAL,
-    "ifc-hybrid": _STEP_GLB_PIPELINE_ADACPP_HYBRID,
-}
-_TESS_TO_GLB_ENGINE = {
-    "native": _STEP_GLB_PIPELINE_LIBTESS2,
-    "pyocc": _STEP_GLB_PIPELINE_OCC,
-    "adacpp-occ": _STEP_GLB_PIPELINE_ADACPP_OCC,
-    "cgal": _STEP_GLB_PIPELINE_ADACPP_CGAL,
-    "ifc-hybrid": _STEP_GLB_PIPELINE_ADACPP_HYBRID,
-}
+def _tess_token_to_pipeline(tok: str) -> str:
+    """Tessellator token -> the `step_glb_pipeline` knob. Resolves legacy tokens and any DISCOVERED
+    track name, including ones that postdate this module (e.g. adacpp:cdt)."""
+    from ada.cad.registry import tess_track_by_name
+
+    name = _LEGACY_TESS_ALIASES.get(tok, tok)
+    if name == "occ":
+        return _STEP_GLB_PIPELINE_OCC  # adapy's own BRepMesh (no stream override)
+    track = tess_track_by_name(name)
+    if track is None or track.pipeline is None:
+        return _STEP_GLB_PIPELINE_LIBTESS2
+    # Every adacpp track maps to the stream selector by its own pipeline token; the few that predate
+    # discovery keep their historic _STEP_GLB_PIPELINE_* identity so audit rows stay comparable.
+    return {
+        "libtess2": _STEP_GLB_PIPELINE_LIBTESS2,
+        "occ": _STEP_GLB_PIPELINE_ADACPP_OCC,
+        "cgal": _STEP_GLB_PIPELINE_ADACPP_CGAL,
+        "hybrid": _STEP_GLB_PIPELINE_ADACPP_HYBRID,
+    }.get(track.pipeline, f"adacpp-{track.pipeline}")
+
+
+def _tess_token_to_glb_engine(tok: str) -> str:
+    """Tessellator token -> the `glb_tess_engine` knob (the non-STEP BatchTessellator selector).
+    Same discovery-backed resolution as _tess_token_to_pipeline."""
+    return _tess_token_to_pipeline(tok)
 
 
 def _glb_source_family(source_ext: str) -> str:
@@ -1071,8 +1190,8 @@ def _glb_serializer_options(source_ext: str) -> list[dict]:
     of it. ``enum_by`` maps each serializer value to its allowed tessellator
     tokens; ``runtime='client'`` flags the browser-side serializers."""
     fam = _glb_source_family(source_ext)
-    serializers = [s for s in _GLB_SERIALIZER_ORDER if (s, fam) in _GLB_SERIALIZER_TESS]
-    enum_by = {s: list(_GLB_SERIALIZER_TESS[(s, fam)]) for s in serializers}
+    serializers = [s for s in _GLB_SERIALIZER_ORDER if _glb_serializer_tess(s, fam)]
+    enum_by = {s: list(_glb_serializer_tess(s, fam)) for s in serializers}
     # Union of tessellator tokens across serializers, ordered by first appearance.
     tess_tokens: list[str] = []
     for s in serializers:
@@ -1103,7 +1222,10 @@ def _glb_serializer_options(source_ext: str) -> list[dict]:
             "title": "Tessellator",
             "default": enum_by[default_ser][0],
             "enum": tess_tokens,
-            "labels": {t: _GLB_TESS_LABELS.get(t, t) for t in tess_tokens},
+            "labels": {t: _glb_tess_label(t) for t in tess_tokens},
+            # Per-token tooltips, sourced from each track's own declaration. Empty for adapy's own
+            # tokens, which the frontend renders without a tooltip.
+            "descriptions": {t: _glb_tess_description(t) for t in tess_tokens if _glb_tess_description(t)},
             # Dependent dropdown: the valid tessellators for each serializer. The
             # frontend repopulates + reselects when the serializer changes.
             "enum_by": enum_by,
@@ -1142,11 +1264,11 @@ def _apply_glb_serializer(
         # generic/IFC 'cpp' = the native_ifc_to_glb default path — nothing to force.
         return step_glb_pipeline, glb_tess_engine, False
     if serializer == _GLB_SERIALIZER_PYTHON:
-        tok = tessellator or _GLB_SERIALIZER_TESS[(_GLB_SERIALIZER_PYTHON, fam)][0]
+        tok = tessellator or _glb_serializer_tess(_GLB_SERIALIZER_PYTHON, fam)[0]
         if fam == "step":
-            step_glb_pipeline = _TESS_TO_STEP_PIPELINE.get(tok, _STEP_GLB_PIPELINE_LIBTESS2)
+            step_glb_pipeline = _tess_token_to_pipeline(tok)
         else:
-            glb_tess_engine = _TESS_TO_GLB_ENGINE.get(tok, _GLB_TESS_ENGINE_DEFAULT)
+            glb_tess_engine = _tess_token_to_glb_engine(tok)
         return step_glb_pipeline, glb_tess_engine, True
     return step_glb_pipeline, glb_tess_engine, False
 
@@ -1280,7 +1402,7 @@ def _resolve_step_glb_pipeline(step_glb_pipeline: str | None) -> str:
         .strip()
         .lower()
     )
-    if choice not in _STEP_GLB_PIPELINES:
+    if choice not in _step_glb_pipelines():
         logger.warning("unknown ADAPY_STEP_GLB_PIPELINE %r; falling back to %s", choice, _STEP_GLB_PIPELINE_DEFAULT)
         return _STEP_GLB_PIPELINE_DEFAULT
     return choice
@@ -1304,22 +1426,16 @@ def _cad_config_for_pipeline(pipe: str):
     """Map a STEP→GLB pipeline to a ``CadConfig`` for the streaming converter, or
     ``None`` for the OCC-builtin path (and as a graceful fallback when the requested
     adacpp tessellation path isn't available in this environment)."""
-    from ada.cad.registry import CadConfig, TessellationPath, available_paths
+    from ada.cad.registry import CadConfig, tess_track_by_name
     from ada.config import logger
 
-    mapping = {
-        _STEP_GLB_PIPELINE_LIBTESS2: TessellationPath.ADACPP_LIBTESS2,
-        _STEP_GLB_PIPELINE_ADACPP_OCC: TessellationPath.ADACPP_OCC,
-        _STEP_GLB_PIPELINE_ADACPP_CGAL: TessellationPath.ADACPP_CGAL,
-        _STEP_GLB_PIPELINE_ADACPP_HYBRID: TessellationPath.ADACPP_HYBRID,
-    }
-    tp = mapping.get(pipe)
-    if tp is None:
+    name = _pipeline_to_track_name(pipe)
+    if name is None:
         return None  # occ-builtin → OCC streaming default
-    if tp not in available_paths():
-        logger.warning("step-glb pipeline %r unavailable (adacpp missing); using occ-builtin", pipe)
+    if tess_track_by_name(name) is None:
+        logger.warning("step-glb pipeline %r unavailable in this environment; using occ-builtin", pipe)
         return None
-    return CadConfig(path=tp)
+    return CadConfig(path=name)
 
 
 def _via_ada(
@@ -2476,7 +2592,7 @@ def _register_ada_loadable() -> None:
         "name": "step_glb_pipeline",
         "type": "enum",
         "default": _STEP_GLB_PIPELINE_DEFAULT,
-        "enum": list(_STEP_GLB_PIPELINES),
+        "enum": list(_step_glb_pipelines()),
         "description": (
             "STEP→GLB tessellation engine. 'adacpp-native' (default) runs the whole STEP→GLB in "
             "adacpp C++ (reader + thread pool + GLB writer) — fastest + lowest-memory, and 1:1 with "

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -886,7 +886,7 @@ _STEP_GLB_PIPELINE_ADACPP_HYBRID = "adacpp-hybrid"
 # Fully-native: adacpp does the whole STEP->GLB in-process (C++ reader + thread pool + GLB writer),
 # replacing the Python reader + multiprocess pool. Fastest + lowest memory, and now byte-faithful to
 # the Python path — geometry, product names, per-instance picking, and the full assembly tree are
-# validated 1:1 on the crane (see native_step_to_glb / validate_native_vs_python.py). This is the
+# validated 1:1 on the large reference assembly (see native_step_to_glb / validate_native_vs_python.py). This is the
 # default; it degrades gracefully to libtess2 if adacpp's native entry point is missing or the
 # conversion raises.
 _STEP_GLB_PIPELINE_ADACPP_NATIVE = "adacpp-native"

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -892,28 +892,32 @@ _STEP_GLB_PIPELINE_ADACPP_HYBRID = "adacpp-hybrid"
 _STEP_GLB_PIPELINE_ADACPP_NATIVE = "adacpp-native"
 
 
+# The four historic (adacpp track pipeline <-> `step_glb_pipeline` token) identities. Pinned in
+# BOTH directions from one dict so the two mappings cannot drift; everything else is structural
+# (``adacpp:X`` <-> ``adacpp-X``), which is what lets a track added later in adacpp resolve
+# end-to-end without an edit here.
+_HISTORIC_TRACK_PIPELINE = {
+    "libtess2": _STEP_GLB_PIPELINE_LIBTESS2,
+    "occ": _STEP_GLB_PIPELINE_ADACPP_OCC,
+    "cgal": _STEP_GLB_PIPELINE_ADACPP_CGAL,
+    "hybrid": _STEP_GLB_PIPELINE_ADACPP_HYBRID,
+}
+_HISTORIC_PIPELINE_TRACK = {v: f"adacpp:{k}" for k, v in _HISTORIC_TRACK_PIPELINE.items()}
+
+
 def _pipeline_to_track_name(pipe: str) -> str | None:
-    """`step_glb_pipeline` token -> discovered track name, or None for the OCC-builtin path.
+    """`step_glb_pipeline` token -> adacpp track name, or None for the paths that aren't a track
+    (occ-builtin, adacpp-native).
 
-    The inverse of _tess_token_to_pipeline. Both directions are derived from discovery, so a track
-    added in adacpp resolves end-to-end (dropdown -> pipeline token -> CadConfig -> env) with no
-    change here. The four historic identities are pinned so existing configs and audit rows keep
-    meaning what they meant.
+    VOCABULARY, not capability: this says what a token *means*, never whether this process can run
+    it. Availability is checked one layer up, in :func:`_cad_config_for_pipeline`, which warns and
+    degrades. Keeping the two apart is what makes the answer identical in the API, the worker and
+    the test envs — see :func:`_tess_token_to_pipeline` for what the conflation cost.
     """
-    from ada.cad.registry import available_tess_tracks
-
-    historic = {
-        _STEP_GLB_PIPELINE_LIBTESS2: "adacpp:libtess2",
-        _STEP_GLB_PIPELINE_ADACPP_OCC: "adacpp:occ",
-        _STEP_GLB_PIPELINE_ADACPP_CGAL: "adacpp:cgal",
-        _STEP_GLB_PIPELINE_ADACPP_HYBRID: "adacpp:hybrid",
-    }
-    if pipe in historic:
-        return historic[pipe]
-    if pipe.startswith("adacpp-"):
-        cand = f"adacpp:{pipe[len('adacpp-'):]}"
-        if any(t.name == cand for t in available_tess_tracks()):
-            return cand
+    if pipe in _HISTORIC_PIPELINE_TRACK:
+        return _HISTORIC_PIPELINE_TRACK[pipe]
+    if pipe.startswith("adacpp-") and pipe != _STEP_GLB_PIPELINE_ADACPP_NATIVE:
+        return f"adacpp:{pipe[len('adacpp-'):]}"
     return None  # occ-builtin / adacpp-native / unknown → not a stream CadConfig
 
 
@@ -992,29 +996,80 @@ def available_step_glb_pipelines() -> tuple[str, ...]:
     return avail or _step_glb_pipelines()
 
 
+def available_tess_tokens() -> frozenset[str]:
+    """The `tessellator` tokens THIS process can actually run — the serializer×tessellator analogue
+    of :func:`available_step_glb_pipelines`, for per-worker capability advertisement.
+
+    Every discovered track name (``occ``, ``adacpp:libtess2``, ``adacpp:cdt``, ...) plus the ``cpp``
+    serializer's pinned ``native`` token, which is adacpp's in-process writer and so rides on adacpp
+    being importable.
+
+    Client tokens (``wasm-native`` / ``pyodide``) are deliberately ABSENT: they run in the browser,
+    so no server-side probe can answer for them and they must never be gated on what a worker has
+    installed — see ``worker._gate_advertised_engines``.
+    """
+    from ada.cad.registry import (
+        CadBackendName,
+        available_tess_tracks,
+        backend_available,
+    )
+
+    toks = {t.name for t in available_tess_tracks()}
+    if backend_available(CadBackendName.ADACPP):
+        toks.add("native")
+    return frozenset(toks)
+
+
 # Non-STEP →GLB engine toggle (xml / ifc / sat / fem / obj / stl → glb via to_gltf's
-# BatchTessellator). Reuses the STEP option's names so the admin panel reads consistently,
-# but maps to the BatchTessellator stream selector (ADA_STREAM_TESS_PIPELINE = libtess2|occ|
-# cgal|hybrid); "occ-builtin" = the default OCC BatchTessellator (no stream override). The OCC
-# *streaming* reader is STEP-source-specific, so it isn't offered here. Default stays OCC
-# (libtess2 is opt-in).
-_GLB_TESS_ENGINES = (
-    _STEP_GLB_PIPELINE_OCC,  # "occ-builtin" — default
+# BatchTessellator). Reuses the STEP option's names so the admin panel reads consistently, but maps
+# to the BatchTessellator stream selector (ADA_STREAM_TESS_PIPELINE); "occ-builtin" = the default
+# OCC BatchTessellator (no stream override).
+_GLB_TESS_ENGINES_STATIC = (
+    _STEP_GLB_PIPELINE_OCC,  # "occ-builtin"
     _STEP_GLB_PIPELINE_LIBTESS2,
     _STEP_GLB_PIPELINE_ADACPP_OCC,
     _STEP_GLB_PIPELINE_ADACPP_CGAL,
     _STEP_GLB_PIPELINE_ADACPP_HYBRID,
 )
+
+
+def _glb_tess_engines() -> tuple[str, ...]:
+    """The `glb_tess_engine` vocabulary: adapy's own tokens + every discovered adacpp track.
+
+    ``adacpp-native`` is excluded — it is a whole-file STEP code path, not a BatchTessellator
+    kernel. Derived rather than listed for the same reason as :func:`_step_glb_pipelines`: the tuple
+    this replaced could not grow a track added later in adacpp.
+
+    Shaped like _step_glb_pipelines() — a static base that discovery only ADDS to — so the answer
+    is the same in every process. Returning just what adacpp reports would make the VOCABULARY
+    env-dependent (an adacpp-less API would stop knowing the word "adacpp-cgal" rather than knowing
+    it and not offering it), which is the conflation _tess_token_to_pipeline exists to avoid.
+    Capability is applied by ``worker._gate_advertised_engines``.
+    """
+    out = list(_GLB_TESS_ENGINES_STATIC)
+    for tok in _adacpp_stream_pipelines():
+        if tok not in out:
+            out.append(tok)
+    return tuple(out)
+
+
 # Advertised default for the non-STEP →GLB engine option. Kept in lockstep with the RUNTIME default
 # (`_default_glb_tess_engine`, which returns libtess2 whenever adacpp is importable) so the SPA/audit
 # UI reflects the path actually taken. libtess2 gracefully degrades to OCC on an adacpp-less pool.
 _GLB_TESS_ENGINE_DEFAULT = _STEP_GLB_PIPELINE_LIBTESS2
-_GLB_ENGINE_TO_STREAM = {
-    _STEP_GLB_PIPELINE_LIBTESS2: "libtess2",
-    _STEP_GLB_PIPELINE_ADACPP_OCC: "occ",
-    _STEP_GLB_PIPELINE_ADACPP_CGAL: "cgal",
-    _STEP_GLB_PIPELINE_ADACPP_HYBRID: "hybrid",
-}
+
+
+def _glb_engine_to_stream(engine: str) -> str | None:
+    """`glb_tess_engine` token -> the ``ADA_STREAM_TESS_PIPELINE`` value, or None for the OCC
+    BatchTessellator default (``occ-builtin`` / unknown).
+
+    Derived from the engine token, not a table: the table this replaced listed exactly the four
+    engines that existed when it was written, so a track discovered later (``adacpp-cdt``) missed
+    it, resolved to None, and SILENTLY ran the OCC BatchTessellator — the user picked a kernel and
+    got a different one, with nothing logged.
+    """
+    track = _pipeline_to_track_name(engine)
+    return None if track is None else track.split(":", 1)[1]
 
 
 # ---------------------------------------------------------------------------
@@ -1054,6 +1109,16 @@ _GLB_SERIALIZER_LABELS = {
 # in-browser pipeline and gates them on client capability (wasmSupport).
 _GLB_CLIENT_SERIALIZERS = frozenset({_GLB_SERIALIZER_WASM})
 
+# The two in-browser engines the `wasm` serializer offers, most-preferred first. adapy's OWN
+# vocabulary, unlike the python serializer's (discovered from adacpp): these name browser pipelines
+# — the adacpp embind module and the Pyodide wheel stack — that no adacpp build reports and no
+# worker runs. The SPA matches "wasm-native" to pick the embind pipeline, so this tuple and
+# services/conversion/index.ts share one contract; test_wasm_engine_tokens_are_the_spa_contract
+# pins it.
+_WASM_ENGINE_NATIVE = "wasm-native"
+_WASM_ENGINE_PYODIDE = "pyodide"
+_WASM_GLB_ENGINES = (_WASM_ENGINE_NATIVE, _WASM_ENGINE_PYODIDE)
+
 # Labels adapy OWNS: its own serializer-pinned token and the two in-browser engines, none of which
 # adacpp knows about. Every adacpp track's label + description comes from the track itself
 # (_glb_tess_label / _glb_tess_description), so a new track arrives fully described.
@@ -1090,15 +1155,14 @@ def _glb_tess_description(tok: str) -> str:
     return track.description if track is not None else ""
 
 
-# Per (serializer, source-family) the tessellator tokens offered. ``step`` =
-# STEP/STP sources (own streaming reader + OCC reader); ``generic`` = every
-# other →GLB source (ifc / xml / sat / fem / obj / stl) driven by to_gltf's
-# BatchTessellator. The lists ARE the enum_by mapping the frontend uses to
-# repopulate the tessellator dropdown when the serializer changes.
-# LEGACY tessellator tokens -> discovered track name. The python serializer's vocabulary used to be
-# this list; it is now DISCOVERED (see _python_tess_tokens), which is the only reason `adacpp:cdt`
-# can reach the UI at all — a hand-written list cannot grow a track added later in adacpp. These
-# aliases keep stored configs, the admin panel and older SPA builds resolving.
+# LEGACY tessellator tokens -> track name. The python serializer's vocabulary used to be a
+# hand-written list; it is now DISCOVERED (see _python_tess_tokens), which is the only reason
+# `adacpp:cdt` can reach the UI at all — a hand-written list cannot grow a track added later in
+# adacpp. These aliases keep stored configs, the admin panel and older SPA builds resolving.
+#
+# `pyocc` and `occ` BOTH land on adapy's own OCC track, because they always were the same engine:
+# the pre-discovery table mapped both to `occ-builtin` and merely labelled them differently
+# ("PythonOCC (OCC)" vs "OCC streaming reader"), so the STEP dropdown listed one engine twice.
 _LEGACY_TESS_ALIASES = {
     "native": "adacpp:libtess2",
     "pyocc": "occ",
@@ -1109,11 +1173,18 @@ _LEGACY_TESS_ALIASES = {
 }
 
 
-def _python_tess_tokens(fam: str) -> list[str]:
+def _python_tess_tokens() -> list[str]:
     """The `python` serializer's tessellator tokens — DISCOVERED from adacpp, not enumerated here.
 
     Adding a track in adacpp makes it appear in this dropdown with no change in adapy. The order puts
     the declared default first (the dropdown's default is enum_by[...][0]).
+
+    Takes no source family ON PURPOSE. The pre-discovery table split step/generic, but only to list
+    the duplicate `occ` alias on STEP (see _LEGACY_TESS_ALIASES) — every real kernel was offered to
+    both. Each track reaches both families: STEP via `step_glb_pipeline`, everything else via
+    `glb_tess_engine` -> ADA_STREAM_TESS_PIPELINE, and adapy's own OCC track is the BatchTessellator
+    default on generic. So there is no family split left to honour, and a `fam` argument here would
+    be a lie about a distinction that no longer exists.
     """
     from ada.cad.registry import available_tess_tracks
 
@@ -1122,8 +1193,8 @@ def _python_tess_tokens(fam: str) -> list[str]:
     return [t.name for t in ranked]
 
 
-def _glb_serializer_tess(serializer: str, fam: str) -> list[str] | None:
-    """Tessellator tokens for a (serializer, family), or None if that pair isn't offered.
+def _glb_serializer_tess(serializer: str) -> list[str] | None:
+    """Tessellator tokens for a serializer, or None if it isn't offered.
 
     `cpp` pins its own tessellator and `wasm` runs in-browser engines adacpp doesn't know about, so
     both stay declared here — they are adapy's own. Only the `python` serializer, which is the one
@@ -1132,9 +1203,9 @@ def _glb_serializer_tess(serializer: str, fam: str) -> list[str] | None:
     if serializer == _GLB_SERIALIZER_CPP:
         return ["native"]
     if serializer == _GLB_SERIALIZER_WASM:
-        return ["wasm-native", "pyodide"]
+        return list(_WASM_GLB_ENGINES)
     if serializer == _GLB_SERIALIZER_PYTHON:
-        return _python_tess_tokens(fam)
+        return _python_tess_tokens()
     return None
 
 
@@ -1150,29 +1221,28 @@ _GLB_SERIALIZER_ORDER = (
 # tessellator token → effective engine knob, reusing the existing pipeline
 # identities so there is exactly one definition of each engine.
 def _tess_token_to_pipeline(tok: str) -> str:
-    """Tessellator token -> the `step_glb_pipeline` knob. Resolves legacy tokens and any DISCOVERED
-    track name, including ones that postdate this module (e.g. adacpp:cdt)."""
-    from ada.cad.registry import tess_track_by_name
+    """Tessellator token -> the `step_glb_pipeline` knob. Resolves legacy tokens and any track name,
+    including ones that postdate this module (e.g. ``adacpp:cdt`` -> ``adacpp-cdt``).
 
+    VOCABULARY, not capability — deliberately: this used to resolve the token by LOOKING THE TRACK
+    UP in ``available_tess_tracks()`` and falling back to libtess2 when it wasn't found, which made
+    the same stored token mean different engines in different processes (``cgal`` -> ``adacpp-cgal``
+    where adacpp is importable, ``libtess2`` where it isn't). Worse, the fallback was itself an
+    adacpp engine, so it could not be what an adacpp-less pool meant. Resolution is now purely
+    structural and identical everywhere; whether the resolved engine can actually RUN is decided by
+    ``available_step_glb_pipelines`` / ``_gate_advertised_engines`` / ``_cad_config_for_pipeline``.
+    """
     name = _LEGACY_TESS_ALIASES.get(tok, tok)
     if name == "occ":
         return _STEP_GLB_PIPELINE_OCC  # adapy's own BRepMesh (no stream override)
-    track = tess_track_by_name(name)
-    if track is None or track.pipeline is None:
-        return _STEP_GLB_PIPELINE_LIBTESS2
-    # Every adacpp track maps to the stream selector by its own pipeline token; the few that predate
-    # discovery keep their historic _STEP_GLB_PIPELINE_* identity so audit rows stay comparable.
-    return {
-        "libtess2": _STEP_GLB_PIPELINE_LIBTESS2,
-        "occ": _STEP_GLB_PIPELINE_ADACPP_OCC,
-        "cgal": _STEP_GLB_PIPELINE_ADACPP_CGAL,
-        "hybrid": _STEP_GLB_PIPELINE_ADACPP_HYBRID,
-    }.get(track.pipeline, f"adacpp-{track.pipeline}")
+    if not name.startswith("adacpp:"):
+        return _STEP_GLB_PIPELINE_LIBTESS2  # unknown token → the OCC-free default
+    return _HISTORIC_TRACK_PIPELINE.get(name.split(":", 1)[1], f"adacpp-{name.split(':', 1)[1]}")
 
 
 def _tess_token_to_glb_engine(tok: str) -> str:
     """Tessellator token -> the `glb_tess_engine` knob (the non-STEP BatchTessellator selector).
-    Same discovery-backed resolution as _tess_token_to_pipeline."""
+    Same structural resolution as _tess_token_to_pipeline."""
     return _tess_token_to_pipeline(tok)
 
 
@@ -1188,10 +1258,14 @@ def _glb_serializer_options(source_ext: str) -> list[dict]:
     serializer→tessellator dependency all come from the module spec above, so
     the frontend can render the two dependent dropdowns without hardcoding any
     of it. ``enum_by`` maps each serializer value to its allowed tessellator
-    tokens; ``runtime='client'`` flags the browser-side serializers."""
-    fam = _glb_source_family(source_ext)
-    serializers = [s for s in _GLB_SERIALIZER_ORDER if _glb_serializer_tess(s, fam)]
-    enum_by = {s: list(_glb_serializer_tess(s, fam)) for s in serializers}
+    tokens; ``runtime='client'`` flags the browser-side serializers.
+
+    ``source_ext`` no longer selects the tessellator vocabulary (every kernel reaches every source
+    family — see :func:`_python_tess_tokens`); it is kept because it names the row this schema is
+    attached to and because the resolver still splits on family to pick the ENGINE KNOB.
+    """
+    serializers = [s for s in _GLB_SERIALIZER_ORDER if _glb_serializer_tess(s)]
+    enum_by = {s: list(_glb_serializer_tess(s)) for s in serializers}
     # Union of tessellator tokens across serializers, ordered by first appearance.
     tess_tokens: list[str] = []
     for s in serializers:
@@ -1238,6 +1312,56 @@ def _glb_serializer_options(source_ext: str) -> list[dict]:
     ]
 
 
+# Option-dict keys that are per-value MAPPINGS rather than scalars: each key is an enum value (or,
+# for enum_by, a value of the option it depends_on). Two pools advertising the same option each
+# carry entries only for the values THEY advertise, so these merge key-by-key.
+_OPTION_MAP_KEYS = ("labels", "descriptions", "runtime")
+
+
+def merge_option_into(cur: dict, incoming: dict) -> None:
+    """Union one worker's advertisement of an option into the accumulated one, in place.
+
+    Lives here, next to the code that BUILDS these dicts (_glb_serializer_options), because how two
+    advertisements of a schema combine is a fact about the schema.
+
+    First-writer-wins on everything but ``enum`` — which is what the API's merge used to be —
+    silently loses data as soon as two pools differ. A thin pool advertising
+    ``enum_by={'python': ['occ']}`` pinned that for the whole cluster, while the adacpp pool's
+    tracks, already unioned into ``enum``, reached the dropdown with no serializer offering them:
+    rendered and unselectable. The per-value maps fail the same way — whichever pool registered
+    first decides, and tokens only the other pool knows arrive unlabelled.
+
+    So: union ``enum`` and each ``enum_by`` list, fill in the per-value maps, and leave scalars
+    (``default``/``title``/``description``/``type``/``depends_on``) to the first writer — those
+    describe the option itself rather than its values, and every pool derives them from this module.
+    """
+    import copy
+
+    if isinstance(incoming.get("enum"), list) and isinstance(cur.get("enum"), list):
+        cur["enum"] = cur["enum"] + [v for v in incoming["enum"] if v not in cur["enum"]]
+    if isinstance(incoming.get("enum_by"), dict):
+        by = cur.get("enum_by")
+        if not isinstance(by, dict):
+            cur["enum_by"] = copy.deepcopy(incoming["enum_by"])
+        else:
+            for key, vals in incoming["enum_by"].items():
+                if not isinstance(vals, list):
+                    continue
+                have = by.get(key)
+                by[key] = have + [v for v in vals if v not in have] if isinstance(have, list) else list(vals)
+    for key in _OPTION_MAP_KEYS:
+        if not isinstance(incoming.get(key), dict):
+            continue
+        have = cur.get(key)
+        if isinstance(have, dict):
+            # setdefault, not update: a pool contributes descriptions for the values it knows and
+            # can never blank out another pool's.
+            for k, v in incoming[key].items():
+                have.setdefault(k, v)
+        else:
+            cur[key] = dict(incoming[key])
+
+
 def _apply_glb_serializer(
     source_ext: str,
     serializer: str | None,
@@ -1264,7 +1388,7 @@ def _apply_glb_serializer(
         # generic/IFC 'cpp' = the native_ifc_to_glb default path — nothing to force.
         return step_glb_pipeline, glb_tess_engine, False
     if serializer == _GLB_SERIALIZER_PYTHON:
-        tok = tessellator or _glb_serializer_tess(_GLB_SERIALIZER_PYTHON, fam)[0]
+        tok = tessellator or _glb_serializer_tess(_GLB_SERIALIZER_PYTHON)[0]
         if fam == "step":
             step_glb_pipeline = _tess_token_to_pipeline(tok)
         else:
@@ -1380,7 +1504,7 @@ def _glb_engine_stream_value(engine: str | None) -> str | None:
     import os
 
     choice = (engine or os.environ.get("ADAPY_GLB_TESS_ENGINE", "") or _default_glb_tess_engine()).strip().lower()
-    return _GLB_ENGINE_TO_STREAM.get(choice)
+    return _glb_engine_to_stream(choice)
 
 
 def _resolve_step_glb_pipeline(step_glb_pipeline: str | None) -> str:
@@ -2612,7 +2736,7 @@ def _register_ada_loadable() -> None:
         "name": "glb_tess_engine",
         "type": "enum",
         "default": _GLB_TESS_ENGINE_DEFAULT,
-        "enum": list(_GLB_TESS_ENGINES),
+        "enum": list(_glb_tess_engines()),
         "description": (
             "→GLB tessellation engine. 'libtess2' (default) is adacpp's OCC-free boundary "
             "tessellator — renders curved surfaces OCC "

--- a/src/ada/comms/rest/storage.py
+++ b/src/ada/comms/rest/storage.py
@@ -86,7 +86,7 @@ def _gzip_level() -> int:
     """gzip level for derived-output at-rest compression. Default 6, NOT the zlib/
     ``gzip.open`` default of 9: on large repetitive ASCII (a multi-GB OBJ/STEP export)
     level 9 costs ~8x the CPU of level 6 for a <1% smaller file — the level-9 pathology
-    that made the crane STEP->obj job spend ~900 s of its ~1070 s wall in gzip alone.
+    that made the large-assembly STEP->obj job spend ~900 s of its ~1070 s wall in gzip alone.
     ``ADA_DERIVED_GZIP_LEVEL`` overrides (clamped to 1..9)."""
     raw = os.environ.get("ADA_DERIVED_GZIP_LEVEL", "").strip()
     if raw:

--- a/src/ada/comms/rest/utilities/diff.py
+++ b/src/ada/comms/rest/utilities/diff.py
@@ -21,7 +21,7 @@ Diff types:
 
 Identity modes (byName/byCentroid/byProperty) prefer the native adacpp core
 (``adacpp.cad.glb_diff``): it parses one model at a time (never both full models
-resident) + extracts the removed overlay in C++ — the memory fix for crane-scale
+resident) + extracts the removed overlay in C++ — the memory fix for large-assembly-scale
 diffs. The pure-Python parser below is the fallback (and powers byCoverage). The
 GLB structure produced by adapy is::
 
@@ -438,7 +438,7 @@ def build_removed_overlay_glb(ref_glb: bytes, removed_names: list[str]) -> bytes
 
 # --------------------------------------------------------------------------- #
 # Native core (adacpp.cad.glb_diff): parse+match+overlay in C++, one model at a  #
-# time (never both full models resident) — the memory fix for crane-scale diffs. #
+# time (never both full models resident) — the memory fix for large-assembly-scale diffs. #
 # --------------------------------------------------------------------------- #
 # Overlays are throwaway diff artefacts → an EPHEMERAL prefix that a storage
 # lifecycle rule auto-disposes (vs the persistent, admin-managed _derived/). A
@@ -554,7 +554,7 @@ def diff(
 
     # Identity modes (byName/byCentroid/byProperty): prefer the native core — it
     # summarises one model at a time (never both, geometry not retained) and extracts
-    # the overlay in C++, keeping crane-scale diffs under the worker memory cap. Both
+    # the overlay in C++, keeping large-assembly-scale diffs under the worker memory cap. Both
     # GLBs stay on disk (path-based) so nothing copies through Python. byCoverage has
     # no native equivalent (per-cell binning) and stays on the Python path.
     glb_diff = _native_glb_diff() if diff_type in _NATIVE_MODE else None

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -184,27 +184,113 @@ async def _audit_done(
         logger.exception("worker: audit update failed for job %s", job_id)
 
 
+def _gate_enum_option(opt: dict | None, allowed: set[str] | frozenset[str]) -> None:
+    """Filter one enum option's values to ``allowed`` and repair its default in place.
+
+    An option that would filter to EMPTY is left untouched: a stale-but-selectable dropdown beats an
+    empty one, and an empty enum reads to the API's union as "this pool advertises nothing" rather
+    than "this pool couldn't tell".
+    """
+    if not opt or not isinstance(opt.get("enum"), list):
+        return
+    kept = [e for e in opt["enum"] if e in allowed]
+    if not kept:
+        return
+    opt["enum"] = kept
+    if opt.get("default") not in kept:
+        opt["default"] = kept[0]
+
+
+def _gate_serializer_axis(ser: dict | None, tess: dict | None, allowed: frozenset[str]) -> None:
+    """Gate the serializer × tessellator pair to the kernels this worker has, in place.
+
+    CLIENT serializers pass through ungated. ``wasm`` executes in the user's browser, so this
+    worker lacking adacpp says nothing about whether the browser can run it; filtering it here
+    would make the SPA lose the in-browser option because a *server* pool was thin. That is why the
+    runtime map — not a name check — decides: :func:`converter.available_tess_tokens` deliberately
+    omits the client tokens, so gating them against it would drop every one of them.
+
+    A server serializer whose kernels all vanish is dropped entirely (with its label/runtime entry),
+    and the tessellator enum is rebuilt as the union of what survived. B-rep rows ride the same
+    path: their second axis is a WRITER, but "can this process run it" is the same question about
+    the same backends, so the same token set answers it.
+    """
+    from .converter import _GLB_CLIENT_SERIALIZERS
+
+    if not ser or not tess or not isinstance(tess.get("enum_by"), dict):
+        return
+    enum_by: dict[str, list[str]] = {}
+    for s, toks in tess["enum_by"].items():
+        if not isinstance(toks, list):
+            continue
+        if s in _GLB_CLIENT_SERIALIZERS:
+            enum_by[s] = list(toks)
+            continue
+        kept = [t for t in toks if t in allowed]
+        if kept:
+            enum_by[s] = kept
+    if not enum_by:
+        return
+    tess["enum_by"] = enum_by
+
+    if isinstance(ser.get("enum"), list):
+        ser["enum"] = [s for s in ser["enum"] if s in enum_by]
+        if ser.get("default") not in ser["enum"] and ser["enum"]:
+            ser["default"] = ser["enum"][0]
+        for key in ("labels", "runtime"):
+            if isinstance(ser.get(key), dict):
+                ser[key] = {s: v for s, v in ser[key].items() if s in enum_by}
+
+    order = [s for s in (ser.get("enum") or []) if s in enum_by] or list(enum_by)
+    toks: list[str] = []
+    for s in order:
+        for t in enum_by[s]:
+            if t not in toks:
+                toks.append(t)
+    tess["enum"] = toks
+    # Mirror _glb_serializer_options' own rule (the default tessellator is the default serializer's
+    # first) so a serializer dropped above takes its default with it.
+    default_ser = ser.get("default")
+    if default_ser in enum_by and enum_by[default_ser]:
+        tess["default"] = enum_by[default_ser][0]
+    elif toks and tess.get("default") not in toks:
+        tess["default"] = toks[0]
+    for key in ("labels", "descriptions"):
+        if isinstance(tess.get(key), dict):
+            tess[key] = {t: v for t, v in tess[key].items() if t in toks}
+
+
 def _gate_advertised_engines(conversions: list[dict]) -> list[dict]:
-    """Restrict each conversion's ``step_glb_pipeline`` enum (and its default) to the engines this
-    worker can actually run, so the API's per-worker union + engine routing reflect real capability.
+    """Restrict every advertised engine/kernel enum to what this worker can actually run, so the
+    API's per-worker union and its engine routing reflect real capability.
     Deep-copies so the shared ConverterRegistry option dicts aren't mutated.
 
-    The runnable set comes from ``available_step_glb_pipelines()``, which gates the adacpp engines on
-    find_spec presence (overlay-robust) rather than an import-based native probe — see the note there."""
+    Gates THREE axes, not one. Gating only ``step_glb_pipeline`` (as this did) left the
+    ``serializer``/``tessellator`` dropdowns — the ones the SPA actually renders — advertising every
+    kernel the registry knows, including ones this pool has no build of. A job then routed here on
+    the strength of that advert and silently fell back, so the user picked a track and got a
+    different one. ``glb_tess_engine`` carries the same engine vocabulary for non-STEP sources and
+    was equally ungated.
+
+    The runnable sets come from ``available_step_glb_pipelines()`` / ``available_tess_tokens()``,
+    which gate the adacpp engines on find_spec presence (overlay-robust) rather than an
+    import-based native probe — see the note there.
+    """
     import copy
 
-    from .converter import available_step_glb_pipelines
+    from .converter import available_step_glb_pipelines, available_tess_tokens
 
-    avail = set(available_step_glb_pipelines())
+    engines = set(available_step_glb_pipelines())
+    tokens = available_tess_tokens()
     gated = copy.deepcopy(conversions)
     for row in gated:
         for opts in (row.get("options") or {}).values():
-            for opt in opts:
-                if opt.get("name") != "step_glb_pipeline" or not isinstance(opt.get("enum"), list):
-                    continue
-                opt["enum"] = [e for e in opt["enum"] if e in avail]
-                if isinstance(opt.get("default"), str) and opt["default"] not in avail and opt["enum"]:
-                    opt["default"] = opt["enum"][0]
+            if not isinstance(opts, list):
+                continue
+            by_name = {o.get("name"): o for o in opts if isinstance(o, dict)}
+            for name in ("step_glb_pipeline", "glb_tess_engine"):
+                _gate_enum_option(by_name.get(name), engines)
+            _gate_serializer_axis(by_name.get("serializer"), by_name.get("tessellator"), tokens)
     return gated
 
 

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -1733,7 +1733,7 @@ async def _process_one(
         # still uncompressed; this is transport compression, transparent to the
         # GLTF loader. Whole-file load only — gzip-at-rest is not Range-safe.)
         # OBJ / STL / STEP exports are also gzip-at-rest: the native STEP→mesh writer
-        # emits unsimplified geometry (the crane obj is ~7.7 GB raw, 73 M tris), and
+        # emits unsimplified geometry (the reference assembly's obj is ~7.7 GB raw, 73 M tris), and
         # storing it raw made the UPLOAD ~57% of that job's wall time. obj/step are
         # ASCII (compress dramatically); binary STL less so but still a net win. These
         # are whole-file export downloads (never Range-fetched, unlike FEA field blobs
@@ -1782,7 +1782,7 @@ async def _process_one(
             # drops the tmpfile + work dir once the upload settles either way.
             # put_path returns the at-rest gzip vs upload split so the audit can
             # attribute the post-conversion tail (gzip-at-rest was ~85% of the
-            # crane STEP->obj wall — see storage._gzip_level).
+            # large-assembly STEP->obj wall — see storage._gzip_level).
             put_timing = await storage.put_path(scope, job.derived_key, upload_path, content_encoding=derived_encoding)
             if isinstance(convert_meta, dict) and isinstance(put_timing, dict):
                 # Distinct from the GLB meshopt ``compress_ms`` above: ``gzip_ms`` is

--- a/src/ada/config.py
+++ b/src/ada/config.py
@@ -146,6 +146,14 @@ class Config:
             [
                 ConfigEntry("read_curve_ignore_bspline", bool, False),
                 ConfigEntry("import_raise_exception_on_failed_advanced_face", bool, False),
+                # A flat plate's boundary keeps only its edge ENDPOINTS, so an edge that follows a
+                # curve (intcurve/ellipse) collapses to the chord between its corners — e.g. a deck
+                # plate meeting a curved hull skin renders straight while the skin beside it curves.
+                # On => sample the curve and carry the samples as extra outline points, so the plate
+                # follows the curve. STOPGAP: Plate/CurvePoly2d has only line+arc segments, so the
+                # samples are ours, not the neighbour's, and the seam still isn't shared. Off =>
+                # the pre-2026-07-14 chord. See dap plan/v3/notes_plate_bspline_edges.md.
+                ConfigEntry("plate_curved_edges", bool, True),
             ],
         ),
         ConfigSection(

--- a/src/ada/occ/tessellating.py
+++ b/src/ada/occ/tessellating.py
@@ -913,7 +913,9 @@ class BatchTessellator:
         _record_tess_fallback(reason, gt)
         # Strict mode: a fall back to OCC is a hard failure, so a conversion can enforce/measure
         # 100% stream-kernel (libtess2/adacpp-*) coverage rather than silently completing on OCC.
-        if os.environ.get("ADA_STREAM_TESS_STRICT", "").strip().lower() not in ("", "0", "false", "no", "off"):
+        from ada.cad.registry import stream_tess_strict
+
+        if stream_tess_strict():
             logger.warning(msg)
             raise TessellationFallbackError(msg)
         if os.environ.get("ADA_TESS_FALLBACK_DEBUG"):

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -410,7 +410,7 @@ def _stream_workers() -> int:
 
     The cap is a *memory* bound, not a throughput one: each worker holds a chunk of the
     model's tessellated mesh in flight back to the parent, so peak RSS scales ~linearly
-    with worker count. On the crane (26 M tris) 8 workers peaked ~6.2 GB and 4 ~4.7 GB;
+    with worker count. On the large reference assembly (26 M tris) 8 workers peaked ~6.2 GB and 4 ~4.7 GB;
     3 keeps it near a ~4 GB pod ceiling (the spill-bounded parent alone is ~2.1 GB). Bump
     ``ADA_STEP_STREAM_WORKERS`` on a roomier pod to trade RAM for speed.
 
@@ -745,7 +745,7 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
             )
             # Dispatch order. Default: index order (arbitrary). With ADA_STEP_STREAM_LPT=1,
             # longest-processing-time-first — sort solids heaviest (most shell faces) first
-            # so a few very slow solids (e.g. dense engine blocks, ~70 s each on the crane)
+            # so a few very slow solids (e.g. dense engine blocks, ~70 s each on the large reference assembly)
             # overlap the bulk instead of being grabbed last while other workers idle. The
             # weight is a cheap shell-face-count (~2 preads/solid, no full build); the
             # original ``seq`` is preserved for stable solid_N naming regardless of order.

--- a/src/ada/visit/scene_handling/scene_from_step_stream.py
+++ b/src/ada/visit/scene_handling/scene_from_step_stream.py
@@ -184,15 +184,19 @@ def _tessellate_geom_worker(geom):
         # ADA_EXT_data + picking) is unchanged, so it stays memory-bounded and contract-compliant.
         _pipeline = os.environ.get("ADA_STREAM_TESS_PIPELINE")
         if _pipeline and hasattr(be, "tessellate_stream"):
-            defl = float(os.environ.get("ADA_STREAM_TESS_DEFLECTION", "2.0"))
-            from ada.cad.registry import DEFAULT_STREAM_TESS_ANGULAR_DEG
+            from ada.cad.registry import (
+                stream_tess_defaults,
+                stream_tess_model_scale_env,
+            )
 
-            ang = float(os.environ.get("ADA_STREAM_TESS_ANGULAR", str(DEFAULT_STREAM_TESS_ANGULAR_DEG)))
+            defl, ang = stream_tess_defaults()
             # Adaptive coarsening: relax the angular ceiling on features small vs the whole model, so a
             # large assembly (e.g. the boiler's asm_22) doesn't over-tessellate every small pipe/torus
             # into a slivery "crows nest". model_scale (the model bbox diagonal) is estimated once by
             # the parent and passed via env; 0 => off (fixed angular), matching native_step_to_glb.
-            mscale = float(os.environ.get("ADA_STREAM_TESS_MODEL_SCALE", "0") or "0")
+            # _env (ungated): the parent already made the adaptive decision before exporting the scale,
+            # and this runs in a pool worker that may not have inherited ADA_STREAM_TESS_ADAPTIVE.
+            mscale = stream_tess_model_scale_env()
             gi = geom.geometry.geometry if hasattr(geom.geometry, "geometry") else geom.geometry
             bm = be.tessellate_stream(
                 [(gid or "0", gi)], pipeline=_pipeline, deflection=defl, angular_deg=ang, model_scale=mscale
@@ -505,13 +509,12 @@ def _tessellate_stream(source: StepStreamSource, graph, bt, sink) -> dict:
     import os
 
     if os.environ.get("ADA_STREAM_TESS_PIPELINE") and "ADA_STREAM_TESS_MODEL_SCALE" not in os.environ:
-        _adaptive = (os.environ.get("ADA_STREAM_TESS_ADAPTIVE") or "").strip().lower() not in {
-            "0",
-            "false",
-            "no",
-            "off",
-        }
-        if _adaptive:
+        from ada.cad.registry import (
+            DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE,
+            stream_tess_adaptive,
+        )
+
+        if stream_tess_adaptive(default=DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE):
             try:
                 from ada.cadit.step.model_scale import estimate_step_model_scale
 

--- a/src/ada_cli/audit.py
+++ b/src/ada_cli/audit.py
@@ -62,9 +62,16 @@ WASM_TARGETS_BY_FORMAT = {
 }
 # adacpp wheels below this version predate the OCCT symbol-isolation fix
 # (-fvisibility=hidden) + serialize_brep — a sweep with one validates the OLD
-# broken engine, so we refuse it unless explicitly overridden.
+# broken engine, so we refuse it unless explicitly overridden. This is a FLOOR,
+# not the default: see ADACPP_DEFAULT_IMAGE.
 ADACPP_MIN_VERSION = (0, 9, 0)
-ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.9.0"
+# The sweep exists to validate the in-browser engine users actually get, so this must track the
+# viewer's base — deploy/Dockerfile.viewer's ARG ADACPP_BASE_IMAGE, which is the single source of
+# that pin. It sat at 0.9.0 (== the floor above) while the viewer moved on, so a default sweep
+# validated a wheel six releases older than the one it shipped.
+# Duplicated as a literal because it cannot be derived: ada_cli ships in a wheel that carries no
+# deploy/ tree. tests/core/test_deploy_pins.py fails if the two drift.
+ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.15.0"
 IFC_WASM_WHEEL = (
     "https://ifcopenshell.github.io/wasm-wheels/" "ifcopenshell-0.8.5-cp313-cp313-pyodide_2025_0_wasm32.whl"
 )

--- a/src/ada_cli/files.py
+++ b/src/ada_cli/files.py
@@ -27,7 +27,7 @@ _TRANSFER_TIMEOUT_SECONDS = 30 * 60
 # Extensions worth gzipping at rest. The presigned PUT goes STRAIGHT to object storage, bypassing the
 # API's server-side gzip — so without a client-side pass these land uncompressed and every download
 # pays full size. Includes .glb/.gltf to match the worker's gzip-at-rest for derived GLBs (a meshopt
-# crane GLB still gzips ~0.46x). Safe because the viewer loads geometry WHOLE-FILE (no Range) and the
+# large-assembly GLB still gzips ~0.46x). Safe because the viewer loads geometry WHOLE-FILE (no Range) and the
 # browser decompresses transparently; the blob GET advertises `Accept-Ranges: none` for gzip objects so
 # nothing Range-fetches them, and the download-progress overshoot is capped viewer-side. (Field `.bin`
 # artefacts stay raw precisely because they ARE Range-fetched per step — see the FEA field-blob note.)

--- a/src/frontend/src/services/auth/oidc.ts
+++ b/src/frontend/src/services/auth/oidc.ts
@@ -1,5 +1,5 @@
 // OIDC PKCE code-flow client. Provider-agnostic: works against
-// Authentik (homelab) and Azure AD direct (enterprise) — both expose
+// Authentik (self-hosted) and Azure AD direct (enterprise) — both expose
 // `.well-known/openid-configuration` and a token endpoint that accepts
 // the standard PKCE exchange.
 //

--- a/src/frontend/src/services/conversion/wasmSupport.ts
+++ b/src/frontend/src/services/conversion/wasmSupport.ts
@@ -38,7 +38,19 @@ export interface WasmFormat {
 //   - step/stp: GLB only — from_step defaults to the OCC reader (not wasm-safe);
 //     non-GLB targets wait on routing read_step_file through the CadBackend.
 //   - mesh:     trimesh → glb (mesh→mesh round-trips aren't worker-registry pairs).
-// Mirrors the worker's converter.py registry for the wasm-loadable sources.
+//
+// NOT sourced from window.CONVERSION_MATRIX, and deliberately so. That matrix is
+// what the WORKER pools advertise; this is what THIS BROWSER can do, and the two
+// are different questions with different answers — the notes above are limits of
+// the wasm build (pyodide wheels, embind modules) that no worker has or reports.
+// Driving this off the matrix would also invert the dependency: it is empty when
+// the queue is disabled (dev / desktop / embed) or when no worker is live, which
+// is exactly when the in-browser engine is the ONLY one — the SPA would forget
+// its own capabilities because a server pool was down.
+//
+// The serializer/tessellator DROPDOWN is a separate axis and *is* schema-driven
+// from the matrix (see serializerMatrix.ts); this table only decides which
+// (source, target) cells the browser can be handed at all.
 const WASM_TARGETS_BY_FORMAT: Record<PyodideSourceFormat, readonly string[]> = {
     sat: ["glb", "obj", "stl", "step", "xml", "ifc"],
     ifc: ["glb", "obj", "stl", "step", "xml", "ifc"],

--- a/tests/comms/rest/test_audit_cli.py
+++ b/tests/comms/rest/test_audit_cli.py
@@ -148,3 +148,55 @@ def test_add_parser_routes_subcommands():
     ]:
         ns = parser.parse_args(["audit", name] + (["1"] if name == "profile" else []))
         assert ns.func is fn
+
+
+# ── wasm-sweep: --adacpp-image ────────────────────────────────────────────
+
+
+def test_wasm_sweep_honours_the_adacpp_image_default(monkeypatch, tmp_path):
+    """`--adacpp-image` IS live, and its default decides which engine a sweep validates.
+
+    Worth pinning because it is reasonable to assume otherwise: nearly every `ada audit` subcommand
+    (runs / run / log / perf / profile) reports on work the WORKERS did, so the engine is whatever
+    the pool happens to run and no client-side image pin could matter. `wasm-sweep` is the one that
+    inverts that — it re-runs a prior run's cells LOCALLY under node+pyodide to validate the
+    in-browser engine, and the wheel it loads comes from this image. That is why the default has to
+    track the viewer's base (tests/core/test_deploy_pins.py pins the equality): it sat at 0.9.0
+    while the viewer moved on, so a default sweep validated a wheel six releases behind what shipped
+    — silently, since a stale-but-valid wheel sweeps perfectly happily.
+    """
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    ac.add_parser(sub)
+    ns = parser.parse_args(["audit", "wasm-sweep", "run-1"])
+    assert ns.func is ac.cmd_wasm_sweep
+    assert ns.adacpp_image == ac.ADACPP_DEFAULT_IMAGE
+
+    # Neither --adacpp-wheel nor $ADACPP_WHEEL set => the image is what gets extracted.
+    monkeypatch.delenv("ADACPP_WHEEL", raising=False)
+    wheel = tmp_path / "ada_cpp-0.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl"
+    wheel.touch()
+    seen = {}
+
+    def _fake_extract(image, dest):
+        seen["image"] = image
+        return wheel
+
+    monkeypatch.setattr(ac, "_extract_adacpp_from_image", _fake_extract)
+    ns.out = str(tmp_path)
+    assert ac._resolve_adacpp_wheel(ns) == str(wheel)
+    assert seen["image"] == ac.ADACPP_DEFAULT_IMAGE, "the --adacpp-image default never reached the extraction"
+
+
+def test_wasm_sweep_explicit_wheel_beats_the_image(monkeypatch, tmp_path):
+    """An explicit --adacpp-wheel short-circuits the image, so a local build can be swept."""
+    wheel = tmp_path / "ada_cpp-0.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl"
+    wheel.touch()
+
+    def _boom(image, dest):  # pragma: no cover - must not run
+        raise AssertionError("must not extract from the image when a wheel is given")
+
+    monkeypatch.setattr(ac, "_extract_adacpp_from_image", _boom)
+    monkeypatch.delenv("ADACPP_WHEEL", raising=False)
+    ns = argparse.Namespace(adacpp_wheel=str(wheel), adacpp_image="unused", out=str(tmp_path))
+    assert ac._resolve_adacpp_wheel(ns) == str(wheel)

--- a/tests/comms/rest/test_converter_step_routing.py
+++ b/tests/comms/rest/test_converter_step_routing.py
@@ -7,6 +7,8 @@ sources and keep the default OCC writer for everything else.
 
 import pathlib
 
+import pytest
+
 import ada
 from ada.api.spatial.part import Part
 from ada.comms.rest import converter as conv
@@ -374,3 +376,26 @@ def test_api_merge_is_order_independent():
     full_first = _merged(_FULL_POOL_TESS, ["occ"])
     assert set(thin_first["enum_by"]["python"]) == set(full_first["enum_by"]["python"])
     assert set(thin_first["enum"]) == set(full_first["enum"])
+
+
+def test_wasm_engine_tokens_are_the_spa_contract():
+    """The wasm serializer's engine tokens are a cross-language contract, so pin both ends.
+
+    adapy declares them (_WASM_GLB_ENGINES) and the SPA branches on them as string literals —
+    `resolved.tessellator === "wasm-native"` picks the embind pipeline over Pyodide in
+    services/conversion/index.ts. Nothing else connects the two: rename the token here and the
+    comparison silently stops matching, so every in-browser job quietly routes to Pyodide instead of
+    the native module. That is a fallback, not an error, so no test would otherwise notice.
+    """
+    spa = pathlib.Path(__file__).parents[3] / "src/frontend/src/services/conversion/index.ts"
+    if not spa.is_file():  # sdist / wheel test envs ship no frontend tree
+        pytest.skip(f"frontend source not present at {spa}")
+    src = spa.read_text(encoding="utf-8")
+    assert f'=== "{conv._WASM_ENGINE_NATIVE}"' in src, (
+        f"the SPA no longer branches on {conv._WASM_ENGINE_NATIVE!r}; in-browser jobs would "
+        "silently fall through to Pyodide instead of the native embind module"
+    )
+    # Both tokens must reach the dropdown, and neither may collide with a discovered track name
+    # (which would make the resolver ambiguous about whether a job is client- or server-side).
+    assert conv._glb_serializer_tess("wasm") == list(conv._WASM_GLB_ENGINES)
+    assert not set(conv._WASM_GLB_ENGINES) & set(conv._python_tess_tokens())

--- a/tests/comms/rest/test_converter_step_routing.py
+++ b/tests/comms/rest/test_converter_step_routing.py
@@ -75,7 +75,13 @@ def test_glb_serializer_tessellator_advertised_single_source():
     """The reconvert dropdowns are data-driven: every → GLB row advertises a
     serializer enum with labels + a client/server runtime split, and a
     dependent tessellator enum keyed by serializer (enum_by). The frontend
-    renders straight from this — no hardcoded vocabulary."""
+    renders straight from this — no hardcoded vocabulary.
+
+    Asserts the SHAPE only. The tessellator vocabulary is discovered from adacpp, so its VALUES
+    differ per environment (this suite runs with and without adacpp installed) — pinning them here
+    is what makes a test env-dependent. `test_worker_advert_*` covers the values, against a
+    synthetic worker whose capability is stated rather than probed.
+    """
     for ext in (".step", ".ifc", ".sat"):
         ser, tess = _serializer_tessellator(ext)
         assert ser["type"] == "enum" and tess["type"] == "enum"
@@ -89,20 +95,32 @@ def test_glb_serializer_tessellator_advertised_single_source():
         assert tess["depends_on"] == "serializer"
         assert set(tess["enum_by"]) == set(ser["enum"])
         assert tess["enum_by"]["cpp"] == ["native"]
-        assert "pyocc" in tess["enum_by"]["python"] and "cgal" in tess["enum_by"]["python"]
         assert tess["enum_by"]["wasm"] == ["wasm-native", "pyodide"]
-    # STEP exposes the OCC streaming reader as an extra python kernel; generic does not.
+        # the python serializer offers whatever this env discovered — never nothing, and every
+        # token it offers must be describable (the SPA renders labels straight from this).
+        assert tess["enum_by"]["python"], "the python serializer must always offer a kernel"
+        assert set(tess["enum_by"]["python"]) <= set(tess["enum"])
+        assert set(tess["labels"]) >= set(tess["enum"])
+    # Same kernels for every source family. The pre-discovery table split step/generic, but only to
+    # list a duplicate `occ` alias on STEP; each real kernel reaches both (STEP via
+    # step_glb_pipeline, generic via glb_tess_engine).
     step_tess = _serializer_tessellator(".step")[1]
     ifc_tess = _serializer_tessellator(".ifc")[1]
-    assert "occ" in step_tess["enum_by"]["python"]
-    assert "occ" not in ifc_tess["enum_by"]["python"]
+    assert step_tess["enum_by"]["python"] == ifc_tess["enum_by"]["python"]
     # new names are in the API allowlist
     assert {"serializer", "tessellator"} <= conv.ConverterRegistry.all_options()
 
 
 def test_apply_glb_serializer_resolves_to_engine_knobs():
     """The serializer/tessellator tokens fold into the existing engine knobs;
-    unset tokens leave explicit knobs untouched (full back-compat)."""
+    unset tokens leave explicit knobs untouched (full back-compat).
+
+    Resolution is VOCABULARY, not capability: the same token resolves to the same engine whether or
+    not adacpp is importable here. It used to look the track up in available_tess_tracks() and fall
+    back to libtess2 when absent, which made a stored `cgal` config mean adacpp-cgal in one process
+    and libtess2 in another — and libtess2 is itself adacpp, so it could never be the right answer
+    for a pool that lacked adacpp. Capability is enforced separately (see the gating tests).
+    """
     ap = conv._apply_glb_serializer
     # cpp/STEP -> adacpp-native pipeline, server path
     assert ap(".step", "cpp", None, step_glb_pipeline=None, glb_tess_engine=None) == (
@@ -137,6 +155,40 @@ def test_apply_glb_serializer_resolves_to_engine_knobs():
     )
 
 
+def test_token_resolution_is_env_independent():
+    """A track name resolves structurally, so a token that postdates this module (adacpp:cdt) and a
+    token whose kernel isn't installed both still mean what they say."""
+    assert conv._tess_token_to_pipeline("adacpp:cdt") == "adacpp-cdt"
+    assert conv._pipeline_to_track_name("adacpp-cdt") == "adacpp:cdt"
+    # the four historic identities are pinned, and round-trip
+    for track, pipe in conv._HISTORIC_TRACK_PIPELINE.items():
+        assert conv._tess_token_to_pipeline(f"adacpp:{track}") == pipe
+        assert conv._pipeline_to_track_name(pipe) == f"adacpp:{track}"
+    # adapy's own OCC track is not an adacpp pipeline
+    assert conv._tess_token_to_pipeline("occ") == conv._STEP_GLB_PIPELINE_OCC
+    assert conv._pipeline_to_track_name(conv._STEP_GLB_PIPELINE_OCC) is None
+    # adacpp-native is a whole-file code path, not a track
+    assert conv._pipeline_to_track_name(conv._STEP_GLB_PIPELINE_ADACPP_NATIVE) is None
+
+
+def test_glb_engine_stream_value_covers_discovered_tracks():
+    """The non-STEP engine → ADA_STREAM_TESS_PIPELINE mapping is derived, not a table.
+
+    The table it replaced listed the four engines that existed when it was written, so a track
+    discovered later resolved to None and SILENTLY ran the OCC BatchTessellator instead — the user
+    picked a kernel and got a different one, with nothing logged.
+    """
+    assert conv._glb_engine_to_stream("adacpp-cdt") == "cdt"
+    assert conv._glb_engine_to_stream("libtess2") == "libtess2"
+    assert conv._glb_engine_to_stream("adacpp-cgal") == "cgal"
+    # occ-builtin means "no stream override" (the OCC BatchTessellator default)
+    assert conv._glb_engine_to_stream("occ-builtin") is None
+    # every advertised engine except occ-builtin must map to a real stream pipeline
+    for engine in conv._glb_tess_engines():
+        if engine != conv._STEP_GLB_PIPELINE_OCC:
+            assert conv._glb_engine_to_stream(engine), f"{engine} advertised but resolves to no kernel"
+
+
 def test_brep_target_exposes_serializer_writer_axis():
     """B-rep→B-rep rows (step→ifc, ifc→step) advertise the same shared selector, but the 2nd axis is
     titled 'Writer' (no tessellation) and mirrors the serializer 1:1."""
@@ -158,3 +210,167 @@ def test_brep_target_exposes_serializer_writer_axis():
     assert conv._brep_writer_is_python("python") is True
     assert conv._brep_writer_is_python("cpp") is False
     assert conv._brep_writer_is_python("wasm") is False
+
+
+# --------------------------------------------------------------------------- #
+# Worker capability advertisement.
+#
+# These build the option schema themselves rather than reading the local registry, so what a worker
+# "can run" is STATED, not probed. That is the whole point: the local registry answers differently
+# depending on whether adacpp/pythonocc happen to be importable in the current test env, and a test
+# that reads it is really asserting on its own environment. It also lets us model a heterogeneous
+# cluster (a thin pool + a full pool), which no single test env can be.
+# --------------------------------------------------------------------------- #
+
+_FULL_POOL_TESS = ["adacpp:libtess2", "adacpp:cdt", "adacpp:cgal", "occ"]
+
+
+def _serializer_schema(python_tess: list[str]) -> list[dict]:
+    """A →GLB option pair shaped exactly like _glb_serializer_options() emits."""
+    enum_by = {"cpp": ["native"], "python": list(python_tess), "wasm": ["wasm-native", "pyodide"]}
+    tokens = [t for s in ("cpp", "python", "wasm") for t in enum_by[s]]
+    tokens = list(dict.fromkeys(tokens))
+    return [
+        {
+            "name": "serializer",
+            "type": "enum",
+            "title": "Serializer",
+            "default": "cpp",
+            "enum": ["cpp", "python", "wasm"],
+            "labels": {"cpp": "C++", "python": "Python", "wasm": "WASM"},
+            "runtime": {"cpp": "server", "python": "server", "wasm": "client"},
+        },
+        {
+            "name": "tessellator",
+            "type": "enum",
+            "title": "Tessellator",
+            "default": enum_by["cpp"][0],
+            "enum": tokens,
+            "labels": {t: f"label:{t}" for t in tokens},
+            "descriptions": {t: f"desc:{t}" for t in tokens},
+            "enum_by": enum_by,
+            "depends_on": "serializer",
+        },
+    ]
+
+
+def _conversions(python_tess: list[str], engines: list[str]) -> list[dict]:
+    return [
+        {
+            "from": ".step",
+            "to": ["glb"],
+            "options": {
+                "glb": _serializer_schema(python_tess)
+                + [{"name": "step_glb_pipeline", "type": "enum", "default": "adacpp-native", "enum": list(engines)}],
+            },
+        }
+    ]
+
+
+def _gate(monkeypatch, *, tokens: set[str], engines: list[str], python_tess=None):
+    from ada.comms.rest import worker as wk
+
+    monkeypatch.setattr(conv, "available_tess_tokens", lambda: frozenset(tokens))
+    monkeypatch.setattr(conv, "available_step_glb_pipelines", lambda: tuple(engines))
+    rows = _conversions(python_tess or _FULL_POOL_TESS, ["adacpp-native", "libtess2", "occ-builtin", "adacpp-cgal"])
+    gated = wk._gate_advertised_engines(rows)
+    return {o["name"]: o for o in gated[0]["options"]["glb"]}
+
+
+def test_worker_gates_tessellator_not_just_the_pipeline(monkeypatch):
+    """A pool advertises only kernels it has a build of.
+
+    Gating stopped at `step_glb_pipeline`, so the serializer/tessellator dropdowns — the ones the
+    SPA actually renders — kept advertising every kernel the registry knew. A job routed here on
+    that advert and silently fell back to another kernel.
+    """
+    by_name = _gate(
+        monkeypatch,
+        tokens={"occ"},  # a pool with pythonocc but no adacpp
+        engines=["occ-builtin"],
+    )
+    tess, ser = by_name["tessellator"], by_name["serializer"]
+    assert tess["enum_by"]["python"] == ["occ"]
+    assert "adacpp:cdt" not in tess["enum"] and "adacpp:cgal" not in tess["enum"]
+    # cpp pins adacpp's in-process writer, so it goes with adacpp
+    assert "cpp" not in ser["enum"] and "cpp" not in tess["enum_by"]
+    assert ser["default"] == "python", "the default must move off a serializer this pool dropped"
+    assert tess["default"] == "occ"
+    # the engine knob is still gated (the behaviour that already existed)
+    assert by_name["step_glb_pipeline"]["enum"] == ["occ-builtin"]
+    # labels/descriptions follow the surviving tokens — no orphans
+    assert set(tess["labels"]) == set(tess["enum"])
+
+
+def test_worker_never_gates_client_engines(monkeypatch):
+    """wasm runs in the USER'S BROWSER. A worker without adacpp must not strip it.
+
+    available_tess_tokens() deliberately omits the client tokens (no server probe can answer for
+    them), so gating them against it would drop every one — and the SPA would lose the in-browser
+    option because a server pool was thin.
+    """
+    by_name = _gate(monkeypatch, tokens={"occ"}, engines=["occ-builtin"])
+    tess, ser = by_name["tessellator"], by_name["serializer"]
+    assert tess["enum_by"]["wasm"] == ["wasm-native", "pyodide"]
+    assert "wasm" in ser["enum"] and ser["runtime"]["wasm"] == "client"
+    assert {"wasm-native", "pyodide"} <= set(tess["enum"])
+
+
+def test_worker_advertises_every_discovered_track(monkeypatch):
+    """A track that postdates this module rides through gating untouched."""
+    by_name = _gate(monkeypatch, tokens=set(_FULL_POOL_TESS) | {"native"}, engines=["adacpp-native", "libtess2"])
+    tess = by_name["tessellator"]
+    assert "adacpp:cdt" in tess["enum_by"]["python"]
+    assert by_name["serializer"]["default"] == "cpp" and tess["default"] == "native"
+
+
+def test_worker_gating_does_not_mutate_the_shared_registry(monkeypatch):
+    """The registry's option dicts are module-level and shared; gating must deep-copy."""
+    from ada.comms.rest import worker as wk
+
+    monkeypatch.setattr(conv, "available_tess_tokens", lambda: frozenset({"occ"}))
+    monkeypatch.setattr(conv, "available_step_glb_pipelines", lambda: ("occ-builtin",))
+    rows = _conversions(_FULL_POOL_TESS, ["adacpp-native", "libtess2"])
+    wk._gate_advertised_engines(rows)
+    assert rows[0]["options"]["glb"][1]["enum_by"]["python"] == _FULL_POOL_TESS
+
+
+# --------------------------------------------------------------------------- #
+# API-side merge across a heterogeneous cluster.
+# --------------------------------------------------------------------------- #
+
+
+def _merged(*pools: list[str]) -> dict:
+    """Merge N pools' `tessellator` option the way the API's registry merge does."""
+    cur = None
+    for tess in pools:
+        opt = {o["name"]: o for o in _serializer_schema(tess)}["tessellator"]
+        if cur is None:
+            cur = opt
+        else:
+            conv.merge_option_into(cur, opt)
+    return cur
+
+
+def test_api_merge_unions_enum_by_across_pools():
+    """A thin pool registering first must not pin the cluster's vocabulary.
+
+    The merge unioned `enum` but took FIRST-WRITER for `enum_by`, so a thin pool's
+    enum_by['python'] == ['occ'] won for the whole cluster while the full pool's tracks were still
+    unioned into `enum` — reaching the dropdown with no serializer offering them, i.e. rendered and
+    unselectable.
+    """
+    merged = _merged(["occ"], _FULL_POOL_TESS)
+    assert set(merged["enum_by"]["python"]) == set(_FULL_POOL_TESS)
+    assert set(merged["enum"]) >= set(_FULL_POOL_TESS)
+    # every advertised token is describable regardless of which pool contributed it
+    assert set(merged["labels"]) >= set(merged["enum"])
+    assert set(merged["descriptions"]) >= set(merged["enum"])
+
+
+def test_api_merge_is_order_independent():
+    """Whichever pool happens to register first, the cluster advertises the same thing."""
+    thin_first = _merged(["occ"], _FULL_POOL_TESS)
+    full_first = _merged(_FULL_POOL_TESS, ["occ"])
+    assert set(thin_first["enum_by"]["python"]) == set(full_first["enum_by"]["python"])
+    assert set(thin_first["enum"]) == set(full_first["enum"])

--- a/tests/core/cad/test_tess_env_defaults.py
+++ b/tests/core/cad/test_tess_env_defaults.py
@@ -1,0 +1,136 @@
+"""Every ADA_STREAM_TESS_* read goes through ada.cad.registry — one nominal config, one density.
+
+These knobs used to be re-implemented inline at ~10 call sites (the native STEP->GLB / ->OBJ / ->STL
+/ ->IFC / ->STEP paths, the object stream path, the AP242 writer). The literals happened to agree,
+but the *boolean spellings* did not: scene_from_step_stream omitted "" from its falsy set, so an
+explicitly-empty ADA_STREAM_TESS_ADAPTIVE read as ON there and OFF everywhere else. These tests pin
+the parse so the same env can't mean two densities on two call paths again.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from ada.cad.registry import (
+    DEFAULT_STREAM_TESS_ADAPTIVE,
+    DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE,
+    DEFAULT_STREAM_TESS_ANGULAR_DEG,
+    DEFAULT_STREAM_TESS_DEFLECTION,
+    stream_tess_adaptive,
+    stream_tess_defaults,
+    stream_tess_face_regions,
+    stream_tess_model_scale,
+    stream_tess_model_scale_env,
+    stream_tess_strict,
+)
+
+# Spellings that mean "off" for every ADA_STREAM_TESS_* boolean. "" is falsy: an explicitly-empty
+# env var means off, not on.
+FALSY = ("0", "false", "FALSE", "no", "off", "", "  ")
+TRUTHY = ("1", "true", "yes", "on")
+
+
+def test_defaults_unset(monkeypatch):
+    monkeypatch.delenv("ADA_STREAM_TESS_DEFLECTION", raising=False)
+    monkeypatch.delenv("ADA_STREAM_TESS_ANGULAR", raising=False)
+    assert stream_tess_defaults() == (DEFAULT_STREAM_TESS_DEFLECTION, DEFAULT_STREAM_TESS_ANGULAR_DEG)
+
+
+def test_defaults_env_override(monkeypatch):
+    monkeypatch.setenv("ADA_STREAM_TESS_DEFLECTION", "0.5")
+    monkeypatch.setenv("ADA_STREAM_TESS_ANGULAR", "3.5")
+    assert stream_tess_defaults() == (0.5, 3.5)
+
+
+@pytest.mark.parametrize("default", [False, True])
+@pytest.mark.parametrize("value", FALSY)
+def test_adaptive_falsy_spellings_are_off_regardless_of_default(monkeypatch, value, default):
+    """The regression: "" must be OFF on every path. scene_from_step_stream used to read it as ON."""
+    monkeypatch.setenv("ADA_STREAM_TESS_ADAPTIVE", value)
+    assert stream_tess_adaptive(default=default) is False
+
+
+@pytest.mark.parametrize("default", [False, True])
+@pytest.mark.parametrize("value", TRUTHY)
+def test_adaptive_truthy_spellings_are_on_regardless_of_default(monkeypatch, value, default):
+    monkeypatch.setenv("ADA_STREAM_TESS_ADAPTIVE", value)
+    assert stream_tess_adaptive(default=default) is True
+
+
+def test_adaptive_unset_honours_the_callers_default(monkeypatch):
+    """The default differs by call path on purpose: OFF for the object stream path (a library API
+    whose density must not shift), ON for the whole-file native converters (transfer-size/timeout
+    sensitive). An explicit env setting overrides both — see the parametrized tests above."""
+    monkeypatch.delenv("ADA_STREAM_TESS_ADAPTIVE", raising=False)
+    assert stream_tess_adaptive() is DEFAULT_STREAM_TESS_ADAPTIVE is False
+    assert stream_tess_adaptive(default=DEFAULT_STREAM_TESS_ADAPTIVE_NATIVE) is True
+
+
+def test_model_scale_requires_adaptive(monkeypatch):
+    monkeypatch.setenv("ADA_STREAM_TESS_MODEL_SCALE", "32.0")
+    monkeypatch.setenv("ADA_STREAM_TESS_ADAPTIVE", "0")
+    assert stream_tess_model_scale() == 0.0  # adaptive off => no reference scale
+    monkeypatch.setenv("ADA_STREAM_TESS_ADAPTIVE", "1")
+    assert stream_tess_model_scale() == 32.0
+
+
+def test_model_scale_tolerates_garbage(monkeypatch):
+    monkeypatch.setenv("ADA_STREAM_TESS_ADAPTIVE", "1")
+    monkeypatch.setenv("ADA_STREAM_TESS_MODEL_SCALE", "not-a-float")
+    assert stream_tess_model_scale() == 0.0
+    assert stream_tess_model_scale_env() == 0.0
+
+
+def test_model_scale_env_is_ungated(monkeypatch):
+    """A pool worker reads the scale the parent exported and must NOT re-gate on the adaptive env.
+
+    stream_tess_model_scale() defaults adaptive OFF, so if the ungated reader didn't exist a worker
+    that never inherited ADA_STREAM_TESS_ADAPTIVE would silently tessellate at a fixed angle while
+    the parent believed adaptive was on — a whole-model density change with no error.
+    """
+    monkeypatch.delenv("ADA_STREAM_TESS_ADAPTIVE", raising=False)
+    monkeypatch.setenv("ADA_STREAM_TESS_MODEL_SCALE", "32.0")
+    assert stream_tess_model_scale_env() == 32.0  # presence of the scale IS the signal
+    assert stream_tess_model_scale() == 0.0  # the gated reader honours its own OFF default
+
+
+@pytest.mark.parametrize(
+    "fn, key",
+    [(stream_tess_face_regions, "ADA_STREAM_TESS_FACE_REGIONS"), (stream_tess_strict, "ADA_STREAM_TESS_STRICT")],
+)
+def test_opt_in_flags_default_off(monkeypatch, fn, key):
+    monkeypatch.delenv(key, raising=False)
+    assert fn() is False
+    for v in FALSY:
+        monkeypatch.setenv(key, v)
+        assert fn() is False, f"{key}={v!r} must be off"
+    for v in TRUTHY:
+        monkeypatch.setenv(key, v)
+        assert fn() is True, f"{key}={v!r} must be on"
+
+
+def test_no_call_site_reimplements_the_env_parse():
+    """Source-level guard: only registry.py may parse an ADA_STREAM_TESS_* value.
+
+    Other modules may still *route* the pipeline selector (os.environ.get("ADA_STREAM_TESS_PIPELINE"))
+    or set/pop vars for a subprocess — what they must not do is re-derive a default or a falsy set,
+    which is how the density silently diverged by call path.
+    """
+    src = pathlib.Path(__file__).resolve().parents[3] / "src" / "ada"
+    assert src.is_dir(), src
+    offenders = []
+    for py in src.rglob("*.py"):
+        if py.name == "registry.py" and py.parent.name == "cad":
+            continue
+        text = py.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if "ADA_STREAM_TESS_" not in line or line.lstrip().startswith("#"):
+                continue
+            # A default= argument to environ.get on a TESS var re-derives a default.
+            if "environ.get(" in line and line.count('"') >= 4 and "PIPELINE" not in line:
+                offenders.append(f"{py.relative_to(src.parent.parent)}:{lineno}: {line.strip()}")
+    assert not offenders, "re-implemented ADA_STREAM_TESS_* defaults; use ada.cad.registry helpers:\n" + "\n".join(
+        offenders
+    )

--- a/tests/core/cad/test_tess_track_discovery.py
+++ b/tests/core/cad/test_tess_track_discovery.py
@@ -1,0 +1,93 @@
+"""adapy DISCOVERS the tessellation-track vocabulary; it must not enumerate it.
+
+adacpp declares which tracks a given build provides (``adacpp.cad.tess_tracks()``); adapy adds only
+its own (pythonocc's BRepMesh) and publishes the union. Adding a track in adacpp must show up here,
+in the converter's option schema, and in the frontend dropdown with NO adapy change.
+
+The legacy ``TessellationPath`` enum is the thing this replaces: it is a hand-written list, so it
+cannot see any track added after it was written (e.g. ``adacpp:cdt``). It is kept for back-compat
+only, and these tests pin that the discovered list is a strict superset.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.cad.registry import (
+    CadBackendName,
+    TessellationPath,
+    TessTrack,
+    available_tess_tracks,
+    tess_track_by_name,
+)
+
+
+def test_discovery_returns_descriptors_not_bare_names():
+    tracks = available_tess_tracks()
+    assert tracks, "at least adapy's own OCC track or an adacpp track must be available"
+    for t in tracks:
+        assert isinstance(t, TessTrack)
+        assert t.name and t.label, f"{t.name!r} must carry a human label for the UI"
+        assert isinstance(t.watertight, bool)
+        assert isinstance(t.backend, CadBackendName)
+
+
+def test_track_names_are_unique():
+    names = [t.name for t in available_tess_tracks()]
+    assert len(names) == len(set(names))
+
+
+def test_adapy_owns_only_the_occ_track():
+    """Every non-OCC track must come from adacpp. If adapy ever hardcodes another one, this fails."""
+    pytest.importorskip("OCC")
+    non_occ = [t for t in available_tess_tracks() if t.backend is not CadBackendName.OCC]
+    assert all(t.backend is CadBackendName.ADACPP for t in non_occ)
+    occ = [t for t in available_tess_tracks() if t.backend is CadBackendName.OCC]
+    assert len(occ) == 1 and occ[0].pipeline is None, "OCC is BRepMesh: it has no adacpp pipeline arg"
+
+
+def test_adacpp_tracks_are_discovered_from_adacpp():
+    """The vocabulary must match what adacpp declares — not a list maintained in adapy."""
+    pytest.importorskip("adacpp")
+    import adacpp
+
+    decl = getattr(adacpp.cad, "tess_tracks", None)
+    if decl is None:
+        pytest.skip("adacpp predates the tess_tracks declaration")
+    declared = {t["name"] for t in decl()}
+    discovered = {t.pipeline for t in available_tess_tracks() if t.backend is CadBackendName.ADACPP}
+    assert discovered == declared, "adapy must publish exactly what adacpp declares"
+
+
+def test_discovery_sees_tracks_the_legacy_enum_cannot():
+    """The whole point: a track added to adacpp after the enum was written is still reachable."""
+    pytest.importorskip("adacpp")
+    import adacpp
+
+    if getattr(adacpp.cad, "tess_tracks", None) is None:
+        pytest.skip("adacpp predates the tess_tracks declaration")
+    discovered = {t.name for t in available_tess_tracks()}
+    legacy = {p.value for p in TessellationPath}
+    # Not a strict-superset assertion on purpose: availability differs by env (an adacpp-only env has
+    # no pythonocc, so no "occ"). What must hold is that discovery never MISSES an adacpp track.
+    adacpp_declared = {f"adacpp:{t['name']}" for t in adacpp.cad.tess_tracks()}
+    assert adacpp_declared <= discovered
+    if "adacpp:cdt" in adacpp_declared:
+        assert "adacpp:cdt" not in legacy, "cdt postdates the enum — that is why discovery exists"
+        assert tess_track_by_name("adacpp:cdt") is not None
+
+
+def test_lookup_by_name_and_unknown():
+    tracks = available_tess_tracks()
+    assert tess_track_by_name(tracks[0].name) == tracks[0]
+    assert tess_track_by_name("definitely-not-a-track") is None
+
+
+def test_watertight_is_advertised():
+    """A caller must be able to ASK which tracks are watertight rather than know it."""
+    pytest.importorskip("adacpp")
+    if getattr(__import__("adacpp").cad, "tess_tracks", None) is None:
+        pytest.skip("adacpp predates the tess_tracks declaration")
+    wt = [t.name for t in available_tess_tracks() if t.watertight]
+    assert "adacpp:cdt" in wt, "cdt is the watertight track and must advertise itself as such"
+    assert "adacpp:libtess2" not in wt, "libtess2+pin halves cracks but is not watertight"

--- a/tests/core/cadit/sat/test_plate_curved_edges.py
+++ b/tests/core/cadit/sat/test_plate_curved_edges.py
@@ -1,0 +1,86 @@
+"""A flat plate's curved boundary edges must not collapse to their chords.
+
+``PlateFactory.get_points`` keeps only edge ENDPOINTS, so a plate whose boundary follows a curve
+(a deck plate meeting a curved hull skin) rendered as a straight chord between its corners while the
+skin beside it curved. ``Config().sat_plate_curved_edges`` samples the curve into extra outline
+points. See dap plan/v3/notes_plate_bspline_edges.md for why this is a stopgap.
+
+Synthetic fixtures: the real reproducer (OP1_v1007_hullskin.xml, face FACE00004482 — a 0.072 m bulge
+flattened out of a 1.4 m plate) is a client model and is not committed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ada.cadit.sat.read.plate_edge_curves import _clip_to_endpoints, _de_boor
+
+
+def _circle_ring(n=2048, r=1.0):
+    t = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    return [(float(r * np.cos(x)), float(r * np.sin(x)), 0.0) for x in t]
+
+
+def test_clip_closed_takes_the_short_arc():
+    """A plate boundary edge is the short way round a ring, never the long way."""
+    ring = _circle_ring()
+    a, b = (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)  # a quarter turn apart
+    inner = _clip_to_endpoints(ring, a, b, n=24, closed=True)
+    assert inner, "expected interior points along the arc"
+    # Every point must be on the r=1 circle and inside the FIRST quadrant (the short arc).
+    arr = np.array(inner)
+    assert np.allclose(np.linalg.norm(arr[:, :2], axis=1), 1.0, atol=1e-6)
+    assert (arr[:, 0] >= -1e-9).all() and (arr[:, 1] >= -1e-9).all()
+    # ...and the walk must be monotone from a to b, i.e. short arc length ~ pi/2, not 3*pi/2.
+    walk = np.vstack([[a], arr, [b]])
+    assert np.linalg.norm(np.diff(walk, axis=0), axis=1).sum() == pytest.approx(np.pi / 2, rel=0.02)
+
+
+def test_clip_open_never_wraps():
+    """Regression: treating an OPEN curve's samples as a ring wraps from its end back to its start.
+
+    That inserted a jump straight across the plate — measured on the real model as a 1.79 m step on
+    a 1.4 m plate (perimeter 8.86 m instead of ~5 m), producing a bow-tie the collinear pruner then
+    collapsed. An open curve must be SLICED, never taken modulo.
+    """
+    # An open polyline: a straight run in x. a/b are interior, so a wrapping impl would jump.
+    pts = [(float(x), 0.0, 0.0) for x in np.linspace(0.0, 10.0, 101)]
+    a, b = (2.0, 0.0, 0.0), (4.0, 0.0, 0.0)
+    inner = _clip_to_endpoints(pts, a, b, n=24, closed=False)
+    arr = np.array(inner)
+    assert len(arr), "expected interior points"
+    # Strictly between a and b: nothing from outside [2, 4] may appear.
+    assert arr[:, 0].min() > 2.0 - 1e-9 and arr[:, 0].max() < 4.0 + 1e-9
+    # Monotone increasing => no wrap-around jump.
+    assert (np.diff(arr[:, 0]) > 0).all()
+    walk = np.vstack([[a], arr, [b]])
+    steps = np.linalg.norm(np.diff(walk, axis=0), axis=1)
+    assert steps.sum() == pytest.approx(2.0, rel=1e-6)  # the true span, not a trip via the ends
+
+
+def test_clip_open_handles_reversed_direction():
+    pts = [(float(x), 0.0, 0.0) for x in np.linspace(0.0, 10.0, 101)]
+    inner = _clip_to_endpoints(pts, (4.0, 0.0, 0.0), (2.0, 0.0, 0.0), n=24, closed=False)
+    arr = np.array(inner)
+    assert (np.diff(arr[:, 0]) < 0).all(), "must run near->far, i.e. descending here"
+
+
+def test_de_boor_matches_a_known_bezier():
+    """degree-3 with clamped knots and 4 control points IS a cubic Bezier — check against it."""
+    cp = np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    knots = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=float)
+    for t in (0.0, 0.25, 0.5, 0.75, 1.0):
+        got = _de_boor(float(t), knots, cp, 3)
+        m = 1.0 - t
+        want = m**3 * cp[0] + 3 * m**2 * t * cp[1] + 3 * m * t**2 * cp[2] + t**3 * cp[3]
+        assert np.allclose(got, want, atol=1e-12), f"t={t}: {got} != {want}"
+
+
+def test_de_boor_straight_spline_is_straight():
+    """A spline whose control points are collinear must sample to a line — this is why the two
+    'intcurve' edges on the real plate correctly contribute nothing (sagitta 0.0)."""
+    cp = np.array([[float(i), 0.0, 0.0] for i in range(5)])
+    knots = np.array([0, 0, 0, 0, 1, 2, 2, 2, 2], dtype=float)
+    pts = np.array([_de_boor(float(t), knots, cp, 3) for t in np.linspace(0, 2, 20)])
+    assert np.allclose(pts[:, 1:], 0.0, atol=1e-12)

--- a/tests/core/cadit/step/read/test_stream_units.py
+++ b/tests/core/cadit/step/read/test_stream_units.py
@@ -61,7 +61,7 @@ def test_representation_length_scale_none_when_no_unit():
 
 def _step_with_unit_at_end(tmp_path, unit_stmt: str, pad_bytes: int) -> str:
     # A STEP file whose LENGTH_UNIT record sits at the very END of the DATA section,
-    # past a large body — the real-world layout (e.g. ~99.7% into a 778 MB crane file)
+    # past a large body — the real-world layout (e.g. ~99.7% into a 778 MB reference file)
     # that made the old whole-file mmap.find fault the entire file into RSS.
     head = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n"
     body = "".join(f"#{i}=CARTESIAN_POINT('p',(0.,0.,0.));\n" for i in range(1, pad_bytes // 40 + 2))

--- a/tests/core/test_deploy_pins.py
+++ b/tests/core/test_deploy_pins.py
@@ -1,0 +1,100 @@
+"""The adacpp wasm base version must live in exactly ONE place.
+
+It didn't, and it shipped wrong for two releases. deploy/Dockerfile.viewer declared the pin as an
+``ARG ADACPP_BASE_IMAGE`` default, but both CI systems passed ``--build-arg ADACPP_BASE_IMAGE=...``
+with their own literal — and a passed build-arg OVERRIDES an ARG default. Each literal sat under a
+"keep in sync with deploy/Dockerfile.viewer" comment, and both had drifted to 0.13.2 while the
+Dockerfile said 0.14.0. So the published viewer and the hosted deploy both built on a base two
+releases old, and bumping the Dockerfile changed nothing but the comment. A third copy — the audit
+CLI's default image — was still on 0.9.0, so wasm sweeps validated an engine six releases older than
+the one that shipped.
+
+Comments asserting the invariant are what failed, twice. These tests enforce it instead:
+the workflows now DERIVE the pin (github lets the ARG default stand; forgejo seds it out), and where
+duplication is unavoidable — ada_cli ships in a wheel with no deploy/ tree — CI pins the equality.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+# Only CONCRETE version literals. The prose in these files legitimately writes
+# "ghcr.io/krande/adacpp-wasm-base:<ver>" as a placeholder, which must not trip this.
+_CONCRETE_PIN = re.compile(r"adacpp-wasm-base:(\d+\.\d+\.\d+)")
+_ARG_PIN = re.compile(r"^ARG ADACPP_BASE_IMAGE=(\S+)$", re.MULTILINE)
+
+_REPO = pathlib.Path(__file__).parents[2]
+_DOCKERFILE = _REPO / "deploy" / "Dockerfile.viewer"
+
+# Files allowed to carry a concrete pin, and why.
+_DOCKERFILE_REL = "deploy/Dockerfile.viewer"  # THE pin
+_AUDIT_REL = "src/ada_cli/audit.py"  # must equal it; can't derive from a wheel
+
+_needs_repo = pytest.mark.skipif(
+    not _DOCKERFILE.is_file(),
+    reason=f"no repo tree at {_REPO} (sdist/wheel test env) — deploy/ is not packaged",
+)
+
+
+def _dockerfile_pin() -> str:
+    found = _ARG_PIN.findall(_DOCKERFILE.read_text(encoding="utf-8"))
+    assert len(found) == 1, f"expected exactly one ARG ADACPP_BASE_IMAGE in {_DOCKERFILE_REL}, got {found}"
+    return found[0]
+
+
+@_needs_repo
+def test_dockerfile_declares_exactly_one_concrete_pin():
+    """The ARG default is the pin, and it is a real tag — an empty or templated default would make
+    the derived consumers (forgejo's sed, the unpassed build-arg) resolve to nothing."""
+    pin = _dockerfile_pin()
+    assert _CONCRETE_PIN.search(pin), f"the ARG default must be a concrete tag, got {pin!r}"
+
+
+@_needs_repo
+def test_no_workflow_restates_the_wasm_base_version():
+    """A workflow carrying its own version literal is the exact bug this file documents.
+
+    github's publish-image must not pass the build-arg at all (so the ARG default stands); forgejo
+    must sed the value out of the Dockerfile. Either one hardcoding a version silently overrides the
+    pin, and — as happened — nothing notices until someone diffs a running image.
+    """
+    offenders = []
+    for wf in sorted((_REPO / ".github" / "workflows").glob("*.y*ml")) + sorted(
+        (_REPO / ".forgejo" / "workflows").glob("*.y*ml")
+    ):
+        for i, line in enumerate(wf.read_text(encoding="utf-8").splitlines(), 1):
+            if _CONCRETE_PIN.search(line):
+                offenders.append(f"{wf.relative_to(_REPO)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "workflows must DERIVE the adacpp wasm base pin from "
+        f"{_DOCKERFILE_REL}, never restate it:\n  " + "\n  ".join(offenders)
+    )
+
+
+@_needs_repo
+def test_audit_default_image_matches_the_viewer_pin():
+    """The wasm sweep must validate the engine that actually ships.
+
+    ada_cli can't read deploy/ (it ships in a wheel without it), so this literal is the one
+    unavoidable duplicate — which is exactly why the equality is pinned here rather than trusted.
+    """
+    from ada_cli.audit import ADACPP_DEFAULT_IMAGE
+
+    assert ADACPP_DEFAULT_IMAGE == _dockerfile_pin(), (
+        f"ada_cli.audit.ADACPP_DEFAULT_IMAGE ({ADACPP_DEFAULT_IMAGE}) has drifted from the pin in "
+        f"{_DOCKERFILE_REL} ({_dockerfile_pin()}) — a sweep would validate a different engine than "
+        "the viewer serves"
+    )
+
+
+@_needs_repo
+def test_audit_default_is_at_or_above_the_refusal_floor():
+    """The default must not sit below the version the sweep refuses to run."""
+    from ada_cli.audit import ADACPP_DEFAULT_IMAGE, ADACPP_MIN_VERSION
+
+    m = _CONCRETE_PIN.search(ADACPP_DEFAULT_IMAGE)
+    assert m, f"ADACPP_DEFAULT_IMAGE must carry a concrete version, got {ADACPP_DEFAULT_IMAGE!r}"
+    assert tuple(int(p) for p in m.group(1).split(".")) >= ADACPP_MIN_VERSION


### PR DESCRIPTION
## Ready for review — `ada-cpp 0.14.0` pinned and verified

The blocker is cleared: 0.14.0 is on conda-forge, pinned here, and the tests that mattered now
actually run.

- [x] `ada-cpp 0.14.0` published to conda-forge
- [x] `pixi.toml` (adacpp + adacpp-runtime) → `0.14.0.*`
- [x] `pixi.lock` regenerated — 15 entries across every platform/env
- [x] `deploy/Dockerfile.viewer` → `adacpp-wasm-base:0.14.0`
- [x] `deploy/Dockerfile.worker` — 23 lines of stale pre-release markers retired
- [x] forgejo `ADACPP_BRANCH` variable cleared, so the worker uses the pinned package
- [x] the two guarded tests confirmed running

**Why the pin was load-bearing, not bookkeeping.** Against an older `ada-cpp` the discovery tests do
not fail — they skip:

```python
decl = getattr(adacpp.cad, "tess_tracks", None)
if decl is None:
    pytest.skip("adacpp predates the tess_tracks declaration")
```

So this branch was green while testing none of the feature it adds. Verified against the real conda
package (adacpp resolves from `site-packages`, not a `build/dist` overlay):

| | before | after |
|---|---|---|
| `test_adacpp_tracks_are_discovered_from_adacpp` | SKIPPED | **PASSED** |
| `test_watertight_is_advertised` | SKIPPED | **PASSED** |

235 passed, 6 skipped across `tests/core/cad`, `cadit/ngeom`, `cadit/step`.

## What this does

**adapy stops enumerating the tessellator vocabulary and asks for it instead.** adacpp declares which
tracks a build provides via `tess_tracks()`; adapy contributes only its own (pythonocc's BRepMesh) and
publishes the union to Python callers, the REST option schema, and the frontend dropdown.

Already proven in practice: `hybrid-cdt` was added upstream and then removed again before release, and
**neither touched this repo**. The env now reports `['libtess2', 'cdt', 'occ', 'cgal', 'hybrid']` — no
`hybrid-cdt` — with no adapy change to drop it.

The legacy `TessellationPath` enum is kept for back-compat and marked as such. It is the thing this
replaces: a hand-written list cannot see a track added after it was written.

Also here:

- **`fix: route every ADA_STREAM_TESS_* read through the cad registry`** — the same nominal config
  produced different meshes depending on the call path, because `native_step_to_glb`,
  `native_ifc_to_glb` and `scene_from_step_stream` each re-read `os.environ` directly with their own
  defaults. Zero behaviour change (the values never actually diverged); it removes the ways they
  could, and fixes one falsy-set bug where `""` was treated as unset.
- **`fix(sat): flat plates no longer flatten their curved boundary edges`** — a `Plate` outline is a
  `CurvePoly2d` of line/arc segments with no B-spline segment type, so a spline boundary edge was
  reduced to a chord. This samples the curve and splices the points into the outline. A deliberate
  stopgap, written up in the dap notes; the real fix is B-spline segment support in `Plate`. Uses a
  hand-written de Boor on numpy — scipy is not a core adapy dependency.

## Note on the worker overlay

The `ADACPP_BRANCH` mechanism stays (it is how the next pre-release gets previewed), but its trap is
now documented where the markers were: it is driven by a **forgejo repo variable**, and while that
names a branch the overlay is built and placed on `PYTHONPATH` *ahead* of the conda `ada-cpp` — so the
worker silently runs the branch build and the pinned version is never exercised. Cleared for 0.14.0.

Upstream counterpart: adacpp #39.