### PR TITLE
feat: worker detail modal in the admin Workers tab

### DIFF
--- a/src/frontend/src/components/admin/WorkerInfoModal.tsx
+++ b/src/frontend/src/components/admin/WorkerInfoModal.tsx
@@ -1,0 +1,240 @@
+import React, {useEffect, useState} from "react";
+import {ApiError, viewerApi, WorkerEntry, WorkerPackage} from "@/services/viewerApi";
+
+// Per-worker detail modal opened from the info button in WorkersTab. Everything shown here is
+// already in hand (the registration entry the row was built from) except the conda package
+// manifest, which is lazy-fetched by image tag via the same endpoint the audit log uses.
+
+function fmtDuration(seconds: number): string {
+    if (seconds < 0) return "—";
+    if (seconds < 60) return `${Math.round(seconds)}s`;
+    if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+    if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+    return `${Math.round(seconds / 86400)}d`;
+}
+
+function fmtRelative(epoch: number, nowEpoch: number): string {
+    const dt = nowEpoch - epoch;
+    if (dt < 0) return "in the future";
+    if (dt < 60) return `${Math.round(dt)}s ago`;
+    if (dt < 3600) return `${Math.round(dt / 60)}m ago`;
+    if (dt < 86400) return `${Math.round(dt / 3600)}h ago`;
+    return `${Math.round(dt / 86400)}d ago`;
+}
+
+function fmtClock(epoch: number): string {
+    try {
+        return new Date(epoch * 1000).toLocaleString();
+    } catch {
+        return String(epoch);
+    }
+}
+
+const Chip: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <span className="inline-block bg-gray-700 text-gray-100 text-xs px-2 py-0.5 rounded-sm mr-1 mb-1 font-mono">
+        {children}
+    </span>
+);
+
+const Section: React.FC<{title: string; children: React.ReactNode}> = ({title, children}) => (
+    <div className="space-y-1">
+        <div className="text-[11px] uppercase tracking-wide text-gray-400">{title}</div>
+        {children}
+    </div>
+);
+
+const Row: React.FC<{label: string; children: React.ReactNode}> = ({label, children}) => (
+    <>
+        <dt className="text-gray-400">{label}</dt>
+        <dd className="text-gray-100 break-all">{children}</dd>
+    </>
+);
+
+// Conda package manifest for the worker image, lazy-fetched on mount. Mirrors the audit log's
+// WorkerPackages disclosure (same endpoint), auto-loaded and always-open in this dedicated modal.
+const PackageList: React.FC<{imageTag: string}> = ({imageTag}) => {
+    const [pkgs, setPkgs] = useState<WorkerPackage[] | null>(null);
+    const [err, setErr] = useState<string | null>(null);
+    const [filter, setFilter] = useState("");
+
+    useEffect(() => {
+        let alive = true;
+        viewerApi
+            .adminWorkerPackages(imageTag)
+            .then((r) => alive && setPkgs(r.packages))
+            .catch((e) => alive && setErr(e instanceof ApiError ? e.message : String(e)));
+        return () => {
+            alive = false;
+        };
+    }, [imageTag]);
+
+    const f = filter.trim().toLowerCase();
+    const shown = (pkgs || []).filter((p) => !f || p.name.toLowerCase().includes(f));
+
+    if (err) return <div className="text-[11px] text-red-400">{err}</div>;
+    if (!pkgs) return <div className="text-[11px] text-gray-400">Loading…</div>;
+    return (
+        <div className="space-y-1">
+            <input
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="filter (ada-cpp, occt…)"
+                className="bg-gray-950 border border-gray-700 rounded-sm px-2 py-0.5 text-[11px] text-gray-100 w-48"
+            />
+            <div className="max-h-56 overflow-auto">
+                <dl className="grid grid-cols-[1fr_max-content] gap-x-3 gap-y-0.5 font-mono text-[11px]">
+                    {shown.map((p) => (
+                        <React.Fragment key={p.name}>
+                            <dt className="text-gray-300 break-all">{p.name}</dt>
+                            <dd className="text-gray-400 text-right whitespace-nowrap">
+                                {p.version ?? "—"}
+                                {p.build ? ` (${p.build})` : ""}
+                            </dd>
+                        </React.Fragment>
+                    ))}
+                </dl>
+            </div>
+            <div className="text-[10px] text-gray-500">
+                {shown.length} / {pkgs.length} packages
+            </div>
+        </div>
+    );
+};
+
+const WorkerInfoModal: React.FC<{worker: WorkerEntry; now: number; onClose: () => void}> = ({
+    worker,
+    now,
+    onClose,
+}) => {
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    const w = worker;
+    const sha = w.image_tag?.replace(/^sha-/, "") || null;
+    const conversions = w.conversions ?? [];
+    const utilities = w.utilities ?? [];
+    const sourceExts = w.source_exts ?? [];
+
+    return (
+        <div
+            className="fixed inset-0 z-60 flex items-start sm:items-center justify-center bg-black/70 p-4 overflow-y-auto"
+            onClick={onClose}
+        >
+            <div
+                className="bg-gray-900 border border-gray-700 rounded-sm shadow-xl flex flex-col max-w-2xl w-full max-h-[calc(100dvh-2rem)] sm:max-h-[85dvh] my-auto"
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-label="Worker details"
+            >
+                <div className="flex items-start gap-3 border-b border-gray-700 px-4 py-2">
+                    <div className="flex-1 min-w-0">
+                        <div className="text-sm font-semibold flex items-center gap-2">
+                            <span
+                                className={`inline-block w-2 h-2 rounded-full ${w.online ? "bg-green-400" : "bg-gray-500"}`}
+                                title={w.online ? "online" : "offline"}
+                            />
+                            Worker details
+                        </div>
+                        <div className="text-xs text-gray-400 font-mono break-all">{w.worker_id}</div>
+                    </div>
+                    <button
+                        type="button"
+                        className="shrink-0 text-gray-300 hover:text-white text-xl leading-none px-2"
+                        onClick={onClose}
+                        aria-label="Close"
+                        title="Close (Esc)"
+                    >
+                        ×
+                    </button>
+                </div>
+
+                <div className="flex-1 overflow-auto p-4 space-y-4 text-sm">
+                    <Section title="Identity">
+                        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs font-mono">
+                            <Row label="Status">{w.online ? "online" : "offline"}</Row>
+                            <Row label="Image tag">
+                                {w.image_tag || <span className="text-gray-500 italic">—</span>}
+                            </Row>
+                            <Row label="Commit">{sha || <span className="text-gray-500 italic">—</span>}</Row>
+                            <Row label="Started">
+                                {fmtClock(w.started_at)} · up {fmtDuration(now - w.started_at)}
+                            </Row>
+                            <Row label="Heartbeat">
+                                {fmtClock(w.last_heartbeat)} · {fmtRelative(w.last_heartbeat, now)}
+                            </Row>
+                        </dl>
+                    </Section>
+
+                    <Section title={`Capabilities (${w.capabilities.length})`}>
+                        {w.capabilities.length === 0 ? (
+                            <div className="text-xs text-gray-500 italic">none</div>
+                        ) : (
+                            <div>{w.capabilities.map((c) => <Chip key={c}>{c}</Chip>)}</div>
+                        )}
+                    </Section>
+
+                    <Section title={`Source extensions (${sourceExts.length})`}>
+                        {sourceExts.length === 0 ? (
+                            <div className="text-xs text-gray-500 italic">none advertised</div>
+                        ) : (
+                            <div>{sourceExts.map((e) => <Chip key={e}>{e}</Chip>)}</div>
+                        )}
+                    </Section>
+
+                    <Section title={`Conversions (${conversions.length})`}>
+                        {conversions.length === 0 ? (
+                            <div className="text-xs text-gray-500 italic">none advertised</div>
+                        ) : (
+                            <div className="max-h-40 overflow-auto">
+                                <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-0.5 font-mono text-[11px]">
+                                    {conversions.map((c) => (
+                                        <React.Fragment key={c.from}>
+                                            <dt className="text-gray-300">{c.from}</dt>
+                                            <dd className="text-gray-400 break-all">
+                                                → {(c.to ?? []).join(", ") || "—"}
+                                            </dd>
+                                        </React.Fragment>
+                                    ))}
+                                </dl>
+                            </div>
+                        )}
+                    </Section>
+
+                    <Section title={`Utilities (${utilities.length})`}>
+                        {utilities.length === 0 ? (
+                            <div className="text-xs text-gray-500 italic">none advertised</div>
+                        ) : (
+                            <ul className="text-[11px] space-y-0.5">
+                                {utilities.map((u, i) => (
+                                    <li key={u.name ?? i} className="break-all">
+                                        <span className="font-mono text-gray-200">{u.name ?? `utility ${i}`}</span>
+                                        {u.description ? (
+                                            <span className="text-gray-400"> — {u.description}</span>
+                                        ) : null}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Section>
+
+                    <Section title="Packages">
+                        {w.image_tag ? (
+                            <PackageList imageTag={w.image_tag}/>
+                        ) : (
+                            <div className="text-xs text-gray-500 italic">
+                                No image tag — package manifest is keyed by image tag.
+                            </div>
+                        )}
+                    </Section>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default WorkerInfoModal;

--- a/src/frontend/src/components/admin/WorkersTab.tsx
+++ b/src/frontend/src/components/admin/WorkersTab.tsx
@@ -1,5 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {ApiError, viewerApi, WorkerEntry} from "@/services/viewerApi";
+import InfoIcon from "@/components/icons/InfoIcon";
+import WorkerInfoModal from "./WorkerInfoModal";
 
 // Live view of every worker pod that recently published a heartbeat.
 // The endpoint just scans a NATS KV bucket — no DB hit — so the
@@ -48,6 +50,7 @@ const WorkersTab: React.FC = () => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [pruning, setPruning] = useState(false);
+    const [infoWorker, setInfoWorker] = useState<WorkerEntry | null>(null);
 
     const fetchWorkers = async () => {
         setLoading(true);
@@ -140,6 +143,7 @@ const WorkersTab: React.FC = () => {
                         <th className="px-2 py-2">Capabilities</th>
                         <th className="px-2 py-2">Uptime</th>
                         <th className="px-2 py-2">Last heartbeat</th>
+                        <th className="px-2 py-2 w-8"></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -166,6 +170,17 @@ const WorkersTab: React.FC = () => {
                             <td className="px-2 py-1.5 text-gray-300">
                                 {fmtRelative(w.last_heartbeat, now)}
                             </td>
+                            <td className="px-2 py-1.5 text-right">
+                                <button
+                                    type="button"
+                                    onClick={() => setInfoWorker(w)}
+                                    className="text-gray-400 hover:text-white p-1 rounded-sm hover:bg-gray-800"
+                                    title="Worker details (versions, conversions, packages)"
+                                    aria-label="Worker details"
+                                >
+                                    <InfoIcon className="w-4 h-4"/>
+                                </button>
+                            </td>
                         </tr>
                     ))}
                 </tbody>
@@ -180,7 +195,16 @@ const WorkersTab: React.FC = () => {
                     >
                         <div className="flex items-center gap-2 mb-1">
                             <Dot online={w.online}/>
-                            <span className="font-mono text-xs break-all">{w.worker_id}</span>
+                            <span className="font-mono text-xs break-all flex-1">{w.worker_id}</span>
+                            <button
+                                type="button"
+                                onClick={() => setInfoWorker(w)}
+                                className="shrink-0 text-gray-400 hover:text-white p-1 rounded-sm hover:bg-gray-700"
+                                title="Worker details"
+                                aria-label="Worker details"
+                            >
+                                <InfoIcon className="w-5 h-5"/>
+                            </button>
                         </div>
                         <div className="text-xs text-gray-400 grid grid-cols-2 gap-1">
                             <span>Image</span>
@@ -198,6 +222,10 @@ const WorkersTab: React.FC = () => {
                     </div>
                 ))}
             </div>
+
+            {infoWorker && (
+                <WorkerInfoModal worker={infoWorker} now={now} onClose={() => setInfoWorker(null)}/>
+            )}
         </div>
     );
 };

--- a/src/frontend/src/components/icons/InfoIcon.tsx
+++ b/src/frontend/src/components/icons/InfoIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const InfoIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5}
-         stroke="currentColor" className="w-6 h-6">
+         stroke="currentColor" {...props} className={props.className ?? "w-6 h-6"}>
         <path strokeLinecap="round" strokeLinejoin="round"
               d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
     </svg>

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -956,6 +956,20 @@ export interface CompressionSweepState {
     orphaned: boolean;
 }
 
+/** One advertised conversion: a source extension and every target it can produce. */
+export interface WorkerConversion {
+    from: string;
+    to: string[];
+}
+
+/** One advertised @utility spec. Only `name`/`description` are rendered; extra keys are tolerated. */
+export interface WorkerUtilitySpec {
+    name?: string;
+    description?: string;
+
+    [key: string]: unknown;
+}
+
 /** One worker pod's self-reported registration entry. */
 export interface WorkerEntry {
     worker_id: string;
@@ -964,6 +978,11 @@ export interface WorkerEntry {
     started_at: number;
     last_heartbeat: number;
     online: boolean;
+    // The backend registration payload (worker.py) also advertises these; they are optional
+    // because the type historically dropped them and older workers may omit them.
+    source_exts?: string[];
+    conversions?: WorkerConversion[];
+    utilities?: WorkerUtilitySpec[];
 }
 
 export const viewerApi = {


### PR DESCRIPTION
Adds an **info button** to each worker row in the admin panel's **Workers** tab (desktop table + mobile card). Clicking it opens a modal with all the info the worker advertises.

## What the modal shows
- **Identity** — worker id, image tag, **commit sha** (stripped from the `sha-…` tag), started-at + uptime, last heartbeat, online status.
- **Capabilities** — the advertised capability chips.
- **Source extensions** — extensions this pod is licensed to handle.
- **Conversions** — the full advertised conversion matrix (`from → to[]`).
- **Utilities** — advertised `@utility` specs (name + description).
- **Packages** — the conda package manifest (adapy, **ada-cpp**, occt, ifcopenshell, numpy, …), lazy-fetched by image tag with a filter.

## Why it's small
Frontend-only. The backend **already** sends `source_exts` / `conversions` / `utilities` on the worker registration payload (`worker.py`) and serves the package manifest via `GET /api/admin/worker-packages/{image_tag}` — the `WorkerEntry` TS type just dropped the extra fields. So this:
- widens `WorkerEntry` (+ `WorkerConversion` / `WorkerUtilitySpec`) to surface what's already sent,
- adds `WorkerInfoModal.tsx` mirroring the existing `CliTokenButton` modal + `AuditLogTab`'s `WorkerPackages` fetch/filter,
- makes `InfoIcon` honor an overriding `className` (backward-compatible; existing callers pass none) so it fits a row button.

No backend changes.

**Verified:** `build:serve` (the deploy build) passes; `tsc --noEmit` clean on the changed files. Interactive check happens on the deployed branch (needs a live worker + admin auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)