### PR TITLE
fix(rest): stop doc normalizers deleting keys they do not declare

### DIFF
--- a/src/ada/comms/rest/catalog.py
+++ b/src/ada/comms/rest/catalog.py
@@ -352,12 +352,14 @@ def _equipment_doc_model():
     import re
     from typing import List, Literal, Optional
 
-    from pydantic import BaseModel, Field, conlist, field_validator
+    from pydantic import BaseModel, ConfigDict, Field, conlist, field_validator
 
     Vec3 = conlist(float, min_length=3, max_length=3)
     _HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
     class CatalogPort(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
         name: str
         position: Vec3 = Field(default_factory=lambda: [0.0, 0.0, 0.0])
         direction_vector: Vec3 = Field(default_factory=lambda: [0.0, 0.0, 1.0])
@@ -383,6 +385,13 @@ def _equipment_doc_model():
         lz: float = 1.0
 
     class EquipmentTypeDoc(BaseModel):
+        # See the note on ProceduralDoc in .procedural: a normalizer that DROPS
+        # what it does not recognise turns a stale field name into a no-op with
+        # no error, and (for anything keyed on the normalized dict) into a hash
+        # collision. Round-trip unknown keys instead; declared fields below are
+        # still validated, so a malformed known field is still a loud 422.
+        model_config = ConfigDict(extra="allow")
+
         bbox: BBox = Field(default_factory=BBox)
         mass: float = 1000.0
         # equipment-local centre of gravity; defaults to the bbox centroid at
@@ -403,9 +412,12 @@ def _equipment_doc_model():
 def _system_doc_model():
     from typing import Literal, Optional
 
-    from pydantic import BaseModel
+    from pydantic import BaseModel, ConfigDict
 
     class SystemTemplateDoc(BaseModel):
+        # Round-trip unknown keys rather than deleting them — see EquipmentTypeDoc.
+        model_config = ConfigDict(extra="allow")
+
         type: Literal["piping", "duct", "cable", "electrical"] = "piping"
         medium: Optional[str] = None
         # electrical service voltage in volts (informational; only meaningful
@@ -512,9 +524,14 @@ def validate_system_doc(doc: dict) -> dict:
 def _engine_doc_model():
     from typing import List, Literal, Optional
 
-    from pydantic import BaseModel, model_validator
+    from pydantic import BaseModel, ConfigDict, model_validator
 
     class ProceduralEngineDoc(BaseModel):
+        # An engine MANIFEST describes third-party code, so this model is the least
+        # entitled of all of them to decide which keys matter. Round-trip what we
+        # do not recognise — see EquipmentTypeDoc.
+        model_config = ConfigDict(extra="allow")
+
         # ``builtin`` = the in-repo adapy engine (no external code); ``wheel`` = an
         # external engine cloned+built into a pyodide wheel; ``server`` = an engine
         # with native deps that only runs in a server worker (never in the browser).
@@ -527,6 +544,14 @@ def _engine_doc_model():
         deploy_key_secret: Optional[str] = None
         # Dotted ``module:callable`` entrypoint with signature ``compile(doc) -> bytes``.
         entrypoint: Optional[str] = None
+        # Explicit xlsx export/import handlers. ada.topo_model.engines reads both
+        # off this manifest (engine_supports_excel / _xlsx_entrypoint) but neither
+        # was declared, so validate_engine_doc removed them and the resolver fell
+        # back to deriving siblings of ``entrypoint`` — silently exporting through
+        # the wrong handler, or reporting "no Excel format" for an engine that has
+        # one.
+        export_entrypoint: Optional[str] = None
+        import_entrypoint: Optional[str] = None
         # Extra deps the browser must micropip-install for this engine's wheel.
         pyodide_deps: List[str] = []
         # ``kind:server`` routing: the worker-pool capability tag that has this
@@ -549,8 +574,10 @@ def _engine_doc_model():
                     raise ValueError(f"{self.kind!r} engine requires 'repo_url'")
                 if not self.entrypoint:
                     raise ValueError(f"{self.kind!r} engine requires 'entrypoint' (module:callable)")
-            if self.entrypoint is not None and ":" not in self.entrypoint:
-                raise ValueError("entrypoint must be a dotted 'module:callable' path")
+            for name in ("entrypoint", "export_entrypoint", "import_entrypoint"):
+                value = getattr(self, name)
+                if value is not None and ":" not in value:
+                    raise ValueError(f"{name} must be a dotted 'module:callable' path")
             return self
 
     return ProceduralEngineDoc

--- a/src/ada/comms/rest/procedural.py
+++ b/src/ada/comms/rest/procedural.py
@@ -407,7 +407,7 @@ def _doc_model():
     # on the first commit/compile, not at API boot.
     from typing import Optional
 
-    from pydantic import BaseModel, Field
+    from pydantic import BaseModel, ConfigDict, Field
 
     from ada.topo_model.engines import DEFAULT_ENGINE_SLUG, PROCEDURAL_SCHEMA_VERSION
 
@@ -419,10 +419,40 @@ def _doc_model():
         TopoLoftMember,
         TopoOpening,
         TopoSpace,
+        TopoStructure,
         TopoSystem,
     )
 
+    class CellGroup(BaseModel):
+        """One cell GROUP — a named structure with its own blueprint. A space
+        names its group via ``STRUCTURE_NAME``; ungrouped spaces omit it. Only an
+        engine advertising ``supports_grouping`` acts on these."""
+
+        # extra="allow" for the same reason as ProceduralDoc below: a grouping
+        # engine may hang its own per-group settings here and we must not eat them.
+        model_config = ConfigDict(extra="allow")
+
+        name: str
+        blueprint: Optional[str] = None
+
     class ProceduralDoc(BaseModel):
+        # A procedural document is not adapy's private struct — it is authored by
+        # whichever engine owns the model (built-in or external) and round-tripped
+        # by the viewer, which stores UI state on it. pydantic's DEFAULT of
+        # extra="ignore" made this model a lossy filter over every such document:
+        # any key not declared below was deleted by validate_doc without a word.
+        #
+        # That silent delete is not a missing value, it is a CACHE COLLISION.
+        # doc_content_hash() hashes this normalized doc to key the preview blob, so
+        # two documents differing only in a dropped key hash IDENTICALLY and the
+        # viewer is served the previously built GLB — a control that changes
+        # nothing, and no error anywhere to say so. That is exactly how the
+        # Blueprint dropdown (``blueprint_name``) stayed broken.
+        #
+        # So: preserve what we do not understand. Unknown keys round-trip and
+        # participate in the hash. Declared fields below are still validated.
+        model_config = ConfigDict(extra="allow")
+
         # Routing/identity header (see ada.topo_model.engines.EngineBinding):
         # ``engine`` selects the procedural engine that compiles this model and
         # ``schema_version`` records the doc-schema it was authored against. Both
@@ -475,6 +505,35 @@ def _doc_model():
         # into inter-station band cells + plates (see ada.topo_model.builder)
         loft_members: list[TopoLoftMember] = Field(default_factory=list)
 
