### PR TITLE
feat: add three plugin extension points (admin region, model load, public settings)

### DIFF
--- a/src/frontend/src/__tests__/plugins/demoPlugin.test.tsx
+++ b/src/frontend/src/__tests__/plugins/demoPlugin.test.tsx
@@ -21,7 +21,17 @@ function fakeCtx(pluginId = ""): AdaPluginContext {
     pluginId,
     api: { base: "/api", plugin: (id?: string) => `/api/plugins/${id ?? pluginId}` },
     stores: {} as AdaPluginContext["stores"],
-    scene: { add() {}, remove() {}, requestRender() {}, paintField() {}, getActiveFeaMesh: () => null, getSelectedFeaRangeIds: () => [] },
+    scene: {
+      add() {},
+      remove() {},
+      requestRender() {},
+      paintField() {},
+      getActiveFeaMesh: () => null,
+      getSelectedFeaRangeIds: () => [],
+      setSelectedFeaRanges() {},
+      loadModelFromUrl: async () => {},
+      unloadModel() {},
+    },
     scope: () => "user:me",
     theme: {
       bg: "#111827",

--- a/src/frontend/src/__tests__/plugins/registry.test.ts
+++ b/src/frontend/src/__tests__/plugins/registry.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, test } from "node:test";
 import {
   _versionSatisfies,
   disablePlugin,
+  getAdminTabs,
   getPanelsForRegion,
   getRegisteredPlugins,
   getResultSidecarLoaders,
@@ -29,6 +30,9 @@ function fakeCtx(): AdaPluginContext {
       paintField() {},
       getActiveFeaMesh: () => null,
       getSelectedFeaRangeIds: () => [],
+      setSelectedFeaRanges() {},
+      loadModelFromUrl: async () => {},
+      unloadModel() {},
     },
     scope: () => "user:me",
     theme: {
@@ -96,6 +100,52 @@ test("orders panels within a region by (order, id)", () => {
   });
   const ids = getPanelsForRegion("fem-sidebar", fakeCtx()).map((p) => p.panel.id);
   assert.deepEqual(ids, ["a:early", "z:p", "a:late"]);
+});
+
+test("admin tabs: labelled from asTab, ordered, and gated by activation", () => {
+  registerPlugin({
+    id: "later",
+    panels: [
+      { id: "t", region: "admin", order: 20, asTab: { label: "Later" }, render: () => null },
+    ],
+  });
+  registerPlugin({
+    id: "first",
+    panels: [
+      { id: "t", region: "admin", order: 1, asTab: { label: "First" }, render: () => null },
+      // No asTab: an admin panel is always a tab, so it falls back to its id.
+      { id: "unlabelled", region: "admin", order: 5, render: () => null },
+      // Another region must not leak into the admin strip.
+      { id: "sidebar", region: "fem-sidebar", render: () => null },
+    ],
+  });
+  registerPlugin({
+    id: "off",
+    activationPredicate: () => false,
+    panels: [{ id: "t", region: "admin", asTab: { label: "Off" }, render: () => null }],
+  });
+
+  const tabs = getAdminTabs(fakeCtx());
+  assert.deepEqual(
+    tabs.map((t) => [t.panel.id, t.label]),
+    [
+      ["first:t", "First"],
+      ["first:unlabelled", "first:unlabelled"],
+      ["later:t", "Later"],
+    ],
+  );
+  assert.deepEqual(
+    tabs.map((t) => t.pluginId),
+    ["first", "first", "later"],
+  );
+});
+
+test("admin tabs are empty when no plugin contributes one", () => {
+  registerPlugin({
+    id: "nope",
+    panels: [{ id: "p", region: "top-panel", render: () => null }],
+  });
+  assert.deepEqual(getAdminTabs(fakeCtx()), []);
 });
 
 test("respects whole-plugin and per-slot activation predicates", () => {

--- a/src/frontend/src/components/admin/AdminPanel.tsx
+++ b/src/frontend/src/components/admin/AdminPanel.tsx
@@ -1,6 +1,8 @@
 import React, {useEffect, useState} from "react";
 import {AdminTab} from "@/state/adminPanelStore";
 import {useMeStore} from "@/state/meStore";
+import ErrorBoundary from "@/components/common/ErrorBoundary";
+import {disablePlugin, getAdminTabs, makePluginContextStandalone} from "@/plugins";
 import AuditLogTab from "./AuditLogTab";
 import AuditRunsTab from "./AuditRunsTab";
 import CliTokenButton from "./CliTokenButton";
@@ -36,9 +38,12 @@ const VALID_TABS = new Set<AdminTab>([
     "equipment", "system", "engines",
 ]);
 
-function readTabFromHash(): AdminTab {
-    const raw = (window.location.hash || "").replace(/^#/, "").trim() as AdminTab;
-    return VALID_TABS.has(raw) ? raw : "audit";
+// A tab id is either one of the built-ins above or a plugin panel's namespaced
+// id (``{pluginId}:{panelId}``). ``extra`` carries the plugin ones so a deep link
+// to a plugin tab survives a reload instead of falling back to "audit".
+function readTabFromHash(extra: ReadonlySet<string>): string {
+    const raw = (window.location.hash || "").replace(/^#/, "").trim();
+    return VALID_TABS.has(raw as AdminTab) || extra.has(raw) ? raw : "audit";
 }
 
 interface AdminPanelProps {
@@ -55,14 +60,21 @@ interface AdminPanelProps {
 const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false, initialTab}) => {
     const syncHash = !embedded;
     const isAdmin = useMeStore((s) => s.isAdmin);
-    const [tab, setTab] = useState<AdminTab>(() => (syncHash ? readTabFromHash() : (initialTab ?? "audit")));
+    // Plugin-contributed tabs. Recomputed each render (like PluginPanelRegion)
+    // so a plugin whose activation predicate flips shows/hides its tab live.
+    const pluginTabs = getAdminTabs(makePluginContextStandalone(""));
+    const pluginTabIds = new Set(pluginTabs.map((t) => t.panel.id));
+    const [tab, setTab] = useState<string>(() =>
+        syncHash ? readTabFromHash(pluginTabIds) : (initialTab ?? "audit"),
+    );
+    const activePlugin = pluginTabs.find((t) => t.panel.id === tab) ?? null;
 
     // Two-way bind ``tab`` to ``window.location.hash`` so reloads stay
     // on the selected tab AND back/forward navigation works inside
     // the page. setTab writes; popstate / hashchange reads back.
     useEffect(() => {
         if (!syncHash) return;
-        const onChange = () => setTab(readTabFromHash());
+        const onChange = () => setTab(readTabFromHash(pluginTabIds));
         window.addEventListener("hashchange", onChange);
         return () => window.removeEventListener("hashchange", onChange);
     }, [syncHash]);
@@ -153,6 +165,15 @@ const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false, initialTab}) =
                     <TabButton active={tab === "engines"} onClick={() => setTab("engines")}>
                         Engines
                     </TabButton>
+                    {pluginTabs.map(({panel, label}) => (
+                        <TabButton
+                            key={panel.id}
+                            active={tab === panel.id}
+                            onClick={() => setTab(panel.id)}
+                        >
+                            {label}
+                        </TabButton>
+                    ))}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                     <CliTokenButton/>
@@ -193,6 +214,44 @@ const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false, initialTab}) =
                     <div className="h-full overflow-y-auto p-3 sm:p-4">
                         <ProceduralEngineAdminPanel embedded/>
                     </div>
+                )}
+                {activePlugin && (
+                    // Same containment contract as every other plugin slot host:
+                    // a crashing panel disables its plugin for the session rather
+                    // than white-screening the admin page.
+                    <ErrorBoundary
+                        key={activePlugin.panel.id}
+                        label={`Plugin ${activePlugin.pluginId}`}
+                        fallback={(error, reset) => {
+                            disablePlugin(
+                                activePlugin.pluginId,
+                                `admin panel render threw: ${error.message}`,
+                            );
+                            return (
+                                <div className="p-4 text-sm">
+                                    <div className="font-semibold text-red-300">
+                                        Plugin “{activePlugin.pluginId}” hit an error
+                                    </div>
+                                    <div className="mt-1 mb-2 break-words text-gray-400 text-xs">
+                                        {error.message}
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={reset}
+                                        className="rounded-sm bg-gray-700 px-2 py-1 text-white hover:bg-gray-600"
+                                    >
+                                        Retry
+                                    </button>
+                                </div>
+                            );
+                        }}
+                    >
+                        <div className="h-full overflow-y-auto">
+                            {activePlugin.panel.render(
+                                makePluginContextStandalone(activePlugin.pluginId),
+                            )}
+                        </div>
+                    </ErrorBoundary>
                 )}
             </main>
         </div>

--- a/src/frontend/src/plugins/context.ts
+++ b/src/frontend/src/plugins/context.ts
@@ -15,6 +15,7 @@ import {
   getActiveFeaSelectedRangeIds,
   setActiveFeaSelectedRangeIds,
 } from "@/utils/scene/handlers/load_fea_streaming";
+import { useModelState } from "@/state/modelState";
 import { getSingletonViewerStores, type AdaViewerStores } from "@/state/AdaViewerContext";
 import type {
   AdaPluginContext,
@@ -85,6 +86,33 @@ function makeSceneHandle(): SceneHandle {
     getActiveFeaMesh: () => getActiveFeaMesh(),
     getSelectedFeaRangeIds: () => getActiveFeaSelectedRangeIds(),
     setSelectedFeaRanges: (rangeIds, additive) => setActiveFeaSelectedRangeIds(rangeIds, additive),
+    async loadModelFromUrl(owner, url, opts) {
+      // Dynamic import for the same reason overlay_file_in_scene is dynamically
+      // imported at its call sites: the loader pulls in three + GLTFLoader +
+      // the meshopt decoder, and this module is on the boot path.
+      const { setupModelLoaderAsync } = await import(
+        "@/components/viewer/sceneHelpers/setupModelLoader"
+      );
+      const sourceName =
+        opts?.sourceName || url.split("?")[0].split("/").pop() || `${owner}-model`;
+      const group = await setupModelLoaderAsync(
+        url,
+        opts?.translate ?? true,
+        undefined,
+        sourceName,
+        opts?.headers,
+      );
+      // Register the source -> group mapping so the model shows up in the
+      // loaded-sources list and `unloadModel` can drop just this one, exactly as
+      // core's own overlay path does.
+      useModelState.getState().registerLoadedSource(sourceName, group);
+      requestRender();
+    },
+    unloadModel(sourceName) {
+      void import("@/utils/scene/handlers/unload_source_from_scene").then(
+        ({ unload_source_from_scene }) => unload_source_from_scene(sourceName),
+      );
+    },
   };
 }
 

--- a/src/frontend/src/plugins/registry.ts
+++ b/src/frontend/src/plugins/registry.ts
@@ -20,13 +20,15 @@ import type { AdaViewerStores } from "@/state/AdaViewerContext";
 export const PLUGIN_API_VERSION = "1.0.0";
 
 // The named mount regions core exposes in Phase 1. Deliberately small
-// (`fem-sidebar` covers the FEM simulation panel, `top-panel` the menu bar);
-// more are added on demand rather than up-front.
+// (`fem-sidebar` covers the FEM simulation panel, `top-panel` the menu bar,
+// `admin` the /admin page's tab strip); more are added on demand rather than
+// up-front.
 export type PluginRegion =
   | "fem-sidebar"
   | "top-panel"
   | "scene-info"
-  | "storage-detail";
+  | "storage-detail"
+  | "admin";
 
 export type PluginLogLevel = "debug" | "info" | "warn" | "error";
 
@@ -78,6 +80,26 @@ export interface SceneHandle {
   // ``additive`` false (default) replaces the selection; true unions. No-op when
   // no FEA model is loaded. Plain string ids — no three import, names no plugin.
   setSelectedFeaRanges: (rangeIds: string[], additive?: boolean) => void;
+  // Load a GLB/glTF from an arbitrary URL and overlay it in the scene, the same
+  // way core's own storage-browser load does — a plugin sourcing geometry from
+  // somewhere core knows nothing about (an external catalog, a signed URL) has no
+  // other way in: `add` takes an already-built Object3D, and core's loaders all
+  // resolve a key under a viewer scope. Resolves once the model is in the scene.
+  //
+  // `sourceName` is the identity the model is registered under (defaults to the
+  // URL's filename) and the handle `unloadModel` takes. `headers` are passed to
+  // the loader for a URL that needs auth; omit for an already-signed one.
+  // `translate` (default true) reuses the first-loaded model's recentering frame
+  // so an overlay lands aligned rather than re-derived from its own bbox.
+  loadModelFromUrl: (
+    owner: string,
+    url: string,
+    opts?: { sourceName?: string; headers?: Record<string, string>; translate?: boolean },
+  ) => Promise<void>;
+  // Remove a model previously loaded through `loadModelFromUrl` (or any source
+  // registered under that name), disposing its GPU resources. No-op when the
+  // name is not loaded.
+  unloadModel: (sourceName: string) => void;
 }
 
 /** Namespaced REST client helper — plugin routes live under `/api/plugins/{id}`. */
@@ -142,6 +164,10 @@ export interface PanelSlot {
   // Simulation panel (alongside the built-in "animation" tab) rather than
   // stacking it inline. Buttonless / non-`asTab` fem-sidebar panels keep
   // rendering inline via `PluginPanelRegion` — this is purely additive.
+  //
+  // `admin` panels are ALWAYS tabs (the admin page is a tab strip), so there
+  // `asTab` is optional and only supplies the label; without it the namespaced
+  // panel id is shown.
   asTab?: {
     label: string;
     order?: number;
@@ -412,6 +438,26 @@ export function findSimulationTabById(panelId: string): SimulationTabEntry | nul
     }
   }
   return null;
+}
+
+/** One plugin-contributed admin tab. */
+export interface AdminTabEntry {
+  pluginId: string;
+  panel: PanelSlot;
+  label: string;
+}
+
+/** `admin` panels, filtered by activation exactly like `getPanelsForRegion` and
+ * ordered by `(order ?? 0, id)`. Core appends these after the built-in admin
+ * tabs; each carries its owning `pluginId` so core can build a per-plugin ctx and
+ * ErrorBoundary-wrap the mount. Empty when no plugin advertises an admin tab (the
+ * page then looks byte-identical to the pre-plugin admin page). */
+export function getAdminTabs(ctx: AdaPluginContext): AdminTabEntry[] {
+  return getPanelsForRegion("admin", ctx).map(({ pluginId, panel }) => ({
+    pluginId,
+    panel,
+    label: panel.asTab?.label ?? panel.id,
+  }));
 }
 
 /** Color-field providers available under the given ctx, ordered by `id`. */


