### PR TITLE
fix: weld thick curved-shell cap-wall seams watertight

### DIFF
--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -23,7 +23,7 @@
 # MUST stay >=0.9.0 — older bases ship an emscripten 3.1.58 wheel that micropip
 # refuses against pyodide 0.29.4 ("Wheel was built with Emscripten v3.1.58 but
 # Pyodide was built with v4.0.9").
-ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.18.0
+ARG ADACPP_BASE_IMAGE=ghcr.io/krande/adacpp-wasm-base:0.19.0
 FROM ${ADACPP_BASE_IMAGE} AS adacpp-wheel
 
 # Stage 0b: build the pure-python adapy wheel for pyodide. The browser

--- a/pixi.lock
+++ b/pixi.lock
@@ -8229,7 +8229,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.18.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.19.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -8858,7 +8858,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.18.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.19.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -9256,7 +9256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.18.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.19.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -9468,7 +9468,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.18.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.19.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
@@ -10097,7 +10097,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.18.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.19.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.9.1-hf036a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py312h80b0991_2.conda
@@ -10495,7 +10495,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.18.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.19.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py312he06e257_2.conda
@@ -10977,7 +10977,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.18.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.19.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -11259,7 +11259,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.18.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.19.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -11452,7 +11452,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.18.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.19.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -12521,7 +12521,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.18.0-py312h29cc896_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.19.0-py312h29cc896_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/asyncpg-0.31.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
@@ -12855,7 +12855,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.48.0-he364bde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.18.0-py312h9b4feea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.19.0-py312h9b4feea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/asyncpg-0.31.0-py312hf7082af_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.5.0-py312h5f4ecc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py312h4b46afd_1.conda
@@ -13079,7 +13079,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.18.0-py312h710a262_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.19.0-py312h710a262_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/asyncpg-0.31.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.5.0-py312h06d0912_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py312hc6d9e41_1.conda
@@ -13231,29 +13231,28 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.18.0-py312h29cc896_0.conda
-  sha256: 922c13c51c891488fb8e3466933ad5a3337323d2880805b82e5977f423e45fa0
-  md5: ef4f3cfaf12393a4a0dc08b6f155e818
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ada-cpp-0.19.0-py312h29cc896_0.conda
+  sha256: a8572422385affbc0af6c99d881d4af91e8089e03d2cc979939414b4b13193e9
+  md5: 95f83e7e55f1485e1ee625aecece54be
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
   - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - libgcc >=14
   - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - ifcopenshell >=0.8.5,<0.8.6.0a0
+  - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
   license: GPL-3.0-or-later
-  license_family: GPL
   purls:
   - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.18.0,<0.18.1.0a0
-  size: 15495648
-  timestamp: 1784533793981
+    - ada-cpp >=0.19.0,<0.19.1.0a0
+  size: 15496860
+  timestamp: 1785082128602
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py312h5d8c7f2_0.conda
   sha256: 52f4d07b10fe4a1ded570b0708594d2d9075223e1dd94d0c5988eb71f724a5f2
   md5: 68edaee7692efb8bbef5e95375090189
@@ -24524,28 +24523,27 @@ packages:
     - _openmp_mutex >=4.5
   size: 8328
   timestamp: 1764092562779
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.18.0-py312h9b4feea_0.conda
-  sha256: 08ea1d4dbb99a75a893652ebbd523f2fb3783b2d4f799e8e410e47e6b21692d9
-  md5: be2bd2d75840e14d56beb8b6449f02d7
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ada-cpp-0.19.0-py312h9b4feea_0.conda
+  sha256: 4c9eeb7bd9e6df7daf19a11e6670d80e16d33c9a0f120be18e1f35fa91c40c94
+  md5: 3d71a6128319293dd0309327975121c9
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
-  - libcxx >=19
   - __osx >=11.0
-  - occt >=7.9.3,<7.9.4.0a0
-  - rocksdb >=10.6.2,<10.7.0a0
+  - libcxx >=19
   - ifcopenshell >=0.8.5,<0.8.6.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - rocksdb >=10.6.2,<10.7.0a0
   - python_abi 3.12.* *_cp312
