### PR TITLE
feat(viewer): let a deployment pick the default UI shell at runtime

### DIFF
--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -63,6 +63,13 @@ ENV ADA_PLUGINS_EXTRA=${EXTRA_PLUGINS_ENABLE}
 # still reaches the built-in one, and the switcher in the menu bar appears as soon
 # as a second shell is registered. Like EXTRA_PLUGINS_ENABLE, the value lives in
 # the CI config — never in this repo.
+#
+# This bakes the default into the image. A hosted deployment can instead set
+# ADA_VIEWER_UI_DEFAULT on the API pod (chart value `ui.default`), which the
+# server serves to the browser via /config.js and which outranks this — so one
+# image can serve deployments that want different UIs. Prefer that unless the
+# image is meant to be a one-UI artefact. EXTRA_PLUGINS_ENABLE has no runtime
+# equivalent: it decides what the image actually contains.
 ARG UI_DEFAULT=""
 ENV ADA_UI_DEFAULT=${UI_DEFAULT}
 

--- a/deploy/helm/adapy-viewer/templates/deployment.yaml
+++ b/deploy/helm/adapy-viewer/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
             - name: ADA_VIEWER_NATS_URL
               value: {{ $natsUrl | quote }}
             {{- end }}
+            {{- with .Values.ui.default }}
+            - name: ADA_VIEWER_UI_DEFAULT
+              value: {{ . | quote }}
+            {{- end }}
             {{- include "adapy-viewer.authEnv" . | nindent 12 }}
             {{- include "adapy-viewer.databaseEnv" . | nindent 12 }}
           {{- if eq .Values.storage.kind "local" }}

--- a/deploy/helm/adapy-viewer/values.yaml
+++ b/deploy/helm/adapy-viewer/values.yaml
@@ -228,6 +228,21 @@ storage:
     hostPath: ""
     existingClaim: ""
 
+## Which UI this deployment boots into. A plugin can contribute a whole
+## alternative viewer UI ("UI shell"); an image that carries more than one
+## can be pointed at either of them here, so two deployments sharing an
+## image do not have to agree, and switching (or rolling back) a UI is an
+## edit here plus a pod restart rather than an image rebuild.
+##
+## Empty leaves the image's own build-time default in place — the setting is
+## additive, so a chart upgrade changes nothing until you set it. The value
+## is a shell id the image actually carries; an id it does not carry is
+## logged in the browser console and ignored, falling back to the built-in
+## UI rather than breaking the page. Users can always reach the built-in UI
+## with ``?ui=core``.
+ui:
+  default: ""
+
 ## OIDC bearer-token authentication. Provider-agnostic: works with any
 ## OIDC issuer that publishes a discovery document (Authentik, Azure
 ## AD direct, Auth0, Keycloak, etc.). When auth.enabled is false the

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -8022,6 +8022,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             f"window.STREAMING_ONLY_EXTS = {_json.dumps(streaming_only_exts)};\n"
             f"window.CONVERSION_MATRIX = {_json.dumps(conversion_matrix)};\n"
         )
+
+        # Runtime default UI shell. Emitted ONLY when configured: the frontend
+        # treats an absent global as "no runtime opinion" and keeps whatever
+        # default was baked into the bundle at build time, so an image whose
+        # deployment sets nothing behaves exactly as it did before. An empty
+        # string would instead be a value, and a value has to mean something.
+        if settings.ui_default:
+            body += f"window.ADA_UI_DEFAULT = {_json.dumps(settings.ui_default)};\n"
+
         # config.js is the SPA's source of truth for runtime config
         # (worker registry → extraSourceExts / streamingOnlyExts, image
         # tags, auth) — content changes between requests as workers come

--- a/src/ada/comms/rest/config.py
+++ b/src/ada/comms/rest/config.py
@@ -102,6 +102,11 @@ class Settings:
     # log) so the helm chart's ``postgres.enabled: false`` path stays
     # functional for tiny deployments.
     database_url: str
+    # Default UI shell id served to the browser via /config.js, letting one
+    # image boot into any UI shell it carries. Empty => not configured, and
+    # the frontend keeps whatever default was baked in at build time.
+    # Defaulted last so existing constructors stay valid.
+    ui_default: str = ""
 
 
 def _bool(v: str | None, default: bool) -> bool:
@@ -150,6 +155,10 @@ def load_settings() -> Settings:
     # operators / sub-charts that already inject it (Bitnami Postgres,
     # CNPG, Render, etc.). Empty → shared-only mode.
     database_url = os.environ.get("DATABASE_URL", "").strip()
+    # Runtime override for the frontend's default UI shell. Unset (or blank)
+    # means "not configured" — NOT "the built-in UI" — so an image that was
+    # built with a default UI keeps it unless a deployment says otherwise.
+    ui_default = os.environ.get("ADA_VIEWER_UI_DEFAULT", "").strip()
 
     if kind == "s3":
         s3 = S3Config(
@@ -172,6 +181,7 @@ def load_settings() -> Settings:
             queue=queue,
             auth=auth,
             database_url=database_url,
+            ui_default=ui_default,
         )
 
     if kind == "local":
@@ -189,6 +199,7 @@ def load_settings() -> Settings:
             queue=queue,
             auth=auth,
             database_url=database_url,
+            ui_default=ui_default,
         )
 
     raise ValueError(f"Unsupported ADA_VIEWER_STORAGE_KIND: {kind!r} (expected 's3' or 'local')")

--- a/src/frontend/docs/UI_SHELLS.md
+++ b/src/frontend/docs/UI_SHELLS.md
@@ -21,8 +21,8 @@ different information architecture) is:
 * and something you want to be able to **turn off**, not fork.
 
 So the alternative UI lives in its own repository, is overlaid into the image at
-build time, and is selected by build-time registration — with a guaranteed way
-back to the classic UI at runtime.
+build time, and is selected either at build time or per deployment at runtime —
+with a guaranteed way back to the classic UI at runtime.
 
 ## The contract: `@/viewer-core`
 
@@ -76,6 +76,7 @@ src/frontend/
     UiShellSwitcher.tsx  the switcher; renders NOTHING when only one shell is registered
     registry.generated.ts  AUTO-GENERATED: enabled plugins + DEFAULT_UI_SHELL
   plugins.json           committed config: `enabled`, `defaultUi`