### PR DESCRIPTION
Three general extension points the viewer plugin system was missing. None names a plugin, and all are additive — with no plugin registered, the admin page, the scene and the settings surface behave byte-identically.

All three came out of building a real out-of-tree plugin and hitting walls that were not specific to it.

## 1. `admin` plugin region

`PluginRegion` gains `"admin"`. New `getAdminTabs(ctx)` returns the panels registered there — label from `asTab.label`, falling back to the namespaced panel id, since an admin panel is always a tab (the admin page *is* a tab strip). `AdminPanel.tsx` renders them after its built-in tabs, ErrorBoundary-wrapped exactly like every other slot host, and `readTabFromHash` now accepts plugin tab ids so `/admin#my-plugin:panel` survives a reload.

Before this, a plugin had nowhere to put admin UI: `fem-sidebar` and `top-panel` are viewer chrome, and the admin page's tab set was a closed literal union.

## 2. `SceneHandle.loadModelFromUrl` / `unloadModel`

A plugin sourcing geometry from somewhere core knows nothing about had no way into the scene — `add` takes an already-built `Object3D`, and every core loader resolves a key under a viewer scope. These wrap the existing `setupModelLoaderAsync` + `registerLoadedSource` / `unload_source_from_scene` paths, so a plugin-loaded model is registered, disposed and listed identically to a storage-browser load. The loader import is dynamic, matching how `overlay_file_in_scene` is imported at its call sites, so the boot path does not gain three + GLTFLoader + the meshopt decoder.