+  - occt >=7.9.3,<7.9.4.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: GPL-3.0-or-later
-  license_family: GPL
   purls:
   - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.18.0,<0.18.1.0a0
-  size: 13330216
-  timestamp: 1784533839265
+    - ada-cpp >=0.19.0,<0.19.1.0a0
+  size: 13334529
+  timestamp: 1785082196109
 - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py312h0b1c2f0_0.conda
   sha256: feec9338ff6d56c28c06ec8176b90019d545d902c45132a218ca2320133f5538
   md5: 88eef704008ae051b5a8c54119eab94e
@@ -29852,29 +29850,28 @@ packages:
     - _openmp_mutex >=4.5
   size: 52252
   timestamp: 1770943776666
-- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.18.0-py312h710a262_0.conda
-  sha256: 7fd6029e384ad3abb25ad4553a17d30eecdf795f400a1dbb80455baacfc4d3c5
-  md5: fc12f13dbc2ad00e85e022aa8f26fe74
+- conda: https://conda.anaconda.org/conda-forge/win-64/ada-cpp-0.19.0-py312h710a262_0.conda
+  sha256: 5f44a71bf7ad99d5984fcb347e6221b5ff45570389a57b6ef9b96b8869a00f90
+  md5: 618203886cd2ab0f07236cbc878a0729
   depends:
   - python
   - gmsh >=4.15.2,<4.16.0a0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - occt >=7.9.3,<7.9.4.0a0
+  - python_abi 3.12.* *_cp312
   - ifcopenshell >=0.8.5,<0.8.6.0a0
   - rocksdb >=10.6.2,<10.7.0a0
-  - occt >=7.9.3,<7.9.4.0a0
   - libzlib >=1.3.2,<2.0a0
-  - python_abi 3.12.* *_cp312
   license: GPL-3.0-or-later
-  license_family: GPL
   purls:
   - pkg:pypi/ada-cpp?source=hash-mapping
   run_exports:
     weak:
-    - ada-cpp >=0.18.0,<0.18.1.0a0
-  size: 9728156
-  timestamp: 1784533822335
+    - ada-cpp >=0.19.0,<0.19.1.0a0
+  size: 9727041
+  timestamp: 1785082161117
 - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.13.5-py312h6b91d65_0.conda
   sha256: 539e8fba2b4835ee4437fa8b51056be2cf033ac4155f64a19e87855c2ae2af94
   md5: f5474e6e952ff964319851b1c68b7301

--- a/pixi.toml
+++ b/pixi.toml
@@ -183,7 +183,7 @@ occt = { version = "7.9.3.*", build = "novtk_*" }
 # for every other path (IFC/XML/FEM, occ-builtin fallback). Shares occt 7.9.3 with
 # pyocc (see above) so both coexist in one env.
 [feature.adacpp-runtime.dependencies]
-ada-cpp = "0.18.0.*"
+ada-cpp = "0.19.0.*"
 
 # ada-cpp CAD backend (AdacppBackend) — native CPython build of the
 # wasm-capable kernel. Brings its own occt 7.9.3 + gmsh + ifcopenshell,
@@ -207,8 +207,11 @@ ada-cpp = "0.18.0.*"
 # fidelity; 0.16.1 fixes per-face STEP colours without --face-regions plus CLI positional
 # args and pipeline validation. 0.18 adds AP242 mapped instancing, closed-B-spline
 # tessellation fixes, and the NGEOM record-stream emitters (stream_ngeom_to_step/ifc/glb/mesh
-# + ngeom_to_ifc_body_spf) — adapy's native Genie-XML export legs call these directly.
-ada-cpp = "0.18.0.*"
+# + ngeom_to_ifc_body_spf) — adapy's native Genie-XML export legs call these directly. 0.19 adds
+# the thick-shell cap<->wall seam-weld (Libtess2Opts::cdt_full_patch, env ADA_TESS_WT_CDT_FULL_PATCH,
+# honoured by the record streamer via ngeom_tess_params too) that the converter's curved-shell
+# auto-enable wiring drives — REQUIRED: without it hull/gxml thick shells render with cracked seams.
+ada-cpp = "0.19.0.*"
 
 [feature.adacpp.activation.env]
 ADAPY_CAD_BACKEND = "adacpp"