+        # --- fields the rest of the codebase READS off a normalized doc ------ #
+        # Everything below was already produced and/or consumed somewhere, but was
+        # never declared here — so validate_doc deleted each one on its way
+        # through. extra="allow" above now preserves them regardless; they are
+        # declared anyway so the shape is validated and the contract is written
+        # down. All are Optional/None-defaulted so exclude_none keeps a document
+        # that never used them BYTE-IDENTICAL — and therefore hash-identical, so
+        # no existing preview/revision cache key moves.
+
+        # Cell groups authored by the viewer's cellbuilder (``toDoc``) and read
+        # back by it on open (``groupsFromDoc``). Dropping these did not just lose
+        # the grouping: two docs that differed only in a group's blueprint hashed
+        # the SAME, so the preview served the other group's cached GLB.
+        groups: Optional[list[CellGroup]] = None
+        # Multi-structure models: one topology model per entry, each placed at its
+        # own origin (see ProceduralMultiBuilder). ProceduralBuilder.to_doc emits
+        # these and from_dict reads them back, so an xlsx import of a workbook with
+        # a ``Structures`` sheet went through validate_doc and came out single-
+        # structure.
+        structures: Optional[list[TopoStructure]] = None
+        # Block INTERIOR walls from in-plane routing as well as exterior ones
+        # (read by ada.topo_model.compile._build_systems, written by
+        # ProceduralBuilder.to_doc, carried by the workbook's NO_GO_WALLS column).
+        no_go_walls: Optional[bool] = None
+        # Per-joint detailing option map ``{slug: {enabled, <field>: value}}``.
+        # Normally threaded as a query param, but ProceduralBuilder.from_dict
+        # accepts it off the document as a fallback, which validate_doc removed.
+        detailing_options: Optional[dict] = None
+
     return ProceduralDoc
 
 
@@ -482,14 +541,25 @@ def _validate_doc_shallow(doc: dict) -> dict:
     """Structural check for slim API deployments where ada (numpy) is not
     installed: list fields hold objects with a string NAME. Full pydantic
     validation then happens on the worker at compile time."""
-    out = {
-        "grid": doc.get("grid") or {},
-        "blueprint": doc.get("blueprint") or {},
-        # Carried for the same reason as the pydantic field above: dropping it
-        # here would reintroduce the silent blueprint fallback on the slim image.
-        "blueprint_name": doc.get("blueprint_name"),
-        "equipment_cad": bool(doc.get("equipment_cad")),
-    }
+    # Start from the document itself so a key this shallow path does not know
+    # about SURVIVES, matching ProceduralDoc's extra="allow". Building `out` from
+    # scratch made this function a second, independent whitelist — so the slim API
+    # image silently dropped keys the full path kept, and (because
+    # doc_content_hash runs over the result) collided their cache keys. The
+    # validated values below overwrite these passthrough copies.
+    #
+    # This subsumes the explicit ``blueprint_name`` carry that fixed the Blueprint
+    # dropdown: passthrough keeps it when present and, unlike naming it here,
+    # leaves it ABSENT when it is not -- which is what the pydantic path does via
+    # exclude_none, so the two paths now hash identically either way.
+    out = dict(doc)
+    out.update(
+        {
+            "grid": doc.get("grid") or {},
+            "blueprint": doc.get("blueprint") or {},
+            "equipment_cad": bool(doc.get("equipment_cad")),
+        }
+    )
     # Routing header — mirror EngineBinding's defaults here (ada isn't importable in
     # the slim image, so the constants can't be pulled from ada.topo_model.engines).
     engine = doc.get("engine")
@@ -527,7 +597,10 @@ def _validate_doc_shallow(doc: dict) -> dict:
             if not isinstance(entry, dict) or not isinstance(entry.get("NAME"), str) or not entry["NAME"]:
                 raise ValueError(f"{key}[{i}] must be an object with a non-empty NAME")
         out[key] = entries
-    return out
+    # Mirror the full path's exclude_none so the two normalizers agree key-for-key
+    # on the same input (a null passed through would otherwise show up here and
+    # not there, moving the content hash between the slim and full images).
+    return {k: v for k, v in out.items() if v is not None}
 
 
 def validate_doc(doc: dict) -> dict:

--- a/tests/comms/rest/test_doc_normalizers_never_drop_keys.py
+++ b/tests/comms/rest/test_doc_normalizers_never_drop_keys.py
@@ -1,0 +1,162 @@
+"""No document normalizer may silently drop a key.
+
+Every ``validate_*_doc`` in the REST layer round-trips a caller-supplied dict
+through a pydantic model and returns ``model_dump()`` as the canonical form. That
+result is what gets persisted, what the compiler reads with ``doc.get(...)``, and
+— for procedural docs — what ``doc_content_hash`` hashes into a preview cache key.
+
+pydantic defaults to ``extra="ignore"``. Under that default, a key the model does
+not declare is DELETED on the way through, and the deletion has no failure mode
+attached to it:
+
+* the reader's ``doc.get("...")`` returns ``None`` and takes a default, so the
+  feature quietly does something else instead of erroring; and
+* the content hash is computed over the dict that key is missing from, so two
+  documents that differ ONLY in that key produce the SAME cache key. The endpoint
+  finds an already-built blob and serves it back. The user sees a control that
+  changes nothing, forever, with no error anywhere.
+
+That second effect is why this class survives so long in the wild: it degrades to
+a plausible result, not a broken one. ``blueprint_name`` was one instance;
+``groups``, ``structures``, ``no_go_walls``, ``detailing_options`` and the engine
+manifest's ``export_entrypoint``/``import_entrypoint`` were five more, all found
+by the same question.
+
+So this file asserts the invariant rather than the instances: a normalizer may
+REJECT a key it does not recognise, or it may PRESERVE it, but it may never
+delete it and report success. The validators are discovered by scanning the
+modules, so a normalizer added later is covered without anyone remembering to add
+it here.
+"""
+
+import inspect
+
+import pytest
+
+from ada.comms.rest import catalog as catalog_module
+from ada.comms.rest import procedural as procedural_module
+from ada.comms.rest.procedural import doc_content_hash, validate_doc
+
+# A minimal VALID document per validator, so the only thing under test is what
+# happens to the unrecognised key we add to it.
+_MINIMAL_DOC = {
+    "validate_doc": {"spaces": [{"NAME": "c1"}]},
+    "validate_equipment_doc": {"mass": 500.0},
+    "validate_system_doc": {"type": "piping"},
+    "validate_engine_doc": {
+        "kind": "wheel",
+        "repo_url": "https://example.invalid/engine.git",
+        "entrypoint": "engine.mod:compile",
+    },
+}
+
+
+def _discover_validators():
+    """Every public ``validate_*doc`` normalizer in the REST layer."""
+    found = {}
+    for module in (procedural_module, catalog_module):
+        for name, fn in vars(module).items():
+            if name.startswith("validate_") and name.endswith("doc") and inspect.isfunction(fn):
+                found[name] = fn
+    return found
+
+
+def test_every_normalizer_is_covered_by_this_file():
+    """If a new normalizer appears, it must get a minimal doc here — otherwise the
+    invariant below would silently skip it, which is the very failure mode this
+    file exists to prevent."""
+    assert set(_discover_validators()) == set(_MINIMAL_DOC)
+
+
+@pytest.mark.parametrize("name", sorted(_MINIMAL_DOC))
+def test_normalizer_never_silently_drops_an_unrecognised_key(name):
+    validator = _discover_validators()[name]
+    doc = {**_MINIMAL_DOC[name], "a_key_this_model_does_not_declare": "carry me"}
+
+    try:
+        out = validator(doc)
+    except ValueError:
+        # Rejecting loudly is a fine answer — the caller learns something is
+        # wrong. Silence is the thing that isn't.
+        return
+
+    assert "a_key_this_model_does_not_declare" in out, (
+        f"{name} accepted an unrecognised key and returned success, but the key is "
+        f"gone from the result. Either declare it, or reject it — a silent drop "
+        f"gives the caller no way to find out."
+    )
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        # Each of these is read somewhere off a NORMALIZED procedural doc but was
+        # not declared on ProceduralDoc, so validate_doc deleted it.
+        ("groups", [{"name": "A", "blueprint": "steel_stru"}]),  # viewer cellbuilder
+        ("structures", [{"NAME": "S1"}]),  # ProceduralBuilder.from_dict / to_doc
+        ("no_go_walls", True),  # ada.topo_model.compile._build_systems
+        ("detailing_options", {"a_joint": {"enabled": True}}),  # from_dict fallback
+    ],
+)
+def test_procedural_doc_keys_the_codebase_reads_survive_normalization(key, value):
+    out = validate_doc({"spaces": [{"NAME": "c1"}], key: value})
+
+    assert key in out, f"validate_doc dropped {key!r}, which the codebase reads back off the normalized doc"
+
+
+@pytest.mark.parametrize(
+    "key, a, b",
+    [
+        # The second-order effect, asserted directly: a dropped key does not
+        # merely go missing, it COLLIDES the preview cache key, so the endpoint
+        # serves back the blob built for the other value.
+        ("groups", [{"name": "A", "blueprint": "steel_stru"}], [{"name": "A", "blueprint": "none"}]),
+        ("no_go_walls", True, False),
+        ("structures", [{"NAME": "S1"}], [{"NAME": "S2"}]),
+    ],
+)
+def test_a_changed_doc_key_changes_the_preview_cache_key(key, a, b):
+    base = {"spaces": [{"NAME": "c1"}]}
+    first = doc_content_hash(validate_doc({**base, key: a}))
+    second = doc_content_hash(validate_doc({**base, key: b}))
+
+    assert (
+        first != second
+    ), f"two docs differing only in {key!r} hash the same — the preview cache cannot tell them apart"
+
+
+def test_unchanged_docs_still_hash_the_same():
+    """The other half of the contract: re-previewing an unchanged document must
+    stay free, so an identical doc must still produce an identical key."""
+    doc = {"spaces": [{"NAME": "c1"}], "groups": [{"name": "A", "blueprint": "steel_stru"}]}
+
+    assert doc_content_hash(validate_doc(doc)) == doc_content_hash(validate_doc(doc))
+
+
+def test_a_doc_that_uses_none_of_the_new_fields_is_byte_identical():
+    """The new fields are all None-defaulted and dropped by exclude_none, so an
+    existing document's normalized form — and therefore every cache key already
+    built from it — does not move."""
+    out = validate_doc({"spaces": [{"NAME": "c1"}]})
+
+    assert not {"groups", "structures", "no_go_walls", "detailing_options"} & set(out)
+
+
+def test_shallow_and_full_normalizers_agree_on_which_keys_survive():
+    """The slim API image (no ada importable) falls back to
+    ``_validate_doc_shallow``, a SECOND, independently written normalizer. When
+    the two disagree about a key, the same request normalizes — and therefore
+    hashes — differently depending on which image served it. They have drifted
+    before; this pins them together."""
+    doc = {
+        "spaces": [{"NAME": "c1"}],
+        "groups": [{"name": "A", "blueprint": "steel_stru"}],
+        "no_go_walls": True,
+        "detailing_options": {"a_joint": {"enabled": True}},
+        "a_key_neither_model_declares": "carry me",
+    }
+
+    full = set(validate_doc(doc))
+    shallow = set(procedural_module._validate_doc_shallow(doc))
+
+    assert full == shallow, f"only in full: {sorted(full - shallow)}; only in shallow: {sorted(shallow - full)}"