+  src/index.html         loads /config.js (blocking classic script) before the SPA
   scripts/gen-plugin-registry.mjs  generator (reads ADA_PLUGINS_EXTRA + ADA_UI_DEFAULT)
   packages/plugins/ui-alt/         reference shell plugin (template; not enabled)
 ```
@@ -85,14 +86,27 @@ src/frontend/
 ## Which UI mounts — precedence
 
 1. **`?ui=<id>`** — per-tab override. `?ui=core` is the guaranteed escape hatch
-   back to the built-in UI, whatever the image was built with.
+   back to the built-in UI, whatever the image was built or configured with.
 2. **`localStorage["ada:ui"]`** — the user's sticky choice from the switcher.
-3. **`DEFAULT_UI_SHELL`** — stamped into the bundle at build time from
-   `ADA_UI_DEFAULT` (build-arg `UI_DEFAULT`) or `plugins.json` `defaultUi`.
-4. **`core`** — the built-in UI.
+3. **`window.ADA_UI_DEFAULT`** — the **runtime** default, served per deployment
+   from `/config.js` (`ADA_VIEWER_UI_DEFAULT` on the API pod).
+4. **`DEFAULT_UI_SHELL`** — the **build-time** default, stamped into the bundle
+   from `ADA_UI_DEFAULT` (build-arg `UI_DEFAULT`) or `plugins.json` `defaultUi`.
+5. **`core`** — the built-in UI.
+
+**Runtime beats build time, and both lose to the user.** The runtime value is
+what makes one image serve two deployments with different UIs, and makes changing
+(or rolling back) the default a config edit and a pod restart instead of an image
+rebuild. It sits *below* `?ui=` and the switcher so a deployment can never take
+`?ui=core` away from a user.
+
+Unset means *unset*, not `core`: an image whose deployment configures nothing
+keeps whatever `UI_DEFAULT` it was built with, so this is purely additive.
 
 An id that is not registered in this build never blanks the viewer: it is logged
-and resolution continues down the list.
+and resolution continues down the list. That matters most for the runtime value,
+which is the one place a typo now reaches a live deployment rather than failing a
+build — the worst case is the next source down, ultimately the built-in UI.
 
 Switching from the switcher persists the choice and reloads — a shell owns the
 whole tree (canvas, websocket, stores), so hot-swapping would mean tearing all of
@@ -180,6 +194,10 @@ docker build -f deploy/Dockerfile.viewer \
   package (bare names are expanded to `@adapy-plugins/<name>`).
 * `UI_DEFAULT` → `ADA_UI_DEFAULT` → `DEFAULT_UI_SHELL` in the generated registry.
 
+`EXTRA_PLUGINS_ENABLE` is what decides which shells the image **carries** and is
+necessarily a build input. `UI_DEFAULT` only decides which of them it **boots
+into**, and that part does not have to be baked in — see below.
+
 In forgejo CI both are Action **variables** (`EXTRA_PLUGINS_*`, `UI_DEFAULT`); the
 UI repo is cloned into `src/frontend/packages/plugins/` by the workflow, so adapy's
 committed source never names it. Because they are build inputs rather than repo
@@ -188,6 +206,34 @@ one (or delete the branch image) when changing it.
 
 Omit `UI_DEFAULT` to ship **both** UIs with the classic one as the default; the
 switcher appears in the menu bar as soon as a second shell is registered.
+
+## Choosing the default at runtime instead
+
+For a hosted deployment, set `ADA_VIEWER_UI_DEFAULT` on the API pod:
+
+```bash
+ADA_VIEWER_UI_DEFAULT=my-ui   # a shell id the image carries
+```
+
+The server puts it on `window.ADA_UI_DEFAULT` in `/config.js`, which `index.html`
+loads as a **blocking, non-deferred classic script** while Vite emits the SPA
+entry as a (deferred) module — so the global is always set before any shell
+resolution runs. There is no async ordering to think about.
+
+Via the chart that is `ui.default`:
+
+```yaml
+ui:
+  default: my-ui
+```
+
+Leave it empty and nothing changes: the image's build-time default still applies.
+
+Prefer this over `UI_DEFAULT` whenever the image already carries the shell.
+One image then serves every deployment, deployments can disagree, and rolling a
+UI back is an edit plus a restart rather than a rebuild — which also sidesteps
+the "flipping `UI_DEFAULT` alone does not trigger a rebuild" trap above. Keep
+`UI_DEFAULT` for images that are meant to be one-UI artefacts.
 
 ## Trying it locally
 

--- a/src/frontend/packages/plugins/ui-alt/README.md
+++ b/src/frontend/packages/plugins/ui-alt/README.md
@@ -34,6 +34,15 @@ the package; `UI_DEFAULT` (→ `ADA_UI_DEFAULT`) stamps `DEFAULT_UI_SHELL` into 
 generated registry. Omit `UI_DEFAULT` to ship both UIs with the classic one as
 the default and the alternative reachable from the switcher / `?ui=my-ui`.
 
+## ...or picking the default per deployment
+
+Which shells an image **carries** is a build decision. Which one it **boots
+into** does not have to be: set `ADA_VIEWER_UI_DEFAULT=my-ui` on the API pod
+(chart value `ui.default`) and the server hands it to the browser through
+`/config.js`. It outranks the build-time default and is outranked by the
+switcher and `?ui=`, so one image can serve several deployments and a UI
+rollback is a config edit plus a restart. Unset changes nothing.
+
 ## Trying this scaffold locally
 
 ```bash

--- a/src/frontend/src/__tests__/plugins/uiShells.test.ts
+++ b/src/frontend/src/__tests__/plugins/uiShells.test.ts
@@ -13,6 +13,7 @@ import {
   registerUiShell,
   resetUiShells,
   resolveUiShell,
+  runtimeDefaultUiShellId,
   setBuildDefaultUiShellId,
   type UiShellSpec,
 } from "@/plugins/uiShells";
@@ -68,7 +69,7 @@ test("a shell without an id or load() is rejected, not registered", () => {
   assert.deepEqual(listUiShells(), []);
 });
 
