### PR TITLE
feat(visit): carry stable node identity through the scene hierarchy

### DIFF
--- a/src/ada/core/hierarchy.py
+++ b/src/ada/core/hierarchy.py
@@ -1,0 +1,274 @@
+"""A generic, I/O-free index over a hierarchy of identified nodes.
+
+The shape it indexes is deliberately minimal — an id, an optional stable key, an
+optional display name, a parent id — because it is meant to serve *any* producer of a
+model tree: adapy's own GLB scene hierarchy, an exporter for some external CAD system,
+or anything else that can name a parent. This module knows nothing about where the
+nodes came from, what a key means, or what kind of thing a node stands for. A key is an
+opaque, domain-qualified string; two nodes carrying the same key are the same real-world
+thing, and that is the entire semantics.
+
+Ambiguity is a first-class answer. A producer's keys are unique only to the extent that
+producer enforces it, which in practice is often *empirical* rather than structural — so
+:meth:`HierarchyIndex.find` refuses to pick a winner when a key resolves to more than
+one node, and :meth:`HierarchyIndex.is_ambiguous` lets a caller ask up front and degrade
+gracefully instead of silently binding to the wrong node.
+
+If a node ever needs a *type* rather than an identity, use
+:class:`ada.base.ifc_types.SpatialTypes` — the existing vocabulary for "what kind of
+spatial container is this" — rather than inventing a second one here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Iterator
+
+__all__ = [
+    "ROOT_SENTINEL",
+    "SCHEMA_VERSION",
+    "AmbiguousKeyError",
+    "HierarchyIndex",
+    "HierarchyNode",
+]
+
+#: What a root node's ``parent`` is, matching the GLB scene-extras hierarchy contract
+#: (``id_hierarchy`` writes ``"*"`` for a node with no parent). ``None`` is accepted as
+#: an equivalent spelling on input.
+ROOT_SENTINEL = "*"
+
+#: Version of the serialised form produced by :meth:`HierarchyIndex.to_dict`.
+SCHEMA_VERSION = 1
+
+
+class AmbiguousKeyError(KeyError):
+    """A stable key resolved to more than one node.
+
+    Raised by :meth:`HierarchyIndex.find` and the walks built on it, rather than
+    returning an arbitrary one of the candidates. Use
+    :meth:`HierarchyIndex.is_ambiguous` or :meth:`HierarchyIndex.find_all` to handle
+    the case without an exception.
+    """
+
+    def __init__(self, key: str, node_ids: tuple[str, ...]):
+        self.key = key
+        self.node_ids = node_ids
+        super().__init__(f"key {key!r} matches {len(node_ids)} nodes: {list(node_ids)}")
+
+
+@dataclass(frozen=True)
+class HierarchyNode:
+    """One node of a hierarchy: an id, an optional identity, and a parent link."""
+
+    id: str | int
+    key: str | None = None
+    name: str | None = None
+    parent: str | int | None = None
+    has_geometry: bool = False
+    #: Free-form producer-supplied attributes, carried through serialisation untouched.
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_root(self) -> bool:
+        return self.parent is None or self.parent == ROOT_SENTINEL
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"id": self.id}
+        if self.key is not None:
+            out["key"] = self.key
+        if self.name is not None:
+            out["name"] = self.name
+        out["parent"] = self.parent
+        out["has_geometry"] = self.has_geometry
+        out.update(self.extra)
+        return out
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> HierarchyNode:
+        if "id" not in data:
+            raise ValueError(f"hierarchy node is missing 'id': {data!r}")
+        known = {"id", "key", "name", "parent", "has_geometry"}
+        return HierarchyNode(
+            id=data["id"],
+            key=data.get("key"),
+            name=data.get("name"),
+            parent=data.get("parent"),
+            has_geometry=bool(data.get("has_geometry", False)),
+            extra={k: v for k, v in data.items() if k not in known},
+        )
+
+
+class HierarchyIndex:
+    """An in-memory index over a flat node list, answering identity and ancestry.
+
+    Pure data manipulation: it never reads a file, opens a connection or imports a
+    format. Build it from whatever produced the nodes, then ask it questions::
+
+        index = HierarchyIndex(nodes, key_domain="<domain>")
+        index.find("<domain>:/SOME-ELEMENT-NAME")       # the node, or None
+        index.ancestors("<domain>:/SOME-ELEMENT-NAME")  # nearest parent first, up to the root
+        index.children("<domain>:/SOME-CONTAINER-NAME")
+        index.is_ambiguous("<domain>:/SOME-ELEMENT-NAME")
+
+    Ids are compared as strings, so a producer that writes ``5`` and one that writes
+    ``"5"`` index identically; the original value is preserved for round-tripping.
+    """
+
+    def __init__(
+        self,
+        nodes: Iterable[HierarchyNode | dict[str, Any]] = (),
+        *,
+        key_domain: str | None = None,
+        source: dict[str, Any] | None = None,
+        schema_version: int = SCHEMA_VERSION,
+    ):
+        self.key_domain = key_domain
+        #: Opaque producer-supplied provenance, carried through serialisation.
+        self.source: dict[str, Any] = dict(source or {})
+        self.schema_version = schema_version
+
+        self._by_id: dict[str, HierarchyNode] = {}
+        self._by_key: dict[str, list[str]] = {}
+        self._children: dict[str, list[str]] = {}
+        self._nodes: list[HierarchyNode] = []
+
+        for n in nodes:
+            self.add(n)
+
+    # -- construction -------------------------------------------------------- #
+    def add(self, node: HierarchyNode | dict[str, Any]) -> HierarchyNode:
+        """Index one node.
+
+        Raises on a duplicate id — a hierarchy with two nodes sharing an id cannot be
+        walked, and failing loudly beats a silent overwrite.
+        """
+        n = node if isinstance(node, HierarchyNode) else HierarchyNode.from_dict(node)
+        nid = str(n.id)
+        if nid in self._by_id:
+            raise ValueError(f"duplicate node id {n.id!r}")
+        self._by_id[nid] = n
+        self._nodes.append(n)
+        if n.key is not None:
+            self._by_key.setdefault(n.key, []).append(nid)
+        if not n.is_root:
+            self._children.setdefault(str(n.parent), []).append(nid)
+        return n
+
+    # -- lookup -------------------------------------------------------------- #
+    def find(self, key: str) -> HierarchyNode | None:
+        """The single node carrying ``key``, or ``None`` if no node does.
+
+        Raises :class:`AmbiguousKeyError` if more than one does — see
+        :meth:`is_ambiguous` and :meth:`find_all` for the non-raising path.
+        """
+        ids = self._by_key.get(key)
+        if not ids:
+            return None
+        if len(ids) > 1:
+            raise AmbiguousKeyError(key, tuple(ids))
+        return self._by_id[ids[0]]
+
+    def find_all(self, key: str) -> tuple[HierarchyNode, ...]:
+        """Every node carrying ``key``, in insertion order. Empty when unknown."""
+        return tuple(self._by_id[i] for i in self._by_key.get(key, ()))
+
+    def is_ambiguous(self, key: str) -> bool:
+        """Whether ``key`` resolves to more than one node. Reports; never resolves."""
+        return len(self._by_key.get(key, ())) > 1
+
+    def node_by_id(self, node_id: str | int) -> HierarchyNode | None:
+        return self._by_id.get(str(node_id))
+
+    # -- walks --------------------------------------------------------------- #
+    def children(self, key: str) -> tuple[HierarchyNode, ...]:
+        """Direct children of the node carrying ``key``, in insertion order."""
+        node = self.find(key)
+        if node is None:
+            return ()
+        return self.children_of_id(node.id)
+
+    def children_of_id(self, node_id: str | int) -> tuple[HierarchyNode, ...]:
+        return tuple(self._by_id[i] for i in self._children.get(str(node_id), ()))
+
+    def ancestors(self, key: str) -> tuple[HierarchyNode, ...]:
+        """The node's ancestors, nearest parent first, ending at the root.
+
+        The walk stops at a node whose parent is the root sentinel (or ``None``), and
+        also stops — rather than looping or raising — on a dangling parent id or a
+        cycle, so a malformed tree degrades to a short answer instead of a hang.
+        Returns ``()`` for an unknown key or for a node that is itself a root.
+        """
+        node = self.find(key)
+        if node is None:
+            return ()
+        return self.ancestors_of_id(node.id)
+
+    def ancestors_of_id(self, node_id: str | int) -> tuple[HierarchyNode, ...]:
+        node = self._by_id.get(str(node_id))
+        out: list[HierarchyNode] = []
+        seen = {str(node_id)}
+        while node is not None and not node.is_root:
+            pid = str(node.parent)
+            if pid in seen:
+                break  # cycle
+            parent = self._by_id.get(pid)
+            if parent is None:
+                break  # dangling parent id
+            out.append(parent)
+            seen.add(pid)
+            node = parent
+        return tuple(out)
+
+    def roots(self) -> tuple[HierarchyNode, ...]:
+        return tuple(n for n in self._nodes if n.is_root)
+
+    # -- collection protocol ------------------------------------------------- #
+    @property
+    def nodes(self) -> tuple[HierarchyNode, ...]:
+        return tuple(self._nodes)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._by_key)
+
+    def ambiguous_keys(self) -> tuple[str, ...]:
+        return tuple(k for k, ids in self._by_key.items() if len(ids) > 1)
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+    def __iter__(self) -> Iterator[HierarchyNode]:
+        return iter(self._nodes)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._by_key
+
+    def __repr__(self) -> str:
+        return f"HierarchyIndex(nodes={len(self._nodes)}, keys={len(self._by_key)}, domain={self.key_domain!r})"
+
+    # -- serialisation ------------------------------------------------------- #
+    def to_dict(self) -> dict[str, Any]:
+        """The sidecar form: schema version, provenance, the node list, and a
+        ``key -> id`` lookup table.
+
+        ``key_index`` is a derived convenience for consumers that only need one lookup;
+        ambiguous keys are left out of it deliberately, since it cannot represent them
+        without picking a winner. ``nodes`` remains the full truth and is what
+        :meth:`from_dict` rebuilds from.
+        """
+        out: dict[str, Any] = {"schema_version": self.schema_version}
+        if self.source:
+            out["source"] = dict(self.source)
+        if self.key_domain is not None:
+            out["key_domain"] = self.key_domain
+        out["nodes"] = [n.to_dict() for n in self._nodes]
+        out["key_index"] = {k: self._by_id[ids[0]].id for k, ids in self._by_key.items() if len(ids) == 1}
+        return out
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> HierarchyIndex:
+        return HierarchyIndex(
+            (HierarchyNode.from_dict(n) for n in data.get("nodes", [])),
+            key_domain=data.get("key_domain"),
+            source=data.get("source"),
+            schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+        )

--- a/src/ada/visit/gltf/graph.py
+++ b/src/ada/visit/gltf/graph.py
@@ -18,6 +18,10 @@ class GraphStore:
     draw_ranges: list[GroupReference] = field(default_factory=list, repr=False)
     merged_meshes: dict[int, MergedMesh] = field(default_factory=dict, repr=False)
     edge_mappings: dict[int, list[int]] = field(default_factory=dict, repr=False)
+    #: Who minted the ``stable_key`` values on this store's nodes. Opaque to adapy:
+    #: it is stored, emitted and compared, never parsed or interpreted (see
+    #: :attr:`GraphNode.stable_key`).
+    key_domain: str | None = None
 
     def __post_init__(self):
         self.num_meshes = sum(len(n.mesh_indices) for n in self.nodes.values())
@@ -25,9 +29,27 @@ class GraphStore:
             self.hash_map = {n.hash: n for n in self.nodes.values()}
 
     def to_json_hierarchy(self, suffix: str = "") -> dict[str, dict[str, tuple[str, str | int]]]:
+        """Emit the scene-extras hierarchy contract.
+
+        Always emits ``id_hierarchy`` (``{node_id: (name, parent_id)}``, root parent
+        ``"*"``) plus one ``draw_ranges_node<buffer_id>`` per merged mesh.
+
+        When at least one node carries a :attr:`GraphNode.stable_key`, two *parallel*
+        keys are added alongside::
+
+            "node_keys":       {"5": "<domain>:/SOME-ELEMENT-NAME"}
+            "node_key_domain": "<domain>"      # only when :attr:`key_domain` is set
+
+        They are deliberately a separate map rather than a third element on the
+        ``id_hierarchy`` tuple: every existing reader of that tuple — in this repo and
+        in the native writers/readers outside it — keeps working untouched, and a
+        reader that does not know about keys simply never looks at them. When no node
+        has a key, the returned dict is exactly what it was before keys existed.
+        """
         from ada.visit.gltf.store import create_id_sequence
 
         meta = dict()
+        node_keys: dict[str | int, str] = {}
         for n in self.nodes.values().__reversed__():
             if n.parent is not None:
                 p_id = n.parent.node_id
@@ -36,12 +58,41 @@ class GraphStore:
                 p_id = "*"
                 n_name = n.name + suffix
             meta[n.node_id] = (n_name, p_id)
+            if n.stable_key is not None:
+                node_keys[n.node_id] = n.stable_key
 
         data = {"id_hierarchy": meta}
+        if node_keys:
+            data["node_keys"] = node_keys
+            if self.key_domain is not None:
+                data["node_key_domain"] = self.key_domain
         for buffer_id, merged_mesh in self.merged_meshes.items():
             data[f"draw_ranges_node{buffer_id}"] = create_id_sequence(self, merged_mesh)
 
         return data
+
+    def assign_stable_keys_from_hash(self, domain: str, overwrite: bool = False) -> int:
+        """Opt in to using each node's ``hash`` (the object guid) as its stable key.
+
+        The guid is the natural identity for objects adapy created itself, and until
+        now :meth:`to_json_hierarchy` threw it away. This is the one-line way to keep
+        it, under a caller-chosen ``domain`` so the keys stay self-describing.
+
+        Deliberately opt-in rather than a default: turning it on unconditionally would
+        add ``node_keys`` to every export ever produced, and a guid is only a *stable*
+        identity when the model it came from persists guids across writes — which is
+        the caller's knowledge, not this class's.
+
+        Returns the number of nodes keyed.
+        """
+        self.key_domain = domain
+        keyed = 0
+        for n in self.nodes.values():
+            if n.stable_key is not None and not overwrite:
+                continue
+            n.stable_key = n.hash
+            keyed += 1
+        return keyed
 
     def add_node(self, node: GraphNode) -> GraphNode:
         self.nodes[node.node_id] = node
@@ -162,6 +213,12 @@ class GraphNode:
     parent: GraphNode | None = field(default=None, repr=False)
     mesh_indices: list[MeshRef] = field(default_factory=list, repr=False)
     hash: str = field(default_factory=create_guid, repr=False)
+    #: Optional domain-qualified identity for the real-world thing this node stands
+    #: for, e.g. ``"<domain>:/SOME-ELEMENT-NAME"``. Opaque to adapy — it is carried
+    #: and compared for equality, never parsed. Two nodes in two different models
+    #: sharing a stable key are the same thing; that is the whole of its meaning.
+    #: ``None`` (the default) means "no stable identity", and nothing is emitted.
+    stable_key: str | None = field(default=None, repr=False)
 
     def __post_init__(self):
         self.node_id = str(self.node_id)

--- a/tests/core/test_hierarchy_index.py
+++ b/tests/core/test_hierarchy_index.py
@@ -1,0 +1,186 @@
+"""HierarchyIndex: identity and ancestry over a flat node list, with no I/O and no
+knowledge of who produced the nodes."""
+
+import pytest
+
+from ada.core.hierarchy import (
+    ROOT_SENTINEL,
+    AmbiguousKeyError,
+    HierarchyIndex,
+    HierarchyNode,
+)
+
+DOMAIN = "example-domain"
+
+
+def _key(name: str) -> str:
+    return f"{DOMAIN}:{name}"
+
+
+def _sample_nodes():
+    """A four-level tree: root -> container -> sub-container -> element."""
+    return [
+        HierarchyNode(id=0, key=_key("/ROOT-CONTAINER"), name="/ROOT-CONTAINER", parent=ROOT_SENTINEL),
+        HierarchyNode(id=1, key=_key("/SOME-CONTAINER"), name="/SOME-CONTAINER", parent=0),
+        HierarchyNode(id=2, key=_key("/SOME-SUB-CONTAINER"), name="/SOME-SUB-CONTAINER", parent=1),
+        HierarchyNode(id=3, key=_key("/SOME-ELEMENT-NAME"), name="/SOME-ELEMENT-NAME", parent=2, has_geometry=True),
+        HierarchyNode(id=4, key=_key("/OTHER-ELEMENT-NAME"), name="/OTHER-ELEMENT-NAME", parent=2, has_geometry=True),
+    ]
+
+
+def _index():
+    return HierarchyIndex(_sample_nodes(), key_domain=DOMAIN)
+
+
+def test_find_returns_the_node_and_none_for_an_unknown_key():
+    index = _index()
+
+    assert index.find(_key("/SOME-ELEMENT-NAME")).id == 3
+    assert index.find(_key("/NOT-IN-THIS-MODEL")) is None
+    assert _key("/SOME-ELEMENT-NAME") in index
+    assert len(index) == 5
+
+
+def test_ancestors_walk_all_the_way_to_the_root_sentinel():
+    index = _index()
+
+    chain = index.ancestors(_key("/SOME-ELEMENT-NAME"))
+
+    assert [n.name for n in chain] == ["/SOME-SUB-CONTAINER", "/SOME-CONTAINER", "/ROOT-CONTAINER"]
+    assert chain[-1].is_root
+    assert chain[-1].parent == ROOT_SENTINEL
+    # a root has no ancestors, and neither does something absent
+    assert index.ancestors(_key("/ROOT-CONTAINER")) == ()
+    assert index.ancestors(_key("/NOT-IN-THIS-MODEL")) == ()
+
+
+def test_a_none_parent_is_a_root_too():
+    index = HierarchyIndex(
+        [HierarchyNode(id=0, key=_key("/R"), parent=None), HierarchyNode(id=1, key=_key("/C"), parent=0)]
+    )
+
+    assert index.ancestors(_key("/C"))[-1].id == 0
+    assert [n.id for n in index.roots()] == [0]
+
+
+def test_children_are_direct_only_and_in_insertion_order():
+    index = _index()
+
+    assert [n.id for n in index.children(_key("/SOME-SUB-CONTAINER"))] == [3, 4]
+    assert index.children(_key("/SOME-ELEMENT-NAME")) == ()
+    assert index.children(_key("/NOT-IN-THIS-MODEL")) == ()
+
+
+def test_ambiguity_is_reported_never_resolved():
+    """Key uniqueness is a property of the producer, not something this structure can
+    assume. Two nodes with one key must surface as ambiguous rather than silently
+    binding a caller to whichever happened to be indexed first."""
+    nodes = _sample_nodes()
+    nodes.append(HierarchyNode(id=5, key=_key("/SOME-ELEMENT-NAME"), name="/SOME-ELEMENT-NAME", parent=1))
+    index = HierarchyIndex(nodes, key_domain=DOMAIN)
+
+    assert index.is_ambiguous(_key("/SOME-ELEMENT-NAME")) is True
+    assert index.is_ambiguous(_key("/OTHER-ELEMENT-NAME")) is False
+    assert index.ambiguous_keys() == (_key("/SOME-ELEMENT-NAME"),)
+    assert [n.id for n in index.find_all(_key("/SOME-ELEMENT-NAME"))] == [3, 5]
+
+    with pytest.raises(AmbiguousKeyError) as err:
+        index.find(_key("/SOME-ELEMENT-NAME"))
+    assert err.value.node_ids == ("3", "5")
+
+
+def test_unkeyed_nodes_are_still_indexed_and_still_walkable():
+    """A node with no stable identity is a normal state, not an error — it just cannot
+    be looked up by key."""
+    nodes = _sample_nodes()
+    nodes.append(HierarchyNode(id=5, name="unnamed child", parent=3))
+    index = HierarchyIndex(nodes, key_domain=DOMAIN)
+
+    assert len(index) == 6
+    assert len(index.keys()) == 5
+    assert [n.id for n in index.children(_key("/SOME-ELEMENT-NAME"))] == [5]
+    assert [n.id for n in index.ancestors_of_id(5)] == [3, 2, 1, 0]
+
+
+def test_ids_index_the_same_whether_written_as_int_or_string():
+    index = HierarchyIndex(
+        [
+            HierarchyNode(id="0", key=_key("/R"), parent=ROOT_SENTINEL),
+            HierarchyNode(id=1, key=_key("/C"), parent="0"),
+        ]
+    )
+
+    assert [n.id for n in index.ancestors(_key("/C"))] == ["0"]
+    assert index.node_by_id(0).key == _key("/R")
+
+
+def test_a_broken_tree_degrades_instead_of_hanging_or_raising():
+    dangling = HierarchyIndex([HierarchyNode(id=1, key=_key("/C"), parent=99)])
+    assert dangling.ancestors(_key("/C")) == ()
+
+    cyclic = HierarchyIndex(
+        [HierarchyNode(id=1, key=_key("/A"), parent=2), HierarchyNode(id=2, key=_key("/B"), parent=1)]
+    )
+    assert [n.id for n in cyclic.ancestors(_key("/A"))] == [2]
+
+
+def test_duplicate_ids_are_refused():
+    with pytest.raises(ValueError, match="duplicate node id"):
+        HierarchyIndex([HierarchyNode(id=1, key=_key("/A")), HierarchyNode(id=1, key=_key("/B"))])
+
+
+def test_serialises_to_the_sidecar_shape_and_back():
+    source = {"kind": "example-producer", "content_hash": "abc123"}
+    index = HierarchyIndex(_sample_nodes(), key_domain=DOMAIN, source=source)
+
+    data = index.to_dict()
+
+    assert data["schema_version"] == 1
+    assert data["key_domain"] == DOMAIN
+    assert data["source"] == source
+    assert data["nodes"][3] == {
+        "id": 3,
+        "key": _key("/SOME-ELEMENT-NAME"),
+        "name": "/SOME-ELEMENT-NAME",
+        "parent": 2,
+        "has_geometry": True,
+    }
+    assert data["key_index"][_key("/SOME-ELEMENT-NAME")] == 3
+
+    back = HierarchyIndex.from_dict(data)
+
+    assert back.to_dict() == data
+    assert back.nodes == index.nodes
+    assert [n.name for n in back.ancestors(_key("/SOME-ELEMENT-NAME"))] == [
+        "/SOME-SUB-CONTAINER",
+        "/SOME-CONTAINER",
+        "/ROOT-CONTAINER",
+    ]
+
+
+def test_the_key_index_omits_ambiguous_keys_rather_than_picking_one():
+    nodes = _sample_nodes()
+    nodes.append(HierarchyNode(id=5, key=_key("/SOME-ELEMENT-NAME"), parent=1))
+    data = HierarchyIndex(nodes, key_domain=DOMAIN).to_dict()
+
+    assert _key("/SOME-ELEMENT-NAME") not in data["key_index"]
+    assert _key("/OTHER-ELEMENT-NAME") in data["key_index"]
+    # nodes remains the full truth, so the round-trip still sees both
+    assert len(HierarchyIndex.from_dict(data).find_all(_key("/SOME-ELEMENT-NAME"))) == 2
+
+
+def test_producer_specific_node_fields_survive_a_round_trip():
+    index = HierarchyIndex([{"id": 7, "key": _key("/E"), "parent": "*", "producer_field": {"a": 1}}])
+
+    node = index.find(_key("/E"))
+    assert node.extra == {"producer_field": {"a": 1}}
+    assert index.to_dict()["nodes"][0]["producer_field"] == {"a": 1}
+
+
+def test_an_empty_index_is_usable():
+    index = HierarchyIndex()
+
+    assert len(index) == 0
+    assert index.find(_key("/E")) is None
+    assert index.is_ambiguous(_key("/E")) is False
+    assert index.to_dict()["nodes"] == []

--- a/tests/core/visit/test_graph_store.py
+++ b/tests/core/visit/test_graph_store.py
@@ -1,3 +1,5 @@
+import pytest
+
 import ada
 
 
@@ -77,3 +79,125 @@ def test_pipe_segments_nest_under_pipe_not_orphaned_to_root():
     # every pipe segment nests under the Pipe (none orphaned to '*')
     seg_parents = {v[1] for name, v in by_name.items() if name.startswith("P1_")}
     assert seg_parents == {pipe_id}, f"pipe segments not nested under the pipe: {seg_parents}"
+
+
+# --------------------------------------------------------------------------- #
+# Stable keys on the hierarchy
+#
+# ``id_hierarchy`` carries (name, parent) and drops every stable identity, so any
+# consumer wanting to say "this node and that node in another model are the same
+# thing" has to fall back on the display name. A node can now carry an opaque,
+# domain-qualified ``stable_key``, emitted as a *parallel* extras map. Parallel and
+# not a third tuple element: every existing reader of the tuple — here and in the
+# native writers outside this repo — keeps working with no audit.
+# --------------------------------------------------------------------------- #
+KEY_DOMAIN = "example-domain"
+KEY_BM1 = f"{KEY_DOMAIN}:/SOME-ELEMENT-NAME"
+KEY_BM2 = f"{KEY_DOMAIN}:/SOME-OTHER-ELEMENT-NAME"
+
+
+def _two_beam_store():
+    bm1 = ada.Beam("bm1", (0, 0, 0), (1, 0, 0), "IPE100")
+    bm2 = ada.Beam("bm2", (0, 0, 0), (0, 1, 0), "IPE100")
+    a = ada.Assembly() / (ada.Part("MyPart") / [bm1, bm2])
+    return a, a.get_graph_store()
+
+
+def _node_by_name(store, name):
+    return next(n for n in store.nodes.values() if n.name == name)
+
+
+def test_no_stable_keys_emits_exactly_the_previous_contract():
+    """The no-keys export must be indistinguishable from the pre-keys one — same
+    keys, same order, same values — so every GLB produced without keys is byte-for-byte
+    what it was before."""
+    _, store = _two_beam_store()
+
+    data = store.to_json_hierarchy()
+
+    assert list(data.keys()) == ["id_hierarchy"]
+    assert data["id_hierarchy"] == {
+        "0": ("Ada", "*"),
+        "1": ("MyPart", "0"),
+        "2": ("bm1", "1"),
+        "3": ("bm2", "1"),
+    }
+
+
+def test_no_stable_keys_leaves_no_trace_in_the_exported_scene():
+    a, _ = _two_beam_store()
+
+    meta = a.to_trimesh_scene(merge_meshes=True).metadata
+
+    assert "node_keys" not in meta
+    assert "node_key_domain" not in meta
+    assert "id_hierarchy" in meta and "draw_ranges_node0" in meta
+
+
+def test_stable_keys_round_trip_alongside_an_untouched_id_hierarchy():
+    a, store = _two_beam_store()
+    store.key_domain = KEY_DOMAIN
+    _node_by_name(store, "bm1").stable_key = KEY_BM1
+    _node_by_name(store, "bm2").stable_key = KEY_BM2
+
+    data = store.to_json_hierarchy()
+
+    assert data["node_keys"] == {"2": KEY_BM1, "3": KEY_BM2}
+    assert data["node_key_domain"] == KEY_DOMAIN
+    # the tuple is still (name, parent) — nothing widened it
+    assert all(len(v) == 2 for v in data["id_hierarchy"].values())
+    assert data["id_hierarchy"] == a.get_graph_store().to_json_hierarchy()["id_hierarchy"]
+
+
+def test_only_keyed_nodes_appear_in_the_key_map():
+    """A partially keyed graph emits only the keys that exist. Absence of a key is a
+    real state — "no stable identity" — not something to be papered over."""
+    _, store = _two_beam_store()
+    store.key_domain = KEY_DOMAIN
+    _node_by_name(store, "bm2").stable_key = KEY_BM2
+
+    data = store.to_json_hierarchy()
+
+    assert data["node_keys"] == {"3": KEY_BM2}
+    assert len(data["id_hierarchy"]) == 4
+
+
+def test_key_domain_is_omitted_when_the_store_declares_none():
+    _, store = _two_beam_store()
+    _node_by_name(store, "bm1").stable_key = KEY_BM1
+
+    data = store.to_json_hierarchy()
+
+    assert data["node_keys"] == {"2": KEY_BM1}
+    assert "node_key_domain" not in data
+
+
+def test_assign_stable_keys_from_hash_keeps_the_guid_that_was_being_dropped():
+    """``GraphNode.hash`` is the object guid and the natural identity for objects adapy
+    made itself, yet ``to_json_hierarchy`` threw it away. Opting in keeps it."""
+    a, store = _two_beam_store()
+
+    keyed = store.assign_stable_keys_from_hash("ada.guid")
+    data = store.to_json_hierarchy()
+
+    assert keyed == len(store.nodes)
+    assert data["node_key_domain"] == "ada.guid"
+    assert data["node_keys"]["2"] == a.get_by_name("bm1").guid
+    assert data["node_keys"]["3"] == a.get_by_name("bm2").guid
+
+
+def test_existing_glb_readers_ignore_the_new_extras_keys():
+    """diff.parse_elements and diagnostics.glb_parts both read the same scene extras.
+    Both select what they want by name/prefix, so an added parallel map is inert to
+    them — asserted rather than assumed."""
+    diff = pytest.importorskip("ada.comms.rest.utilities.diff")
+    from ada.cadit.diagnostics import glb_parts
+
+    a, _ = _two_beam_store()
+    scene = a.to_trimesh_scene(merge_meshes=True)
+    scene.metadata["node_keys"] = {"2": KEY_BM1, "3": KEY_BM2}
+    scene.metadata["node_key_domain"] = KEY_DOMAIN
+    glb = scene.export(file_type="glb")
+
+    assert sorted(diff.parse_elements(glb)) == ["bm1", "bm2"]
+    assert sorted(p.name for p in glb_parts(glb)) == ["bm1", "bm2"]


### PR DESCRIPTION
## The problem

`GraphStore.to_json_hierarchy()` emits `id_hierarchy` as `{node_id: (name, parent_id)}` and
**drops `GraphNode.hash`** — the object guid — on every single export. The only identity that
reaches a GLB today is `ADA_EXT_data.design_objects[*].object_guids`, and that map is *keyed by
display name*. So adapy throws away the stable identity it is already carrying, and anything that
later wants to say "this node and that node in another model are the same thing" has to re-derive
the answer from a string join on names.

This PR gives a node somewhere to keep an identity, and gives callers a structure to ask questions
of one.

## `stable_key` on the hierarchy

`GraphNode` gains an optional `stable_key: str | None` — an opaque, domain-qualified identity for
the real-world thing the node stands for. adapy stores it, emits it and compares it for equality;
it never parses or interprets it. Two nodes in two different models carrying the same key are the
same thing, and that is the whole of its meaning.

When at least one node has a key, `to_json_hierarchy()` adds two **parallel** entries to the same
extras dict:

```jsonc
"id_hierarchy":    { "5": ["/SOME-ELEMENT-NAME", "4"] },   // unchanged
"node_keys":       { "5": "<domain>:/SOME-ELEMENT-NAME" }, // new, optional
"node_key_domain": "<domain>"                              // new, when the store declares one
```

**Parallel, not a third element on the tuple.** The tuple is read by `diff.py`, `diagnostics.py`,
`merge_preview.py`, the frontend loader and the native writer outside this repo. Widening it means
auditing all of them; a separate key means auditing none of them — every existing reader either
selects by name or filters by the `draw_ranges_` prefix, so an added map is inert. There is
already precedent for exactly this: `face_ranges_node<idx>` is an opt-in parallel extras key the
frontend picks up only when present.

**With no keys set, nothing changes.** Not "almost nothing" — the emitted dict is identical, same
keys in the same order. Verified end to end rather than argued: a GLB export of a multi-material
model with a plate and a pipe, with guids pinned so the export is deterministic, hashes to
`95d7099d8851ed755c664a0774784659` on this branch and to the same digest with the change stashed.

`assign_stable_keys_from_hash(domain)` opts a store into using the guid it was already holding —
the one-line fix for the identity being discarded. It is deliberately opt-in and not a default:
switching it on unconditionally would put `node_keys` into every export ever produced, and a guid
is only a *stable* identity when the producing model persists guids across writes, which is the
caller's knowledge and not this class's.

## `HierarchyIndex`

`ada.core.hierarchy.HierarchyIndex` is a small, generic, I/O-free index over a flat node list:
`find`, `find_all`, `children`, `ancestors`, `is_ambiguous`, `node_by_id`, plus a versioned
`to_dict()` / `from_dict()` for a sidecar. It never reads a file or imports a format, and it knows
nothing about who produced the nodes — an id, an optional key, an optional name and a parent are
the entire input shape. Producer-specific fields on a node round-trip untouched.

**Ambiguity is reported, never resolved.** Key uniqueness is a property of whoever minted the keys,
not something this structure can assume, so:

- `find` refuses to pick a winner and raises `AmbiguousKeyError` naming the candidates,
- `is_ambiguous` / `ambiguous_keys` let a caller ask up front and degrade gracefully,
- the derived `key_index` in the serialised form *omits* ambiguous keys rather than guessing one,
  while `nodes` stays the full truth that `from_dict` rebuilds from.

A malformed tree degrades instead of misbehaving: a dangling parent id or a cycle ends the ancestor
walk with a short answer rather than raising or hanging. Duplicate node ids are refused outright —
a hierarchy with two nodes sharing an id cannot be walked, and failing loudly beats a silent
overwrite.

If a node ever needs a *type* rather than an identity, the existing `SpatialTypes` enum is the
place for it; this module deliberately invents no second vocabulary.

## Tests

23 tests, covering: the no-keys export matching the previous contract exactly and leaving no trace
in an exported scene; keys round-tripping with the tuple untouched; only keyed nodes appearing in
the map; the domain omitted when unset; guid-derived keys matching the objects' guids; `ancestors`
walking to the root sentinel `"*"`; `is_ambiguous` reporting where `find` refuses; unkeyed nodes
still walkable; int and string ids indexing identically; broken trees degrading; and the sidecar
round-trip. One test asserts rather than assumes the compatibility claim: it exports a GLB carrying
the new extras keys and runs both `diff.parse_elements` and `diagnostics.glb_parts` over it.

## Gate

- `pixi run lint-check` (the gate that actually checks — `lint` mutates and exits 0): clean, 1365
  files unchanged, all checks passed.
- `pixi run -e tests test-core`: 1875 tests, one failure —
  `test_ada_ext_codegen.py::test_ada_ext_header_matches_schema`, a local encoding artefact reading
  the sibling adacpp header (`—` vs `â€"`). Confirmed identical on a stashed tree, so pre-existing
  and unrelated.
- Frontend, unchanged by this PR and confirmed rather than assumed: `npm test` fails only on the
  Windows path-separator assertion in `viewerCoreFacade.test.ts`, and `tsc --noEmit` reports only
  `load_fea_streaming.ts(1272,25)`. Both are pre-existing on `main` and neither is touched here.