### PR DESCRIPTION
`blueprint_name` (#267) was not a one-off. This surveys every place a pydantic model normalizes external input in the REST layer, fixes the five other live instances, and adds a test that makes the whole class fail loudly instead of silently.

## The class

Every `validate_*_doc` round-trips a caller-supplied dict through a pydantic model and returns `model_dump()` as the canonical form. pydantic defaults to `extra="ignore"`, so each of those models is a lossy filter over documents it does not own — a key it has not declared is deleted, and nothing says so.

The deletion is not a missing value. `doc_content_hash` hashes that same normalized dict to key the preview blob, so two documents differing **only** in a dropped key hash **identically**; the endpoint finds a blob already built under that key and serves it back. The result is a control that changes nothing, forever, with no error anywhere. It degrades to a *plausible* result rather than a broken one, which is why it survives.

## What the survey found

All five demonstrated by running them, not by reading:

| Key | Model | Who reads it | Consequence |
|---|---|---|---|
| `groups` | `ProceduralDoc` | the **shipped viewer** — `toDoc` writes it, `groupsFromDoc` reads it back on open | grouping lost on every round trip, *and* two groupings hash the same |
| `structures` | `ProceduralDoc` | `ProceduralBuilder.to_doc` / `.from_dict` | a workbook with a `Structures` sheet imports and comes out single-structure |
| `no_go_walls` | `ProceduralDoc` | `compile._build_systems`, workbook `NO_GO_WALLS` column | interior walls stay routable however the workbook is authored |
| `detailing_options` | `ProceduralDoc` | `from_dict` doc-level fallback | fallback never fires |
| `export_entrypoint`, `import_entrypoint` | `ProceduralEngineDoc` | `engines.engine_supports_excel` / `_xlsx_entrypoint` | resolver falls back to deriving siblings of `entrypoint` |

`groups` is the closest twin of the original: authored by the viewer today, and it collides the preview cache key exactly the way `blueprint_name` did.

Checked and **clean**: `EquipmentTypeDoc` and `SystemTemplateDoc` — every key their readers touch is declared. The two other `sha256` cache keys in `app.py` (component-build `inputs`, plugin-job `options`) hash the **raw** request body, never a normalized one, so they cannot collide this way.

## Why `extra="allow"` and not `forbid`

`forbid` would turn an unknown key into a 400 at the boundary. It is wrong here on evidence, not on taste: **the shipped frontend sends `groups` on every commit**, so forbidding unknown keys would turn a working request into a 422 — worse than the bug it fixes. The same argument covers the engine manifest, which describes third-party code.

These documents are authored by engines and clients, not by this module. It should validate the fields it owns and preserve the rest. So: `extra="allow"` on all four document models, plus the six fields declared anyway so their shape *is* validated and the contract is written down.

`_validate_doc_shallow` — the slim image's fallback normalizer — got the same passthrough. It was a second, independently written whitelist, so leaving it alone would mean the same request normalizes, and therefore hashes, differently depending on which image served it.

**No cache key moves.** All six new fields are `None`-defaulted and dropped by `exclude_none`, so a document that uses none of them is byte-identical: a plain doc still hashes `8d9320386c42a8c2` before and after.

## The half that matters

`tests/comms/rest/test_doc_normalizers_never_drop_keys.py` asserts the **invariant**, not the six instances:

> A normalizer may **reject** a key it does not recognise, or it may **preserve** it. It may never delete it and report success.

It discovers the validators by scanning the modules, so a normalizer added later is covered without anyone remembering — and one test fails loudly if a new normalizer shows up without a fixture. It also pins the shallow and full normalizers to the same key set, which is the drift that would otherwise reintroduce this on the slim image alone.

11 of its 15 tests fail on unfixed code (verified by stashing the source change).

## Testing

- `tests/comms/rest`: **13 failed / 310 passed / 5 collection errors** before → **13 failed / 325 passed / 5 collection errors** after. Identical FAILED list; the +15 are this file. The failures and collection errors are pre-existing on `main`.
- `tests/core/topo_model`: 143 passed.
- `pixi run -e lint lint-check`: clean.

## Found but deliberately not fixed

The entity models (`TopoSpace` and friends) carry the same `extra="ignore"`, which neuters the viewer's per-entity `params` round-trip — an external engine's custom entity columns cannot survive a commit. Those models also drive xlsx column generation, so changing them has a far wider blast radius than this, and I could not demonstrate a consumer of a dropped entity key. Left for its own change rather than smuggled into this one.

## Note on #267

Based on `origin/main`, so this does not contain #267's `blueprint_name` fix. Both touch `ProceduralDoc` and `_validate_doc_shallow`; whichever lands second will want a small manual merge. The two fixes are complementary — #267 declares the field, this makes the next undeclared field impossible to lose silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
