### PR TITLE
fix(viewer): reach is_offerable without importing ada.topo_model

### DIFF
--- a/src/ada/comms/engine_specs.py
+++ b/src/ada/comms/engine_specs.py
@@ -1,0 +1,32 @@
+"""Predicates over the engine capability specs workers announce in their heartbeat.
+
+This lives under ``ada.comms`` rather than next to the registry that writes the
+specs (``ada.topo_model.engine_catalog``) for one reason: the REST API runs in a
+*slim* runtime that ships only a subset of the package -- ``ada.comms``,
+``ada.cad``, ``ada.config`` and part of ``ada.sections`` (see
+``deploy/Dockerfile.viewer``). ``ada.topo_model`` is not in that subset, and
+cannot be: importing any of its submodules executes its ``__init__``, which pulls
+in the whole modelling stack.
+
+So a spec predicate the API needs must be reachable without ``ada.topo_model``.
+``engine_catalog`` re-exports it, keeping one definition for both sides.
+
+Keep this module dependency-free (stdlib only) -- that is what makes it safe to
+ship into the slim runtime.
+"""
+
+from __future__ import annotations
+
+__all__ = ["is_offerable"]
+
+
+def is_offerable(spec: dict) -> bool:
+    """Whether a heartbeat spec describes an engine the viewer can offer on its own.
+
+    A spec is offerable exactly when
+    :func:`ada.topo_model.engine_catalog.register_procedural_engine_capabilities`
+    was given both a name and an entrypoint. Older workers advertise capability
+    flags alone; offering one of those would present an engine the viewer has no
+    way to dispatch to.
+    """
+    return bool(spec.get("name")) and bool(spec.get("entrypoint"))

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -4478,7 +4478,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         """
         if not slug:
             return None
-        from ada.topo_model.engine_catalog import is_offerable
+        from ada.comms.engine_specs import is_offerable
 
         spec = (await _live_worker_specs("procedural_engine_specs")).get(slug)
         if spec is None or not is_offerable(spec):
@@ -4555,14 +4555,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # installed and already reachable.
         #
         # Only specs carrying a name AND an entrypoint qualify (see
-        # engine_catalog.is_offerable): older workers advertise capability flags
+        # ada.comms.engine_specs.is_offerable): older workers advertise capability flags
         # alone, and surfacing one of those would offer an engine the viewer
         # cannot dispatch to.
         #
         # Built-ins and DB rows win on slug collision. A row is an explicit
         # admin decision -- possibly pinning a different entrypoint or revision --
         # and must not be silently overridden by whatever a pod happens to run.
-        from ada.topo_model.engine_catalog import is_offerable
+        from ada.comms.engine_specs import is_offerable
 
         known = {*_BUILTIN_ENGINE_SLUGS, *(e.get("slug") for e in engines)}
         advertised = [

--- a/src/ada/topo_model/engine_catalog.py
+++ b/src/ada/topo_model/engine_catalog.py
@@ -84,8 +84,6 @@ def register_procedural_engine_capabilities(
     _ENGINE_CAPABILITY_REGISTRY[slug] = spec
 
 
-
-
 def procedural_engine_specs() -> list[dict]:
     """The registered engine capability specs (a fresh copy so callers can't mutate
     the registry) — the shape the worker advertises in its heartbeat."""

--- a/src/ada/topo_model/engine_catalog.py
+++ b/src/ada/topo_model/engine_catalog.py
@@ -19,6 +19,12 @@ any engine slug.
 
 from __future__ import annotations
 
+# The predicate lives under ada.comms so the REST API can reach it without
+# ada.topo_model, which the slim viewer runtime does not ship. Re-exported here
+# (and in ada.topo_model) so the two sides cannot drift and existing importers
+# keep working.
+from ada.comms.engine_specs import is_offerable
+
 from .engines import BUILTIN_ENGINES
 
 __all__ = [
@@ -78,14 +84,6 @@ def register_procedural_engine_capabilities(
     _ENGINE_CAPABILITY_REGISTRY[slug] = spec
 
 
-def is_offerable(spec: dict) -> bool:
-    """Whether a heartbeat spec describes an engine the viewer can offer on its own.
-
-    Kept next to the writer so the two definitions cannot drift: a spec is
-    offerable exactly when :func:`register_procedural_engine_capabilities` was
-    given both a name and an entrypoint.
-    """
-    return bool(spec.get("name")) and bool(spec.get("entrypoint"))
 
 
 def procedural_engine_specs() -> list[dict]:

--- a/tests/comms/test_engine_specs_slim_runtime.py
+++ b/tests/comms/test_engine_specs_slim_runtime.py
@@ -1,0 +1,71 @@
+"""The engine-spec predicate must be usable without ``ada.topo_model``.
+
+The REST API runs in a slim runtime that ships only ``ada.comms``, ``ada.cad``,
+``ada.config`` and part of ``ada.sections`` (see ``deploy/Dockerfile.viewer``).
+``ada.topo_model`` is absent there and cannot be added: importing any of its
+submodules executes its ``__init__``, which pulls in the whole modelling stack.
+
+An endpoint that imported the predicate from ``ada.topo_model`` therefore raised
+``ModuleNotFoundError`` in the deployed viewer -- a 500 on
+``/scopes/{scope}/procedural-engines``, which is precisely the endpoint that
+surfaces engines a live worker advertises. These tests pin the arrangement that
+fixes it.
+"""
+
+import subprocess
+import sys
+
+from ada.comms.engine_specs import is_offerable
+
+OFFERABLE = {"slug": "demo", "name": "Demo", "entrypoint": "pkg.mod:compile"}
+
+
+def test_a_spec_with_name_and_entrypoint_is_offerable():
+    assert is_offerable(OFFERABLE) is True
+
+
+def test_capability_flags_alone_are_not_offerable():
+    """Older workers announce flags without a name or entrypoint.
+
+    Offering one of those would present an engine the viewer cannot dispatch to.
+    """
+    assert is_offerable({"slug": "demo", "supports_grouping": True}) is False
+
+
+def test_name_without_entrypoint_is_not_offerable():
+    assert is_offerable({"slug": "demo", "name": "Demo"}) is False
+
+
+def test_entrypoint_without_name_is_not_offerable():
+    assert is_offerable({"slug": "demo", "entrypoint": "pkg.mod:compile"}) is False
+
+
+def test_empty_strings_are_treated_as_absent():
+    assert is_offerable({"name": "", "entrypoint": "pkg.mod:compile"}) is False
+    assert is_offerable({"name": "Demo", "entrypoint": ""}) is False
+
+
+def test_importing_the_predicate_does_not_drag_in_topo_model():
+    """The slim-runtime contract, checked in a clean interpreter.
+
+    If this regresses, the viewer image raises ModuleNotFoundError at request
+    time rather than at import time -- i.e. it fails in production, not in CI.
+    """
+    code = (
+        "import sys;"
+        "import ada.comms.engine_specs as m;"
+        "assert m.is_offerable({'name': 'n', 'entrypoint': 'e'});"
+        "assert 'ada.topo_model' not in sys.modules, "
+        "'ada.comms.engine_specs pulled in ada.topo_model';"
+        "print('ok')"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_engine_catalog_still_exports_the_same_object():
+    """Existing importers keep working, and there is only one definition."""
+    from ada.topo_model.engine_catalog import is_offerable as from_catalog
+
+    assert from_catalog is is_offerable


### PR DESCRIPTION
`GET /scopes/{scope}/procedural-engines` returns **500** in the deployed viewer:

```
File "/app/src/ada/comms/rest/app.py", line 4565, in api_procedural_engines_list
    from ada.topo_model.engine_catalog import is_offerable
ModuleNotFoundError: No module named 'ada.topo_model'
```

## Why the module isn't there

The REST API runs in a **slim runtime** that ships only a curated subset of the package — `config.py`, `comms/`, `cad/` and three files from `sections/` (`deploy/Dockerfile.viewer:131-155`) — and its env deliberately does not depend on the full distribution. Confirmed inside a running container: `/app/src/ada` contains exactly `__init__.py  cad  comms  config.py  sections`.

`ada.topo_model` is absent there, and **cannot simply be added**: importing any of its submodules executes `ada/topo_model/__init__.py`, which imports the blueprint/build/builder stack. Copying `engine_catalog.py` alone would not help.

## Why it matters

The endpoint that crashes is the one that surfaces **engines a live worker advertises**. So an engine can register correctly, a worker can announce it correctly, and it still never reaches the UI — the request dies before the `advertised` list is built. The adjacent endpoint at line 4481 carried the same import and the same fate.

This is latent rather than a regression: it breaks for any worker-advertised engine, and only shows up once one exists.

## The change

`is_offerable` is a two-condition predicate over a heartbeat dict with no dependencies, so it moves to **`ada.comms.engine_specs`** — which the slim runtime already ships, and since `comms/` is copied wholesale (`Dockerfile.viewer:133`) **no Dockerfile change is needed**.

`engine_catalog` re-exports it, so there is still one definition and every existing importer (including `ada.topo_model`'s own re-export and `comms/rest/worker.py`) keeps working.

## Tests

`tests/comms/test_engine_specs_slim_runtime.py` — the predicate's behaviour, plus the part that actually regressed:

```python
def test_importing_the_predicate_does_not_drag_in_topo_model():
    # clean interpreter: import the predicate, assert ada.topo_model
    # did not come with it
```

Without that check this fails at **request time in the deployed image** rather than at import time in CI, which is exactly how it got here.

`14 passed` — the new file plus the existing `tests/topo_model/test_engine_self_advertising.py`.

## Not fixed here

`app.py:3789` imports `ada.topo_model.takeoff` in the takeoff-export endpoint and fails the same way. That one genuinely computes a takeoff and needs the modelling stack, so it wants a different answer — either widening the slim image or moving the work to a worker — rather than being folded into this change.