--- a/src/ada/cadit/ngeom/serialize.py
+++ b/src/ada/cadit/ngeom/serialize.py
@@ -455,6 +455,17 @@ class _Encoder:
 
     # --- topology ----------------------------------------------------------------------
     def _edge_curve(self, ec) -> int:
+        # Memoize by object identity, mirroring surface()/curve(). Two faces that
+        # share one EdgeCurve object (e.g. a thickened shell's cap and side-wall
+        # along their common edge — built with an id()-keyed edge copy in
+        # geom.primitive_brep) then emit ONE _EDGE_CURVE record, so the
+        # tessellator sees the faces as sharing that edge and can weld the seam.
+        # Orientation lives on the ORIENTED_EDGE record, not here, so sharing is
+        # safe (same_sense/geom are intrinsic to the shared curve).
+        key = id(ec)
+        hit = self._memo.get(key)
+        if hit is not None:
+            return hit
         geom = -1
         same_sense = getattr(ec, "same_sense", True)
         eg = getattr(ec, "edge_geometry", None)
@@ -463,10 +474,12 @@ class _Encoder:
                 geom = self.curve(eg)
             except _Unsupported:
                 geom = -1
-        return self._add(
+        idx = self._add(
             _EDGE_CURVE,
             self.v3(ec.start) + self.v3(ec.end) + self.i32(geom) + self.i32(1 if same_sense else 0),
         )
+        self._memo[key] = idx
+        return idx
 
     def oriented_edge(self, oe: cu.OrientedEdge) -> int:
         elem = oe.edge_element

--- a/src/ada/cadit/ngeom/serialize.py
+++ b/src/ada/cadit/ngeom/serialize.py
@@ -455,17 +455,6 @@ class _Encoder:
 
     # --- topology ----------------------------------------------------------------------
     def _edge_curve(self, ec) -> int:
-        # Memoize by object identity, mirroring surface()/curve(). Two faces that
-        # share one EdgeCurve object (e.g. a thickened shell's cap and side-wall
-        # along their common edge — built with an id()-keyed edge copy in
-        # geom.primitive_brep) then emit ONE _EDGE_CURVE record, so the
-        # tessellator sees the faces as sharing that edge and can weld the seam.
-        # Orientation lives on the ORIENTED_EDGE record, not here, so sharing is
-        # safe (same_sense/geom are intrinsic to the shared curve).
-        key = id(ec)
-        hit = self._memo.get(key)
-        if hit is not None:
-            return hit
         geom = -1
         same_sense = getattr(ec, "same_sense", True)
         eg = getattr(ec, "edge_geometry", None)
@@ -474,12 +463,10 @@ class _Encoder:
                 geom = self.curve(eg)
             except _Unsupported:
                 geom = -1
-        idx = self._add(
+        return self._add(
             _EDGE_CURVE,
             self.v3(ec.start) + self.v3(ec.end) + self.i32(geom) + self.i32(1 if same_sense else 0),
         )
-        self._memo[key] = idx
-        return idx
 
     def oriented_edge(self, oe: cu.OrientedEdge) -> int:
         elem = oe.edge_element

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -767,6 +767,26 @@ def _native_ngeom_mesh_route(
     return None
 
 
+def _model_has_thick_curved_shells(model) -> bool:
+    """True when the model carries a thickened curved-shell plate (``PlateCurved`` with
+    thickness). Those are the faces whose analytic ClosedShell grows a cap<->wall seam —
+    the case ``ADA_TESS_WT_CDT_FULL_PATCH`` welds watertight. Short-circuits on the first
+    match; any walk failure returns False so seam-weld selection never fails a conversion."""
+    try:
+        from ada import PlateCurved
+        from ada.config import Config
+
+        if not Config().geom_thicken_curved_shells:
+            return False
+        for p in model.get_all_parts_in_assembly(include_self=True):
+            for pl in p.plates:
+                if isinstance(pl, PlateCurved) and pl.t:
+                    return True
+    except Exception:  # noqa: BLE001 - detection must never fail the conversion
+        return False
+    return False
+
+
 def _export_with_ada(
     model,
     target_format: str,
@@ -800,71 +820,85 @@ def _export_with_ada(
     if target_format == "glb":
         on_progress("tessellating", 0.55)
         buf = io.BytesIO()
-        if merge_meshes is None:
-            import os as _os
-
-            merge_env = (_os.environ.get("ADA_GLB_MERGE_MESHES") or "").strip().lower()
-            merge_meshes = merge_env not in {"0", "false", "no", "off"}
-        # Fully-native record path (Genie-XML sources): adacpp tessellates and writes the GLB
-        # itself — no Python scene assembly. merge_meshes=False is the one-node-per-object debug
-        # layout, which the merge-by-colour native writer can't express; that stays on Python.
-        if merge_meshes:
-            native_out = _native_ngeom_mesh_route(
-                model, source_ext, "glb", out_path, on_progress, glb_tess_engine=glb_tess_engine
-            )
-            if native_out is not None:
-                return native_out
-        # FEM beam (line) elements render as line geometry by default; the solid (swept-
-        # profile) representation is delivered as a separate beam_solids sidecar the viewer
-        # lazy-loads when the "show beams as solid" toggle is on (mirrors the FEA-results path).
-        #
-        # Tessellation-engine selection (glb_tess_engine row option): to_gltf's BatchTessellator
-        # reads ADA_STREAM_TESS_PIPELINE, so set it from the per-job engine for the duration of
-        # the call and restore after. None/occ-builtin → force the OCC default (clear any ambient
-        # override); libtess2/adacpp-* → the matching OCC-free stream pipeline.
         import os as _os
 
-        _stream = _glb_engine_stream_value(glb_tess_engine)
-        _prev_stream = _os.environ.get("ADA_STREAM_TESS_PIPELINE")
-        if _stream:
-            _os.environ["ADA_STREAM_TESS_PIPELINE"] = _stream
-        else:
-            _os.environ.pop("ADA_STREAM_TESS_PIPELINE", None)
-        # Strict coverage (only meaningful alongside a non-OCC engine): make a stream→OCC
-        # fallback a hard error. Set the flag for the duration of to_gltf, restored below.
-        _prev_strict = _os.environ.get("ADA_STREAM_TESS_STRICT")
-        if strict_tess and _stream:
-            _os.environ["ADA_STREAM_TESS_STRICT"] = "1"
-        else:
-            _os.environ.pop("ADA_STREAM_TESS_STRICT", None)
+        if merge_meshes is None:
+            merge_env = (_os.environ.get("ADA_GLB_MERGE_MESHES") or "").strip().lower()
+            merge_meshes = merge_env not in {"0", "false", "no", "off"}
+        # Watertight cap<->wall seam-weld for thick curved shells (hull strakes / gxml curved
+        # plates): route their shared near-full faces through boundary-first CDT so per-solid
+        # welding closes the seam that the UV-grid fast path leaves cracked. Scoped over the whole
+        # GLB leg — both the native record route and the Python ``to_gltf`` fall-through read
+        # ADA_TESS_WT_CDT_FULL_PATCH in adacpp. Only set when such a plate is present (the adacpp
+        # side further gates on real shared-edge pins), so flat-plate / crane models are untouched;
+        # an explicit ambient value is respected. Restored in the finally for the next job.
+        _prev_cdt = _os.environ.get("ADA_TESS_WT_CDT_FULL_PATCH")
+        if _prev_cdt is None and _model_has_thick_curved_shells(model):
+            _os.environ["ADA_TESS_WT_CDT_FULL_PATCH"] = "1"
         try:
-            model.to_gltf(buf, merge_meshes=merge_meshes)
-        except ValueError as exc:
-            from ada.cadit.wasm_convert import _is_empty_scene
-
-            if not _is_empty_scene(exc):
-                raise
-            # The source parsed to zero renderable geometry (e.g. a SAT file holding only a
-            # wire/construction body, or an IFC with metadata only). Emit a valid seeded GLB so
-            # the conversion succeeds with an empty scene instead of erroring — same trick the
-            # step-stream and scene-based glb paths already use via _seed_empty_scene.
-            import trimesh
-
-            scene = trimesh.Scene()
-            _seed_empty_scene(scene)
-            buf = io.BytesIO()
-            scene.export(buf, file_type="glb")
-        finally:
-            if _prev_stream is None:
+            # Fully-native record path (Genie-XML sources): adacpp tessellates and writes the GLB
+            # itself — no Python scene assembly. merge_meshes=False is the one-node-per-object debug
+            # layout, which the merge-by-colour native writer can't express; that stays on Python.
+            if merge_meshes:
+                native_out = _native_ngeom_mesh_route(
+                    model, source_ext, "glb", out_path, on_progress, glb_tess_engine=glb_tess_engine
+                )
+                if native_out is not None:
+                    return native_out
+            # FEM beam (line) elements render as line geometry by default; the solid (swept-
+            # profile) representation is delivered as a separate beam_solids sidecar the viewer
+            # lazy-loads when the "show beams as solid" toggle is on (mirrors the FEA-results path).
+            #
+            # Tessellation-engine selection (glb_tess_engine row option): to_gltf's BatchTessellator
+            # reads ADA_STREAM_TESS_PIPELINE, so set it from the per-job engine for the duration of
+            # the call and restore after. None/occ-builtin → force the OCC default (clear any ambient
+            # override); libtess2/adacpp-* → the matching OCC-free stream pipeline.
+            _stream = _glb_engine_stream_value(glb_tess_engine)
+            _prev_stream = _os.environ.get("ADA_STREAM_TESS_PIPELINE")
+            if _stream:
+                _os.environ["ADA_STREAM_TESS_PIPELINE"] = _stream
+            else:
                 _os.environ.pop("ADA_STREAM_TESS_PIPELINE", None)
+            # Strict coverage (only meaningful alongside a non-OCC engine): make a stream→OCC
+            # fallback a hard error. Set the flag for the duration of to_gltf, restored below.
+            _prev_strict = _os.environ.get("ADA_STREAM_TESS_STRICT")
+            if strict_tess and _stream:
+                _os.environ["ADA_STREAM_TESS_STRICT"] = "1"
             else:
-                _os.environ["ADA_STREAM_TESS_PIPELINE"] = _prev_stream
-            if _prev_strict is None:
                 _os.environ.pop("ADA_STREAM_TESS_STRICT", None)
+            try:
+                model.to_gltf(buf, merge_meshes=merge_meshes)
+            except ValueError as exc:
+                from ada.cadit.wasm_convert import _is_empty_scene
+
+                if not _is_empty_scene(exc):
+                    raise
+                # The source parsed to zero renderable geometry (e.g. a SAT file holding only a
+                # wire/construction body, or an IFC with metadata only). Emit a valid seeded GLB so
+                # the conversion succeeds with an empty scene instead of erroring — same trick the
+                # step-stream and scene-based glb paths already use via _seed_empty_scene.
+                import trimesh
+
+                scene = trimesh.Scene()
+                _seed_empty_scene(scene)
+                buf = io.BytesIO()
+                scene.export(buf, file_type="glb")
+            finally:
+                if _prev_stream is None:
+                    _os.environ.pop("ADA_STREAM_TESS_PIPELINE", None)
+                else:
+                    _os.environ["ADA_STREAM_TESS_PIPELINE"] = _prev_stream
+                if _prev_strict is None:
+                    _os.environ.pop("ADA_STREAM_TESS_STRICT", None)
+                else:
+                    _os.environ["ADA_STREAM_TESS_STRICT"] = _prev_strict
+            on_progress("ready", 1.0)
+            return buf.getvalue()
+        finally:
+            if _prev_cdt is None:
+                _os.environ.pop("ADA_TESS_WT_CDT_FULL_PATCH", None)
             else:
-                _os.environ["ADA_STREAM_TESS_STRICT"] = _prev_strict
-        on_progress("ready", 1.0)
-        return buf.getvalue()
+                _os.environ["ADA_TESS_WT_CDT_FULL_PATCH"] = _prev_cdt
     if target_format == "ifc":
         on_progress("writing-ifc", 0.55)
         # The DEFAULT xml->ifc path is the streaming writer below (model.to_ifc(streaming=True)):

--- a/src/ada_cli/audit.py
+++ b/src/ada_cli/audit.py
@@ -71,7 +71,7 @@ ADACPP_MIN_VERSION = (0, 9, 0)
 # validated a wheel six releases older than the one it shipped.
 # Duplicated as a literal because it cannot be derived: ada_cli ships in a wheel that carries no
 # deploy/ tree. tests/core/test_deploy_pins.py fails if the two drift.
-ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.18.0"
+ADACPP_DEFAULT_IMAGE = "ghcr.io/krande/adacpp-wasm-base:0.19.0"
 IFC_WASM_WHEEL = "https://ifcopenshell.github.io/wasm-wheels/ifcopenshell-0.8.5-cp313-cp313-pyodide_2025_0_wasm32.whl"
 
 

--- a/tests/comms/rest/test_curved_shell_seam_weld.py
+++ b/tests/comms/rest/test_curved_shell_seam_weld.py
@@ -1,0 +1,101 @@
+"""The converter auto-enables the thick-curved-shell seam-weld (ADA_TESS_WT_CDT_FULL_PATCH)
+for models that carry a thickened PlateCurved, and leaves it off otherwise.
+
+The flag routes a thick curved shell's shared near-full cap/wall faces through adacpp's
+boundary-first CDT so the per-solid weld closes the cap<->wall seam (a hull strake that
+otherwise renders with a visible crack). This test pins the adapy-side wiring only — the
+native tessellation is stubbed, so it needs no adacpp build.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import ada
+import ada.geom.curves as cu
+import ada.geom.surfaces as su
+from ada.api.plates.base_pl import PlateCurved
+from ada.comms.rest import converter as C
+from ada.geom import Geometry
+from ada.geom.curves import KnotType
+from ada.geom.direction import Direction
+from ada.geom.points import Point
+
+
+def _curved_face() -> su.AdvancedFace:
+    surf = su.BSplineSurfaceWithKnots(
+        u_degree=2,
+        v_degree=1,
+        control_points_list=[
+            [Point(0, 0, 0), Point(0, 1, 0)],
+            [Point(0.5, 0, 0.3), Point(0.5, 1, 0.3)],
+            [Point(1, 0, 0), Point(1, 1, 0)],
+        ],
+        surface_form=su.BSplineSurfaceForm.UNSPECIFIED,
+        u_closed=False,
+        v_closed=False,
+        self_intersect=False,
+        u_multiplicities=[3, 3],
+        v_multiplicities=[2, 2],
+        u_knots=[0.0, 1.0],
+        v_knots=[0.0, 1.0],
+        knot_spec=KnotType.UNSPECIFIED,
+    )
+    p00, p10, p11, p01 = Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0)
+    e0 = cu.EdgeCurve(p00, p10, edge_geometry=cu.Line(p00, Direction(1, 0, 0)), same_sense=True)
+    e1 = cu.EdgeCurve(p10, p11, edge_geometry=cu.Line(p10, Direction(0, 1, 0)), same_sense=True)
+    e2 = cu.EdgeCurve(p01, p11, edge_geometry=cu.Line(p01, Direction(1, 0, 0)), same_sense=True)
+    e3 = cu.EdgeCurve(p01, p00, edge_geometry=cu.Line(p01, Direction(0, -1, 0)), same_sense=True)
+    loop = cu.EdgeLoop(
+        edge_list=[
+            cu.OrientedEdge(p00, p10, edge_element=e0, orientation=True),
+            cu.OrientedEdge(p10, p11, edge_element=e1, orientation=True),
+            cu.OrientedEdge(p11, p01, edge_element=e2, orientation=False),
+            cu.OrientedEdge(p01, p00, edge_element=e3, orientation=True),
+        ]
+    )
+    return su.AdvancedFace(bounds=[su.FaceBound(bound=loop, orientation=True)], face_surface=surf, same_sense=True)
+
+
+def _curved_shell_model() -> ada.Assembly:
+    pl = PlateCurved("curved", Geometry("curved", _curved_face(), None), t=0.025)
+    return ada.Assembly("m") / (ada.Part("p") / pl)
+
+
+def _flat_plate_model() -> ada.Assembly:
+    pl = ada.Plate.from_3d_points("flat", [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], 0.02)
+    return ada.Assembly("m") / (ada.Part("p") / pl)
+
+
+def test_detects_thick_curved_shell():
+    assert C._model_has_thick_curved_shells(_curved_shell_model()) is True
+
+
+def test_flat_plate_not_detected():
+    assert C._model_has_thick_curved_shells(_flat_plate_model()) is False
+
+
+@pytest.mark.parametrize("builder, expect_flag", [(_curved_shell_model, "1"), (_flat_plate_model, None)])
+def test_converter_scopes_seam_weld_flag(monkeypatch, tmp_path, builder, expect_flag):
+    """The native GLB route sees ADA_TESS_WT_CDT_FULL_PATCH set iff the model has a thick
+    curved shell, and the ambient env is unchanged after the call (no leak)."""
+    monkeypatch.delenv("ADA_TESS_WT_CDT_FULL_PATCH", raising=False)
+    out = tmp_path / "out.glb"
+    seen = {}
+
+    def _fake_native(model, source_ext, target, out_path, on_progress, *, glb_tess_engine=None):
+        seen["flag"] = os.environ.get("ADA_TESS_WT_CDT_FULL_PATCH")
+        out_path.write_bytes(b"glTF-stub")
+        return out_path  # short-circuits _export_with_ada before to_gltf/adacpp
+
+    monkeypatch.setattr(C, "_native_ngeom_mesh_route", _fake_native)
+
+    result = C._export_with_ada(
+        builder(), "glb", out, lambda *_: None, merge_meshes=True, source_ext=".xml", glb_tess_engine="libtess2"
+    )
+    assert result == out
+    assert seen["flag"] == expect_flag
+    # restored: the scoped set must not leak into the next job
+    assert "ADA_TESS_WT_CDT_FULL_PATCH" not in os.environ


### PR DESCRIPTION
## What

Welds the cap↔wall seams of thickened curved-shell plates so hull strakes (and any `PlateCurved` with thickness) render **watertight** instead of with a visible crack along every seam.

**Auto-enable the seam-weld for curved-shell GLB conversions** (`comms/rest/converter.py`): detect thickened `PlateCurved` geometry in the model and scope `ADA_TESS_WT_CDT_FULL_PATCH=1` over the whole GLB export leg (both the native record route and the `to_gltf` fall-through), so a thick curved shell's shared near-full cap/wall faces route through adacpp's boundary-first CDT and the per-solid weld closes the seam. Flat-plate / non-shell models never set the flag (and adacpp further gates on real shared-edge pins), so their tessellation is unchanged; the scoped set is restored in a `finally` so it can't leak into the next job.

## Depends on

Krande/adacpp#45 — **merged and released as ada-cpp 0.19.0** (on conda-forge). This PR bumps the `ada-cpp` pin to `0.19.0.*` (+ re-lock) and moves the wasm-base image pin to 0.19.0, so the record-stream path honours `ADA_TESS_WT_CDT_FULL_PATCH` in CI and production.

## Verification

- `tests/comms/rest/test_curved_shell_seam_weld.py` (new): detection is `True` for a thick `PlateCurved` / `False` for a flat `Plate`; the native route sees the flag set iff the model has a thick curved shell, and the ambient env is unchanged after the call.
- End-to-end through `_export_with_ada` with **no manual env**: a 12-plate curved-edge barrel section (generic, no client data) goes **576 open edges / watertight=False → 0 open / 0 non-manifold / watertight=True**.
- `tests/core/cadit/ngeom` + `tests/core/cadit/step/read/test_native_reader.py` + `tests/core/api/plates/test_plate_curved_thick.py` green (47 passed, 1 OCC-oracle skip). ruff / black / isort clean.

## Note

An earlier revision also memoized `_edge_curve` by identity; it was **dropped** — the weld is fully handled by `cdt_full_patch` (boundary pinning + position weld), and the memo made serialization depend on per-reader object sharing, breaking the native↔Python reader byte-identity oracle. The converter wiring is the whole fix.

## Performance

Favourable: on curved shell plates the boundary-first CDT the flag selects produces **fewer triangles and is faster** than the cracked grid fast path (−39% tris / −26% time at fine density). It only triggers where a thick curved shell exists, so flat-plate and non-shell conversions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJL3nLZg6crXgEWy5SCCi1

