### PR TITLE
fix(rest): keep blueprint_name through doc normalization

### DIFF
--- a/src/ada/comms/rest/procedural.py
+++ b/src/ada/comms/rest/procedural.py
@@ -433,6 +433,21 @@ def _doc_model():
         # blueprint compile options (whitelisted by the compiler), e.g.
         # {"reinforce_internal_walls": true}
         blueprint: dict = Field(default_factory=dict)
+        # The structural blueprint the user picked in the viewer's Blueprint
+        # dropdown, as a top-level scalar (kept OUT of the ``blueprint`` options
+        # dict, which is a whitelist of per-blueprint parameters).
+        #
+        # It MUST be declared here even though nothing in this module reads it.
+        # pydantic defaults to ``extra="ignore"``, so an undeclared key is
+        # silently dropped by ``validate_doc`` -- and that drop was invisible
+        # twice over. The compiler reads ``doc.get("blueprint_name")`` and, not
+        # finding it, fell back to the engine default; and ``doc_content_hash``
+        # hashes this normalized doc, so every blueprint produced the SAME
+        # preview cache key and the viewer served the previously built GLB back.
+        # The net effect was a Blueprint dropdown that changed nothing, with no
+        # error anywhere -- switching ENGINE appeared to work only because
+        # ``engine`` is declared.
+        blueprint_name: Optional[str] = None
         # named design ruleset (routing/penetration rules) resolved by the
         # compiler via ada.topo_model.resolve_design_rules; unknown -> standard
         design_rules: Optional[str] = None
@@ -470,6 +485,9 @@ def _validate_doc_shallow(doc: dict) -> dict:
     out = {
         "grid": doc.get("grid") or {},
         "blueprint": doc.get("blueprint") or {},
+        # Carried for the same reason as the pydantic field above: dropping it
+        # here would reintroduce the silent blueprint fallback on the slim image.
+        "blueprint_name": doc.get("blueprint_name"),
         "equipment_cad": bool(doc.get("equipment_cad")),
     }
     # Routing header — mirror EngineBinding's defaults here (ada isn't importable in

--- a/tests/comms/rest/test_procedural_blueprint_name_survives.py
+++ b/tests/comms/rest/test_procedural_blueprint_name_survives.py
@@ -1,0 +1,56 @@
+"""``blueprint_name`` must survive doc normalization, and must change the cache key.
+
+It is a top-level scalar on the procedural document, set when the user picks an
+entry in the viewer's Blueprint dropdown. ``ProceduralDoc`` did not declare it,
+and pydantic defaults to ``extra="ignore"`` -- so ``validate_doc`` dropped it
+silently, with two compounding consequences:
+
+* the compiler reads ``doc.get("blueprint_name")``, did not find it, and fell
+  back to the engine default; and
+* ``doc_content_hash`` hashes the normalized doc, so every blueprint hashed the
+  SAME and the preview key collided, serving back the previously built GLB.
+
+The visible symptom was a dropdown that changed nothing and raised nothing.
+Switching *engine* appeared to work only because ``engine`` is declared.
+"""
+
+from ada.comms.rest.procedural import doc_content_hash, validate_doc
+
+_DOC = {
+    "spaces": [{"NAME": "c1", "X": 0, "Y": 0, "Z": 0, "DX": 5, "DY": 5, "DZ": 3, "FUNCTION": "space", "INCLUDE": True}]
+}
+
+
+def _doc(**over) -> dict:
+    return {**_DOC, **over}
+
+
+def test_blueprint_name_survives_validation():
+    out = validate_doc(_doc(blueprint_name="steel_stru"))
+
+    assert out["blueprint_name"] == "steel_stru"
+
+
+def test_absent_blueprint_name_stays_absent_rather_than_inventing_one():
+    # exclude_none drops it entirely; the compiler's own default then applies,
+    # which is the pre-existing behaviour for a doc that never named one.
+    assert "blueprint_name" not in validate_doc(_doc())
+
+
+def test_changing_blueprint_changes_the_content_hash():
+    a = doc_content_hash(validate_doc(_doc(blueprint_name="steel_stru")))
+    b = doc_content_hash(validate_doc(_doc(blueprint_name="none")))
+    c = doc_content_hash(validate_doc(_doc(blueprint_name="an-engine-supplied-blueprint")))
+
+    # Three distinct keys. When these collided, the preview endpoint found a
+    # cached blob under the first-built key and returned it for every blueprint.
+    assert len({a, b, c}) == 3
+
+
+def test_same_blueprint_still_hashes_stably():
+    # The other half of the contract: re-previewing an unchanged doc must stay
+    # free, so an identical doc must still produce an identical key.
+    first = doc_content_hash(validate_doc(_doc(blueprint_name="steel_stru")))
+    second = doc_content_hash(validate_doc(_doc(blueprint_name="steel_stru")))
+
+    assert first == second


### PR DESCRIPTION
The viewer's Blueprint dropdown changed nothing. No error, no warning — picking a different blueprint re-rendered the same model, while switching **engine** worked.

## One omission, two failures

`ProceduralDoc` never declared `blueprint_name`, and pydantic defaults to `extra="ignore"`. So `validate_doc` silently dropped it, and that broke two things at once:

1. **The compiler never saw it.** `compile`/`preview` read `doc.get("blueprint_name")` off the *normalized* doc, didn't find it, and fell back to the engine default.
2. **The preview cache key collapsed.** `doc_content_hash` hashes that same normalized doc — so every blueprint produced an **identical key**, and the endpoint found a blob already built under it and served that back.

The second is why the symptom would have survived fixing only the first.

## What it looked like

Repeated fetches of one blob whose hash never moved while the blueprint selection did:

```
.../preview/9d5c2f68e90a5a26.<engine>.<detailing>.glb
.../preview/9d5c2f68e90a5a26.<detailing>.glb
```

`engine` differs between those two because **`engine` is a declared field**. That is the entire difference between the dropdown that worked and the one that didn't.

## The fix

Declare the field. Also carry it through `_validate_doc_shallow` — otherwise the slim API image, which takes that fallback when `ada` is not importable, reintroduces the same silent drop.

`exclude_none` still drops it when absent, so a doc that never named a blueprint behaves exactly as before and the compiler's own default applies.

## Tests

Four, in `tests/comms/rest/test_procedural_blueprint_name_survives.py`:

- the field survives normalization
- an absent value stays absent rather than being invented
- **three different blueprints produce three different content hashes** — the collision that served the stale blob
- the same blueprint still hashes stably, so re-previewing an unchanged doc stays free

**Two fail on unfixed code**, verified by stashing the change rather than assuming.

## Regression check on the rest of the suite

```
tests/comms/rest  on clean main : 15 failed, 5 collection errors
tests/comms/rest  on this branch: 13 failed, 5 collection errors
diff of the FAILED lists        : exactly the two this PR repairs
```

The 13 failures and 5 collection errors are pre-existing and identical either way — measured on both, not inferred. `pixi run -e lint lint-check` passes.

## The wider point

This class of bug is invisible by construction: an undeclared key on a pydantic model with default `extra` behaviour is dropped with no error at any layer, and here it silently degraded to a *plausible* result rather than a broken one. Worth considering whether the doc model should set `extra="forbid"`, so an unrecognised key is a 400 at the API boundary instead of a silently ignored user selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
