### PR TITLE
fix: bump adacpp pins to 0.16.1

### DIFF
--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -23,7 +23,7 @@
 # MUST stay >=0.9.0 — older bases ship an emscripten 3.1.58 wheel that micropip
 # refuses against pyodide 0.29.4 ("Wheel was built with Emscripten v3.1.58 but
 # Pyodide was built with v4.0.9").
-ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.15.0
+ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.16.1
 FROM ${ADACPP_BASE_IMAGE} AS adacpp-wheel
 
 # Stage 0b: build the pure-python adapy wheel for pyodide. The browser

--- a/pixi.lock
+++ b/pixi.lock
@@ -7546,7 +7546,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.16.1-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8175,7 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.16.1-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -8573,7 +8573,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.16.1-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -8785,7 +8785,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.16.1-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -9414,7 +9414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.16.1-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -9812,7 +9812,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.16.1-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10294,7 +10294,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.16.1-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -10576,7 +10576,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.16.1-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -10769,7 +10769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.16.1-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -11838,7 +11838,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.16.1-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -12172,7 +12172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.16.1-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -12396,7 +12396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.16.1-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -12545,28 +12545,28 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.15.0-py312h29cc896_0.conda
-  sha256: a7683c0208017b94b8780bff12133a3b89bc52dc036899edb82f86c42e8be69d
-  md5: 96893f1a2f70d970288c7ec737a14f10
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.16.1-py312h29cc896_0.conda
+  sha256: 4e89c4483c96663c19827a17c0d6ae93f99c4356aeaa5e97b4a873f8c2b32b83
+  md5: 2ffdf0467bb1a29c5a950a97e930f35a
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
-  - occt >=7.9.3,<7.9.4.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
   - libzlib >=1.3.2,<2.0a0
+  - occt >=7.9.3,<7.9.4.0a0
   - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=compressed-mapping
+  - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.15.0,<0.15.1.0a0
-  size: 15237002
-  timestamp: 1784110658298
+    - ada-cpp >=0.16.1,<0.16.2.0a0
+  size: 15282543
+  timestamp: 1784298690208
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -21770,27 +21770,27 @@ packages:
   purls: []
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.15.0-py312h9b4feea_0.conda
-  sha256: 999d1766f9d1100c03fe66c54411c8fbf7738cbc2b8487ef8437024d31075d62
-  md5: 01e7b38936a2bac19ecd6948946a4084
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.16.1-py312h9b4feea_0.conda
+  sha256: aef223b0a3775be566d0287eda9ccbedbf4b685c68eae4baca3cb23004611b76
+  md5: b26b605b7e7266f0073b307a63e548d1
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - libcxx >=19
   - __osx >=11.0
   - python_abi 3.12.* *_cp312
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
   - libzlib >=1.3.2,<2.0a0
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
   - occt >=7.9.3,<7.9.4.0a0
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=compressed-mapping
+  - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.15.0,<0.15.1.0a0
-  size: 13081434
-  timestamp: 1784110690753
+    - ada-cpp >=0.16.1,<0.16.2.0a0
+  size: 13128560
+  timestamp: 1784298767674
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -25536,28 +25536,28 @@ packages:
     - _openmp_mutex >=4.5
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.15.0-py312h710a262_0.conda
-  sha256: 0b3a6e823ec786bc95f4fee34fb64ebce0c2df3d526d9a483310b2c3f46efa8c
-  md5: e5f16f62d0c3c4e38584f70977bb169f
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.16.1-py312h710a262_0.conda
+  sha256: ace289c75628f15996f08965dd7a231036275fc2089bf3736b4f8aeff1768da2
+  md5: c907f1e6ca2b120f073328597232c94c
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.12.* *_cp312
-  - rocksdb >=10.6.2,<10.7.0a0
-  - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - libzlib >=1.3.2,<2.0a0
   - occt >=7.9.3,<7.9.4.0a0
+  - python_abi 3.12.* *_cp312
+  - ifcopenshell >=0.8.5,<0.8.6.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
   purls:
-  - pkg:pypi/ada-cpp?source=compressed-mapping
+  - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.15.0,<0.15.1.0a0
-  size: 9542481
-  timestamp: 1784110682170
+    - ada-cpp >=0.16.1,<0.16.2.0a0
+  size: 9579187
+  timestamp: 1784298715172
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.toml
+++ b/pixi.toml
@@ -153,7 +153,7 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # for every other path (IFC/XML/FEM, occ-builtin fallback). Shares occt 7.9.3 with
 # pyocc (see above) so both coexist in one env.
 [feature.adacpp-runtime.dependencies]
-ada-cpp = "0.15.0.*"
+ada-cpp = "0.16.1.*"
 
 # ada-cpp CAD backend (AdacppBackend) — native CPython build of the
 # wasm-capable kernel. Brings its own occt 7.9.3 + gmsh + ifcopenshell,
@@ -172,8 +172,11 @@ ada-cpp = "0.15.0.*"
 # vocabulary adacpp declares and ada.cad.registry discovers — plus boundary pinning on by default
 # and the watertight `cdt` track. REQUIRED, not merely nice: the discovery tests skip outright
 # against an older ada-cpp, so a lower pin makes them silently vacuous. 0.15 adds
-# imprint_planar_faces plus win-64 build and cad-API-generator encoding fixes.
-ada-cpp = "0.15.0.*"
+# imprint_planar_faces plus win-64 build and cad-API-generator encoding fixes. 0.16
+# adds native OCC-free STEP/IFC→GLB with tessellation tracks and colour/curved-surface
+# fidelity; 0.16.1 fixes per-face STEP colours without --face-regions plus CLI positional
+# args and pipeline validation.
+ada-cpp = "0.16.1.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/src/ada_cli/audit.py
+++ b/src/ada_cli/audit.py
@@ -71,7 +71,7 @@ ADACPP_MIN_VERSION = (0, 9, 0)
 # validated a wheel six releases older than the one it shipped.
 # Duplicated as a literal because it cannot be derived: ada_cli ships in a wheel that carries no
 # deploy/ tree. tests/core/test_deploy_pins.py fails if the two drift.
-ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.15.0"
+ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.16.1"
 IFC_WASM_WHEEL = (
     "https://ifcopenshell.github.io/wasm-wheels/" "ifcopenshell-0.8.5-cp313-cp313-pyodide_2025_0_wasm32.whl"
 )

--- a/tests/comms/rest/test_audit_cli.py
+++ b/tests/comms/rest/test_audit_cli.py
@@ -174,7 +174,7 @@ def test_wasm_sweep_honours_the_adacpp_image_default(monkeypatch, tmp_path):
 
     # Neither --adacpp-wheel nor $ADACPP_WHEEL set => the image is what gets extracted.
     monkeypatch.delenv("ADACPP_WHEEL", raising=False)
-    wheel = tmp_path / "ada_cpp-0.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl"
+    wheel = tmp_path / "ada_cpp-0.16.1-cp313-cp313-pyodide_2025_0_wasm32.whl"
     wheel.touch()
     seen = {}
 
@@ -190,7 +190,7 @@ def test_wasm_sweep_honours_the_adacpp_image_default(monkeypatch, tmp_path):
 
 def test_wasm_sweep_explicit_wheel_beats_the_image(monkeypatch, tmp_path):
     """An explicit --adacpp-wheel short-circuits the image, so a local build can be swept."""
-    wheel = tmp_path / "ada_cpp-0.15.0-cp313-cp313-pyodide_2025_0_wasm32.whl"
+    wheel = tmp_path / "ada_cpp-0.16.1-cp313-cp313-pyodide_2025_0_wasm32.whl"
     wheel.touch()
 
     def _boom(image, dest):  # pragma: no cover - must not run


### PR DESCRIPTION
adapy `0.32.0` shipped against `ada-cpp 0.15.0`. This bumps every adacpp consumer to the **0.16.1** release (native conda backend + wasm base), which is now published on conda-forge (linux-64/osx-64/win-64) and `ghcr.io/krande/adacpp-wasm-base:0.16.1`.

## Changes
- **`pixi.toml`** — `adacpp-runtime` + `adacpp` feature conda deps → `ada-cpp = "0.16.1.*"`
- **`deploy/Dockerfile.viewer`** — `ARG ADACPP_BASE_IMAGE` wasm-base pin → `:0.16.1` (the single source; github's publish-image lets the ARG default stand, forgejo seds it out)
- **`src/ada_cli/audit.py`** — `ADACPP_DEFAULT_IMAGE` → `:0.16.1`, kept equal to the Dockerfile pin (`tests/core/test_deploy_pins.py` enforces the equality)
- **`pixi.lock`** — re-solved; `ada-cpp 0.16.1` across all envs/platforms, no unrelated churn
- **`tests/comms/rest/test_audit_cli.py`** — fixture wheel filenames bumped for consistency

## What 0.16.x brings
- `0.16.0` — native OCC-free STEP/IFC→GLB with tessellation tracks and colour/curved-surface fidelity
- `0.16.1` — per-face STEP colours without `--face-regions`, CLI positional args, pipeline validation

Merging this `fix:` PR cuts adapy **0.32.1** via semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)