## 3. Publicly-readable settings namespace

`GET /api/settings/{key}` serves keys under the reserved `public.` prefix to any authenticated user, and 403s everything else. There is deliberately **no public setter** — writes stay on `POST /api/admin/settings/{key}`.

A plugin often has to publish one small piece of deployment configuration that its UI needs for *every* user, not just admins: which feature is enabled where, which external catalog a project is bound to. `app_settings` is the natural, migration-free home, but its only read path was admin-gated — so such a plugin's feature would silently become admin-only. Without this, each plugin in that position would have to grow its own core endpoint, and core would end up naming plugins.

The prefix is the whole contract: an admin opting a key into `public.` is opting into it being world-readable within the deployment.

Also: the shared pool-guard's 503 message said "admin endpoints require ..."; it now serves a non-admin route too, so the wording is generic.

## Verification

- `node --import tsx --test src/__tests__/plugins/registry.test.ts` → **10/10 pass**, including 2 new tests covering admin-tab labelling, ordering, activation gating, region isolation, and the empty case.
- `pytest tests/comms/rest/test_public_settings.py` → **8/8 pass**, pinning that a key merely *containing* `public.` is refused, that the prefix check runs *before* the DB gate (403 vs 503 ordering), that a non-admin gets past a gate the admin getter refuses them at, and that POSTing the public path is 405. `test_admin.py` + `test_auth.py` unaffected (16 passed, 8 skipped).
- `npx tsc --noEmit` → this branch leaves **1** error; clean `main` has **3**. The two plugin test fixtures were already missing `setSelectedFeaRanges` from their `SceneHandle` stubs before this change; completing them is why the count drops. The remaining error is `load_fea_streaming.ts(1272)`, pre-existing and unrelated.
- Exercised end to end by overlaying a plugin that uses all three points into `packages/plugins/` and running the real build path — `npm run gen:plugins` with `ADA_PLUGINS_EXTRA` set, then `npm run build:serve`. It builds, and the plugin's code (including its `public.`-namespaced setting key and the new `/settings/` read) is present in the emitted bundle rather than tree-shaken away.

## Not verified

None of the three has been clicked in a running viewer. They are proven to typecheck, register, order, gate, route and bundle — not to render against a live server.