### PR TITLE
fix: drop the empty env block that invalidated publish-image

### DIFF
--- a/.forgejo/workflows/build.yaml
+++ b/.forgejo/workflows/build.yaml
@@ -58,6 +58,9 @@ on:
       - 'deploy/Dockerfile.docs'
       - 'deploy/Dockerfile.docs-fast'
       - 'deploy/viewer-ada-init.py'
+      # Not baked into the image (it's piped in from the checkout), but a change to the startup
+      # gate should still rebuild the viewer so the new gate actually runs against one.
+      - 'deploy/viewer-smoke.py'
       - 'docs/**'
       - 'verification/**'
       - '.forgejo/workflows/build.yaml'
@@ -278,6 +281,7 @@ jobs:
              match_scope "$VIEWER_CHANGED" '^src/frontend/' || \
              match_scope "$VIEWER_CHANGED" '^deploy/Dockerfile\.viewer(-fast)?$' || \
              match_scope "$VIEWER_CHANGED" '^deploy/viewer-ada-init\.py$' || \
+             match_scope "$VIEWER_CHANGED" '^deploy/viewer-smoke\.py$' || \
              match_scope "$VIEWER_CHANGED" '^\.forgejo/workflows/build\.yaml$'; then
             viewer=true
           fi

--- a/.forgejo/workflows/build.yaml
+++ b/.forgejo/workflows/build.yaml
@@ -362,7 +362,7 @@ jobs:
           mkdir -p ~/.docker
           printf '%s' '${{ secrets.REGISTRY_DOCKER_CONFIG }}' > ~/.docker/config.json
 
-      - name: Build and push viewer image
+      - name: Build viewer image
         env:
           REGISTRY_IMAGE: ${{ secrets.VIEWER_REGISTRY_IMAGE }}
           # Full reference to the prebuilt adacpp pyodide wasm base image
@@ -389,6 +389,9 @@ jobs:
           # the gitops bump below pins that exact tag.
           TAG="sha-${GITHUB_SHA::7}-${GITHUB_RUN_NUMBER:-0}"
           BRANCH_TAG="branch-$(printf '%s' "$GITHUB_REF_NAME" | tr '/' '-')"
+          # Hand both tags to the smoke-test + push steps below.
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "BRANCH_TAG=$BRANCH_TAG" >> "$GITHUB_ENV"
           # Fast path: only the curated ada subset changed AND a prior
           # branch image exists. It FROMs that image, so the adacpp wasm
           # base / SPA / pixi env are all inherited — no adacpp pull.
@@ -430,6 +433,26 @@ jobs:
               -t "${REGISTRY_IMAGE}:${BRANCH_TAG}" \
               .
           fi
+
+      # Gate the push on the image actually being able to start. The viewer runtime ships a CURATED
+      # subset of ada (see the COPY block in deploy/Dockerfile.viewer), and nothing else checks that
+      # the subset is complete: the test suite and the worker image both have all of src/ada on the
+      # path, so an import the REST app makes at startup can be missing here while every other check
+      # is green. 0.30.0 shipped exactly that and crashlooped on `No module named 'ada.cad'`, with
+      # the same-commit worker image healthy. Cheap enough to run on every build (one import).
+      - name: Smoke-test the viewer image
+        env:
+          REGISTRY_IMAGE: ${{ secrets.VIEWER_REGISTRY_IMAGE }}
+        run: |
+          docker run --rm -i --entrypoint sh "${REGISTRY_IMAGE}:${TAG}" \
+            -c 'exec /env/bin/python -' < deploy/viewer-smoke.py
+
+      # Only now: a build that fails the smoke test never reaches the registry, so the branch tag
+      # the next fast build FROMs (and the tag the gitops bump pins) stays on the last good image.
+      - name: Push viewer image
+        env:
+          REGISTRY_IMAGE: ${{ secrets.VIEWER_REGISTRY_IMAGE }}
+        run: |
           docker push "${REGISTRY_IMAGE}:${TAG}"
           docker push "${REGISTRY_IMAGE}:${BRANCH_TAG}"
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -52,3 +52,80 @@ jobs:
 
         - name: Runs Tests
           run: pixi run -e tests test
+
+    # Build the viewer image and start the server inside it. Nothing else in this workflow can catch
+    # a viewer that won't boot: lint and the test matrix run against the full src/ada tree, but the
+    # viewer runtime ships a CURATED subset of it (see the COPY block in deploy/Dockerfile.viewer),
+    # so a module the REST app imports at startup can be missing from the image with every job here
+    # green. 0.30.0 shipped exactly that and crashlooped on `No module named 'ada.cad'` — and the
+    # worker image from the same commit was healthy, which is what hid it. The tag-only publish
+    # workflow gates the same thing, but that is a release-time backstop; this is the one that keeps
+    # it out of main.
+    viewer-image:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          # deploy/Dockerfile.viewer FROMs the adacpp wasm base on ghcr (a cross-repo package).
+          packages: read
+        steps:
+        - uses: actions/checkout@v7
+          with:
+            ref: ${{ github.event.pull_request.head.sha || github.ref }}
+            # The scope check below diffs against the PR base, which needs real history.
+            fetch-depth: 0
+
+        # This build is the expensive one in the repo (SPA + pixi solve + the adacpp wasm base), so
+        # a docs-only PR shouldn't pay for it — but anything that can change what lands in the image
+        # must. Mirrors the viewer scope in .forgejo/workflows/build.yaml's detect job. Done inline
+        # rather than as an `on: pull_request: paths:` filter so the job always reports a status:
+        # a path-filtered workflow that never runs leaves a required check pending forever.
+        - name: Does this PR affect the viewer image?
+          id: scope
+          env:
+            BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          run: |
+            CHANGED="$(git diff --name-only "$BASE_SHA"...HEAD || true)"
+            if printf '%s\n' "$CHANGED" | grep -qE '^(src/ada/|src/frontend/|deploy/Dockerfile\.viewer(-fast)?$|deploy/viewer-(ada-init|smoke)\.py$|pixi\.(toml|lock)$|pyproject\.toml$|\.github/workflows/pr-tests\.yml$)'; then
+              echo "build=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "build=false" >> "$GITHUB_OUTPUT"
+              echo "No viewer-affecting paths in this PR; skipping the image build."
+            fi
+
+        - uses: docker/setup-buildx-action@v4
+          if: steps.scope.outputs.build == 'true'
+
+        - name: Log in to GitHub Container Registry
+          if: steps.scope.outputs.build == 'true'
+          uses: docker/login-action@v4
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Build viewer image
+          if: steps.scope.outputs.build == 'true'
+          uses: docker/build-push-action@v7
+          with:
+            context: .
+            file: ./deploy/Dockerfile.viewer
+            # Never pushed — built only to be started. ADACPP_BASE_IMAGE is deliberately not passed
+            # so the pin in deploy/Dockerfile.viewer stands; see publish-image.yaml.
+            push: false
+            load: true
+            tags: adapy-viewer:pr
+            build-args: |
+              IMAGE_TAG=pr-${{ github.event.pull_request.number }}
+            # Read the release cache when it's reachable, but write a PR-scoped one: a PR can only
+            # restore caches from its base branch or its own, so tag-built layers usually aren't
+            # visible here. First run on a PR is cold; later pushes to it hit this.
+            cache-from: |
+              type=gha,scope=viewer-pr
+              type=gha,scope=viewer
+            cache-to: type=gha,mode=max,scope=viewer-pr
+
+        - name: Smoke-test the viewer image
+          if: steps.scope.outputs.build == 'true'
+          run: |
+            docker run --rm -i --entrypoint sh adapy-viewer:pr \
+              -c 'exec /env/bin/python -' < deploy/viewer-smoke.py

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -33,13 +33,11 @@ permissions:
   packages: write
 
 # The prebuilt adacpp pyodide wasm base the viewer FROMs. Published by adacpp's
-# own publish-wasm-base workflow on tag (wheel + manifest under /out/). Pinned
-# to a release so viewer builds are reproducible — bump on adacpp adoption.
+# own publish-wasm-base workflow on tag (wheel + manifest under /out/). Pinned to
+# a release so viewer builds are reproducible — the pin is the ADACPP_BASE_IMAGE
+# ARG default in deploy/Dockerfile.viewer, not here; see the viewer build step.
 # NOTE: this is a cross-repo ghcr package; it must be public (or grant the
 # adapy repo read access) for the GITHUB_TOKEN pull below to resolve it.
-env:
-  # 0.9.0: pyodide_2025_0 ABI (emscripten 4.0.9) + OCCT symbol isolation.
-  # (The adacpp wasm base version is NOT pinned here — see the viewer build step.)
 
 jobs:
   viewer:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -64,14 +64,16 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
 
-      - name: Build and push
+      # Built locally first so the smoke test below can gate the push. The publish itself is the
+      # step after next; this one loads the image into the runner's docker instead.
+      - name: Build viewer image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/Dockerfile.viewer
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          load: true
+          tags: adapy-viewer:smoke
           # ADACPP_BASE_IMAGE is deliberately NOT passed: the pin is the ARG default in
           # deploy/Dockerfile.viewer, and an unpassed build-arg lets that default stand.
           # This used to restate the version as ADACPP_WASM_BASE, which drifted to 0.13.2
@@ -82,6 +84,29 @@ jobs:
             IMAGE_TAG=${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=viewer
           cache-to: type=gha,mode=max,scope=viewer
+
+      # The viewer runtime ships a CURATED subset of ada, and nothing else verifies the subset is
+      # complete — the test suite and the worker image both have all of src/ada on the path. 0.30.0
+      # released a viewer that crashlooped on `No module named 'ada.cad'` with every check green.
+      # See deploy/viewer-smoke.py.
+      - name: Smoke-test the viewer image
+        run: |
+          docker run --rm -i --entrypoint sh adapy-viewer:smoke \
+            -c 'exec /env/bin/python -' < deploy/viewer-smoke.py
+
+      # Re-runs the same build to publish it: every layer is a gha cache hit, so this is an export,
+      # not a rebuild — and a tag whose image can't start never gets published.
+      - name: Push viewer image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./deploy/Dockerfile.viewer
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            IMAGE_TAG=${{ steps.meta.outputs.version }}
+          cache-from: type=gha,scope=viewer
 
   worker:
     runs-on: ubuntu-latest

--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -104,6 +104,14 @@ ENV SSL_CERT_FILE=/env/ssl/cert.pem \
 COPY deploy/viewer-ada-init.py /app/src/ada/__init__.py
 COPY src/ada/config.py /app/src/ada/config.py
 COPY src/ada/comms/ /app/src/ada/comms/
+# ada.cad — the tessellation-track registry. ada.comms.rest.converter imports it at MODULE level
+# (the published step_glb_pipeline/tessellator vocabulary is discovered, not listed), so leaving it
+# out crashlooped the API on startup. Safe to ship into the slim runtime: ada/cad/registry.py is
+# stdlib-only by construction and ada/cad/__init__ keeps numpy/OCC behind function-local imports and
+# a lazy __getattr__, so nothing native is dragged in. With no adacpp installed here, discovery
+# correctly reports no tracks and the API publishes the static vocabulary — the adacpp tracks reach
+# the dropdown from the pools that actually run them, via each worker's advertised enum.
+COPY src/ada/cad/ /app/src/ada/cad/
 # pyproject.toml is the single source of truth for the version. The viewer copies adapy source
 # (no installed-dist metadata) and a stripped ada/__init__ (no __version__), so config.js reads
 # the version from here for window.ADAPY_VERSION (see _resolve_adapy_version).

--- a/deploy/Dockerfile.viewer-fast
+++ b/deploy/Dockerfile.viewer-fast
@@ -48,6 +48,9 @@ ARG IMAGE_TAG=dev
 COPY deploy/viewer-ada-init.py /app/src/ada/__init__.py
 COPY src/ada/config.py /app/src/ada/config.py
 COPY src/ada/comms/ /app/src/ada/comms/
+# ada.cad — imported at module level by ada.comms.rest.converter for the discovered tessellator
+# vocabulary. See the matching COPY in Dockerfile.viewer for why it is safe in the slim runtime.
+COPY src/ada/cad/ /app/src/ada/cad/
 COPY src/ada/sections/categories.py        /app/src/ada/sections/categories.py
 COPY src/ada/sections/profile_lookup.py    /app/src/ada/sections/profile_lookup.py
 COPY src/ada/sections/resources/ProfileDB.json /app/src/ada/sections/resources/ProfileDB.json

--- a/deploy/viewer-smoke.py
+++ b/deploy/viewer-smoke.py
@@ -1,0 +1,47 @@
+"""Startup smoke test for a BUILT viewer image — run it before the image is pushed.
+
+Piped into the image's interpreter by the viewer-build jobs (.forgejo/workflows/build.yaml and
+.github/workflows/publish-image.yaml); it is not part of the shipped source and never runs in the
+test suite.
+
+Why this exists: the viewer runtime ships a CURATED subset of ada (see the COPY block in
+deploy/Dockerfile.viewer), not the whole package. Nothing in the ordinary test suite imports the
+server the way that trimmed image does — the tests, and the worker image, both have all of src/ada
+on the path — so a module the REST app imports at startup can be missing from the image while every
+check stays green. That is not hypothetical: adapy 0.30.0 shipped a viewer that crashlooped on
+`ModuleNotFoundError: No module named 'ada.cad'`, because the published tessellator vocabulary
+became DISCOVERED (imported at module scope) rather than listed, and ada.cad was not in the subset.
+The worker image built from the very same commit was fine, which is exactly what hid it.
+
+So: import the app the way the container does, inside the container, and refuse to push if that
+fails. Keep this cheap and startup-only — it is a packaging gate, not a functional test.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# The REST app builds its object store at import time (create_app -> Storage.from_settings), and the
+# default local store canonicalizes ADA_VIEWER_LOCAL_PATH — /data, a volume in the deployment but an
+# absent path in a bare `docker run`. Create it so a missing mount reads as what it is (an unset
+# environment) instead of a fake failure of this gate.
+pathlib.Path("/data").mkdir(parents=True, exist_ok=True)
+
+# The import under test: this is the line that crashlooped 0.30.0. It transitively runs the
+# module-level registration (_register_ada_loadable and friends) where the discovery imports live.
+import ada.comms.rest.app  # noqa: E402
+from ada.comms.rest.converter import _step_glb_pipelines  # noqa: E402
+
+vocabulary = list(_step_glb_pipelines())
+
+# A vocabulary that imports but comes back empty would leave the frontend with an unselectable
+# engine dropdown — a silent degrade rather than a crash, so assert it rather than trusting the
+# import alone. The API's own list is the static base; adacpp tracks are unioned in from the workers
+# that actually run them, so this stays true in the slim image where no adacpp is installed.
+if not vocabulary:
+    sys.exit("viewer smoke FAILED: published step_glb_pipeline vocabulary is empty")
+
+assert ada.comms.rest.app.app is not None, "viewer smoke FAILED: create_app() produced no ASGI app"
+
+print(f"viewer smoke OK: app imported; step_glb_pipeline vocabulary = {vocabulary}")


### PR DESCRIPTION
fix(ci): drop the empty env block that invalidated publish-image

Every publish-image run since #239 has failed in 0s with "this run likely failed
because of a workflow file issue", on main and on every branch. The workflow was
unparseable: #239 removed ADACPP_WASM_BASE, which was the only key under `env:`,
and left the block behind holding nothing but comments. That parses as null, and
GitHub Actions requires `env` to be a mapping, so it rejected the whole file
before running a step.

Removing the pin was right -- it restated a version the Dockerfile already owns,
and drifted from it. Only the empty block needed to go with it. The note about
where the pin actually lives moves up into the comment above.

Nothing else in .github/workflows has an `env:` that isn't a mapping.
