### PR TITLE
feat: Sesam SIN/SIF reader and writer enrichments

### DIFF
--- a/src/ada/cadit/ifc/utils.py
+++ b/src/ada/cadit/ifc/utils.py
@@ -379,11 +379,23 @@ def write_elem_property_sets(metadata_props, elem, f, owner_history) -> None:
     if len(metadata_props.keys()) == 0 or Config().ifc_export_props is False:
         return None
 
-    if isinstance(list(metadata_props.values())[0], dict):
-        for pro_id, prop_ in metadata_props.items():
-            add_properties_to_elem(pro_id, f, elem, prop_, owner_history=owner_history)
-    else:
+    # Metadata may be homogeneous (every value a nested property-set dict),
+    # flat (all scalar/list values -> one "Properties" set), or MIXED (nested
+    # dicts alongside scalar tags, e.g. a "STRUCTURE_NAME": "Mini" next to
+    # computed sub-dicts). Route each dict value to its own named set and
+    # collect the remaining scalar/list values into a single default set,
+    # rather than assuming homogeneity from the first value alone — a mixed
+    # dict whose first value was a dict crashed on the scalar siblings.
+    nested = {k: v for k, v in metadata_props.items() if isinstance(v, dict)}
+    if not nested:
         add_properties_to_elem("Properties", f, elem, metadata_props, owner_history=owner_history)
+        return None
+
+    for pro_id, prop_ in nested.items():
+        add_properties_to_elem(pro_id, f, elem, prop_, owner_history=owner_history)
+    flat = {k: v for k, v in metadata_props.items() if not isinstance(v, dict)}
+    if flat:
+        add_properties_to_elem("Properties", f, elem, flat, owner_history=owner_history)
 
 
 def add_negative_extrusion(f, origin, loc_z, loc_x, depth, points, parent):

--- a/src/ada/fem/formats/sesam/read/cards.py
+++ b/src/ada/fem/formats/sesam/read/cards.py
@@ -66,6 +66,17 @@ SEC_MAP = {
         BaseTypes.TUBULAR,
         (("dy", "r"), ("t", "wt")),
     ),
