### PR TITLE
feat(viewer-api): add a publicly-readable settings namespace for plugin config

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -2786,6 +2786,35 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         return JSONResponse({"job_id": job.job_id, "derived_key": derived_key})
 
+    # Settings whose key begins with this prefix are readable by ANY
+    # authenticated user; every other key in app_settings stays admin-only.
+    # Writes are always admin-only (POST /api/admin/settings/{key}) — this is a
+    # read window, not a public key/value store.
+    #
+    # It exists because a plugin often has to publish one small piece of
+    # deployment configuration that its UI needs for EVERY user, not just
+    # admins: which feature is enabled where, which external catalog a project
+    # is bound to. Without this each such plugin would need its own core
+    # endpoint, and core would end up naming plugins. The prefix is the whole
+    # contract: an admin opting a key into `public.` is opting into it being
+    # world-readable within the deployment.
+    PUBLIC_SETTING_PREFIX = "public."
+
+    @api.get("/settings/{key}")
+    async def api_get_public_setting(key: str, request: Request) -> JSONResponse:
+        """Read a setting from the publicly-readable namespace. Returns
+        ``{"key": k, "value": v}`` with v=null when unset, exactly like the admin
+        getter. 403 for any key outside the namespace, so this can never be used
+        to read an admin-only setting."""
+        if not key.startswith(PUBLIC_SETTING_PREFIX):
+            raise HTTPException(
+                status_code=403,
+                detail=f"only {PUBLIC_SETTING_PREFIX}* settings are readable here",
+            )
+        pool = _require_pool(request)
+        value = await db_module.get_setting(pool, key)
+        return JSONResponse({"key": key, "value": value})
+
     @api.get("/plugins")
     async def api_plugins(request: Request) -> JSONResponse:
         """Backend plugins advertised to the viewer plugin system: the union of
@@ -4777,7 +4806,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if pool is None:
             raise HTTPException(
                 status_code=503,
-                detail="admin endpoints require a Postgres-backed deployment",
+                detail="this endpoint requires a Postgres-backed deployment",
             )
         return pool
 
@@ -4811,7 +4840,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
     ) -> JSONResponse:
         """Generic key/value get from app_settings. Returns
-        ``{"key": k, "value": v}`` with v=null when unset."""
+        ``{"key": k, "value": v}`` with v=null when unset. Admin-only; keys in
+        the ``public.`` namespace are additionally readable by any authenticated
+        user via ``GET /api/settings/{key}``."""
         pool = _require_pool(request)
         value = await db_module.get_setting(pool, key)
         return JSONResponse({"key": key, "value": value})

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -3760,6 +3760,21 @@ export const viewerApi = {
     return r.text();
   },
 