-test("resolution precedence: url > storage > build default > core", () => {
+test("resolution precedence: url > storage > build default > core (no runtime value)", () => {
   registerCore();
   registerUiShell(shell("alt"), "p1");
   registerUiShell(shell("other"), "p2");
@@ -134,4 +135,106 @@ test("the ui-alt reference package registers a working shell descriptor", () => 
   assert.equal(typeof alt.load, "function");
   // Both UIs offered => the switcher becomes visible in the menu bar.
   assert.equal(listUiShells().length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Runtime default (window.ADA_UI_DEFAULT, served by /config.js). It sits below
+// the two user-driven sources and above the build-time constant, so one image
+// can serve several deployments and a UI rollback is a config edit rather than
+// an image rebuild.
+// ---------------------------------------------------------------------------
+
+/** Run `fn` with a stubbed global `window`, restoring whatever was there. */
+function withWindow<T>(win: unknown, fn: () => T): T {
+  const g = globalThis as { window?: unknown };
+  const had = "window" in g;
+  const prev = g.window;
+  g.window = win;
+  try {
+    return fn();
+  } finally {
+    if (had) g.window = prev;
+    else delete g.window;
+  }
+}
+
+test("the runtime default outranks the build default but loses to storage and ?ui=", () => {
+  registerCore();
+  registerUiShell(shell("alt"), "p1");
+  registerUiShell(shell("other"), "p2");
+  setBuildDefaultUiShellId("other");
+
+  assert.deepEqual(resolveUiShell({ search: "", stored: null, runtimeDefault: "alt" }), {
+    id: "alt",
+    source: "runtime-default",
+    rejected: undefined,
+  });
+  // A user's sticky choice is still the user's choice.
+  assert.equal(resolveUiShell({ search: "", stored: "other", runtimeDefault: "alt" }).source, "storage");
+  // ...and the per-tab escape hatch still reaches the built-in UI.
+  assert.equal(resolveUiShell({ search: "?ui=core", stored: null, runtimeDefault: "alt" }).id, CORE_UI_SHELL_ID);
+});
+
+test("no runtime value leaves the build-time default in charge (existing images unchanged)", () => {
+  registerCore();
+  registerUiShell(shell("alt"), "p1");
+  setBuildDefaultUiShellId("alt");
+
+  for (const runtimeDefault of [null, "", "   "]) {
+    const res = resolveUiShell({ search: "", stored: null, runtimeDefault });
+    assert.equal(res.id, "alt", `runtimeDefault=${JSON.stringify(runtimeDefault)}`);
+    assert.equal(res.source, "build-default");
+  }
+});
+
+test("a runtime default naming an unregistered shell is reported and falls through", () => {
+  registerCore();
+  registerUiShell(shell("alt"), "p1");
+  setBuildDefaultUiShellId("alt");
+
+  // The whole risk this level introduces: a typo now reaches a live deployment
+  // instead of failing the build. Worst case is the next source down.
+  const res = resolveUiShell({ search: "", stored: null, runtimeDefault: "typo-ui" });
+  assert.equal(res.id, "alt");
+  assert.equal(res.source, "build-default");
+  assert.deepEqual(res.rejected, { id: "typo-ui", source: "runtime-default" });
+
+  // ...and with nothing below it either, the built-in UI. Never a blank page.
+  const bare = resolveUiShell({ search: "", stored: null, runtimeDefault: "typo-ui", buildDefault: null });
+  assert.equal(bare.id, CORE_UI_SHELL_ID);
+  assert.equal(bare.source, "builtin");
+  assert.deepEqual(bare.rejected, { id: "typo-ui", source: "runtime-default" });
+});
+
+test("the runtime default is read from window.ADA_UI_DEFAULT when not injected", () => {
+  registerCore();
+  registerUiShell(shell("alt"), "p1");
+
+  withWindow({ ADA_UI_DEFAULT: " alt " }, () => {
+    assert.equal(runtimeDefaultUiShellId(), "alt");
+    assert.equal(resolveUiShell({ search: "", stored: null, buildDefault: null }).id, "alt");
+  });
+});
+
+test("an absent, blank or non-string window.ADA_UI_DEFAULT is not a value", () => {
+  registerCore();
+  registerUiShell(shell("alt"), "p1");
+  setBuildDefaultUiShellId("alt");
+
+  const notValues = [
+    {},
+    { ADA_UI_DEFAULT: "" },
+    { ADA_UI_DEFAULT: "  " },
+    { ADA_UI_DEFAULT: 42 },
+    { ADA_UI_DEFAULT: null },
+  ];
+  for (const win of notValues) {
+    withWindow(win, () => {
+      assert.equal(runtimeDefaultUiShellId(), null, JSON.stringify(win));
+      assert.equal(resolveUiShell({ search: "", stored: null }).source, "build-default");
+    });
+  }
+
+  // No `window` at all (node, embed worker) must not throw either.
+  assert.equal(runtimeDefaultUiShellId(), null);
 });

--- a/src/frontend/src/plugins/uiShells.ts
+++ b/src/frontend/src/plugins/uiShells.ts
@@ -11,9 +11,11 @@
 // shell slot it can live in its OWN repository, be cloned into
 // `packages/plugins/<name>/` during the image build (the exact mechanism the
 // external feature plugins already use — see deploy/Dockerfile.viewer), and be
-// selected as the default at BUILD time. Users can still flip back to the base
-// UI at runtime (`?ui=core`), which is what makes shipping an alternative UI a
-// low-risk operation instead of a fork.
+// selected as the default either at BUILD time or, for an image that carries
+// several shells, per DEPLOYMENT at runtime (`window.ADA_UI_DEFAULT`, served
+// from /config.js). Users can still flip back to the base UI at runtime
+// (`?ui=core`), which is what makes shipping an alternative UI a low-risk
+// operation instead of a fork.
 //
 // Like `registry.ts`, this module is deliberately free of heavy runtime imports
 // (no React runtime, no zustand, no three) so it can be unit-tested under plain
@@ -57,7 +59,7 @@ export interface RegisteredUiShell extends UiShellSpec {
 }
 
 /** Where the active shell id came from — surfaced for logging + the switcher. */
-export type UiShellSource = "url" | "storage" | "build-default" | "builtin";
+export type UiShellSource = "url" | "storage" | "runtime-default" | "build-default" | "builtin";
 
 export interface UiShellResolution {
   id: string;
@@ -142,6 +144,32 @@ function readUrlParam(search?: string): string | null {
   }
 }
 
+/**
+ * The server-supplied default, injected as `window.ADA_UI_DEFAULT` by
+ * `/config.js`. That script is a blocking, non-deferred classic script in
+ * index.html while the SPA entry is a deferred module, so the global is
+ * guaranteed to be set before any of this module runs — there is no async
+ * ordering problem to design around here.
+ *
+ * Absent (dev server, embed bundle, or a deployment that configures nothing)
+ * means *no runtime opinion*, and the build-time default below still applies.
+ * That is what keeps existing images behaving exactly as they did.
+ */
+function readRuntimeDefault(): string | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const raw = (window as { ADA_UI_DEFAULT?: unknown }).ADA_UI_DEFAULT;
+    return typeof raw === "string" ? raw.trim() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The runtime default shell id, or null when the server configured none. */
+export function runtimeDefaultUiShellId(): string | null {
+  return readRuntimeDefault();
+}
+
 function readStorage(): string | null {
   try {
     if (typeof localStorage === "undefined") return null;
@@ -157,6 +185,8 @@ export interface ResolveUiShellOptions {
   search?: string;
   /** Injectable for tests; defaults to `localStorage[ada:ui]`. */
   stored?: string | null;
+  /** Injectable for tests; defaults to `window.ADA_UI_DEFAULT`. */
+  runtimeDefault?: string | null;
   /** Injectable for tests; defaults to the recorded build default. */
   buildDefault?: string | null;
 }
@@ -167,17 +197,32 @@ export interface ResolveUiShellOptions {
  *   1. `?ui=<id>`            — per-tab escape hatch. This is the "always a way
  *                              back to the base UI" guarantee: `?ui=core`.
  *   2. `localStorage ada:ui` — the user's sticky choice from the switcher.
- *   3. build-time default    — `ADA_UI_DEFAULT` baked into the image.
- *   4. `core`                — the built-in UI (or, if core somehow is not
+ *   3. runtime default       — `window.ADA_UI_DEFAULT` from /config.js, i.e.
+ *                              what THIS deployment configured. Above the
+ *                              build-time value so one image can serve several
+ *                              deployments with different UIs, and so changing
+ *                              the UI (or rolling one back) is a config edit
+ *                              and a restart rather than an image rebuild.
+ *                              Below the two user-driven sources so a
+ *                              deployment can never take `?ui=core` away.
+ *   4. build-time default    — `ADA_UI_DEFAULT` baked into the image.
+ *   5. `core`                — the built-in UI (or, if core somehow is not
  *                              registered, the first shell by order).
  *
  * A requested-but-unregistered id never blanks the viewer: it is reported in
- * `rejected` and resolution continues down the list.
+ * `rejected` and resolution continues down the list. That matters most for the
+ * runtime value: a typo there reaches a running deployment, where the same typo
+ * in the build-time value would have been caught at build time. The worst case
+ * is the next source down — ultimately the built-in UI — never a blank page.
  */
 export function resolveUiShell(opts: ResolveUiShellOptions = {}): UiShellResolution {
   const candidates: Array<{ id: string | null; source: UiShellSource }> = [
     { id: readUrlParam(opts.search), source: "url" },
     { id: opts.stored !== undefined ? opts.stored : readStorage(), source: "storage" },
+    {
+      id: opts.runtimeDefault !== undefined ? opts.runtimeDefault : readRuntimeDefault(),
+      source: "runtime-default",
+    },
     { id: opts.buildDefault !== undefined ? opts.buildDefault : _buildDefault, source: "build-default" },
   ];
 

--- a/src/frontend/src/runtime/config.ts
+++ b/src/frontend/src/runtime/config.ts
@@ -100,6 +100,11 @@ declare global {
             to: readonly string[];
             options?: Readonly<Record<string, readonly ConversionOption[]>>;
         }[];
+        // Default UI shell id for THIS deployment (see
+        // src/plugins/uiShells.ts). Absent when the server configures
+        // none, which means the build-time default still applies —
+        // read it through `resolveUiShell`, not from here.
+        ADA_UI_DEFAULT?: string;
         WEBSOCKET_ID?: number | string;
         WEBSOCKET_PORT?: number | string;
         TARGET_INSTANCE_ID?: number | string;

--- a/tests/comms/rest/test_config_js.py
+++ b/tests/comms/rest/test_config_js.py
@@ -1,0 +1,101 @@
+"""GET /config.js — the runtime-config shim the SPA loads before its bundle.
+
+These tests pin the one setting that has to be *absent* rather than empty when
+unconfigured: the default UI shell. The frontend reads a missing
+``window.ADA_UI_DEFAULT`` as "this deployment has no opinion" and keeps the
+default baked into the bundle at build time, so emitting an empty string here
+would silently change the behaviour of every image that predates this setting.
+
+Same shape as test_public_settings.py — ``create_app`` with auth disabled and a
+temp-dir local storage.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+# Importing ada.comms.rest.app evaluates a module-level `create_app()` which
+# materializes a local Storage. Point it at a temp dir so the import succeeds in
+# environments without `./viewer-data`.
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+from fastapi.testclient import TestClient
+
+from ada.comms.rest.app import create_app
+from ada.comms.rest.config import (
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+    load_settings,
+)
+
+
+def _settings(tmp_path, **overrides) -> Settings:
+    base = dict(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _config_js(tmp_path, **overrides) -> str:
+    app = create_app(_settings(tmp_path, **overrides))
+    with TestClient(app) as client:
+        resp = client.get("/config.js")
+    assert resp.status_code == 200
+    return resp.text
+
+
+def test_ui_default_is_emitted_when_configured(tmp_path):
+    body = _config_js(tmp_path, ui_default="alt")
+    assert 'window.ADA_UI_DEFAULT = "alt";' in body
+
+
+def test_ui_default_is_omitted_when_unset(tmp_path):
+    # Unset must not become `window.ADA_UI_DEFAULT = ""`: an empty string is a
+    # value, and the frontend would have to decide what it means.
+    body = _config_js(tmp_path)
+    assert "ADA_UI_DEFAULT" not in body
+    # The rest of the shim is unaffected — this is an additive setting.
+    assert 'window.COMMS_MODE = "rest";' in body
+
+
+def test_ui_default_is_json_encoded(tmp_path):
+    # Same quoting rule as every other string in the shim: a value that
+    # contains a quote must not break out of the JS literal.
+    body = _config_js(tmp_path, ui_default='we"ird')
+    assert 'window.ADA_UI_DEFAULT = "we\\"ird";' in body
+
+
+def test_ui_default_reads_ada_viewer_ui_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADA_VIEWER_STORAGE_KIND", "local")
+    monkeypatch.setenv("ADA_VIEWER_LOCAL_PATH", str(tmp_path))
+    monkeypatch.setenv("ADA_VIEWER_UI_DEFAULT", "  alt  ")
+    assert load_settings().ui_default == "alt"
+
+    monkeypatch.delenv("ADA_VIEWER_UI_DEFAULT")
+    assert load_settings().ui_default == ""


### PR DESCRIPTION
## Why

The UI-shell plugin system lets a plugin contribute an entire alternative viewer UI and be selected as the default — but only at **build time**: build-arg `UI_DEFAULT` → `ADA_UI_DEFAULT` → `gen-plugin-registry.mjs` stamps `DEFAULT_UI_SHELL` into the bundle.

Which shells an image **carries** genuinely has to be a build input — that is what the plugin overlay does. Which one it **boots into** does not, and conflating the two forces one image per UI choice: two deployments sharing an image cannot differ, and rolling a bad UI back means rebuilding an image instead of editing config.

## What

Serve the default at runtime through the mechanism already used for every other per-deployment setting, `/config.js`:

* **Server** — `ADA_VIEWER_UI_DEFAULT` (following the existing `ADA_VIEWER_*` convention) becomes `Settings.ui_default`, and `/config.js` emits `window.ADA_UI_DEFAULT`. Chart value: `ui.default`, rendered onto the API pod.
* **Frontend** — `resolveUiShell` consults it between the user-driven sources and the build-time constant:

  ```
  ?ui=  >  localStorage["ada:ui"]  >  window.ADA_UI_DEFAULT  >  DEFAULT_UI_SHELL  >  core
  ```

  Above the build-time value so one image can serve deployments that want different UIs, and so switching or rolling back a UI is a manifest edit plus a pod restart. Below `?ui=` and the switcher so a deployment can never take `?ui=core` away from a user.

### Additive by construction

Unset means *not configured*, not `core`. The line is **omitted from `/config.js` entirely** rather than emitted as an empty string, so an existing image whose deployment sets nothing resolves exactly as it did before. The build-time path is untouched and still documented.

### Ordering

`index.html` loads `/config.js` as a blocking, non-deferred classic script while Vite emits the SPA entry as a (deferred) module, so the global is always set before shell resolution runs. Verified against the built `dist/index.html`: the entry is `<script type="module">` in `<head>`, `/config.js` is a plain classic `<script>` in `<body>`. No async ordering to design around.

### The new risk, and why it is bounded

A typo now reaches a running deployment where before it would have failed the build. The existing safety properties carry it:

* an unregistered id is reported in `rejected` and resolution continues down the list rather than blanking the viewer — worst case is the next source down, ultimately the built-in UI;
* `UiShellHost` still falls back to `core` when a shell's chunk fails to load or throws while rendering.

Both are covered by tests.

## Tests

`uiShells.ts` stays dependency-free (the global is read behind a local cast, injectable for tests), so this all runs under plain `node --test`:

* runtime default outranks the build default, loses to storage and `?ui=`;
* absent / blank / whitespace / non-string runtime value leaves the build-time default in charge;
* an unregistered runtime id is reported and falls through — to the build default, and with nothing below it, to `core`;
* the value is read off `window.ADA_UI_DEFAULT` when not injected.

Server side (`tests/comms/rest/test_config_js.py`): `/config.js` emits the value when configured, omits it when not, JSON-encodes it like every other string in the shim, and `ADA_VIEWER_UI_DEFAULT` maps to the setting (with trimming).

## Docs

`docs/UI_SHELLS.md` gets the updated precedence table and a "choosing the default at runtime instead" section covering the env var, the chart value, and which wins. `Dockerfile.viewer` and the `ui-alt` README point at the runtime option and say when to prefer each.
