### PR TITLE
chore(frontend): clear the open npm security advisories in the lockfile

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ada-py-viewer",
-  "version": "0.35.1",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ada-py-viewer",
-      "version": "0.35.1",
+      "version": "0.45.0",
       "workspaces": [
         "packages/plugins/*"
       ],
@@ -34,7 +34,7 @@
         "flatbuffers": "25.2.10",
         "lodash": ">=4.18.0",
         "pako": "2.1.0",
-        "postcss": "8.5.14",
+        "postcss": "^8.5.26",
         "prettier": "3.5.3",
         "qs": ">=6.15.2",
         "react": "19.1.0",
@@ -53,6 +53,10 @@
     },
     "node_modules/@adapy-plugins/demo": {
       "resolved": "packages/plugins/demo",
+      "link": true
+    },
+    "node_modules/@adapy-plugins/ui-alt": {
+      "resolved": "packages/plugins/ui-alt",
       "link": true
     },
     "node_modules/@alloc/quick-lru": {
@@ -2225,9 +2229,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2239,7 +2243,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -2298,10 +2302,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3916,9 +3921,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4490,10 +4495,11 @@
       }
     },
     "node_modules/multimatch/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4512,9 +4518,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4762,9 +4768,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4780,8 +4786,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5263,15 +5270,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -6276,6 +6284,10 @@
     },
     "packages/plugins/demo": {
       "name": "@adapy-plugins/demo",
+      "version": "0.1.0"
+    },
+    "packages/plugins/ui-alt": {
+      "name": "@adapy-plugins/ui-alt",
       "version": "0.1.0"
     }
   }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,7 +9,7 @@
     "qs": ">=6.15.2",
     "esbuild": "$esbuild",
     "@babel/core": "^7.29.6",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.1"
   },
   "scripts": {
     "gen:plugins": "node scripts/gen-plugin-registry.mjs",
@@ -41,7 +41,7 @@
     "flatbuffers": "25.2.10",
     "lodash": ">=4.18.0",
     "pako": "2.1.0",
-    "postcss": "8.5.14",
+    "postcss": "^8.5.26",
     "prettier": "3.5.3",
     "qs": ">=6.15.2",
     "react": "19.1.0",


### PR DESCRIPTION
Closes the seven open Dependabot advisories against `src/frontend/package-lock.json`.

All seven are **dev-scope** (`scope=development`): postcss, js-yaml and brace-expansion are build tooling, not runtime. `npm audit --omit=dev` reported **0 vulnerabilities before this change**, so none of them ever reached the shipped viewer bundle. They are still worth clearing — they are real advisories in the build path — but the severity in context is lower than the "high" badge suggests.

## What each one needed

| Alert | Package | Was | Now | Why it was stuck |
|---|---|---|---|---|
| #116, #105 | postcss | 8.5.14 | 8.5.26 | Pinned **exactly** in `package.json`, so no in-range resolution could ever reach the patched line. The pin had to be relaxed. |
| #114, #103 | js-yaml | 4.2.0 | 4.3.1 | The existing `overrides` floor `^4.2.0` already *permitted* the fix; the lockfile just had not been refreshed. Floor raised to `^4.3.1` so it is enforced. |
| #102 | brace-expansion | 2.1.0 | 2.1.4 | Parent range `^2.0.1` already admitted it. |
| #101 | brace-expansion | 1.1.14 | 1.1.18 | Parent range `^1.1.7` already admitted it. |
| #100 | brace-expansion | 5.0.6 | 5.0.9 | Parent range `^5.0.5` already admitted it. |

The three `brace-expansion` alerts are three different major lines in three different subtrees (root, under `multimatch`, under `rimraf`). They do **not** collapse into one update — but they also need **no `overrides` entry**, because every parent already declares a caret range that admits its patched release. A lockfile refresh was sufficient for all three.

`nanoid` 3.3.11 → 3.3.18 came along through postcss's own dependency, and `body-parser` 1.20.4 → 1.20.6 (in-range under express) clears the one remaining low finding, so `npm audit` is now at zero rather than "zero except one".

`npm audit` after: **0 vulnerabilities**, with and without `--omit=dev`.

## Two incidental corrections

The refresh also fixed pre-existing lockfile drift:

- the lockfile's `version` field was stale (`0.35.1` vs `package.json`'s `0.45.0`);
- the `packages/plugins/ui-alt` workspace had **no link entry**, meaning `npm ci` on `main` was not installing that plugin at all.

## Verification

The risk here is the frontend build, not the advisories, so `node_modules` was deleted and reinstalled from the lockfile with `npm ci` before testing. On node 24.9.0 / npm 11.6.0 (Windows):

- **`npm run build`** — succeeds, and emits **byte-identical assets** to the pre-change build (same content hashes: `index-BeL-A295.js`, `index-DB9vy_5i.css`). The toolchain bumps change nothing about the output.
- **`npm test`** — 254 pass / 1 fail / 1 skipped, *identical* to the pre-change baseline captured on `main` before any edit. The single failure is the known Windows path-separator assertion in `viewerCoreFacade.test.ts`; it fails the same way before and after.
- **`npx tsc --noEmit`** — the one pre-existing error at `load_fea_streaming.ts:1272`, unchanged before and after.
- **`pixi run -e lint lint-check`** — passes (no Python is touched by this PR).

`brace-expansion@5.0.9` narrows its `engines` from `18 || 20 || >=22` to `20 || >=22`. Not an issue: this project pins `nodejs = "24.*"`.

## Note on the CodeQL alerts

The five open `py/insecure-temporary-file` code-scanning alerts are **not** included here, because they need no code change — every one of them was already fixed on `main` by #248, which replaced the flagged `tempfile.mktemp()` calls with `tempfile.mkstemp()`. The alerts were stale: `codeql-analysis.yml` runs on a monthly cron, and its last analysis was 2026-08-01 against 0.34.1. A `workflow_dispatch` run against current `main` has been triggered to re-analyze and close them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo