### PR TITLE
fix(cad): make shape-distance queries work on the default backend

### DIFF
--- a/src/ada/cad/__init__.py
+++ b/src/ada/cad/__init__.py
@@ -1799,6 +1799,37 @@ def is_shape_handle(obj: Any) -> bool:
     return active_backend().is_handle(obj)
 
 
+def minimal_distance_between_shapes(shp1, shp2) -> float:
+    """Minimal distance between two shapes, whichever backend produced them.
+
+    Dual-use in the same shape as ``ada.occ.utils.get_points_from_occ_shape``:
+    callers pass either *final* backend handles (``plate.solid_occ()``) or
+    *construction-internal* raw pythonocc shapes. Handles route to the active
+    backend's ``distance`` verb; a raw ``TopoDS_Shape`` falls back to OCC.
+
+    This exists because ``solid_occ()`` returns an active-backend handle -- an
+    adacpp ``ShapeHandle`` under the default backend -- which the pythonocc
+    ``BRepExtrema_DistShapeShape`` loaders reject outright with a bare
+    ``TypeError`` naming ``TopoDS_Shape const &``. Passing one to
+    ``compute_minimal_distance_between_shapes`` is a hard failure on the default
+    backend, not a slow path.
+
+    It lives here rather than beside that function because ``ada.occ.utils``
+    imports pythonocc at module scope, so it cannot be imported at all in an
+    adacpp-only install -- exactly the install where this helper matters most.
+    The pythonocc fallback is therefore imported lazily, inside the branch.
+
+    Returns the distance rather than a ``BRepExtrema_DistShapeShape``, since the
+    adacpp path has no such object to hand back.
+    """
+    if is_shape_handle(shp1) or is_shape_handle(shp2):
+        return float(active_backend().distance(shp1, shp2))
+
+    from ada.occ.utils import compute_minimal_distance_between_shapes
+
+    return float(compute_minimal_distance_between_shapes(shp1, shp2).Value())
+
+
 def is_cad_body(obj: Any) -> bool:
     """True if ``obj`` is a pre-built CAD body of ANY available backend, not just the
     active one.
@@ -1843,6 +1874,7 @@ __all__ = [
     "ShapeHandle",
     "active_backend",
     "is_shape_handle",
+    "minimal_distance_between_shapes",
     "reset_active_backend",
     "select_backend",
     # registry / config

--- a/src/ada/core/clash_check.py
+++ b/src/ada/core/clash_check.py
@@ -95,15 +95,32 @@ def are_beams_connected(bm1: Beam, beams: List[Beam], out_of_plane_tol, point_to
                 nmap[n].append(bm2)
 
 
-def are_plates_touching(pl1: Plate, pl2: Plate, tol=1e-3):
-    """Check if two plates are within tolerance of each other"""
-    from ada.occ.utils import compute_minimal_distance_between_shapes
+def are_plates_touching(pl1: Plate, pl2: Plate, tol=1e-3) -> bool:
+    """Check if two plates are within tolerance of each other.
 
-    dss = compute_minimal_distance_between_shapes(pl1.solid_occ(), pl2.solid_occ())
-    if dss.Value() <= tol:
-        return dss
+    Delegates to ``plates_min_distance``, which is the same question already
+    answered against the active CAD backend -- and cached per plate-GUID pair.
+    This function used to duplicate that logic against pythonocc directly, which
+    is how it got left behind when the rest of the module moved to the backend:
+    it built its own distance from ``solid_occ()``, and ``solid_occ()`` returns
+    an active-backend handle (an adacpp ``ShapeHandle`` by default), which the
+    pythonocc ``BRepExtrema_DistShapeShape`` loaders reject with
+    ``TypeError: ... argument 2 of type 'TopoDS_Shape const &'``. So it raised on
+    every call under the default backend. Nothing in the repo calls it, which is
+    why nothing noticed.
 
-    return None
+    Returns a plain bool rather than the old ``BRepExtrema_DistShapeShape``
+    object, which exists only on the pythonocc path. Note that it deliberately
+    does NOT forward the distance: ``plates_min_distance`` returns ``0.0`` for
+    coincident plates, which is falsy, so a caller testing the result for
+    truthiness would read the most clearly-touching case as "not touching". A
+    bool has no such edge, and a caller reaching for the old ``.Value()`` gets a
+    loud ``AttributeError`` rather than a silently wrong number.
+    """
+    from ada.occ.occ_clash_check import plates_min_distance
+
+    # `is not None`, not truthiness -- see the 0.0 note above.
+    return plates_min_distance(pl1, pl2, tol) is not None
 
 
 def filter_away_beams_along_plate_edges(pl: Plate, beams: Iterable[Beam]) -> List[Beam]:

--- a/src/ada/occ/utils.py
+++ b/src/ada/occ/utils.py
@@ -585,7 +585,17 @@ def rotate_shp_3_axis(shape, revolve_axis, rotation):
 
 
 def compute_minimal_distance_between_shapes(shp1, shp2) -> BRepExtrema_DistShapeShape:
-    """Compute the minimal distance between 2 shapes"""
+    """Compute the minimal distance between 2 raw pythonocc shapes.
+
+    This is the pythonocc primitive and takes ``TopoDS_Shape`` only. It cannot
+    accept an active-backend handle, because the value it returns *is* a
+    pythonocc object and there is no handle -> ``TopoDS_Shape`` bridge to build
+    one from. Anything holding geometry that came out of ``solid_occ()`` /
+    ``shell_occ()`` wants :func:`ada.cad.minimal_distance_between_shapes`
+    instead. That one lives in ``ada.cad`` and not here, because this module
+    imports pythonocc at module scope and so cannot be imported at all in an
+    adacpp-only install.
+    """
 
     dss = BRepExtrema_DistShapeShape()
     dss.LoadS1(shp1)

--- a/tests/core/clash/test_shape_distance_backend.py
+++ b/tests/core/clash/test_shape_distance_backend.py
@@ -1,0 +1,79 @@
+"""Distance queries must work on whatever ``solid_occ()`` actually returns.
+
+``solid_occ()`` hands back an *active-backend handle* -- an adacpp
+``ShapeHandle`` under the default backend, not a pythonocc ``TopoDS_Shape``.
+The pythonocc ``BRepExtrema_DistShapeShape`` loaders reject a handle with a bare
+``TypeError: ... argument 2 of type 'TopoDS_Shape const &'``, so anything that
+composes the two is a hard failure on the default backend rather than a slow
+path.
+
+Two separate things are pinned here:
+
+* ``ada.cad.minimal_distance_between_shapes`` -- the shape-level primitive for
+  callers holding geometry rather than ``Plate`` objects. ``ada.occ.utils`` has
+  no backend-neutral equivalent.
+* ``are_plates_touching`` -- which no longer computes anything itself. It hit the
+  TypeError above because it had been left behind when the rest of this module
+  moved to the backend, so it now delegates to ``plates_min_distance``, the
+  already-migrated path that answers the same question. These assert the two
+  agree, since a silently diverging duplicate is what caused the bug.
+"""
+
+import ada
+from ada.cad import minimal_distance_between_shapes
+from ada.core.clash_check import are_plates_touching
+from ada.occ.occ_clash_check import plates_min_distance
+
+_SQUARE = [(0, 0), (1, 0), (1, 1), (0, 1)]
+
+
+def _plate(name: str, z: float = 0.0) -> ada.Plate:
+    return ada.Plate(name, _SQUARE, 0.01, orientation=ada.Placement((0, 0, z)))
+
+
+def test_minimal_distance_accepts_what_solid_occ_returns():
+    a = ada.PrimBox("a", (0, 0, 0), (1, 1, 1))
+    b = ada.PrimBox("b", (2, 0, 0), (3, 1, 1))
+
+    # The gap is 1.0 along x. Passing the handles straight through is the case
+    # that used to raise TypeError.
+    assert minimal_distance_between_shapes(a.solid_occ(), b.solid_occ()) == 1.0
+
+
+def test_minimal_distance_is_zero_for_overlapping_shapes():
+    a = ada.PrimBox("a", (0, 0, 0), (1, 1, 1))
+    b = ada.PrimBox("b", (0.5, 0, 0), (1.5, 1, 1))
+
+    assert minimal_distance_between_shapes(a.solid_occ(), b.solid_occ()) == 0.0
+
+
+def test_are_plates_touching_returns_a_bool_either_way():
+    touching = are_plates_touching(_plate("pl1"), _plate("pl2", z=0.005))
+    apart = are_plates_touching(_plate("pl3"), _plate("pl4", z=5.0))
+
+    # bool specifically, not a forwarded distance -- coincident plates are at
+    # 0.0, which is falsy and would read as "not touching".
+    assert touching is True
+    assert apart is False
+
+
+def test_are_plates_touching_agrees_with_the_path_it_delegates_to():
+    """The duplicate is gone; this keeps it from growing back."""
+    near = (_plate("pl1"), _plate("pl2", z=0.005))
+    far = (_plate("pl3"), _plate("pl4", z=5.0))
+
+    for pair in (near, far):
+        assert are_plates_touching(*pair) is (plates_min_distance(*pair) is not None)
+
+
+def test_coincident_plates_count_as_touching():
+    """The 0.0-is-falsy case the bool return exists for.
+
+    ``plates_min_distance`` answers 0.0 here, so any implementation that
+    forwarded the distance and let a caller test it for truthiness would report
+    the most clearly-touching pair there is as apart.
+    """
+    pl1, pl2 = _plate("pl1"), _plate("pl2")
+
+    assert plates_min_distance(pl1, pl2) == 0.0
+    assert are_plates_touching(pl1, pl2) is True


### PR DESCRIPTION
`are_plates_touching` raised on **every** call under the default CAD backend. The cause turned out to be duplication, not a missing migration.

## The bug

```python
>>> import ada
>>> from ada.core.clash_check import are_plates_touching
>>> sq = [(0, 0), (1, 0), (1, 1), (0, 1)]
>>> are_plates_touching(ada.Plate("p1", sq, 0.01),
...                     ada.Plate("p2", sq, 0.01, origin=(0, 0, 0.005)))
TypeError: in method 'BRepExtrema_DistShapeShape_LoadS1',
           argument 2 of type 'TopoDS_Shape const &'
```

`solid_occ()` returns an **active-backend handle** — an adacpp `ShapeHandle` under the default backend, not a pythonocc `TopoDS_Shape` — and the pythonocc `BRepExtrema_DistShapeShape` loaders reject a handle outright. Not a slow path or a degraded result: a hard failure, on three lines, with the shipped default.

## The fix: delete the duplicate, don't repair it

`ada.occ.occ_clash_check.plates_min_distance` **already** answers exactly this question against the active backend, with an LRU cache keyed on the plate-GUID pair:

```python
dist = active_backend().distance(s1, s2)
return dist if dist <= tol else None
```

`are_plates_touching` had reimplemented the same question against pythonocc directly, and got left behind when the rest of the module moved to the backend. Since nothing in the repo calls it, nothing noticed. It now delegates:

```python
return plates_min_distance(pl1, pl2, tol) is not None
```

`occ_clash_check` imports no pythonocc at module scope, so this is importable in an adacpp-only install — `pixi run -e tests-adacpp` proves it, since `test_plate_checking` already exercises that path there.

### Behaviour change: returns `bool`

Previously the `BRepExtrema_DistShapeShape` object (always truthy) or `None`.

Forwarding the **distance** instead would be a trap: coincident plates are at `0.0`, which is **falsy**, so any truthiness-based caller would read the most clearly-touching pair there is as apart. A `bool` matches the function's name and has no such edge; a caller reaching for the old `.Value()` gets a loud `AttributeError` rather than a wrong number. `test_coincident_plates_count_as_touching` pins this exact case.

Nothing in this repo calls it, and it could not have worked on the default backend, so no working caller is affected.

## Also: `ada.cad.minimal_distance_between_shapes`

For callers holding **geometry** rather than `Plate` objects, where no backend-neutral equivalent existed — `ada.occ.utils` only offers the pythonocc primitive. Dual-use in the same shape as `get_points_from_occ_shape`: handles route to the backend's `distance` verb, raw `TopoDS_Shape` falls back to OCC.

There is no handle → `TopoDS_Shape` bridge to convert through (`to_topods_pointer` yields a raw `int` for gmsh's `importShapesNativePointer`, not something pythonocc can adopt), so it returns a `float`.

**Why in `ada.cad`, not beside the function it wraps:** `ada/occ/utils.py` imports pythonocc at module scope, so in an adacpp-only install it cannot be imported *even to reach a backend-neutral helper inside it* — exactly the install where this matters:

```
tests/core/clash/test_shape_distance_backend.py:14: in <module>
    from ada.occ.utils import minimal_distance_between_shapes
src/ada/occ/utils.py:9: in <module>
    from OCC.Core.Bnd import Bnd_Box
E   ModuleNotFoundError: No module named 'OCC'
```

So it sits beside `active_backend` / `is_shape_handle`, with the pythonocc fallback imported lazily inside its branch. `compute_minimal_distance_between_shapes` keeps its docstring pointing at it.

## Tests

`tests/core/clash/test_shape_distance_backend.py` — the shape-level primitive on a known gap and on an overlap (the `0.0` that motivated the bool), the plate predicate both ways, the coincident-plate case, and **an agreement check between `are_plates_touching` and the path it delegates to** — a silently diverging duplicate being what caused this in the first place.

Run in **both** CAD environments, since backend-independence is the point:

```
pixi run -e tests         pytest tests/core/clash/ -q   ->  6 passed
pixi run -e tests-adacpp  pytest tests/core/clash/ -q   ->  6 passed
pixi run -e lint          lint-check                    ->  All checks passed!
```

The helper was also validated against a live adacpp backend before being written, where `bbox` and `distance` returned `(0.0, 0.0, 0.0, 1.0, 2.0, 3.0)` and `1.0` for known inputs.

## Not covered here

`ada/api/bounding_box.py` goes through `solid_occ()` too, but is already backend-aware — checked rather than assumed: `PrimBox.bbox()` and `Plate.bbox()` both return correct extents on adacpp. This appears to be the isolated remaining hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
