### PR TITLE
fix: give a procedural compile log its own run identity

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3444,6 +3444,36 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return None
         return spec
 
+    async def _audit_compile_run(
+        request: Request,
+        user: User,
+        scope: Scope,
+        *,
+        job_id: str | None,
+        derived_key: str,
+        target_format: str = "procedural_build",
+    ) -> None:
+        """Open the audit row for one compile RUN, at enqueue time.
+
+        Deliberately the same idiom as a conversion: ``job_id`` is the run id, so
+        the worker's existing terminal-status patch (``_audit_done`` →
+        ``update_audit_by_job``) fills in duration, error, traceback and the run's
+        ``log_key`` on the very same row. That makes a compile visible in the admin
+        audit log — with its log readable through the row's existing "Log" tab —
+        without a second audit surface for procedural runs."""
+        if not job_id:
+            return
+        await _audit(
+            request,
+            user,
+            scope,
+            "compile",
+            key=derived_key,
+            target_format=target_format,
+            status="queued",
+            job_id=job_id,
+        )
+
     def _parse_detailing_options(raw: str | None) -> dict:
         """Parse the ``?detailing_options=<json>`` query param — the per-joint-type
         option map ``{slug: {enabled, <field>: value}}`` the Detailing tab produced.
@@ -3464,6 +3494,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         model_id: str,
         scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
     ) -> JSONResponse:
         from .procedural import (
             procedural_detailing_glb_key,
@@ -3605,6 +3636,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 force_rebuild=force,
                 target_capability=det_spec.get("worker_capability"),
             )
+            # Both stages are compile runs of their own (each writes its own log
+            # under its own job id), so both get an audit row.
+            await _audit_compile_run(request, user, scope_obj, job_id=structural_job.job_id, derived_key=structural_key)
+            await _audit_compile_run(
+                request,
+                user,
+                scope_obj,
+                job_id=detail_job.job_id,
+                derived_key=derived_key,
+                target_format="procedural_detail",
+            )
             return JSONResponse(
                 {
                     "job_id": detail_job.job_id,
@@ -3633,6 +3675,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             force_rebuild=force,
             target_capability=target_capability,
         )
+        await _audit_compile_run(request, user, scope_obj, job_id=job.job_id, derived_key=derived_key)
         return JSONResponse({"job_id": job.job_id, "derived_key": derived_key, "cached": False})
 
     @api.post("/scopes/{scope}/procedural-models/{model_id}/compile-preview")
@@ -3640,6 +3683,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         model_id: str,
         scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
     ) -> JSONResponse:
         """Compile the CURRENT (uncommitted) document — a *preview* — without
         minting a revision. The body carries ``{doc, engine?, lod?}``; the doc is
@@ -3728,6 +3772,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             force_rebuild=force,
             target_capability=target_capability,
         )
+        await _audit_compile_run(request, user, scope_obj, job_id=job.job_id, derived_key=derived_key)
         return JSONResponse({"job_id": job.job_id, "derived_key": derived_key, "cached": False, "doc_hash": doc_hash})
 
     @api.get("/scopes/{scope}/procedural-models/{model_id}/compile-log")
@@ -3736,34 +3781,65 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         model_id: str,
         scope_obj: Scope = Depends(_scope_from_path),
     ) -> PlainTextResponse:
-        """Return the engine log captured during a compile/preview as ``text/plain``.
+        """Return the engine log captured during one compile RUN as ``text/plain``.
 
-        The frontend passes the GLB ``derived_key`` (from the compile/preview
-        response) as ``?key=``; the log is that key's ``.log`` sibling
-        (:func:`procedural_log_key`), so committed / detail / preview / engine
-        variants are all covered by one rule. An empty body means the compile
-        produced no log (or the result was served from a pre-log cached blob).
-        503 when the procedural DB isn't configured, matching the sibling
-        procedural endpoints."""
-        from .procedural import PROCEDURAL_PREFIX, procedural_log_key
+        A log belongs to a RUN, not to a document. Pass ``?run=<job_id>`` — the id
+        the compile/preview response returned — and you get exactly that run's log
+        (:func:`procedural_run_log_key`) or an empty body; a second compile of the
+        very same document can therefore never hand back the first one's output.
+
+        ``?key=<derived GLB key>`` remains for the two lookups that have no run id
+        of their own: a result the endpoint served straight from cache (no run
+        happened just now), and an artifact built before runs existed. It resolves
+        through the key's ``.run`` pointer sidecar to the run that most recently
+        targeted that artifact, falling back to the legacy ``.log`` sibling.
+
+        The response carries ``X-Compile-Run`` naming the run actually served (empty
+        when it came from the legacy sibling), so a caller can tell whether the log
+        it is showing belongs to the run it just triggered. An empty body means that
+        run produced no log. 503 when the procedural DB isn't configured, matching
+        the sibling procedural endpoints."""
+        from .procedural import (
+            PROCEDURAL_PREFIX,
+            is_valid_run_id,
+            procedural_log_key,
+            procedural_run_log_key,
+            procedural_run_pointer_key,
+        )
 
         pool = _require_procedural_pool(request)
         # Scope + existence check (raises 404 when the model isn't in this scope).
         await _get_procedural_in_scope(pool, model_id, scope_obj)
+        run = (request.query_params.get("run") or "").strip()
         key = (request.query_params.get("key") or "").strip()
-        if not key:
-            raise HTTPException(status_code=400, detail="key (derived GLB key) query param is required")
+        if not run and not key:
+            raise HTTPException(status_code=400, detail="run (compile run id) or key (derived GLB key) is required")
+
+        async def _read(blob_key: str) -> str | None:
+            try:
+                data = await storage.get_bytes(scope_obj, blob_key)
+            except Exception:
+                return None
+            return data.decode("utf-8", errors="replace")
+
+        if run:
+            # The run id lands inside a blob key, so it is validated (not merely
+            # escaped) before use — the same confinement `key` gets below.
+            if not is_valid_run_id(run):
+                raise HTTPException(status_code=400, detail="run is not a valid compile run id")
+            text = await _read(procedural_run_log_key(model_id, run))
+            return PlainTextResponse(text or "", headers={"X-Compile-Run": run})
+
         # Confine reads to this model's hidden prefix so the endpoint can't be used
         # to fetch arbitrary blobs by handing it any key.
         if not key.startswith(f"{PROCEDURAL_PREFIX}{model_id}/"):
             raise HTTPException(status_code=400, detail="key is not a derived artifact of this model")
-        log_key = procedural_log_key(key)
-        try:
-            data = await storage.get_bytes(scope_obj, log_key)
-        except Exception:
-            # No log persisted (pre-log cached blob, or the compile never ran).
-            return PlainTextResponse("")
-        return PlainTextResponse(data.decode("utf-8", errors="replace"))
+        pointed = (await _read(procedural_run_pointer_key(key)) or "").strip()
+        if pointed and is_valid_run_id(pointed):
+            text = await _read(procedural_run_log_key(model_id, pointed))
+            return PlainTextResponse(text or "", headers={"X-Compile-Run": pointed})
+        # Legacy: an artifact whose compile predates run-keyed logs.
+        return PlainTextResponse(await _read(procedural_log_key(key)) or "", headers={"X-Compile-Run": ""})
 
     @api.get("/scopes/{scope}/procedural-models/{model_id}/stats")
     async def api_procedural_stats(

--- a/src/ada/comms/rest/procedural.py
+++ b/src/ada/comms/rest/procedural.py
@@ -14,6 +14,8 @@ from functools import lru_cache
 PROCEDURAL_PREFIX = "_procedural/"
 # Hidden prefix for built external-engine wheels (see HIDDEN_PREFIXES).
 ENGINE_PREFIX = "_engines/"
+# How many compile-run logs to retain per procedural model (see procedural_run_dir).
+RUN_LOG_RETENTION = 50
 
 
 def engine_wheel_dir(engine_id: str) -> str:
@@ -176,17 +178,86 @@ def procedural_preview_glb_key(
 
 
 def procedural_log_key(glb_key: str) -> str:
-    """Blob key for the engine-compile LOG captured alongside a procedural GLB.
+    """LEGACY blob key for the engine-compile log: a ``.log`` sibling of the GLB
+    derived key (the same path with ``.log`` swapped in for ``.glb``).
 
-    The log is a *sibling* of the GLB derived key — the same path with ``.log``
-    swapped in for ``.glb`` — so a single rule covers every GLB variant (the
-    committed ``r{rev}.glb``, its ``_detail`` LOD, an engine-suffixed key, and a
-    ``preview/{hash}.glb``) and the log key can never drift from the key the
-    worker actually wrote the GLB to. Deriving it from the GLB key (rather than
-    re-deriving from model/revision/engine/lod) keeps a single source of truth."""
+    Superseded by :func:`procedural_run_log_key` and kept only so artifacts built
+    before compile runs existed still surface their log. Do NOT write here: the
+    derived key is content-addressed, so every compile of the same input shares
+    this one key — the reason a fresh run used to read back an older run's log."""
     if glb_key.endswith(".glb"):
         return f"{glb_key[: -len('.glb')]}.log"
     return f"{glb_key}.log"
+
+
+# ── Compile RUNS ──────────────────────────────────────────────────────
+#
+# A compile LOG belongs to a RUN, not to a document. The derived-artifact keys
+# above are deliberately CONTENT-ADDRESSED (a revision stamp, or the doc's
+# content hash for a preview) so an unchanged input is served from cache for
+# free — which means two different compile ATTEMPTS of the same input share one
+# key. Deriving the log key from the artifact key therefore made a fresh run read
+# back the PREVIOUS run's log: a forced recompile of an unchanged document,
+# whose own log happened to be empty, still showed yesterday's failure.
+#
+# So the log gets its own identity: the queue job id, minted per compile attempt.
+# It is already the id the compile response hands the viewer and the join key of
+# the ``audit_log`` row, so one id names the log blob, the panel's current run and
+# the admin audit entry.
+
+RUN_ID_MAX_LEN = 64
+
+
+def procedural_run_dir(model_id: str) -> str:
+    """Blob-key prefix holding one model's compile-RUN logs. Lives under the
+    model's hidden ``_procedural/`` prefix (never listed) and, like the preview
+    prefix, is GC-able as a group — see :func:`prune_run_log_keys`."""
+    return f"{PROCEDURAL_PREFIX}{model_id}/runs/"
+
+
+def is_valid_run_id(run_id: str) -> bool:
+    """Whether ``run_id`` is safe to interpolate into a blob key. Queue job ids are
+    ``uuid4().hex``; the WASM path prefixes them. Anything outside
+    ``[A-Za-z0-9_-]`` (notably ``/`` and ``.``) is rejected so a caller-supplied
+    id can never escape :func:`procedural_run_dir`."""
+    if not run_id or len(run_id) > RUN_ID_MAX_LEN:
+        return False
+    return all(c.isalnum() or c in "-_" for c in run_id)
+
+
+def procedural_run_log_key(model_id: str, run_id: str) -> str:
+    """Blob key for ONE compile run's log — ``_procedural/{id}/runs/{run}.log``.
+
+    Keyed by the RUN, not by the artifact: every attempt writes its own blob, so a
+    second compile of the very same document can never serve the first's log, and
+    a failed run's log survives alongside the successful run that follows it.
+    Raises on a run id that isn't key-safe (:func:`is_valid_run_id`)."""
+    if not is_valid_run_id(run_id):
+        raise ValueError(f"invalid compile run id: {run_id!r}")
+    return f"{procedural_run_dir(model_id)}{run_id}.log"
+
+
+def procedural_run_pointer_key(derived_key: str) -> str:
+    """Blob key for the RUN-POINTER sidecar of a compiled artifact: a ``.run``
+    sibling of the derived key (one rule for every variant, mirroring
+    :func:`procedural_catalog_fp_key`) holding the id of the run that most
+    recently targeted that key.
+
+    It exists because two lookups have only the artifact key to go on: a compile
+    the endpoint served straight from cache (no run happened now, but the panel
+    still wants the log of the run that built those bytes) and an old artifact
+    from before runs existed. The pointer is written when the run STARTS, not when
+    it succeeds, so a run that fails before producing bytes is still findable."""
+    return f"{derived_key}.run"
+
+
+def prune_run_log_keys(keys_newest_first: list[str], keep: int = RUN_LOG_RETENTION) -> list[str]:
+    """Split a model's run-log keys (already ordered newest-first) into the ones to
+    delete. Retention is per model and generous — a run log is a few KB — but
+    bounded, because runs accumulate without limit where the old artifact-keyed
+    log overwrote itself in place. Pruning an old run's log only costs the admin
+    audit row its "Log" tab; the row itself, with status/duration/error, remains."""
+    return list(keys_newest_first[max(keep, 0) :])
 
 
 def procedural_stats_key(glb_key: str) -> str:

--- a/src/ada/comms/rest/storage.py
+++ b/src/ada/comms/rest/storage.py
@@ -307,6 +307,15 @@ class Storage:
             entries.extend(await self._list_under(scope, str(cp)))
         return entries
 
+    async def list_prefix(self, scope: Scope, prefix: str) -> list[FileEntry]:
+        """Every object under a scope-relative key ``prefix`` (e.g. one procedural
+        model's ``_procedural/{id}/runs/``).
+
+        The bounded counterpart to :meth:`list`: the backend enumerates only that
+        sub-prefix, so a per-model retention sweep costs its own handful of keys
+        rather than a walk of the whole scope."""
+        return await self._list_under(scope, self._full_key(scope, prefix))
+
     async def _list_under(self, scope: Scope, prefix: str) -> list[FileEntry]:
         # obs.list returns a ListStream of pages; each page is a Sequence
         # of ObjectMeta dicts with keys "path", "size", "last_modified",

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import ctypes
+import datetime
 import functools
 import io
 import logging
@@ -1105,6 +1106,114 @@ def _assemble_compile_log(handler: _CompileLogCapture, stdout_buf: io.StringIO, 
     return text
 
 
+def _compile_run_header(
+    *,
+    run_id: str,
+    model_id: str | None,
+    revision: object,
+    engine: str | None,
+    lod: str,
+    detailing: str | None,
+    is_preview: bool,
+    status: str,
+) -> str:
+    """The banner every compile-run log opens with.
+
+    It is what makes a run log SELF-IDENTIFYING: reading one you can tell which
+    run produced it, what it compiled and how it ended — so a log that IS stale
+    (an artifact served from cache, whose log belongs to the run that built it)
+    announces itself instead of masquerading as the run you just triggered."""
+    when = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    what = "preview" if is_preview else f"r{revision}"
+    bits = [
+        f"run {run_id}",
+        f"model {model_id}",
+        what,
+        f"lod={lod}",
+        f"engine={engine or 'adapy-default'}",
+    ]
+    if detailing and detailing != "none":
+        bits.append(f"detailing={detailing}")
+    return f"=== compile {status} · {when} · " + " · ".join(bits) + " ==="
+
+
+async def _put_run_log(storage: "Storage", scope, model_id: str | None, run_id: str, text: str) -> str | None:
+    """Persist ONE compile run's log at its run-stamped key, returning that key.
+
+    ALWAYS writes, even when the engine emitted nothing: an empty run still gets a
+    blob carrying its banner. The old code skipped the write on empty text, which
+    is precisely how a clean recompile left the previous run's failure sitting at
+    the shared artifact-derived key for the panel to show. Best-effort — a log
+    that fails to upload must not fail an otherwise-good compile."""
+    if not model_id:
+        return None
+    try:
+        from .procedural import procedural_run_log_key
+
+        key = procedural_run_log_key(model_id, run_id)
+    except ValueError:
+        logger.warning("worker: refusing to write a compile log for unsafe run id %r", run_id)
+        return None
+    try:
+        await storage.put_bytes(scope, key, text.encode("utf-8"), content_encoding="gzip")
+        return key
+    except Exception:
+        logger.exception("worker: procedural compile-run log upload failed for %s", model_id)
+        return None
+
+
+async def _put_run_pointer(storage: "Storage", scope, derived_key: str, run_id: str) -> None:
+    """Point an artifact key at the run that most recently targeted it (a ``.run``
+    sibling — see procedural.procedural_run_pointer_key).
+
+    Written when the run STARTS, so it is already in place for a run that fails
+    before producing bytes; that failure's log is then what the viewer finds for
+    the artifact, rather than the last SUCCESS's log. Best-effort: without the
+    pointer the log lookup simply falls back to the legacy sibling."""
+    try:
+        from .procedural import procedural_run_pointer_key
+
+        await storage.put_bytes(scope, procedural_run_pointer_key(derived_key), run_id.encode("utf-8"))
+    except Exception:
+        logger.warning("worker: failed to write run-pointer sidecar for %s", derived_key)
+
+
+async def _prune_run_logs(storage: "Storage", scope, model_id: str | None, keep_key: str = "") -> None:
+    """Drop all but the newest ``RUN_LOG_RETENTION`` run logs for one model.
+
+    Run-keyed logs accumulate where the old artifact-keyed log overwrote itself, so
+    the prefix needs a bound. Bounded listing (one model's ``runs/`` prefix only)
+    and best-effort throughout: a pruning failure is never worth failing a compile
+    over, and losing an old run's log only costs its admin audit row the Log tab."""
+    if not model_id:
+        return
+    try:
+        from .procedural import (
+            RUN_LOG_RETENTION,
+            procedural_run_dir,
+            prune_run_log_keys,
+        )
+
+        entries = await storage.list_prefix(scope, procedural_run_dir(model_id))
+        if len(entries) <= RUN_LOG_RETENTION:
+            return
+        # Newest first. last_modified is ISO-8601 (lexicographically sortable) when
+        # the backend reports one; entries without it sort oldest so they go first.
+        ordered = sorted(entries, key=lambda e: (e.last_modified or "", e.key), reverse=True)
+        keys = [e.key for e in ordered if e.key != keep_key]
+        # The run that just finished heads the list whatever the backend reported
+        # for last_modified: the log the caller is about to be handed must survive.
+        if keep_key:
+            keys.insert(0, keep_key)
+        for key in prune_run_log_keys(keys):
+            try:
+                await storage.delete(scope, key)
+            except Exception:
+                logger.debug("worker: could not prune stale compile-run log %s", key)
+    except Exception:
+        logger.warning("worker: compile-run log retention sweep failed for %s", model_id)
+
+
 async def _write_catalog_fp_sidecar(storage: "Storage", scope, derived_key: str, opts: dict | None) -> None:
     """Record the catalog fingerprint a procedural artifact was built from, as a
     ``.catfp`` sibling of ``derived_key`` (see procedural.procedural_catalog_fp_key).
@@ -1171,13 +1280,57 @@ async def _run_procedural_build(
     preview_doc = opts.get("preview_doc")
     is_preview = isinstance(preview_doc, dict)
 
+    # ── This compile's RUN identity ─────────────────────────────────
+    # The queue job id IS the run id. It is minted per compile ATTEMPT (where the
+    # derived key is content-addressed and therefore shared by every attempt of an
+    # unchanged input), it is the id the compile response already hands the
+    # viewer, and it is the ``audit_log`` join key — so one id names this run's log
+    # blob, the panel's current run, and the admin audit entry for it.
+    run_log: dict[str, str] = {"key": "", "body": ""}
+
+    async def _write_run_log(status: str, body: str | None = None) -> None:
+        """(Re)write THIS run's log with the given outcome. Called on every exit
+        path, so a run always leaves a log behind — including one that fails before
+        the engine is ever entered, which used to leave the panel showing whatever
+        the previous run wrote."""
+        if body is not None:
+            run_log["body"] = body
+        header = _compile_run_header(
+            run_id=job_id,
+            model_id=model_id,
+            revision=revision,
+            engine=engine,
+            lod=lod,
+            detailing=detailing,
+            is_preview=is_preview,
+            status=status,
+        )
+        text = f"{header}\n{run_log['body']}" if run_log["body"] else header
+        run_log["key"] = await _put_run_log(storage, scope, model_id, job_id, text) or ""
+
     async def _fail(stage: str, msg: str, trace: str | None = None) -> None:
         await queue.update(job_id, status=JOB_STATUS_ERROR, stage=stage, error=msg)
-        await _audit_done(db_pool, job_id, "error", msg, started_at, traceback=trace)
+        # Rewrite the run log with the failure banner, keeping whatever the engine
+        # had already emitted — a failed run's log must stay retrievable and must
+        # read as a FAILURE, distinguishable from the success that may follow it.
+        await _write_run_log(f"failed at {stage}: {msg}")
+        await _audit_done(
+            db_pool,
+            job_id,
+            "error",
+            msg,
+            started_at,
+            traceback=trace,
+            metrics={"log_key": run_log["key"]} if run_log["key"] else None,
+        )
 
     if not model_id or not isinstance(revision, int):
         await _fail("build", "conversion_options.model_id and revision are required for procedural_build")
         return
+    # Claim the artifact key for this run BEFORE any work: a lookup that has only
+    # the derived key to go on (a cache hit, or a run that dies before writing
+    # bytes) then resolves to this run rather than to whichever ran last.
+    await _put_run_pointer(storage, scope, job.derived_key, job_id)
     if db_pool is None:
         await _fail("build", "procedural build requires DATABASE_URL on the worker")
         return
@@ -1332,25 +1485,14 @@ async def _run_procedural_build(
 
     loop = asyncio.get_running_loop()
     # Capture the engine's logging (and stdout) DURING the compile so the messages
-    # are inspectable from the viewer — persisted as a ``.log`` sibling of the GLB
-    # (procedural_log_key) on BOTH success and failure so errors stay diagnosable.
-    from .procedural import procedural_log_key
-
-    log_key = procedural_log_key(job.derived_key)
+    # are inspectable from the viewer — persisted under THIS RUN's key
+    # (procedural_run_log_key) on BOTH success and failure so errors stay
+    # diagnosable and no run can ever be handed another run's output.
     stdout_buf = io.StringIO()
 
     def _do_compile_captured() -> bytes:
         with contextlib.redirect_stdout(stdout_buf):
             return _do_compile()
-
-    async def _persist_log(handler: _CompileLogCapture, extra: str | None = None) -> None:
-        text = _assemble_compile_log(handler, stdout_buf, extra)
-        if not text:
-            return
-        try:
-            await storage.put_bytes(scope, log_key, text.encode("utf-8"), content_encoding="gzip")
-        except Exception:
-            logger.exception("worker: procedural_build log upload failed for %s", model_id)
 
     with _capture_compile_logs() as log_handler:
         try:
@@ -1358,10 +1500,14 @@ async def _run_procedural_build(
             glb_bytes = await loop.run_in_executor(None, _do_compile_captured)
         except Exception as exc:
             logger.exception("worker: procedural_build failed for %s", model_id)
-            await _persist_log(log_handler, extra=tb_module.format_exc())
+            await _write_run_log(
+                "failed at build", _assemble_compile_log(log_handler, stdout_buf, tb_module.format_exc())
+            )
             await _fail("build", str(exc), tb_module.format_exc())
             return
-        await _persist_log(log_handler)
+        # Unconditional: an engine that logged nothing still gets a blob (its banner
+        # alone), so the next reader sees THIS run and not a leftover from an older one.
+        await _write_run_log("ok", _assemble_compile_log(log_handler, stdout_buf, None))
 
     try:
         await queue.update(job_id, stage="upload", progress=0.90)
@@ -1414,8 +1560,19 @@ async def _run_procedural_build(
             await _fail("artifact", str(exc), tb_module.format_exc())
             return
 
+    await _prune_run_logs(storage, scope, model_id, run_log["key"])
     await queue.update(job_id, status=JOB_STATUS_DONE, stage="ready", progress=1.0, error=None)
-    await _audit_done(db_pool, job_id, "done", None, started_at)
+    # Hand the run's log to the audit row, so the admin panel's existing per-row
+    # "Log" tab (GET /admin/audit/{id}/log) serves a compile exactly as it serves
+    # a conversion — no parallel surface for procedural runs.
+    await _audit_done(
+        db_pool,
+        job_id,
+        "done",
+        None,
+        started_at,
+        metrics={"log_key": run_log["key"]} if run_log["key"] else None,
+    )
 
 
 def _serialize_structural_artifact(assembly) -> "tuple[bytes, dict]":
@@ -1492,9 +1649,41 @@ async def _run_procedural_detail(
     structural_sections_key = opts.get("structural_sections_key")
     lod = "detail" if (opts.get("lod") or "sim") == "detail" else "sim"
 
+    # This stage owns ``derived_key``, so it is the run the viewer's log lookup for
+    # that artifact must find — same run identity (the job id) as the structural
+    # stage, just a different key.
+    run_log: dict[str, str] = {"key": "", "body": ""}
+
+    async def _write_run_log(status: str, body: str | None = None) -> None:
+        if body is not None:
+            run_log["body"] = body
+        header = _compile_run_header(
+            run_id=job_id,
+            model_id=model_id,
+            revision=opts.get("revision"),
+            engine=opts.get("engine"),
+            lod=lod,
+            detailing=opts.get("detailing"),
+            is_preview=False,
+            status=status,
+        )
+        text = f"{header}\n{run_log['body']}" if run_log["body"] else header
+        run_log["key"] = await _put_run_log(storage, scope, model_id, job_id, text) or ""
+
     async def _fail(stage: str, msg: str, trace: str | None = None) -> None:
         await queue.update(job_id, status=JOB_STATUS_ERROR, stage=stage, error=msg)
-        await _audit_done(db_pool, job_id, "error", msg, started_at, traceback=trace)
+        await _write_run_log(f"failed at {stage}: {msg}")
+        await _audit_done(
+            db_pool,
+            job_id,
+            "error",
+            msg,
+            started_at,
+            traceback=trace,
+            metrics={"log_key": run_log["key"]} if run_log["key"] else None,
+        )
+
+    await _put_run_pointer(storage, scope, job.derived_key, job_id)
 
     if not entrypoint or ":" not in str(entrypoint):
         await _fail(
@@ -1564,18 +1753,25 @@ async def _run_procedural_detail(
         options[k] = v
 
     loop = asyncio.get_running_loop()
+    stdout_buf = io.StringIO()
 
     def _do_detail() -> bytes:
         fn = load_entrypoint(entrypoint)
-        return fn(model_bytes, options)
+        with contextlib.redirect_stdout(stdout_buf):
+            return fn(model_bytes, options)
 
-    try:
-        await queue.update(job_id, stage="detail", progress=0.50)
-        glb_bytes = await loop.run_in_executor(None, _do_detail)
-    except Exception as exc:
-        logger.exception("worker: procedural_detail failed for %s", model_id)
-        await _fail("detail", str(exc), tb_module.format_exc())
-        return
+    with _capture_compile_logs() as log_handler:
+        try:
+            await queue.update(job_id, stage="detail", progress=0.50)
+            glb_bytes = await loop.run_in_executor(None, _do_detail)
+        except Exception as exc:
+            logger.exception("worker: procedural_detail failed for %s", model_id)
+            await _write_run_log(
+                "failed at detail", _assemble_compile_log(log_handler, stdout_buf, tb_module.format_exc())
+            )
+            await _fail("detail", str(exc), tb_module.format_exc())
+            return
+        await _write_run_log("ok", _assemble_compile_log(log_handler, stdout_buf, None))
 
     try:
         await queue.update(job_id, stage="upload", progress=0.90)
@@ -1589,8 +1785,16 @@ async def _run_procedural_detail(
     # stage; stamp its own sidecar so the endpoint's staleness check on derived_key works.
     await _write_catalog_fp_sidecar(storage, scope, job.derived_key, job.conversion_options)
 
+    await _prune_run_logs(storage, scope, model_id, run_log["key"])
     await queue.update(job_id, status=JOB_STATUS_DONE, stage="ready", progress=1.0, error=None)
-    await _audit_done(db_pool, job_id, "done", None, started_at)
+    await _audit_done(
+        db_pool,
+        job_id,
+        "done",
+        None,
+        started_at,
+        metrics={"log_key": run_log["key"]} if run_log["key"] else None,
+    )
 
 
 async def _run_procedural_relocations(

--- a/src/frontend/src/components/admin/AuditLogTab.tsx
+++ b/src/frontend/src/components/admin/AuditLogTab.tsx
@@ -17,9 +17,12 @@ import {
 // next_before_id) — that way the table doesn't shift while new audit
 // rows are inserted between pages.
 
-const ACTIONS = ["", "upload", "download", "convert", "view", "render"];
+// "compile" = one procedural compile RUN (app.py _audit_compile_run); its
+// worker attaches the run's log_key, so such a row's Log tab shows the engine
+// output for exactly that run.
+const ACTIONS = ["", "upload", "download", "convert", "compile", "view", "render"];
 const KINDS = ["", "shared", "project", "user"];
-const TARGETS = ["", "glb", "ifc", "xml", "step", "stl", "obj", "sat"];
+const TARGETS = ["", "glb", "ifc", "xml", "step", "stl", "obj", "sat", "procedural_build", "procedural_detail"];
 // Job states the queue writes (queue.py JOB_STATUS_*) — server-side filter.
 const STATUSES = ["", "queued", "running", "done", "error"];
 
@@ -32,6 +35,8 @@ const PROFILE_SETTING_KEY = "profile_conversions";
 // buttons.
 function hasDetails(e: AuditEntry): boolean {
     if (e.action === "convert") return true;
+    // A compile run always has a log to read, even when it succeeded.
+    if (e.action === "compile") return true;
     // Browser view/render rows always carry a client_metrics payload to
     // inspect (per-phase split + per-function frames), fetched lazily.
     if (e.action === "view" || e.action === "render") return true;
@@ -884,7 +889,8 @@ const MetricsTab: React.FC<{
             <div className="px-4 py-3 text-xs text-gray-400">
                 No metrics captured for this entry.
                 {entry.action !== "convert" ? (
-                    <span> Only conversion runs collect resource metrics.</span>
+                    <span> Only conversion runs collect resource metrics; a compile run records
+                        its wall time and its engine log.</span>
                 ) : (
                     <span> The worker that processed this job pre-dates the metrics column.</span>
                 )}

--- a/src/frontend/src/components/viewer/CellBuilderPanel.tsx
+++ b/src/frontend/src/components/viewer/CellBuilderPanel.tsx
@@ -180,6 +180,8 @@ const IconOverlaySection: React.FC = () => {
 // AND failed compiles so engine errors are inspectable without server access.
 const CompileLogSection: React.FC = () => {
   const log = useCellBuilderStore((st) => st.compileLog);
+  const runId = useCellBuilderStore((st) => st.compileLogRunId);
+  const isCurrentRun = useCellBuilderStore((st) => st.compileLogIsCurrentRun);
   const [copied, setCopied] = React.useState(false);
   const onCopy = () => {
     if (!log) return;
@@ -203,8 +205,15 @@ const CompileLogSection: React.FC = () => {
             >
               {copied ? "Copied" : "Copy"}
             </button>
-            <span className="text-gray-500 text-[11px]">
-              engine messages from the last compile
+            <span
+              className="text-gray-500 text-[11px] truncate"
+              title={runId ? `compile run ${runId}` : undefined}
+            >
+              {runId
+                ? isCurrentRun
+                  ? `engine messages · run ${runId.slice(0, 8)}`
+                  : `from an earlier run (${runId.slice(0, 8)}) — this result was cached`
+                : "engine messages from the last compile"}
             </span>
           </div>
           <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words bg-black/40 border border-gray-700 rounded-sm p-1.5 text-[11px] font-mono text-gray-200">

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -2236,21 +2236,31 @@ export const viewerApi = {
     );
   },
 
-  /** Fetch the engine-compile log captured for a compiled/previewed GLB.
-   * `derivedKey` is the GLB key returned by compile/preview; the server reads
-   * that key's `.log` sibling. Returns the log text ("" when none was
-   * persisted — e.g. a pre-log cached blob). Never throws on a missing log. */
+  /** Fetch the log of ONE compile run. Pass `runId` — the `job_id` the
+   * compile/preview response returned — and you get exactly that run's log, so a
+   * recompile of an unchanged document can never be handed the previous run's
+   * output. `derivedKey` is the fallback for a result served from cache (no run
+   * happened just now): the server resolves the artifact's `.run` pointer to
+   * whichever run last targeted it. Returns `{text, runId}` — `runId` is the run
+   * the server actually served ("" for a pre-runs artifact), so the caller can
+   * tell a fresh log from an inherited one. Never throws on a missing log. */
   async proceduralCompileLog(
     scope: ScopeUrl,
     modelId: string,
     derivedKey: string,
-  ): Promise<string> {
-    const qs = `?key=${encodeURIComponent(derivedKey)}`;
+    runId?: string | null,
+  ): Promise<{ text: string; runId: string }> {
+    const qs = runId
+      ? `?run=${encodeURIComponent(runId)}`
+      : `?key=${encodeURIComponent(derivedKey)}`;
     const r = await authedFetch(
       `${runtime.apiBase()}/scopes/${encodeURIComponent(scope)}/procedural-models/${encodeURIComponent(modelId)}/compile-log${qs}`,
     );
-    if (!r.ok) return "";
-    return await r.text();
+    if (!r.ok) return { text: "", runId: "" };
+    return {
+      text: await r.text(),
+      runId: r.headers.get("X-Compile-Run") || runId || "",
+    };
   },
 
   /** Fetch the quantity take-off computed alongside a compiled GLB (the data

--- a/src/frontend/src/state/cellBuilderStore.ts
+++ b/src/frontend/src/state/cellBuilderStore.ts
@@ -389,6 +389,12 @@ interface CellBuilderState {
    * stdout), fetched once the job reaches done/cached/error. null = no log yet
    * (nothing compiled this session); "" = compiled but the engine emitted nothing. */
   compileLog: string | null;
+  // The compile RUN the shown log belongs to (the job id), and whether that run
+  // is the one just triggered. A cache hit shows the log of the run that BUILT
+  // the artifact — still a real run, but not this one, so the panel says so
+  // instead of passing off an old failure as the current build's.
+  compileLogRunId: string | null;
+  compileLogIsCurrentRun: boolean;
   /** Source name of the compiled SIMULATION result currently loaded in the scene. */
   resultSourceName: string | null;
   /** Source name of the compiled DETAIL result currently loaded in the scene. */
@@ -1194,20 +1200,25 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
       startedAt: Date.now(),
     });
     // Clear any prior log while this build runs; it's refetched on completion.
-    set({ compileLog: null });
+    set({ compileLog: null, compileLogRunId: null, compileLogIsCurrentRun: false });
     // Fetch the engine-compile log for a finished (or failed) build and stash it
     // so the panel's "Compile log" section can show the engine's messages. Best
     // effort — a missing log resolves to "" and never blocks the result.
-    const fetchCompileLog = async (derivedKey: string) => {
+    const fetchCompileLog = async (derivedKey: string, runId?: string | null) => {
       const active = get().active;
-      if (!active || !derivedKey) return;
+      if (!active || (!derivedKey && !runId)) return;
       try {
-        const text = await viewerApi.proceduralCompileLog(
+        const res = await viewerApi.proceduralCompileLog(
           currentScopePart(),
           active.modelId,
           derivedKey,
+          runId,
         );
-        set({ compileLog: text });
+        set({
+          compileLog: res.text,
+          compileLogRunId: res.runId || null,
+          compileLogIsCurrentRun: Boolean(runId) && res.runId === runId,
+        });
       } catch {
         // Leave compileLog as-is; the log is a diagnostic, not load-bearing.
       }
@@ -1293,7 +1304,7 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
         });
         autoShow();
         broadcast(res.derived_key);
-        void fetchCompileLog(res.derived_key);
+        void fetchCompileLog(res.derived_key, null);
         fetchStats(res.derived_key);
         return;
       }
@@ -1322,7 +1333,7 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
             });
             autoShow();
             broadcast(st.derived_key || cur.derivedKey || "");
-            void fetchCompileLog(st.derived_key || cur.derivedKey || "");
+            void fetchCompileLog(st.derived_key || cur.derivedKey || "", jobId);
             fetchStats(st.derived_key || cur.derivedKey || "");
             return;
           }
@@ -1336,7 +1347,7 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
               error: st.error ?? "compile failed",
             });
             // A failed compile still persists its log (errors are inspectable).
-            void fetchCompileLog(cur.derivedKey || "");
+            void fetchCompileLog(cur.derivedKey || "", jobId);
             return;
           }
           set({ compileJob: { ...cur, status: "running" } });
@@ -1490,6 +1501,8 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
     systemTypes: [],
     compileJob: null,
     compileLog: null,
+    compileLogRunId: null,
+    compileLogIsCurrentRun: false,
     resultSourceName: null,
     detailSourceName: null,
     repMode: "topology",
@@ -1563,6 +1576,8 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
         conflict: null,
         compileJob: null,
         compileLog: null,
+        compileLogRunId: null,
+        compileLogIsCurrentRun: false,
         panelVisible: true,
         hiddenCellIds: [],
         // Reset the VIEW state to a clean topology view. Without this, a session
@@ -1623,6 +1638,8 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
         panelVisible: false,
         compileJob: null,
         compileLog: null,
+        compileLogRunId: null,
+        compileLogIsCurrentRun: false,
         hiddenCellIds: [],
         // Clean view state on close so it can't taint the next open (see open()).
         repMode: "topology",

--- a/tests/comms/rest/test_procedural_compile_runs.py
+++ b/tests/comms/rest/test_procedural_compile_runs.py
@@ -1,0 +1,497 @@
+"""Compile logs belong to a RUN, not to a document.
+
+Every procedural derived key is content-addressed on purpose — a revision stamp
+for a committed compile, the document's content hash for a preview — so an
+unchanged input is served from cache for free. Deriving the log key from the
+artifact key inherited that property, and a log has no business inheriting it:
+two different compile ATTEMPTS of the same document shared one log key, and the
+worker only wrote it when the engine had actually emitted something. A forced
+recompile that succeeded quietly therefore left the PREVIOUS attempt's failure
+sitting at that key for the viewer to show.
+
+These tests pin the replacement: the queue job id is the run id, each run writes
+its own log unconditionally, the artifact carries a ``.run`` pointer to whichever
+run last targeted it, and each run opens an ``audit_log`` row so the admin panel
+can serve it through the same per-row "Log" tab a conversion gets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as db_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+from ada.comms.rest.procedural import (  # noqa: E402
+    RUN_LOG_RETENTION,
+    doc_content_hash,
+    is_valid_run_id,
+    procedural_glb_key,
+    procedural_log_key,
+    procedural_preview_glb_key,
+    procedural_run_dir,
+    procedural_run_log_key,
+    procedural_run_pointer_key,
+    prune_run_log_keys,
+)
+from ada.comms.rest.queue import JobQueue  # noqa: E402
+
+# The worker is a POSIX-only component (it forks conversions through fcntl), so
+# the handler-level tests below skip off-POSIX and run in CI like every other
+# worker test. The key-convention and endpoint tests run everywhere.
+try:
+    from ada.comms.rest import worker as worker_mod  # noqa: E402
+except ImportError:  # pragma: no cover - non-POSIX dev machine
+    worker_mod = None
+
+needs_worker = pytest.mark.skipif(worker_mod is None, reason="ada.comms.rest.worker requires POSIX (fcntl)")
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+# ── key conventions ──────────────────────────────────────────────────
+
+
+def test_run_log_key_is_keyed_by_run_not_by_artifact():
+    from ada.comms.rest.converter import is_hidden_key
+
+    key = procedural_run_log_key("m1", "abc123")
+    assert key == "_procedural/m1/runs/abc123.log"
+    assert is_hidden_key(key)
+    assert key.startswith(procedural_run_dir("m1"))
+    # THE POINT: the artifact key is shared by every compile of an unchanged
+    # input, the run key never is.
+    assert procedural_log_key(procedural_glb_key("m1", 4)) == procedural_log_key(procedural_glb_key("m1", 4))
+    assert procedural_run_log_key("m1", "run-a") != procedural_run_log_key("m1", "run-b")
+    # ...including for a preview, whose key is the doc's content hash: the same
+    # doc previewed twice hits one blob key but two distinct run logs.
+    h = doc_content_hash({"spaces": []})
+    assert procedural_preview_glb_key("m1", h) == procedural_preview_glb_key("m1", h)
+    assert procedural_run_log_key("m1", "prev-1") != procedural_run_log_key("m1", "prev-2")
+
+
+def test_run_id_must_be_key_safe():
+    assert is_valid_run_id("0f9a3c4e5b6d7a8b")
+    assert is_valid_run_id("wasm-0f9a3c4e")
+    # A run id is interpolated into a blob key, so path-ish and empty ids are
+    # rejected outright rather than escaped.
+    for bad in ("", "../../etc/passwd", "a/b", "run.log", "x" * 200):
+        assert not is_valid_run_id(bad), bad
+        with pytest.raises(ValueError):
+            procedural_run_log_key("m1", bad)
+
+
+def test_run_pointer_key_is_artifact_sibling():
+    assert procedural_run_pointer_key("_procedural/m1/r2.glb") == "_procedural/m1/r2.glb.run"
+    assert procedural_run_pointer_key("_procedural/m1/preview/deadbeef.glb") == (
+        "_procedural/m1/preview/deadbeef.glb.run"
+    )
+
+
+def test_run_log_retention_keeps_the_newest():
+    keys = [f"k{i}" for i in range(RUN_LOG_RETENTION + 3)]
+    doomed = prune_run_log_keys(keys)
+    assert doomed == keys[RUN_LOG_RETENTION:]
+    assert len(doomed) == 3
+    # Under the limit nothing is dropped.
+    assert prune_run_log_keys(keys[:2]) == []
+
+
+# ── the worker: one log per run ──────────────────────────────────────
+
+
+class _FakeStorage:
+    """In-memory stand-in for Storage, recording writes/deletes by key."""
+
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+        self.deleted: list[str] = []
+
+    async def exists(self, scope, key):
+        return key in self.blobs
+
+    async def get_bytes(self, scope, key):
+        if key not in self.blobs:
+            raise FileNotFoundError(key)
+        return self.blobs[key]
+
+    async def put_bytes(self, scope, key, data, content_encoding=None):
+        self.blobs[key] = data
+
+    async def delete(self, scope, key):
+        self.deleted.append(key)
+        self.blobs.pop(key, None)
+
+    async def list_prefix(self, scope, prefix):
+        return [
+            SimpleNamespace(key=k, size=len(v), last_modified=None)
+            for k, v in self.blobs.items()
+            if k.startswith(prefix)
+        ]
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+
+    async def update(self, job_id, **kw):
+        self.updates.append(kw)
+
+
+def _compile_job(job_id: str, derived_key: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        job_id=job_id,
+        derived_key=derived_key,
+        conversion_options={"model_id": "m1", "revision": 2, "lod": "sim", "engine": None},
+    )
+
+
+def _run_build(monkeypatch, storage, *, job_id: str, derived_key: str, compile_fn) -> _FakeQueue:
+    """Drive ``_run_procedural_build`` with the DB + the engine stubbed out, so the
+    test exercises the real logging/keying path around a compile of our choosing."""
+    row = {
+        "id": "m1",
+        "revision": 2,
+        "scope_kind": "shared",
+        "scope_id": None,
+        "engine": None,
+        "name": "M",
+        "doc": {"spaces": [], "equipments": []},
+    }
+
+    async def _get_model(pool, model_id):
+        return row
+
+    async def _catalog(pool, *, scope_kind, scope_id):
+        return {}
+
+    async def _cad_keys(pool, *, scope_kind, scope_id):
+        return {}
+
+    monkeypatch.setattr(db_module, "get_procedural_model", _get_model)
+    monkeypatch.setattr(db_module, "get_equipment_docs_by_scope", _catalog)
+    monkeypatch.setattr(db_module, "get_equipment_cad_keys_by_scope", _cad_keys)
+    monkeypatch.setattr("ada.topo_model.compile.compile_procedural_doc_with_takeoff", compile_fn)
+
+    queue = _FakeQueue()
+    asyncio.run(
+        worker_mod._run_procedural_build(
+            job=_compile_job(job_id, derived_key),
+            scope=SimpleNamespace(kind="shared", id=None),
+            storage=storage,
+            queue=queue,
+            db_pool=object(),
+            started_at=0.0,
+        )
+    )
+    return queue
+
+
+@needs_worker
+def test_second_compile_of_the_same_doc_gets_its_own_log(monkeypatch):
+    # THE REPORTED BUG. Run 1 fails loudly. Run 2 compiles the very same document
+    # (same derived key) and succeeds SILENTLY — the engine emits nothing. Under
+    # the old artifact-keyed scheme run 2 wrote no log at all and the panel kept
+    # serving run 1's error; now each run owns its own blob and the artifact
+    # pointer follows the latest run.
+    storage = _FakeStorage()
+    derived_key = procedural_glb_key("m1", 2)
+
+    def _boom(doc, **kw):
+        raise RuntimeError("engine exploded")
+
+    def _quiet(doc, **kw):
+        return b"glTF", {"mass": 1}
+
+    _run_build(monkeypatch, storage, job_id="run1", derived_key=derived_key, compile_fn=_boom)
+    _run_build(monkeypatch, storage, job_id="run2", derived_key=derived_key, compile_fn=_quiet)
+
+    log1 = storage.blobs[procedural_run_log_key("m1", "run1")].decode()
+    log2 = storage.blobs[procedural_run_log_key("m1", "run2")].decode()
+
+    # Two runs, two logs — neither overwrote the other.
+    assert log1 != log2
+    # The failure is retrievable and reads as a failure...
+    assert "run run1" in log1 and "failed at build" in log1 and "engine exploded" in log1
+    # ...and the later success does NOT carry it. This is the exact regression:
+    # a silent success used to leave the earlier error in place.
+    assert "engine exploded" not in log2
+    assert "run run2" in log2 and "compile ok" in log2
+    # The artifact now points at the run that most recently targeted it, so a
+    # key-only lookup resolves to run 2.
+    assert storage.blobs[procedural_run_pointer_key(derived_key)] == b"run2"
+
+
+@needs_worker
+def test_failed_run_log_survives_the_success_that_follows(monkeypatch):
+    # A failure's log must stay independently retrievable AFTER a later run
+    # succeeds — the run id is the handle the admin audit row keeps.
+    storage = _FakeStorage()
+    derived_key = procedural_glb_key("m1", 2)
+
+    def _boom(doc, **kw):
+        raise RuntimeError("bad blueprint")
+
+    def _ok(doc, **kw):
+        return b"glTF", {}
+
+    _run_build(monkeypatch, storage, job_id="failrun", derived_key=derived_key, compile_fn=_boom)
+    _run_build(monkeypatch, storage, job_id="okrun", derived_key=derived_key, compile_fn=_ok)
+
+    failed = storage.blobs[procedural_run_log_key("m1", "failrun")].decode()
+    ok = storage.blobs[procedural_run_log_key("m1", "okrun")].decode()
+    assert "failed at build" in failed and "bad blueprint" in failed
+    assert "compile ok" in ok and "failed" not in ok
+    # No GLB was written for the failed run, but its log is there regardless.
+    assert storage.blobs[derived_key] == b"glTF"
+
+
+@needs_worker
+def test_run_that_dies_before_the_engine_still_leaves_a_log(monkeypatch):
+    # A run that fails during setup (here: the model row is gone) never reaches
+    # the engine. It must still write its own log rather than leaving the reader
+    # with whatever the previous run wrote.
+    storage = _FakeStorage()
+    derived_key = procedural_glb_key("m1", 2)
+
+    async def _no_model(pool, model_id):
+        return None
+
+    monkeypatch.setattr(db_module, "get_procedural_model", _no_model)
+    asyncio.run(
+        worker_mod._run_procedural_build(
+            job=_compile_job("earlyfail", derived_key),
+            scope=SimpleNamespace(kind="shared", id=None),
+            storage=storage,
+            queue=_FakeQueue(),
+            db_pool=object(),
+            started_at=0.0,
+        )
+    )
+    log = storage.blobs[procedural_run_log_key("m1", "earlyfail")].decode()
+    assert "failed at build" in log and "not found" in log
+    # The pointer is claimed up front, so the viewer finds THIS run for the key.
+    assert storage.blobs[procedural_run_pointer_key(derived_key)] == b"earlyfail"
+
+
+@needs_worker
+def test_run_log_reaches_the_audit_row(monkeypatch):
+    # The worker hands the run's log key to the audit row, which is what lets the
+    # admin panel's existing per-row Log tab serve a compile like a conversion.
+    storage = _FakeStorage()
+    patched: list[dict] = []
+
+    async def _update(pool, **kw):
+        patched.append(kw)
+
+    monkeypatch.setattr(db_module, "update_audit_by_job", _update)
+    _run_build(
+        monkeypatch,
+        storage,
+        job_id="audited",
+        derived_key=procedural_glb_key("m1", 2),
+        compile_fn=lambda doc, **kw: (b"glTF", {}),
+    )
+    assert patched, "no audit row patched"
+    done = patched[-1]
+    assert done["job_id"] == "audited"
+    assert done["status"] == "done"
+    assert done["log_key"] == procedural_run_log_key("m1", "audited")
+
+
+@needs_worker
+def test_old_run_logs_are_pruned(monkeypatch):
+    # Run-keyed logs accumulate where the artifact-keyed one overwrote itself, so
+    # the prefix is bounded. Seed past the retention limit and compile once.
+    storage = _FakeStorage()
+    for i in range(RUN_LOG_RETENTION + 5):
+        storage.blobs[procedural_run_log_key("m1", f"old{i:04d}")] = b"x"
+    _run_build(
+        monkeypatch,
+        storage,
+        job_id="fresh",
+        derived_key=procedural_glb_key("m1", 2),
+        compile_fn=lambda doc, **kw: (b"glTF", {}),
+    )
+    assert storage.deleted, "retention sweep deleted nothing"
+    remaining = [k for k in storage.blobs if k.startswith(procedural_run_dir("m1"))]
+    assert len(remaining) == RUN_LOG_RETENTION
+    # The run that just finished is never the one pruned — its log is exactly what
+    # the caller is about to be handed.
+    assert procedural_run_log_key("m1", "fresh") in remaining
+
+
+# ── the endpoint: serve a run, not an artifact ───────────────────────
+
+
+@pytest.fixture
+def log_client(monkeypatch, tmp_path: pathlib.Path):
+    """App + storage wired against a stubbed model row (no Postgres needed)."""
+    row = {"id": "m1", "revision": 2, "scope_kind": "shared", "scope_id": None, "engine": None, "name": "M", "doc": {}}
+
+    async def _get_model(pool, model_id):
+        return row if model_id == "m1" else None
+
+    monkeypatch.setattr(db_module, "get_procedural_model", _get_model)
+    settings = _settings(tmp_path)
+    from ada.comms.rest.scope import Scope
+    from ada.comms.rest.storage import Storage
+
+    storage = Storage.from_settings(settings)
+
+    def seed(key: str, text: bytes) -> None:
+        asyncio.run(storage.put_bytes(Scope.shared(), key, text))
+
+    app = create_app(settings)
+    with TestClient(app) as client:
+        client.app.state.db_pool = object()
+        yield client, seed
+
+
+def test_compile_log_endpoint_serves_the_requested_run(log_client):
+    client, seed = log_client
+    seed(procedural_run_log_key("m1", "runA"), b"=== compile ok - run runA ===")
+    seed(procedural_run_log_key("m1", "runB"), b"=== compile failed at build - run runB ===")
+
+    base = "/api/scopes/shared/procedural-models/m1/compile-log"
+    r = client.get(base, params={"run": "runA"})
+    assert r.status_code == 200, r.text
+    assert "run runA" in r.text
+    assert r.headers["X-Compile-Run"] == "runA"
+    # The other run is a separate, independently addressable log.
+    assert "run runB" in client.get(base, params={"run": "runB"}).text
+    # A run with no log is an empty 200, not an error (the compile may still be
+    # in flight) — and it is never someone else's log.
+    r = client.get(base, params={"run": "runC"})
+    assert r.status_code == 200 and r.text == ""
+
+
+def test_compile_log_endpoint_rejects_unsafe_input(log_client):
+    client, _ = log_client
+    base = "/api/scopes/shared/procedural-models/m1/compile-log"
+    assert client.get(base).status_code == 400  # neither run nor key
+    assert client.get(base, params={"run": "../../secret"}).status_code == 400
+    # The key path stays confined to this model's own prefix.
+    assert client.get(base, params={"key": "_procedural/other/r1.glb"}).status_code == 400
+
+
+def test_compile_log_endpoint_resolves_a_cached_artifact_through_its_pointer(log_client):
+    # A result served from cache has no run of its own; the artifact's pointer
+    # names the run that built it, and the response says which run that was so
+    # the caller can tell it apart from the run it just triggered.
+    client, seed = log_client
+    key = procedural_glb_key("m1", 2)
+    seed(procedural_run_pointer_key(key), b"builder-run")
+    seed(procedural_run_log_key("m1", "builder-run"), b"built here")
+
+    r = client.get("/api/scopes/shared/procedural-models/m1/compile-log", params={"key": key})
+    assert r.status_code == 200
+    assert r.text == "built here"
+    assert r.headers["X-Compile-Run"] == "builder-run"
+
+
+def test_compile_log_endpoint_falls_back_to_the_legacy_sibling(log_client):
+    # An artifact compiled before runs existed has no pointer; its ``.log``
+    # sibling still resolves, flagged with an empty run id so the caller knows it
+    # cannot attribute the log to any run.
+    client, seed = log_client
+    key = procedural_glb_key("m1", 2)
+    seed(procedural_log_key(key), b"pre-runs log")
+
+    r = client.get("/api/scopes/shared/procedural-models/m1/compile-log", params={"key": key})
+    assert r.status_code == 200
+    assert r.text == "pre-runs log"
+    assert r.headers["X-Compile-Run"] == ""
+
+
+# ── the endpoint: a compile opens an audit row ───────────────────────
+
+
+def test_compile_opens_an_audit_row_for_the_run(monkeypatch, tmp_path: pathlib.Path):
+    # The run is visible in the admin audit log from the moment it is enqueued,
+    # keyed by the same job id the worker later patches with the outcome and the
+    # run's log key.
+    monkeypatch.setattr(JobQueue, "enabled", property(lambda self: True))
+    audits: list[dict] = []
+
+    async def _fake_enqueue(self, source_key, target_format="glb", **kw):
+        return SimpleNamespace(job_id="job-xyz")
+
+    async def _insert_audit(pool, **kw):
+        audits.append(kw)
+
+    async def _get_model(pool, model_id):
+        return {
+            "id": "m1",
+            "revision": 2,
+            "scope_kind": "shared",
+            "scope_id": None,
+            "engine": None,
+            "name": "M",
+            "doc": {"spaces": []},
+        }
+
+    monkeypatch.setattr(JobQueue, "enqueue", _fake_enqueue)
+    monkeypatch.setattr(JobQueue, "list_workers", lambda self: _noop())
+    monkeypatch.setattr(JobQueue, "connect", lambda self: _noop())
+    monkeypatch.setattr(db_module, "get_procedural_model", _get_model)
+    monkeypatch.setattr(db_module, "insert_audit", _insert_audit)
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        client.app.state.db_pool = object()
+        r = client.post("/api/scopes/shared/procedural-models/m1/compile")
+    assert r.status_code == 200, r.text
+    assert r.json()["job_id"] == "job-xyz"
+    row = next(a for a in audits if a["action"] == "compile")
+    # Same id the response returned: the run id joins the response, the log blob
+    # and the audit row.
+    assert row["job_id"] == "job-xyz"
+    assert row["status"] == "queued"
+    assert row["target_format"] == "procedural_build"
+    assert row["key"] == procedural_glb_key("m1", 2)
+
+
+async def _noop():
+    return []


### PR DESCRIPTION
## The report

> the compile logs show the compile log from `2026-08-24 09:28:56 ERROR`. Even if I recompile force it still shows the same error message in the logs. The logs should be associated with an actual compile run. And that compile run should be accessible through the admin panel audit logs.

## The mechanism

Two things had to line up, and both were in the code.

**1. The log key was content-addressed.** `procedural_log_key(glb_key)` derived the log key from the GLB key by swapping `.glb` for `.log`. That is a good rule for a *sidecar of an artifact* — and every procedural derived key is content-addressed on purpose: a revision stamp for a committed compile, the document's content hash for a preview, so an unchanged input is served from cache for free. A log has no business inheriting that. Two different compile **attempts** of the same document shared one log key.

**2. The write was conditional.** `_persist_log` in `_run_procedural_build` did:

```python
text = _assemble_compile_log(handler, stdout_buf, extra)
if not text:
    return
```

`_capture_compile_logs` attaches to the `ada` logger and root. An engine whose own logger does not propagate there, or that writes to stderr rather than stdout, produces an empty capture — so a run that **succeeded quietly** wrote nothing and left the previous attempt's failure sitting at the shared key. On failure the traceback is always non-empty, so a failure always wrote. Hence the asymmetry the report describes: yesterday's failure is durable, today's success is invisible, and forcing a rebuild does not help because the forced run is just as quiet.

Two more holes with the same effect:

- A run failing during setup — model row gone, revision mismatch, engine not registered — returned through `_fail` before the log capture existed, writing **no log at all**.
- `_run_procedural_detail` (the external detailing stage, which owns `derived_key` for that compile) captured no log at any point.

A hash collision makes this worse but is not required: an unchanged document legitimately produces the same key, so a *force* recompile of an unchanged doc reads back the old log by design.

## The fix: a run identity

The queue job id **is** the run id. It is minted per compile attempt, it is already the id the compile response hands the viewer, and it is the `audit_log` join key — so one id names the log blob, the panel's current run, and the admin audit entry.

- **`_procedural/{id}/runs/{run}.log`** holds one run's log. Written on **every** exit path: a quiet success gets a banner-only blob, a build failure gets the capture plus traceback, a setup failure gets the reason. Never conditional. Retention is bounded per model (`RUN_LOG_RETENTION`), with the run that just finished never pruned; the prefix is hidden and GC-able as a group like `preview/`.
- **A `.run` pointer sidecar** on the artifact key names the run that most recently targeted it, claimed when the run *starts*. That covers the two lookups with no run id of their own — a result the endpoint served from cache, and an artifact from before runs existed — and means a run that dies before producing bytes is still what the artifact resolves to, rather than the last success.
- **`GET .../compile-log?run=<id>`** serves exactly that run. `?key=` still works, resolving through the pointer and falling back to the legacy `.log` sibling. `X-Compile-Run` names the run actually served.
- The viewer panel passes the job id it is already polling, and **labels a log it inherited**: "from an earlier run (`abc12345`) — this result was cached", instead of presenting it as the current build's.
- `_run_procedural_detail` gains the same capture and run identity.

`procedural_log_key` is kept read-only, as the legacy fallback.

## Audit visibility

Each compile opens an `audit_log` row at enqueue with `action="compile"`, `job_id` = the run id, `key` = the derived key — the same idiom a conversion uses. The worker's existing terminal patch (`_audit_done` → `update_audit_by_job`) then fills in status, duration, error, traceback and the run's **`log_key`** on that same row. Because the admin panel already streams `log_key` through `GET /admin/audit/{id}/log` behind the per-row "Log" tab, a compile run's engine output is readable there with no new admin surface — only `"compile"` added to the action filter and to the rows that always offer details.

The external-detailing path enqueues two jobs and both get a row, since each is a run with its own log.

## Tests

`tests/comms/rest/test_procedural_compile_runs.py`, 14 tests. The two the brief asked for:

- `test_second_compile_of_the_same_doc_gets_its_own_log` — run 1 fails loudly, run 2 compiles the **same** document and succeeds **silently**. Asserts run 2's log does not contain run 1's error and that the artifact pointer follows run 2. This is the exact regression.
- `test_failed_run_log_survives_the_success_that_follows` — the failure's log stays retrievable by its run id and reads as a failure, distinguishable from the later success.

Plus: a setup failure still leaves a log; the run's log key reaches the audit row; retention keeps the newest and never the fresh run; the endpoint serves the requested run, rejects unsafe run ids, resolves a cached artifact through its pointer, falls back to the legacy sibling; and a compile opens an audit row carrying the same id the response returned.

Handler-level tests skip off-POSIX (the worker imports `fcntl`), matching the existing worker-test convention; they were verified locally against stubbed POSIX modules and pass.

**Baseline:** `pixi run -e viewer-api-tests pytest tests/comms/rest/ --continue-on-collection-errors` — 13 failed / 5 collection errors on `main`, and the **identical** FAILED+ERROR list after this change (310 → 319 passed). `pixi run -e lint lint-check` passes. Frontend: `tsc --noEmit` reports only the one pre-existing error in `load_fea_streaming.ts`; `npm test` 254/256 with the one pre-existing Windows path-separator failure.

## Not touched

The preview/GLB content-addressing is correct and deliberate — only the *log* had the wrong identity. No change to the procedural cache or to doc-model definitions.