+  /** Read a key from the publicly-readable `public.` settings namespace. Any
+   * authenticated user; 403 for a key outside that namespace. Use this (not
+   * `adminGetSetting`) for configuration a non-admin's UI has to see. Writes
+   * remain admin-only — there is no public setter. */
+  async getPublicSetting(key: string): Promise<string | null> {
+    const r = await authedFetch(
+      `${runtime.apiBase()}/settings/${encodeURIComponent(key)}`,
+    );
+    const body = await jsonOrThrow<{ key: string; value: string | null }>(
+      r,
+      `getPublicSetting(${key})`,
+    );
+    return body.value;
+  },
+
   /** Admin: read a key from app_settings. Value is null when unset. */
   async adminGetSetting(key: string): Promise<string | null> {
     const r = await authedFetch(

--- a/tests/comms/rest/test_public_settings.py
+++ b/tests/comms/rest/test_public_settings.py
@@ -1,0 +1,132 @@
+"""GET /api/settings/{key} — the publicly-readable settings namespace.
+
+Writes stay admin-only; this is a read window so a plugin can publish one piece
+of deployment configuration its UI needs for EVERY user, not just admins. The
+whole contract is the key prefix, so these tests pin it: inside the namespace
+behaves like the admin getter, outside it is 403 for admin and non-admin alike.
+
+Same shape as test_admin.py — create_app with auth disabled, and the non-admin
+case produced by monkeypatching User.local_dev.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+# Importing ada.comms.rest.app evaluates a module-level `create_app()` which
+# materializes a local Storage. Point it at a temp dir so the import succeeds in
+# environments without `./viewer-data`.
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ada.comms.rest import auth as auth_module
+from ada.comms.rest.app import create_app
+from ada.comms.rest.config import AuthConfig, LocalConfig, QueueConfig, Settings
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+def _non_admin(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auth_module.User,
+        "local_dev",
+        classmethod(
+            lambda cls: cls(
+                sub="non-admin",
+                email="x@y",
+                display_name="X",
+                groups=frozenset(),
+                is_admin=False,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "audit.perf.thresholds.slow",
+        "profile_conversions",
+        "notpublic.thing",
+        # A key that merely CONTAINS the prefix must not pass — the check is a
+        # prefix, not a substring.
+        "sneaky.public.thing",
+    ],
+)
+def test_non_public_keys_are_refused(tmp_path, key):
+    """403 even for an admin: this route is not an alternate admin getter."""
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        app.state.db_pool = object()  # past the 503 gate; prefix check comes first
+        r = client.get(f"/api/settings/{key}")
+        assert r.status_code == 403, r.text
+
+
+def test_non_public_key_refused_for_non_admin_too(monkeypatch, tmp_path):
+    _non_admin(monkeypatch)
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        app.state.db_pool = object()
+        assert client.get("/api/settings/profile_conversions").status_code == 403
+
+
+def test_public_key_reaches_the_db_gate(tmp_path):
+    """A key inside the namespace passes the prefix check and falls through to
+    the pool requirement — 503, not 403. That ordering is the point: the prefix
+    decides access, the DB decides availability."""
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        r = client.get("/api/settings/public.some_plugin.binding")
+        assert r.status_code == 503, r.text
+
+
+def test_public_key_is_readable_by_a_non_admin(monkeypatch, tmp_path):
+    """The whole reason this endpoint exists — a non-admin must get past the
+    gate that /api/admin/settings would have refused them at."""
+    _non_admin(monkeypatch)
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        r = client.get("/api/settings/public.some_plugin.binding")
+        assert r.status_code == 503, r.text
+        # ...whereas the admin getter refuses this user outright.
+        assert client.get("/api/admin/settings/public.some_plugin.binding").status_code == 403
+
+
+def test_there_is_no_public_setter(monkeypatch, tmp_path):
+    """Read window only. A POST to the public path must not exist — otherwise
+    any authenticated user could write deployment configuration."""
+    _non_admin(monkeypatch)
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        app.state.db_pool = object()
+        r = client.post("/api/settings/public.some_plugin.binding", json={"value": "x"})
+        assert r.status_code == 405, r.text


### PR DESCRIPTION
Re-lands the third extension point from #253, which never made it to `main`.

## What happened

#253 was titled "three plugin extension points (admin region, model load, **public settings**)" and its body documents the settings namespace in detail. Only two landed: the squash merge (`d864467c`) carries the admin region and `SceneHandle.loadModelFromUrl`, and the commit implementing the settings namespace was written **after** the squash and pushed to the already-merged branch, so it was never part of any merge.

The result is a contract that is documented but absent. An out-of-tree plugin built against #253's description calls `viewerApi.getPublicSetting(...)`, which does not exist on any released `main`, and the panel dies with:

```
TypeError: viewerApi.getPublicSetting is not a function
```

`git log -S getPublicSetting origin/main` returns nothing today; `--all` finds it only on the dead branch.

## The change

Unchanged from what #253 described:

`GET /api/settings/{key}` serves keys under the reserved `public.` prefix to any authenticated user and 403s everything else — so it can never be used as an alternate admin getter. There is deliberately **no public setter**: writes stay on `POST /api/admin/settings/{key}`.

A plugin often has to publish one small piece of deployment configuration that its UI needs for *every* user, not just admins. `app_settings` is the natural, migration-free home, but its only read path was admin-gated — so such a plugin's feature would silently become admin-only. Without this, each plugin in that position would have to grow its own core endpoint, and core would end up naming plugins.

The prefix is the whole contract: an admin opting a key into `public.` is opting into it being world-readable within the deployment.

Also: the shared pool-guard's 503 message said "admin endpoints require ..."; it now serves a non-admin route too, so the wording is generic.

No facade change is needed — `viewerApi` is already re-exported wholesale from `@/viewer-core/app`, so the new method reaches plugins through the existing contract. The addition is non-breaking, so `VIEWER_CORE_API_VERSION` stays at `1.0.0`.

## Verification (actually run, on this branch)

- `pytest tests/comms/rest/test_public_settings.py tests/comms/rest/test_admin.py tests/comms/rest/test_auth.py` → **24 passed, 8 skipped**. The 8 new tests pin that a key merely *containing* `public.` is refused, that the prefix check runs *before* the DB gate (403 vs 503 ordering), that a non-admin gets past a gate the admin getter refuses them at, and that POSTing the public path is 405.
- `black --check` / `ruff check` / `isort --check-only` on both changed Python files → **clean**.
- `tsc --noEmit` → **1 error**, `load_fea_streaming.ts(1272)`. Verified pre-existing: reverting just `viewerApi.ts` to `origin/main` and re-running gives the **same 1 error**.
- `npm test` → one failure, `viewerCoreFacade.test.ts` "every facade entry point declares the contract version exactly once". Verified pre-existing and Windows-only — it compares `rel()` output against `"src/viewer-core/index.ts"` and gets `src\viewer-core\index.ts` on Win32. Same failure on clean `origin/main` (pass 4 / fail 1). This branch touches neither `viewer-core` nor that test.

## Not verified

Not clicked in a running viewer against a live Postgres — same caveat #253 carried.