+    "GLSEC": (
+        BaseTypes.ANGULAR,
+        (
+            ("hz", "h"),
+            ("ty", "t_w"),
+            ("by", "w_top"),
+            ("tz", "t_ftop"),
+            ("by", "w_btn"),
+            ("tz", "t_fbtn"),
+        ),
+    ),
 }
 MAT_MAP = {
     "MISOSEL": (
@@ -146,6 +157,7 @@ re_gbeamg = get_ff_regex(
 GIORH = DataCard("GIORH", ("geono", "hz", "ty", "bt", "tt", "bb", "tb", "sfy", "sfz", "NLOBYT|", "NLOBYB|", "NLOBZ|"))
 GBOX = DataCard("GBOX", ("geono", "hz", "ty", "tb", "tt", "by", "sfy", "sfz"))
 GPIPE = DataCard("GPIPE", ("geono", "di", "dy", "t", "sfy", "sfz"))
+GLSEC = DataCard("GLSEC", ("geono", "hz", "ty", "by", "tz", "sfy", "sfz", "NLOBY|", "NLOBZ|"))
 # Generic beam properties — area + moments of inertia only, no
 # profile geometry. The streaming bake uses these to synthesise a
 # tubular approximation for elements that reference a sec_id with
@@ -263,6 +275,10 @@ re_rvnodrea = get_ff_regex(
     "RVNODREA", "nfield", "ires", "inod", "irrea|", "irboc|", "itrans|", "F1|", "F2|", "F3|", "F4|", "F5|", "F6|"
 )
 
+# Result-case combination definitions. ``bulk`` is ``nres`` triplets of
+# ``(component IRES, real factor, imag factor)`` — the combined result IRES
+# (``ires``) is a *factored superposition* of the listed basic result cases.
+RDRESCMB = DataCard("RDRESCMB", ["nfield", "ires", "complx", "nres", "bulk"])
 re_rdrescmb = get_ff_regex("RDRESCMB", "nfield", "ires", "complx", "nres", "bulk")
 
 TDRESREF = DataCard("TDRESREF", ("nfield", "ires", "codnam", "codtxt", "name"))

--- a/src/ada/fem/formats/sesam/read/read_sections.py
+++ b/src/ada/fem/formats/sesam/read/read_sections.py
@@ -36,6 +36,7 @@ def get_sections(bulk_str, fem: FEM, mass_elem, spring_elem) -> FemSections:
         (get_isection(m, sect_names, fem) for m in cards.GIORH.to_ff_re().finditer(bulk_str)),
         (get_box_section(m, sect_names, fem) for m in cards.GBOX.to_ff_re().finditer(bulk_str)),
         (get_tubular_section(m, sect_names, fem) for m in cards.re_gpipe.finditer(bulk_str)),
+        (get_angular_section(m, sect_names, fem) for m in cards.GLSEC.to_ff_re().finditer(bulk_str)),
         (get_flatbar(m, sect_names, fem) for m in cards.re_gbarm.finditer(bulk_str)),
     )
 
@@ -86,6 +87,23 @@ def get_box_section(match, sect_names, fem) -> Section:
         t_w=roundoff(d["ty"]),
         t_ftop=roundoff(d["tt"]),
         t_fbtn=roundoff(d["tb"]),
+        parent=fem.parent,
+    )
+
+
+def get_angular_section(match, sect_names, fem) -> Section:
+    d = match.groupdict()
+    sec_id = str_to_int(d["geono"])
+    return Section(
+        name=sect_names[sec_id],
+        sec_id=sec_id,
+        sec_type=Section.TYPES.ANGULAR,
+        h=roundoff(d["hz"]),
+        w_top=roundoff(d["by"]),
+        w_btn=roundoff(d["by"]),
+        t_w=roundoff(d["ty"]),
+        t_ftop=roundoff(d["tz"]),
+        t_fbtn=roundoff(d["tz"]),
         parent=fem.parent,
     )
 

--- a/src/ada/fem/formats/sesam/results/read_sif.py
+++ b/src/ada/fem/formats/sesam/results/read_sif.py
@@ -103,7 +103,7 @@ OTHER_CARDS = [
     # coverage was being silently dropped.
     cards.GBEAMG,
 ]
-SECTION_CARDS = [cards.GIORH, cards.GBOX, cards.GPIPE]
+SECTION_CARDS = [cards.GIORH, cards.GBOX, cards.GPIPE, cards.GLSEC]
 RESULT_CARDS = [
     cards.RVNODDIS,
     cards.RVSTRESS,
@@ -330,13 +330,16 @@ class SifReader:
         if member_map is None:
             return None
         set_map = self.get_tdsetnam_map()
-        istype_i, isorig_i = cards.GSETMEMB.get_indices_from_names(["ISTYPE", "ISORIG"])
         sets = dict()
-        for set_id, props in member_map.items():
-            eltype = props[istype_i]
-            set_type = "nset" if eltype == 1 else "elset"
+        for set_id, members_by_type in member_map.items():
             set_name = set_map[set_id][-1]
-            members = props[isorig_i:]
+            # A set may carry both node (ISTYPE 1) and element (ISTYPE 2) records;
+            # prefer the element membership (what element scoping needs) and fall
+            # back to nodes for a pure node set.
+            if members_by_type["elset"]:
+                set_type, members = "elset", members_by_type["elset"]
+            else:
+                set_type, members = "nset", members_by_type["nset"]
             sets[set_name] = FemSet(set_name, members, set_type=set_type)
         return sets
 
@@ -609,7 +612,20 @@ class SifReader:
         res = self._other.get(cards.GSETMEMB.name)
         if res is None:
             return None
-        return {int(x[1]): [int(i) for i in x] for x in res}
+        # A Sesam set with many members is written as several GSETMEMB records
+        # that share the same set id (ISREF) but continue the member list, and a
+        # single set may mix node records (ISTYPE 1) with element records
+        # (ISTYPE 2). Concatenate the member chunks per set and per type — keying
+        # by ISREF alone (last record wins) silently dropped most members. ISORIG
+        # is a header field, not a member; the members are the fields after it.
+        isref_i, istype_i, isorig_i = cards.GSETMEMB.get_indices_from_names(["ISREF", "ISTYPE", "ISORIG"])
+        merged: dict[int, dict[str, list[int]]] = {}
+        for x in res:
+            rec = [int(i) for i in x]
+            entry = merged.setdefault(rec[isref_i], {"nset": [], "elset": []})
+            key = "nset" if rec[istype_i] == 1 else "elset"
+            entry[key].extend(rec[isorig_i + 1 :])
+        return merged
 
     def get_rdresref(self):
         res = self.get_result(cards.RDRESREF.name)[0][1]
@@ -847,20 +863,23 @@ class Sif2Mesh:
         nsp_i, eltyp_i = cards.RDPOINTS.get_indices_from_names(["nsp", "ieltyp"])
 
         rdpoints_map = self.sif.get_rdpoints_map()
-        # No element result-point geometry → no per-element force
-        # visualisation we can construct. Some eigen decks ship
-        # RDPOINTS as an empty type-block in every super-element;
-        # the nodal field path still works and is the primary bake
-        # output.
-        if not rdpoints_map:
-            return []
+        # RDPOINTS supplies the element type and result-point count, but it is
+        # only needed by the *shell* (stress) path. Some SINs (e.g. SESTRA
+        # "smart load combination" / force-only runs) ship no RDPOINTS at all
+        # yet still carry beam/line forces in RVFORCES. For line elements both
+        # pieces are recoverable without it — the element type from the mesh and
+        # the result-point count from the record length — so don't bail here.
+        rdforces_map = self.sif.get_rdforces_map()
+        elem_type_by_id = self._element_source_type_map() if not rdpoints_map else {}
 
         def keyfunc(x):
-            iielno = x[ielno_i]
-            rdpoints_res = rdpoints_map[iielno]
-            _nsp = int(rdpoints_res[nsp_i])
-            _elem_type = int(rdpoints_res[eltyp_i])
-            return x[ires_i], _nsp, _elem_type, x[irforc_i]
+            iielno = int(x[ielno_i])
+            rdpoints_res = rdpoints_map.get(iielno)
+            if rdpoints_res is not None:
+                return x[ires_i], int(rdpoints_res[nsp_i]), int(rdpoints_res[eltyp_i]), x[irforc_i]
+            ncomp = len(rdforces_map.get(int(x[irforc_i]), ())) or 1
+            nsp = (len(x) - (irforc_i + 1)) // ncomp
+            return x[ires_i], nsp, elem_type_by_id.get(iielno, -1), x[irforc_i]
 
         field_results = []
 
@@ -874,6 +893,20 @@ class Sif2Mesh:
             field_results.append(field_data)
 
         return field_results
+
+    def _element_source_type_map(self) -> dict[int, int]:
+        """Map element id → Sesam source element type, from the converted mesh.
+
+        Fallback for the element type when RDPOINTS is absent (line-force path).
+        """
+        out: dict[int, int] = {}
+        if self.mesh is None:
+            return out
+        for block in self.mesh.elements:
+            source_type = int(block.elem_info.source_type)
+            for eid in block.identifiers:
+                out[int(eid)] = source_type
+        return out
 
     def _get_line_field_data(self, rv_forces, ires, irforc, elem_type, nsp) -> ElementFieldData:
         from ada.fem.results.common import ElementFieldData
@@ -908,9 +941,13 @@ class Sif2Mesh:
 
         field_results = []
 
-        for (ires, nsp, elem_type, irstrs), rv_stresses in groupby(
-            sorted(sif.get_result(cards.RVSTRESS.name)[0][1][1:], key=keyfunc), key=keyfunc
-        ):
+        # Skip stress records whose element has no RDPOINTS entry — without the
+        # result-point definition there is no integration-point field to build.
+        # Real models occasionally carry such RVSTRESS rows; dropping them is
+        # safer than failing the whole read.
+        rv_rows = [x for x in sif.get_result(cards.RVSTRESS.name)[0][1][1:] if x[iielno_i] in rdpoints_map]
+
+        for (ires, nsp, elem_type, irstrs), rv_stresses in groupby(sorted(rv_rows, key=keyfunc), key=keyfunc):
             if elem_type not in (25, 24):
                 continue
 

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -39,7 +39,7 @@ _OTHER_CARDS = (
     cards.TDRESREF,
     cards.GBEAMG,
 )
-_SECTION_CARDS = (cards.GIORH, cards.GBOX, cards.GPIPE)
+_SECTION_CARDS = (cards.GIORH, cards.GBOX, cards.GPIPE, cards.GLSEC)
 _RESULT_CARDS = (
     cards.RVNODDIS,
     cards.RVSTRESS,
@@ -59,7 +59,7 @@ _RESULT_CARDS = (
 _TEXT_CARDS = {"TDSECT", "TDSETNAM", "TDMATER", "TDRESREF"}
 
 
-def _records_for(sin: SinFile, card, *, step: int | None = None) -> list[list]:
+def _records_for(sin: SinFile, card, *, step: int | None = None, elements: set[int] | None = None) -> list[list]:
     """Pull every record of one type into the SifReader-compatible
     list shape.
 
@@ -93,8 +93,12 @@ def _records_for(sin: SinFile, card, *, step: int | None = None) -> list[list]:
     # Only RV* records carry IRES in their first data word — apply the
     # step filter just there.
     rec_filter = step if (step is not None and type_name in _RV_TYPE_NAMES) else None
+    # ``elements`` narrows RVFORCES to the records whose IELNO (second data
+    # word) the caller needs — a caller that only reads line forces for a small
+    # subset of beam elements avoids decoding the whole model's forces.
+    elem_filter = elements if type_name == cards.RVFORCES.name else None
     out_num: list[list] = []
-    for rec in sin.iter_records(type_name, where_first_word=rec_filter):
+    for rec in sin.iter_records(type_name, where_first_word=rec_filter, where_second_word=elem_filter):
         # NFIELD is len(rec) + 1 (the count includes itself); +1 for
         # the implicit prefix word that SIN stores but iter_records
         # strips.
@@ -249,7 +253,8 @@ class SinReader(SifReader):
             sh[0, : len(super_header)] = super_header
             rows = np.vstack((sh, arr)) if arr.shape[0] else sh
         else:
-            rows = _records_for(self.sin, card, step=step)
+            elements = getattr(self, "_forces_elements", None) if card.name == cards.RVFORCES.name else None
+            rows = _records_for(self.sin, card, step=step, elements=elements)
             rows = [super_header, *rows]
         # The card's record bytes are now copied into ``rows`` — drop the
         # mmap pages so the next (often equally large) RV* table doesn't
@@ -272,12 +277,27 @@ class SinMetadata:
     ``"RVSTRESS"``, ``"RVFORCES"``) — the GLB/picker layer maps them
     to display names. Values are sorted unique IRES (step / result-
     reference id) values seen in that type's records.
+
+    ``combinations`` maps a combination result IRES → ``{basic IRES:
+    factor}`` (read from RDRESCMB); ``result_names`` maps any result
+    IRES → its label (from TDRESREF). A combination IRES may *or may
+    not* also appear in ``field_steps`` — SESTRA "smart load
+    combinations" usually store only the basic cases, so combination
+    results must be reconstructed by superposing the basic fields.
     """
 
     types: list[str]
     node_count: int
     element_count: int
     field_steps: dict[str, list[int]]
+    combinations: dict[int, dict[int, float]] = None
+    result_names: dict[int, str] = None
+
+    def __post_init__(self) -> None:
+        if self.combinations is None:
+            self.combinations = {}
+        if self.result_names is None:
+            self.result_names = {}
 
     @property
     def steps(self) -> list[int]:
@@ -290,6 +310,62 @@ class SinMetadata:
     @property
     def fields(self) -> list[str]:
         return list(self.field_steps.keys())
+
+    @property
+    def combination_ids(self) -> list[int]:
+        """All defined combination result IRES, sorted."""
+        return sorted(self.combinations)
+
+    @property
+    def selectable_cases(self) -> list[int]:
+        """Every result case a check can request: basic RV* steps plus any
+        defined combinations (which superpose those basic steps)."""
+        return sorted(set(self.steps) | set(self.combinations))
+
+
+def read_result_combinations(sin: SinFile) -> dict[int, dict[int, float]]:
+    """Read result-case combination definitions from a SIN.
+
+    Returns ``{combination IRES: {basic IRES: factor}}``. Each RDRESCMB
+    record is ``[ires, complx, nres, *triplets]`` where ``triplets`` is
+    ``nres`` groups of ``(component IRES, real factor, imag factor)``. The
+    imaginary factor is ignored (real-valued static combinations); zero
+    factors are dropped (the basic case contributes nothing and need not be
+    read). Component IRES reference basic result cases whose first RV* data
+    word (``ires``) equals them, so they double as the streaming step id.
+    """
+    if "RDRESCMB" not in sin.type_blocks:
+        return {}
+    out: dict[int, dict[int, float]] = {}
+    for rec in sin.iter_records("RDRESCMB"):
+        if len(rec) < 3:
+            continue
+        ires = int(round(rec[0]))
+        nres = int(round(rec[2]))
+        triplets = rec[3:]
+        comps: dict[int, float] = {}
+        for i in range(nres):
+            base = 3 * i
+            if base + 1 >= len(triplets):
+                break
+            basic = int(round(triplets[base]))
+            factor = float(triplets[base + 1])
+            if factor != 0.0:
+                comps[basic] = comps.get(basic, 0.0) + factor
+        out[ires] = comps
+    return out
+
+
+def read_result_names(sin: SinFile) -> dict[int, str]:
+    """Map result IRES → label from the SIN's TDRESREF text records."""
+    if "TDRESREF" not in sin.type_blocks:
+        return {}
+    out: dict[int, str] = {}
+    for prefix, text in sin.iter_text_records("TDRESREF"):
+        if not prefix or not text:
+            continue
+        out[int(round(prefix[0]))] = text
+    return out
 
 
 _RV_TYPE_NAMES = ("RVNODDIS", "RVSTRESS", "RVFORCES")
@@ -336,6 +412,8 @@ def read_sin_metadata(sin_file: str | pathlib.Path) -> SinMetadata:
             node_count=node_count,
             element_count=element_count,
             field_steps=field_steps,
+            combinations=read_result_combinations(sin),
+            result_names=read_result_names(sin),
         )
     finally:
         sin.close()
@@ -370,6 +448,27 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     return s2m.convert(name_path)
 
 
+def iter_sin_step_results(sin_file: str | pathlib.Path, steps, *, forces_elements: set[int] | None = None):
+    """Yield ``(step, FEAResult)`` reading the SIN once and reusing the mesh.
+
+    On large multi-step SINs this is dramatically faster than calling
+    :func:`read_sin_file` per step: the file is opened and its type blocks
+    decoded **once**, the step-invariant static blocks and the mesh are read
+    **once**, and only each step's RV* tables are re-read. Each yielded
+    ``FEAResult`` shares the same cached :class:`~ada.fem.results.common.Mesh`
+    instance. No LIS/MLG enrichment (not needed for value extraction).
+
+    ``forces_elements``: when given, the per-step RVFORCES decode is narrowed to
+    these element ids (IELNO). A caller that only reads line forces for a small
+    subset of beam elements avoids decoding the whole model's forces every step.
+    Leave ``None`` (the bake / full-materialise paths) to read all.
+    """
+    sin = open_sin(sin_file)
+    with SinStreamReader(sin, forces_elements=forces_elements) as reader:
+        for step in steps:
+            yield int(step), reader._load_step(int(step))
+
+
 class SinStreamReader:
     """Memory-bounded ``FEAStreamReader`` for Sesam SIN.
 
@@ -391,7 +490,7 @@ class SinStreamReader:
     Accepts a :class:`SinFile` or any ``ByteSource`` (wrapped into one).
     """
 
-    def __init__(self, source) -> None:
+    def __init__(self, source, *, forces_elements: set[int] | None = None) -> None:
         from ada.fem.formats.sesam.results.sin_reader import SinFile
 
         self.sin = source if isinstance(source, SinFile) else SinFile(source=source)
@@ -399,6 +498,9 @@ class SinStreamReader:
         self._rep = None  # FEAResultStreamAdapter over the first step (geometry/specs/beams)
         self._mesh = None  # step-invariant Mesh, built once and reused across steps
         self._reader = None  # one SinReader; static blocks read once, RV* re-read per step
+        # Optional RVFORCES element-id narrowing for callers that read line
+        # forces for only a small subset of beam elements.
+        self._forces_elements = set(forces_elements) if forces_elements is not None else None
 
     # ── lifecycle ─────────────────────────────────────────────────────
     def close(self) -> None:
@@ -441,6 +543,7 @@ class SinStreamReader:
         # RDPOINTS blocks once, then only re-read this step's RV* tables.
         if self._reader is None:
             self._reader = SinReader(sin=self.sin)
+            self._reader._forces_elements = self._forces_elements
             self._reader._load_static()
         reader = self._reader
         reader.load_step(int(step), cards=cards)
@@ -555,4 +658,13 @@ class SinStreamReader:
         return None
 
 
-__all__ = ["SinMetadata", "SinReader", "SinStreamReader", "read_sin_file", "read_sin_metadata"]
+__all__ = [
+    "SinMetadata",
+    "SinReader",
+    "SinStreamReader",
+    "iter_sin_step_results",
+    "read_result_combinations",
+    "read_result_names",
+    "read_sin_file",
+    "read_sin_metadata",
+]

--- a/src/ada/fem/formats/sesam/results/sin_reader.py
+++ b/src/ada/fem/formats/sesam/results/sin_reader.py
@@ -43,9 +43,6 @@ SLOT_VALUE_OFFSET = 4  # high 4 bytes of each 8-byte slot hold the value
 # path caused 15 GiB heap allocations on a 5 GB SIN and froze the
 # host machine.
 _MAX_RECORDS_PER_BLOCK = 50_000_000
-# Hard cap on individual dim values for the same reason. A single dim
-# > 10^8 is almost certainly a junk u32 read.
-_MAX_DIM_VALUE = 100_000_000
 # Upper bound on a single record's byte size. Real SIF records are
 # NFIELD words wide; even outliers like GELMNT1 with 20 node-ids cap
 # out at < 200 bytes. 4 KiB gives generous padding for variable-NFIELD
@@ -445,20 +442,19 @@ def _decode_type_block(source: ByteSource, preamble_off: int, next_preamble: int
         caps.append(_read_u32_slot(source, payload + (4 + 2 * d) * SLOT_STRIDE))
         dims.append(_read_u32_slot(source, payload + (4 + 2 * d + 1) * SLOT_STRIDE))
 
-    # Reject obvious-garbage dims before they balloon the pointer table.
-    # A junk u32 read can put 2^31 in a dim slot; allocating a list of
-    # 2 billion Python ints is what froze the host machine.
-    if any(d > _MAX_DIM_VALUE for d in dims):
-        raise ValueError(f"dim value > {_MAX_DIM_VALUE} in block {name!r}: {dims} — likely junk header")
-
     total_records = 1
     for d in dims:
         total_records *= d
-    if total_records > _MAX_RECORDS_PER_BLOCK:
-        raise ValueError(
-            f"block {name!r} dims {dims} → {total_records} records "
-            f"exceeds {_MAX_RECORDS_PER_BLOCK} cap — likely junk header"
-        )
+
+    # A dim slot can hold a junk / uninitialised value (e.g. a GSETMEMB ``cap``
+    # field of ~1e8 in some exports). Do NOT drop the block over that — the
+    # pointer table is authoritative: ``_read_pointer_table`` clamps the read to
+    # the file size and truncates at the first invalid pointer, so it finds the
+    # real record count regardless of the dim. Only cap the *requested* slot
+    # count so a 2-billion dim can't balloon the request before that clamp.
+    read_cap = total_records + 1
+    if read_cap <= 0 or read_cap > _MAX_RECORDS_PER_BLOCK:
+        read_cap = _MAX_RECORDS_PER_BLOCK
 
     # Stream the pointer table (each slot is 8 bytes, the value half in
     # the +4 word), validating + truncating at the real cutoff as it
@@ -476,7 +472,7 @@ def _decode_type_block(source: ByteSource, preamble_off: int, next_preamble: int
     # records live at slots[1..N]. dims=(N,) therefore needs N+1 slots,
     # otherwise the last record (id N) falls off the end — multi-super-
     # element files would lose one node/element per SE.
-    pointer_table = _read_pointer_table(source, pointer_table_offset, total_records + 1)
+    pointer_table = _read_pointer_table(source, pointer_table_offset, read_cap)
     total_records = int(pointer_table.size)
 
     records_start = pointer_table_offset + total_records * SLOT_STRIDE
@@ -964,7 +960,13 @@ class SinFile:
         out[:, 1:] = src.gather_f32(word_idx).reshape(nz.size, n_data)
         return out
 
-    def iter_records(self, name: str, *, where_first_word: int | None = None) -> Iterator[tuple[float, ...]]:
+    def iter_records(
+        self,
+        name: str,
+        *,
+        where_first_word: int | None = None,
+        where_second_word: set[int] | None = None,
+    ) -> Iterator[tuple[float, ...]]:
         """Yield one tuple of float32 values per populated record (the
         SIF "data" fields).
 
@@ -1009,6 +1011,12 @@ class SinFile:
                 # skip mismatches before paying for the full unpack.
                 first = int(src.f32(data_byte))
                 if first != where_first_word:
+                    continue
+            if where_second_word is not None:
+                # Same cheap pre-filter on the second data word (e.g. IELNO
+                # for RVFORCES) — skip records for elements the caller does
+                # not need before paying for the full per-record unpack.
+                if n_data < 2 or int(src.f32(data_byte + 4)) not in where_second_word:
                     continue
             yield struct.unpack(f"<{n_data}f", src.read(data_byte, n_data * 4))
 

--- a/src/ada/fem/formats/sesam/write/write_bm_profiles.py
+++ b/src/ada/fem/formats/sesam/write/write_bm_profiles.py
@@ -30,11 +30,13 @@ def general_beam(sec: Section, sec_id) -> str:
 
 def angular(sec: Section, sec_id) -> str:
     p = sec.properties
+    width = sec.w_top if sec.w_top is not None else sec.w_btn
+    thickness = sec.t_ftop if sec.t_ftop is not None else sec.t_fbtn
     return write_ff(
         "GLSEC",
         [
-            (sec_id, sec.h, sec.t_w, sec.w_btn),
-            (sec.t_fbtn, p.Sfy, p.Sfz, 1),
+            (sec_id, sec.h, sec.t_w, width),
+            (thickness, p.Sfy, p.Sfz, 1),
         ],
     )
 

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -1750,6 +1750,7 @@ def build_manifest(
     mesh_glb_filename: str,
     field_metas: list[FieldArtefactMeta],
     *,
+    source_sha256: str | None = None,
     elem_field_metas: list[ElementFieldArtefactMeta] | None = None,
     mesh_edges_filename: str | None = None,
     n_edges: int = 0,
@@ -1994,6 +1995,8 @@ def build_manifest(
         "mesh": mesh_meta,
         "fields": fields_payload,
     }
+    if source_sha256:
+        manifest["source_sha256"] = str(source_sha256)
     if history is not None and (history.regions or history.variables or history.series):
         manifest["history"] = build_history_payload(history)
     if lineage is not None and (lineage.get("assembly_guid") or lineage.get("groups")):
@@ -2291,6 +2294,7 @@ def bake_fea_artefacts_from_source(
     out_dir: os.PathLike,
     *,
     src_key: str = "",
+    source_sha256: str | None = None,
     legacy_glb_url_template: str | None = None,
 ) -> "BakeResult":
     """End-to-end bake from a source file path. Picks the right
@@ -2306,6 +2310,7 @@ def bake_fea_artefacts_from_source(
             reader,
             out_dir,
             src=src,
+            source_sha256=source_sha256,
             legacy_glb_url_template=legacy_glb_url_template,
         )
 
@@ -2323,6 +2328,7 @@ def bake_artefacts(
     out_dir: os.PathLike,
     *,
     src: str = "",
+    source_sha256: str | None = None,
     legacy_glb_url_template: str | None = None,
     nodal_only: bool = True,
     include_element_fields: bool = True,
@@ -2497,6 +2503,7 @@ def bake_artefacts(
 
     manifest = build_manifest(
         src=src,
+        source_sha256=source_sha256,
         mesh_geom=geom,
         mesh_glb_filename=mesh_glb_path.name,
         field_metas=field_metas,

--- a/tests/core/cadit/ifc/roundtripping/test_property_sets.py
+++ b/tests/core/cadit/ifc/roundtripping/test_property_sets.py
@@ -11,3 +11,20 @@ def test_create_beam_with_property_sets():
     f = b.to_ifc(file_obj_only=True)
     for pset in f.by_type("IfcPropertySet"):
         assert pset.OwnerHistory.is_a() == "IfcOwnerHistory"
+
+
+def test_write_mixed_metadata_property_sets():
+    # Metadata mixing a nested property-set dict with a scalar tag must not
+    # crash the IFC writer. The old heuristic keyed off the first value only —
+    # a dict sorting first sent the scalar sibling ("Mini") through .items().
+    # Nested dicts become their own named sets; scalars land in "Properties".
+    bm = ada.Beam("bm1", (0, 0, 0), (1, 0, 0), "IPE300")
+    bm.metadata = {"Grouping": {"level": 2}, "STRUCTURE_NAME": "Mini"}
+    a = ada.Assembly("A") / (ada.Part("P") / bm)
+    f = a.to_ifc(file_obj_only=True)
+
+    psets = {p.Name: p for p in f.by_type("IfcPropertySet")}
+    assert "Grouping" in psets
+    assert "Properties" in psets
+    prop_names = {pr.Name for pr in psets["Properties"].HasProperties}
+    assert "STRUCTURE_NAME" in prop_names

--- a/tests/core/fem/results/test_fea_artefacts.py
+++ b/tests/core/fem/results/test_fea_artefacts.py
@@ -1004,6 +1004,23 @@ def test_build_manifest_omits_history_when_empty(monkeypatch):
     assert "history" not in manifest
 
 
+def test_build_manifest_includes_optional_source_hash():
+    from ada.fem.results.artefacts import MeshGeometry, build_manifest
+
+    geom = MeshGeometry(
+        points=np.zeros((1, 3), dtype=np.float64),
+        cell_blocks=[],
+    )
+    manifest = build_manifest(
+        src="dummy.SIN",
+        source_sha256="abc123",
+        mesh_geom=geom,
+        mesh_glb_filename="fea.mesh.glb",
+        field_metas=[],
+    )
+    assert manifest["source_sha256"] == "abc123"
+
+
 def test_classify_field_by_name():
     """Spot-check the name-based fallback so unfamiliar solvers get a
     sensible category. The bake-level test asserts the manifest


### PR DESCRIPTION
Core adapy Sesam-format enrichments, split out from the (frontend-oriented) capacity plugin work so adapy itself stays feature-complete. Pure backend reader/writer improvements — no UI, no plugin coupling.

## What's included
- **GLSEC angular (L) sections** — read (`cards.GLSEC` + `get_angular_section`, wired into the SIF/SIN section-card lists) and write (`write_bm_profiles.angular` now uses a `w_top`/`t_ftop` fallback instead of always taking the bottom flange).
- **GSETMEMB set-membership fix** — a Sesam set is written as several records sharing `ISREF`, and a set may mix node (`ISTYPE 1`) and element (`ISTYPE 2`) records. Keying by `ISREF` alone (last record wins) silently dropped most members. Now concatenated per set and per type, preferring element membership for scoping.
- **Force-only / no-RDPOINTS SINs** (e.g. SESTRA "smart load combination" runs) — recover line/beam forces from `RVFORCES` without `RDPOINTS` (element type from the mesh, result-point count from the record length); skip `RVSTRESS` rows lacking an `RDPOINTS` entry rather than failing the whole read.
- **SIN decode robustness** — a junk/uninitialised dim slot no longer drops a valid block; the pointer table is authoritative, so only the *requested* slot count is capped.
- **Result-case combinations** — read `RDRESCMB` (combination → `{basic: factor}`) and `TDRESREF` labels into `SinMetadata` (`combinations`/`result_names`, `combination_ids`/`selectable_cases`).
- **Optional RVFORCES element narrowing** — `iter_records(where_second_word=...)`, `_records_for(elements=...)`, `SinStreamReader(forces_elements=...)`, plus a single-open `iter_sin_step_results` helper for fast multi-step reads. All opt-in (default `None` = read all), no behaviour change for existing callers.
- **Optional `source_sha256`** provenance field on the FEA manifest.

## Verification
- `pixi run -e lint lint-check` — clean
- `pixi run -e tests pytest tests/core/fem/formats tests/core/fem/results tests/core/fem/sections` — 212 passed, 8 skipped
- Targeted Sesam/artefact suite (172 passed) incl. a new `test_build_manifest_includes_optional_source_hash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)