### PR TITLE
fix(cad): guard the native merge_cells against a single operand

### DIFF
--- a/src/ada/cad/__init__.py
+++ b/src/ada/cad/__init__.py
@@ -1603,7 +1603,21 @@ class AdacppBackend:
         fn = getattr(self._cad, "merge_cells", None)
         if fn is None:
             raise NotImplementedError("adacpp.cad.merge_cells is not available in this build")
-        return list(fn(list(solids), float(tolerance)))
+        # CellsBuilder is a general-fuse of >= 2 operands; handed a single solid (or
+        # none) OCCT reports an error rather than a no-op. Merging one cell has
+        # nothing to fuse, so return the operands unchanged. OccBackend.merge_cells
+        # already guards this case, and the two backends must agree — without it a
+        # one-space model builds on OCC and dies on native with OCCT's generic
+        # "BOPAlgo_CellsBuilder reported errors".
+        if len(solids) <= 1:
+            return list(solids)
+        try:
+            return list(fn(list(solids), float(tolerance)))
+        except RuntimeError as e:
+            # OCCT's failure text names the algorithm but not the call that fed it.
+            # Re-raise with the operand count and tolerance so a report of this is
+            # actionable without a debugger attached to the worker.
+            raise RuntimeError(f"{e} (operands={len(solids)}, tolerance={float(tolerance)!r})") from e
 
     def non_manifold_merge(self, shapes: list[ShapeHandle], tolerance: float = 1e-6, glue: bool = True) -> ShapeHandle:
         fn = getattr(self._cad, "non_manifold_merge", None)

--- a/tests/core/cad/test_merge_cells_guard.py
+++ b/tests/core/cad/test_merge_cells_guard.py
@@ -1,0 +1,62 @@
+"""merge_cells must behave the same on both CAD backends for degenerate operand counts.
+
+OCCT's BOPAlgo_CellsBuilder is a general-fuse of >= 2 operands: handed one solid (or
+none) it reports an error instead of doing nothing. OccBackend guards that; the adacpp
+backend is a thin passthrough to C++ and used to hand the single solid straight to
+OCCT, so a one-cell model built fine on OCC and failed on native with the generic
+"BOPAlgo_CellsBuilder reported errors".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.cad import AdacppBackend
+
+
+class _StubCad:
+    """Stands in for ``adacpp.cad`` so the guard is testable without the native build."""
+
+    def __init__(self, raises: bool = False):
+        self.calls: list[tuple[int, float]] = []
+        self._raises = raises
+
+    def merge_cells(self, solids, tolerance):
+        self.calls.append((len(solids), tolerance))
+        if self._raises:
+            raise RuntimeError("merge_cells: BOPAlgo_CellsBuilder reported errors")
+        return list(solids)
+
+
+def _backend(stub: _StubCad) -> AdacppBackend:
+    # Bypass __init__ so no real adacpp import is needed.
+    be = AdacppBackend.__new__(AdacppBackend)
+    be._cad = stub
+    return be
+
+
+@pytest.mark.parametrize("solids", [[], ["solid-a"]])
+def test_merge_cells_short_circuits_below_two_operands(solids):
+    stub = _StubCad(raises=True)
+
+    assert _backend(stub).merge_cells(solids, tolerance=1e-4) == solids
+    assert stub.calls == []  # OCCT never saw the degenerate call
+
+
+def test_merge_cells_still_delegates_two_or_more_operands():
+    stub = _StubCad()
+
+    assert _backend(stub).merge_cells(["a", "b"], tolerance=1e-4) == ["a", "b"]
+    assert stub.calls == [(2, 1e-4)]
+
+
+def test_merge_cells_error_carries_operand_count_and_tolerance():
+    stub = _StubCad(raises=True)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _backend(stub).merge_cells(["a", "b", "c"], tolerance=1e-4)
+
+    message = str(excinfo.value)
+    assert "BOPAlgo_CellsBuilder reported errors" in message
+    assert "operands=3" in message
+    assert "0.0001" in message


### PR DESCRIPTION
## The bug

A one-cell procedural model failed to build with:

```
merge_cells: BOPAlgo_CellsBuilder reported errors
```

`BOPAlgo_CellsBuilder` is a general-fuse of **>= 2 operands**. Handed a single solid (or none) OCCT reports an error rather than treating it as a no-op.

`OccBackend.merge_cells` already guards this — the comment there even calls out "this is what a single-space model (one PrimBox) needs". `AdacppBackend.merge_cells` is a thin passthrough to C++ and did not, so the same model built on the OCC backend and died on the native one. The two backends are meant to be interchangeable, so the guard belongs on both.

## Reproduced

Against the native backend, before this change:

```
BACKEND: ada.cad.AdacppBackend
ONE solid:  FAIL -> RuntimeError: merge_cells: BOPAlgo_CellsBuilder reported errors
TWO solids: OK -> 2 cells
OCC ONE solid: OK -> 1 cells
```

After: a one-cell model compiles to a valid GLB on the native backend, verified end to end.

## Changes

- `AdacppBackend.merge_cells` returns the operands unchanged for `len(solids) <= 1`, matching `OccBackend`.
- OCCT's failure text names the algorithm but not the call that fed it. The error is re-raised with the operand count and tolerance, so `... reported errors (operands=3, tolerance=0.0001)` is actionable without attaching a debugger.
- `tests/core/cad/test_merge_cells_guard.py` covers both, using a stub for `adacpp.cad` so it runs without the native build. Verified meaningful: two of the tests fail if the guard is removed.

`pixi run -e tests` on `tests/core/cad`: 49 passed, 12 skipped. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo