### PR TITLE
feat(engines): let a worker advertise a procedural engine it has installed

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3519,6 +3519,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
             if eng is not None:
                 target_capability = (eng.get("doc") or {}).get("worker_capability")
+            else:
+                target_capability = await _advertised_engine_capability(engine)
 
         if is_external_detailing:
             # Two-stage pipeline. Stage 1: the structural build on the default (or
@@ -3675,6 +3677,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
             if eng is not None:
                 target_capability = (eng.get("doc") or {}).get("worker_capability")
+            else:
+                target_capability = await _advertised_engine_capability(engine)
 
         job = await queue.enqueue(
             f"_synthetic/procedural/{row['id']}/preview/{doc_hash}/{lod}",
@@ -3876,7 +3880,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         eng = await db_module.get_procedural_engine_by_slug(
             pool, scope_kind=scope_obj.kind, scope_id=scope_obj.id, slug=engine
         )
-        return (eng.get("doc") or {}).get("worker_capability") if eng else None
+        if eng is not None:
+            return (eng.get("doc") or {}).get("worker_capability")
+        return await _advertised_engine_capability(engine)
 
     @api.post("/scopes/{scope}/procedural-models/{model_id}/export-xlsx")
     async def api_procedural_export_xlsx(
@@ -4459,6 +4465,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="system template not found")
         return JSONResponse({"status": "archived"})
 
+    async def _advertised_engine_capability(slug: str | None) -> str | None:
+        """The worker capability of an engine a live worker advertises itself.
+
+        Complements the database lookup at every routing site: a self-advertising
+        engine has no row, so without this its jobs would silently route to the
+        DEFAULT pool -- the engine would appear in the list, be selectable, and
+        then run somewhere that does not have it.
+
+        A row always wins where one exists; this is only consulted when the
+        lookup came back empty.
+        """
+        if not slug:
+            return None
+        from ada.topo_model.engine_catalog import is_offerable
+
+        spec = (await _live_worker_specs("procedural_engine_specs")).get(slug)
+        if spec is None or not is_offerable(spec):
+            return None
+        return spec.get("worker_capability")
+
     # ── /api/scopes/{scope}/procedural-engines ──────────────────────
     #
     # Registry of pluggable procedural-modelling engines. The built-in
@@ -4521,7 +4547,38 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             summary["supports_grouping"] = bool(
                 spec.get("supports_grouping") if spec is not None else summary.get("supports_grouping", False)
             )
-        return JSONResponse({"procedural_engines": [*summaries, *engines]})
+
+        # Engines a live worker advertises in full. A worker can only honestly
+        # announce an engine whose code it has, so this is the authoritative
+        # answer to "what can actually run right now" -- and it removes the
+        # manual step of creating a row per scope for an engine that is already
+        # installed and already reachable.
+        #
+        # Only specs carrying a name AND an entrypoint qualify (see
+        # engine_catalog.is_offerable): older workers advertise capability flags
+        # alone, and surfacing one of those would offer an engine the viewer
+        # cannot dispatch to.
+        #
+        # Built-ins and DB rows win on slug collision. A row is an explicit
+        # admin decision -- possibly pinning a different entrypoint or revision --
+        # and must not be silently overridden by whatever a pod happens to run.
+        from ada.topo_model.engine_catalog import is_offerable
+
+        known = {*_BUILTIN_ENGINE_SLUGS, *(e.get("slug") for e in engines)}
+        advertised = [
+            {
+                "id": f"worker:{spec['slug']}",
+                "slug": spec["slug"],
+                "name": spec["name"],
+                "description": spec.get("description", ""),
+                "revision": 0,
+                "origin": "worker",
+                "supports_grouping": bool(spec.get("supports_grouping", False)),
+            }
+            for slug, spec in sorted(engine_caps.items())
+            if slug not in known and is_offerable(spec)
+        ]
+        return JSONResponse({"procedural_engines": [*summaries, *engines, *advertised]})
 
     @api.post("/scopes/{scope}/procedural-engines", status_code=201)
     async def api_procedural_engines_create(

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -1213,10 +1213,11 @@ async def _run_procedural_build(
         eng_row = await db_module.get_procedural_engine_by_slug(
             db_pool, scope_kind=row["scope_kind"], scope_id=row["scope_id"], slug=engine
         )
-        if eng_row is None:
-            await _fail("build", f"procedural engine {engine!r} not found in scope")
+        eng_doc = ((eng_row or {}).get("doc") if eng_row else None) or _advertised_engine_doc(engine)
+        if eng_doc is None:
+            await _fail("build", f"procedural engine {engine!r} is neither registered in scope nor advertised here")
             return
-        external_entrypoint = (eng_row.get("doc") or {}).get("entrypoint")
+        external_entrypoint = eng_doc.get("entrypoint")
         if not external_entrypoint:
             await _fail("build", f"engine {engine!r} manifest has no entrypoint")
             return
@@ -1675,6 +1676,33 @@ async def _run_procedural_relocations(
     await _audit_done(db_pool, job_id, "done", None, started_at)
 
 
+def _advertised_engine_doc(engine: str | None) -> dict | None:
+    """A manifest-shaped doc for an engine THIS worker advertises itself.
+
+    A self-advertising engine deliberately has no database row -- that is the
+    whole point of advertising -- so its manifest has to come from the registry
+    the engine populated at import (see ADA_WORKER_PRELOAD and
+    ``register_procedural_engine_capabilities``). Returns the same
+    ``{kind, entrypoint, worker_capability}`` shape a row's ``doc`` carries, so
+    every caller needs nothing beyond the fallback itself.
+
+    Only offerable specs qualify: a spec carrying capability flags alone
+    describes an engine the viewer already knows about, not one this worker can
+    dispatch to on its own.
+    """
+    if not engine:
+        return None
+    from ada.topo_model.engine_catalog import is_offerable, procedural_engine_specs
+
+    for spec in procedural_engine_specs():
+        if spec.get("slug") == engine and is_offerable(spec):
+            doc: dict = {"kind": "server", "entrypoint": spec["entrypoint"]}
+            if spec.get("worker_capability"):
+                doc["worker_capability"] = spec["worker_capability"]
+            return doc
+    return None
+
+
 async def _resolve_engine_manifest(db_pool: "asyncpg.Pool", row: dict, engine: str | None) -> dict | None:
     """The registry manifest doc for a NON-default, non-builtin engine (its
     ``entrypoint``/``worker_capability``/xlsx-sibling fields), resolved by slug in
@@ -1686,7 +1714,9 @@ async def _resolve_engine_manifest(db_pool: "asyncpg.Pool", row: dict, engine: s
     eng_row = await db_module.get_procedural_engine_by_slug(
         db_pool, scope_kind=row["scope_kind"], scope_id=row["scope_id"], slug=engine
     )
-    return (eng_row or {}).get("doc") if eng_row else None
+    # A row wins when present -- it is an explicit admin registration and may
+    # pin a different entrypoint than whatever this pod happens to run.
+    return ((eng_row or {}).get("doc") if eng_row else None) or _advertised_engine_doc(engine)
 
 
 async def _run_procedural_export_xlsx(
@@ -1972,10 +2002,10 @@ async def _run_procedural_import_xlsx(
         eng_row = await db_module.get_procedural_engine_by_slug(
             db_pool, scope_kind=scope.kind, scope_id=scope.id, slug=engine
         )
-        if eng_row is None:
-            await _fail("import", f"procedural engine {engine!r} not found in scope")
+        manifest_doc = ((eng_row or {}).get("doc") if eng_row else None) or _advertised_engine_doc(engine)
+        if manifest_doc is None:
+            await _fail("import", f"procedural engine {engine!r} is neither registered in scope nor advertised here")
             return
-        manifest_doc = (eng_row or {}).get("doc")
 
     from ada.comms.rest.procedural import procedural_source_key, validate_doc
     from ada.topo_model.engines import (

--- a/src/ada/topo_model/__init__.py
+++ b/src/ada/topo_model/__init__.py
@@ -33,6 +33,7 @@ from .detailing_catalog import (
     register_detailing_engine,
 )
 from .engine_catalog import (
+    is_offerable,
     procedural_engine_specs,
     register_procedural_engine_capabilities,
 )
@@ -73,6 +74,7 @@ __all__ = [
     "procedural_blueprint_specs",
     "procedural_cell_type_specs",
     "procedural_engine_specs",
+    "is_offerable",
     "procedural_opening_type_specs",
     "procedural_template_specs",
     "propose_relocations",

--- a/src/ada/topo_model/engine_catalog.py
+++ b/src/ada/topo_model/engine_catalog.py
@@ -24,6 +24,7 @@ from .engines import BUILTIN_ENGINES
 __all__ = [
     "register_procedural_engine_capabilities",
     "procedural_engine_specs",
+    "is_offerable",
 ]
 
 # engine slug -> {"slug", "supports_grouping"}. Insertion-ordered; last writer per
@@ -35,14 +36,56 @@ def register_procedural_engine_capabilities(
     slug: str,
     *,
     supports_grouping: bool = False,
+    name: str | None = None,
+    description: str | None = None,
+    entrypoint: str | None = None,
+    worker_capability: str | None = None,
 ) -> None:
-    """Register (or replace) the capability flags an engine advertises. ``slug`` is
-    the engine slug (e.g. an external engine); ``supports_grouping`` advertises whether
-    the engine compiles per-group blueprints. Idempotent by ``slug``."""
-    _ENGINE_CAPABILITY_REGISTRY[slug] = {
+    """Register (or replace) what an engine advertises. Idempotent by ``slug``.
+
+    ``slug`` and ``supports_grouping`` alone register capability FLAGS for an
+    engine the viewer already knows about (a built-in, or a row an admin
+    created). That is the original behaviour and is unchanged.
+
+    Passing ``name`` AND ``entrypoint`` additionally makes the engine
+    SELF-ADVERTISING: the viewer will offer it wherever a live worker announces
+    it, with no database row and no admin step. This is the difference between
+    "an engine that exists supports grouping" and "this engine exists at all".
+
+    ``entrypoint`` is the usual ``module:callable``, resolved by the worker at
+    job time. ``worker_capability`` is the pool the job must be routed to; leave
+    it unset for an engine any worker can run.
+
+    A worker can only honestly advertise an engine whose code it has, so the
+    registration belongs in the engine package itself, run at import (see
+    ``ADA_WORKER_PRELOAD``). An engine that stops being installed stops being
+    offered when that worker's heartbeat goes stale, which is the point: the
+    list reflects what can actually run right now.
+    """
+    spec: dict = {
         "slug": slug,
         "supports_grouping": bool(supports_grouping),
     }
+    # Only a spec carrying BOTH a name and an entrypoint is offerable. Older
+    # workers advertise flags alone, and a half-filled descriptor would surface
+    # an engine the viewer cannot dispatch to -- worse than not offering it.
+    if name and entrypoint:
+        spec["name"] = name
+        spec["description"] = description or ""
+        spec["entrypoint"] = entrypoint
+        if worker_capability:
+            spec["worker_capability"] = worker_capability
+    _ENGINE_CAPABILITY_REGISTRY[slug] = spec
+
+
+def is_offerable(spec: dict) -> bool:
+    """Whether a heartbeat spec describes an engine the viewer can offer on its own.
+
+    Kept next to the writer so the two definitions cannot drift: a spec is
+    offerable exactly when :func:`register_procedural_engine_capabilities` was
+    given both a name and an entrypoint.
+    """
+    return bool(spec.get("name")) and bool(spec.get("entrypoint"))
 
 
 def procedural_engine_specs() -> list[dict]:

--- a/tests/topo_model/test_engine_self_advertising.py
+++ b/tests/topo_model/test_engine_self_advertising.py
@@ -1,0 +1,113 @@
+"""A worker can advertise an engine it has, with no database row.
+
+Before this, a procedural engine existed for the viewer only as a row an admin
+created per scope. Installing the engine's package in a worker was necessary but
+not sufficient — the engine simply did not appear, and there was nothing in the
+running system to tell you why.
+
+The registry now carries a full descriptor, so a worker announcing it in its
+heartbeat is enough for the viewer to offer the engine and route to it. This is
+the shape detailing engines already use.
+
+The distinction these tests pin is *offerability*: a spec carrying capability
+flags alone describes an engine the viewer already knows about, while a spec
+carrying a name and an entrypoint describes one it can offer on its own. Getting
+that wrong in either direction is bad — surfacing a flags-only spec offers an
+engine nothing can dispatch to, and ignoring a full spec puts us back to manual
+registration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.topo_model.engine_catalog import (
+    is_offerable,
+    procedural_engine_specs,
+    register_procedural_engine_capabilities,
+)
+
+
+@pytest.fixture()
+def clean_slug():
+    """Register under a slug no built-in uses, and leave the registry as found.
+
+    The registry is module-level and pre-seeded with the built-ins, so a test
+    that registered without cleaning up would leak into every later assertion.
+    """
+    slug = "test-engine-xyz"
+    yield slug
+    from ada.topo_model.engine_catalog import _ENGINE_CAPABILITY_REGISTRY
+
+    _ENGINE_CAPABILITY_REGISTRY.pop(slug, None)
+
+
+def _spec_for(slug: str) -> dict | None:
+    return next((s for s in procedural_engine_specs() if s["slug"] == slug), None)
+
+
+def test_flags_only_registration_is_not_offerable(clean_slug):
+    # The original call shape. It says "this engine supports grouping", not
+    # "this engine exists" — offering it would surface an engine with no
+    # entrypoint for the viewer to dispatch to.
+    register_procedural_engine_capabilities(clean_slug, supports_grouping=True)
+    spec = _spec_for(clean_slug)
+    assert spec is not None
+    assert spec["supports_grouping"] is True
+    assert not is_offerable(spec)
+
+
+def test_full_descriptor_is_offerable(clean_slug):
+    register_procedural_engine_capabilities(
+        clean_slug,
+        supports_grouping=True,
+        name="Test Engine",
+        description="An engine used by the tests.",
+        entrypoint="some_package.engine:compile",
+        worker_capability="test-pool",
+    )
+    spec = _spec_for(clean_slug)
+    assert is_offerable(spec)
+    assert spec["name"] == "Test Engine"
+    assert spec["entrypoint"] == "some_package.engine:compile"
+    assert spec["worker_capability"] == "test-pool"
+
+
+def test_a_name_without_an_entrypoint_is_not_offerable(clean_slug):
+    # Half a descriptor is the dangerous case: enough to look like an engine in
+    # a list, not enough to run. It must fail closed.
+    register_procedural_engine_capabilities(clean_slug, name="Test Engine")
+    assert not is_offerable(_spec_for(clean_slug))
+
+
+def test_an_entrypoint_without_a_name_is_not_offerable(clean_slug):
+    register_procedural_engine_capabilities(clean_slug, entrypoint="some_package.engine:compile")
+    assert not is_offerable(_spec_for(clean_slug))
+
+
+def test_worker_capability_is_optional(clean_slug):
+    # An engine any worker can run advertises no pool; routing then leaves
+    # target_capability unset, which is the default pool.
+    register_procedural_engine_capabilities(clean_slug, name="Test Engine", entrypoint="some_package.engine:compile")
+    spec = _spec_for(clean_slug)
+    assert is_offerable(spec)
+    assert "worker_capability" not in spec
+
+
+def test_registration_is_idempotent_and_replaces(clean_slug):
+    register_procedural_engine_capabilities(clean_slug, name="First", entrypoint="some_package.engine:compile")
+    register_procedural_engine_capabilities(clean_slug, name="Second", entrypoint="other_package.engine:compile")
+    specs = [s for s in procedural_engine_specs() if s["slug"] == clean_slug]
+    assert len(specs) == 1, "re-registering a slug must replace, not duplicate"
+    assert specs[0]["name"] == "Second"
+
+
+def test_builtins_remain_flags_only():
+    # The built-ins are listed statically by the endpoint and must NOT be
+    # re-offered as worker-advertised engines, or they would appear twice.
+    from ada.topo_model.engines import BUILTIN_ENGINES
+
+    for slug in BUILTIN_ENGINES:
+        spec = _spec_for(slug)
+        assert spec is not None, f"built-in {slug} should still announce its flags"
+        assert not is_offerable(spec), f"built-in {slug} must not be offerable as a worker engine"


### PR DESCRIPTION
A procedural engine existed for the viewer only as a **database row an admin created per scope**. Installing the engine's package in a worker was necessary but not sufficient — the engine simply didn't appear in the engines list, and nothing in the running system said why.

Detailing engines already work the other way: an external one appears while its pool is online, with no row (`/detailing-engines` unions live heartbeat specs, and its docstring says *"No hardcoded external engines"*). This brings procedural engines to the same shape.

## The registry now carries a descriptor

`register_procedural_engine_capabilities(slug, name=..., entrypoint=..., worker_capability=...)` makes an engine **self-advertising**. Passing flags alone keeps the original meaning — *"this engine, which the viewer already knows about, supports grouping"*.

`is_offerable()` is the discriminator, and lives next to the writer so the two definitions can't drift.

**Half a descriptor fails closed.** A name without an entrypoint is enough to look like an engine in a list and not enough to run one — the worst outcome available, worse than not offering it.

## Routing had to change too, and that's what makes this safe

Listing alone would have shipped a selectable-but-undispatchable engine. **Six sites** resolved an engine by database slug:

| layer | sites | without a row |
|---|---|---|
| API | 2 compile paths + xlsx export/import | `target_capability` stayed `None` → job routed to the **default pool** |
| worker | build, import, manifest resolve | failed with `engine manifest has no entrypoint` |

Each now falls back to the advertised spec — the API to the live heartbeat, the worker to its own in-process registry, which it can answer from because it registered the engine itself.

**A row always wins where one exists.** It's an explicit admin decision and may pin a different entrypoint or revision than whatever a given pod happens to run.

Built-ins keep announcing flags only, so the endpoint's static entries aren't duplicated by a worker re-announcing them.

## Verified

`tests/comms/rest/` is unchanged at **3 failed / 20 passed / 3 skipped** across the engine, engine-build and detailing suites, both with and without this change — verified by stashing and re-running. Those 3 are pre-existing platform failures.

7 new tests pin the offerability contract in **both** directions: a flags-only spec must not be offered, a full spec must be, and each half-descriptor must fail closed.

## One difference from detailing worth noting

Detailing puts the entrypoint **in the job**, so the executing worker needs no lookup at all. The fallback here relies on the executing worker sharing the advertising worker's registry — true when a pool is one image, which it is, but the detailing shape would survive a heterogeneous pool. Worth considering if pools ever stop being homogeneous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo