### PR TITLE
chore: skip the tess-env source lint when there is no source tree

### DIFF
--- a/tests/core/cad/test_tess_env_defaults.py
+++ b/tests/core/cad/test_tess_env_defaults.py
@@ -119,7 +119,10 @@ def test_no_call_site_reimplements_the_env_parse():
     which is how the density silently diverged by call path.
     """
     src = pathlib.Path(__file__).resolve().parents[3] / "src" / "ada"
-    assert src.is_dir(), src
+    if not src.is_dir():
+        # Only a repo checkout has src/; when the suite runs against an installed package (the
+        # conda-forge feedstock copies tests/ alone) there is no source tree to lint.
+        pytest.skip(f"source-tree lint; no src/ada at {src}")
     offenders = []
     for py in src.rglob("*.py"):
         if py.name == "registry.py" and py.parent.name == "cad":


### PR DESCRIPTION
## What

`test_no_call_site_reimplements_the_env_parse` (added in #239) greps `src/ada` for call sites that re-derive `ADA_STREAM_TESS_*` defaults instead of going through `ada.cad.registry`. It asserted the directory exists:

```python
src = pathlib.Path(__file__).resolve().parents[3] / "src" / "ada"
assert src.is_dir(), src
```

That fails outright wherever the suite runs against an *installed* package rather than a checkout. The conda-forge feedstock copies `tests/` and `files/` alone into `$PREFIX/etc/conda/test-files/`, so there is no `src/` sibling and the 0.31.0 version bump PR went red on it — 1369 passed, this one failed.

## Why skip rather than adapt it

The lint is only meaningful against a source tree, and a checkout is the only place it can catch anything before it ships. Pointing it at the installed `ada` package instead would lint a copy nobody edits.

The guard keeps its teeth where it counts: in a checkout all 31 tests in the file still run and pass, with no skip. In an installed layout it skips with a reason. Verified both ways locally — the second by copying `tests/` to a directory with no sibling `src/` and importing `ada` from elsewhere, which reproduces the feedstock's situation.

## Related

conda-forge/ada-py-feedstock#120 carries a `--deselect` for this node ID so 0.31.0 can build. Once this lands, that deselect is redundant and can be dropped at the next version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)