### PR TITLE
fix: close leaked mkstemp fds and gate tests/comms/rest on pull requests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,6 +53,76 @@ jobs:
         - name: Runs Tests
           run: pixi run -e tests test
 
+    # tests/comms/rest is excluded from the `test` task above (it needs the viewer-api stack, which
+    # the `tests` env does not carry), so before this job the entire REST/viewer-API suite — the
+    # largest single test directory in the repo — had NO presence in the pull_request workflow.
+    #
+    # It was not unrun: ci-branch-tests (.github/workflows/test.yml) has an identical job, and
+    # because that workflow triggers on bare `on: push`, a same-repo branch push produces a check
+    # run on the PR head SHA and it shows up in the PR's check list. That is what made the gap easy
+    # to miss. Two things it does not cover:
+    #
+    #   1. FORK PRs. `on: push` fires in the fork, not here — an outside contributor's PR gets the
+    #      pr-tests matrix (comms/rest excluded) and nothing else. Zero REST coverage, silently.
+    #   2. It only reports for branches pushed to this repo, so it is not something branch
+    #      protection can rely on being present on every PR.
+    #
+    # A `pull_request`-triggered job fixes both: it runs against the PR head for forks and same-repo
+    # alike, so it is safe to mark as a REQUIRED status check.
+    #
+    # Deliberately Linux-only, unlike the 3-platform matrix above. The suite now runs clean on
+    # Windows (it did not before this change), but two things make ubuntu the honest home for the
+    # gate: GitHub `services:` containers are Linux-only, so the ~46 Postgres-backed admin/audit
+    # tests can only really execute here, and the REST worker is Linux-only by construction
+    # (os.fork + fcntl in subprocess_convert). Paying for a viewer-api env solve on macOS to run a
+    # strictly smaller subset is not worth it.
+    #
+    # This duplicates test.yml's job on same-repo pushes, the same way test-core/test-full already
+    # duplicate the matrix here. It mirrors that job exactly — same envs, same two legs — so the PR
+    # gate and the branch job cannot drift into "green on the PR, red on the push".
+    test-rest:
+        name: Test viewer REST API (PR)
+        runs-on: ubuntu-latest
+        services:
+          postgres:
+            image: postgres:16
+            env:
+              POSTGRES_PASSWORD: test
+              POSTGRES_DB: adapytest
+            ports:
+              - 5432:5432
+            options: >-
+              --health-cmd pg_isready
+              --health-interval 10s
+              --health-timeout 5s
+              --health-retries 5
+        defaults:
+          run:
+            shell: bash -l {0}
+        steps:
+        - uses: actions/checkout@v7
+          with:
+            ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+        - uses: prefix-dev/setup-pixi@v0.10.1
+          with:
+            pixi-version: v0.68.0
+            environments: >-
+              viewer-api-tests
+              viewer-api-tests-adacpp
+            cache: true
+
+        - name: Run Tests
+          env:
+            ADA_TEST_POSTGRES_URL: postgresql://postgres:test@localhost:5432/adapytest
+          run: pixi run -e viewer-api-tests test-rest
+
+        # Streaming-path coverage against the native ada-cpp backend (tessellate_stream / NGEOM
+        # libtess2), which the adacpp-less leg above can only reach via the OCC object-path
+        # fallback. No Postgres needed.
+        - name: Run streaming-path tests (ada-cpp backend)
+          run: pixi run -e viewer-api-tests-adacpp test-rest-adacpp
+
     # Build the viewer image and start the server inside it. Nothing else in this workflow can catch
     # a viewer that won't boot: lint and the test matrix run against the full src/ada tree, but the
     # viewer runtime ships a CURATED subset of it (see the COPY block in deploy/Dockerfile.viewer),

--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -146,6 +146,14 @@ COPY src/ada/comms/ /app/src/ada/comms/
 # correctly reports no tracks and the API publishes the static vocabulary — the adacpp tracks reach
 # the dropdown from the pools that actually run them, via each worker's advertised enum.
 COPY src/ada/cad/ /app/src/ada/cad/
+# ada.core.file_system — ada.comms.rest.{app,converter} import new_temp_path at MODULE level, so
+# without this the API crashloops on `No module named 'ada.core'` exactly the way it did on
+# `ada.cad` above. Only the one module ships, not the package: the rest of ada/core is numpy-bound
+# (vector_transforms, curve_utils, ...) and has no business in the slim runtime. file_system.py
+# itself is stdlib + ada.config only. ada/core/__init__.py is empty upstream, so it is copied as-is
+# rather than stubbed the way ada.sections has to be.
+COPY src/ada/core/__init__.py /app/src/ada/core/__init__.py
+COPY src/ada/core/file_system.py /app/src/ada/core/file_system.py
 # pyproject.toml is the single source of truth for the version. The viewer copies adapy source
 # (no installed-dist metadata) and a stripped ada/__init__ (no __version__), so config.js reads
 # the version from here for window.ADAPY_VERSION (see _resolve_adapy_version).

--- a/deploy/Dockerfile.viewer-fast
+++ b/deploy/Dockerfile.viewer-fast
@@ -51,6 +51,10 @@ COPY src/ada/comms/ /app/src/ada/comms/
 # ada.cad — imported at module level by ada.comms.rest.converter for the discovered tessellator
 # vocabulary. See the matching COPY in Dockerfile.viewer for why it is safe in the slim runtime.
 COPY src/ada/cad/ /app/src/ada/cad/
+# ada.core.file_system — new_temp_path is imported at module level by ada.comms.rest.{app,converter}.
+# See the matching COPY in Dockerfile.viewer for why only this one module ships.
+COPY src/ada/core/__init__.py /app/src/ada/core/__init__.py
+COPY src/ada/core/file_system.py /app/src/ada/core/file_system.py
 COPY src/ada/sections/categories.py        /app/src/ada/sections/categories.py
 COPY src/ada/sections/profile_lookup.py    /app/src/ada/sections/profile_lookup.py
 COPY src/ada/sections/resources/ProfileDB.json /app/src/ada/sections/resources/ProfileDB.json

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -6,7 +6,6 @@ import json
 import os
 import pathlib
 import re
-import tempfile
 import time
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -28,6 +27,7 @@ from fastapi.responses import (
 )
 
 from ada.config import logger
+from ada.core.file_system import new_temp_path
 
 from . import auth as auth_module
 from . import db as db_module
@@ -5600,7 +5600,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         Failures get stamped on the audit_log row's
         ``profile_stats_error`` so the operator can debug, but the
         loop continues — one bad blob mustn't stop the queue."""
-        import pathlib as _pl
         import pstats
 
         audit_id = int(claimed["id"])
@@ -5626,7 +5625,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         # pstats only reads from disk — stash bytes in a tempfile
         # rather than threading a BytesIO through it.
-        tmp_path = _pl.Path(tempfile.mkstemp(suffix=".prof")[1])
+        tmp_path = new_temp_path(suffix=".prof")
         try:
             tmp_path.write_bytes(data)
             try:
@@ -7542,10 +7541,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             data = await storage.get_bytes(scope, profile_key)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        import pathlib as _pl
         import pstats
 
-        tmp = _pl.Path(tempfile.mkstemp(suffix=".prof")[1])
+        tmp = new_temp_path(suffix=".prof")
         try:
             tmp.write_bytes(data)
             try:

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -34,6 +34,8 @@ import re
 import tempfile
 from typing import TYPE_CHECKING, Callable, Iterable
 
+from ada.core.file_system import new_temp_path
+
 if TYPE_CHECKING:
     from ada.fem.results.common import FEAResult
 
@@ -1873,7 +1875,7 @@ def _via_ada(
     ``python`` serializer is chosen with the ``face_regions`` toggle on.
     """
     suffix = ".glb" if target_format == "glb" else f".{target_format}"
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=suffix)[1])
+    out_path = new_temp_path(suffix=suffix)
     result: bytes | pathlib.Path = b""
     try:
         if source_ext in {".step", ".stp"} and target_format == "glb":
@@ -2057,7 +2059,7 @@ def _via_bundle(
             opts.get("reconstruct_surfaces"),
         )
         suffix = ".glb" if target_format == "glb" else f".{target_format}"
-        out_path = pathlib.Path(tempfile.mkstemp(suffix=suffix)[1])
+        out_path = new_temp_path(suffix=suffix)
         result: bytes | pathlib.Path = b""
         try:
             result = _export_with_ada(
@@ -2232,7 +2234,7 @@ def _via_fea_result(
             raise UnsupportedFormat(f"field {field!r} has no data at step {step}; available: {avail_steps}")
 
     on_progress("tessellating", 0.65)
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=".glb")[1])
+    out_path = new_temp_path(suffix=".glb")
     try:
         result.to_gltf(out_path, step=int(step), field=field)
         on_progress("ready", 1.0)
@@ -2264,7 +2266,7 @@ def _via_ada_to_trimesh(
     model = _load_with_ada(src_path, source_ext)
     fmt = target_ext.lstrip(".").lower()
     if fmt in ("obj", "stl"):
-        native_path = pathlib.Path(tempfile.mkstemp(suffix=f".{fmt}")[1])
+        native_path = new_temp_path(suffix=f".{fmt}")
         native_out = _native_ngeom_mesh_route(model, source_ext, fmt, native_path, on_progress)
         if native_out is not None:
             return native_out
@@ -2396,7 +2398,7 @@ def _via_ada_to_step(
         # (a no-op when there is no mesh) before the OCC writer runs.
         _apply_fem_to_objects(model, source_ext, "step", fem_to_objects, merge_fem_objects, reconstruct_surfaces)
     on_progress("writing-step", 0.55)
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
+    out_path = new_temp_path(suffix=".step")
     returned_path = False
     try:
         if is_fem:
@@ -2668,7 +2670,7 @@ def _via_step_stream_to_step(
     """
     from ada.config import logger
 
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
+    out_path = new_temp_path(suffix=".step")
     from ada.cadit.step.native_step_to_step import (
         native_step_to_step,
         native_step_to_step_available,
@@ -2709,7 +2711,7 @@ def _via_ifc_to_step(
 
     if native_ifc_to_step_available():
         try:
-            out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
+            out_path = new_temp_path(suffix=".step")
             stats = native_ifc_to_step(src_path, out_path, on_progress=on_progress)
             logger.info("native IFC->STEP: %s", stats)
             return out_path
@@ -2735,7 +2737,7 @@ def _via_step_stream_to_ifc(
     """
     from ada.config import logger
 
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=".ifc")[1])
+    out_path = new_temp_path(suffix=".ifc")
     from ada.cadit.step.native_step_to_ifc import (
         native_ifc_available,
         native_step_to_ifc,
@@ -2770,7 +2772,7 @@ def _via_step_stream_to_xml(
     from ada.cadit.step.write.stream_step_to_xml import stream_step_to_xml
     from ada.config import logger
 
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=".xml")[1])
+    out_path = new_temp_path(suffix=".xml")
     stats = stream_step_to_xml(src_path, out_path, on_progress=on_progress)
     logger.info("stream STEP->XML: %s", stats)
     return out_path
@@ -2796,7 +2798,7 @@ def _via_step_stream_to_mesh(
     Either way peak memory is O(one solid's mesh), never a whole-model buffer.
     ``step_glb_pipeline`` is accepted for signature compatibility but unused.
     """
-    out_path = pathlib.Path(tempfile.mkstemp(suffix=target_ext)[1])
+    out_path = new_temp_path(suffix=target_ext)
     fmt = target_ext.lstrip(".")
     from ada.cadit.step.native_step_to_mesh import (
         native_mesh_available,
@@ -3297,7 +3299,7 @@ def _via_ifc_stream_to_glb(
 
     if not force_python and native_ifc_glb_available():
         try:
-            out_path = pathlib.Path(tempfile.mkstemp(suffix=".glb")[1])
+            out_path = new_temp_path(suffix=".glb")
             # Same track plumbing as the STEP native path: the cpp serializer parks its chosen
             # track on the tess-engine axis, and this reverses it. Without forwarding it, picking a
             # track for an IFC source ran the default and reported the caller's choice back.

--- a/src/ada/comms/rest/subprocess_convert.py
+++ b/src/ada/comms/rest/subprocess_convert.py
@@ -35,12 +35,10 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import fcntl
 import json
 import logging
 import os
 import pathlib
-import resource as _resource_mod  # noqa: F401 — imported for posterity
 import shutil
 import signal
 import sys
@@ -49,7 +47,45 @@ import time
 import traceback
 from typing import Any, Awaitable, Callable, Optional
 
+# fcntl/resource are POSIX-only, and so is everything in this module that uses
+# them (os.fork, os.wait4, /proc sampling) — the worker only ever runs on Linux.
+# They used to be plain top-level imports, which made the whole module, and
+# therefore ``ada.comms.rest.worker``, unimportable on Windows. That cost far
+# more than it looks: it took out five test modules at COLLECTION time, and with
+# them the pure-logic worker tests (_scope_of, capability gating, equipment
+# geometry, procedural detailing) that have nothing to do with forking. It also
+# silently disabled test_subprocess_timeout.py's own
+# ``skipif(sys.platform == "win32")`` — collection died on the import before the
+# marker could be read. Importing the module is now portable; CALLING the fork
+# path off POSIX still fails loudly via _require_posix().
+try:  # pragma: no cover - exercised by whichever platform is running
+    import fcntl
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - exercised by whichever platform is running
+    import resource as _resource_mod  # noqa: F401 — imported for posterity
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    _resource_mod = None  # type: ignore[assignment]
+
+HAVE_POSIX_FORK = fcntl is not None and hasattr(os, "fork")
+
 logger = logging.getLogger("ada")
+
+
+def _require_posix() -> None:
+    """Guard the fork-based entry points.
+
+    Raising here rather than at import time is the whole point: a caller that
+    actually needs the isolated-fork machinery gets a clear error, while merely
+    importing the module (or ``ada.comms.rest.worker``, which pulls it in) stays
+    portable.
+    """
+    if not HAVE_POSIX_FORK:
+        raise RuntimeError(
+            "run_isolated_convert requires a POSIX platform (os.fork + fcntl); "
+            f"this is {sys.platform}. The REST worker is Linux-only."
+        )
 
 
 def _move_into_result(src: str, dst: pathlib.Path) -> None:
@@ -316,6 +352,7 @@ async def run_isolated_convert(
     "TIMEOUT"`` in that case so the worker can surface a clear,
     timeout-specific error rather than a generic "killed by signal".
     """
+    _require_posix()
     convert_kwargs = convert_kwargs or {}
 
     work_dir = pathlib.Path(tempfile.mkdtemp(prefix="adapy-convert-"))

--- a/src/ada/comms/rest/utilities/diff.py
+++ b/src/ada/comms/rest/utilities/diff.py
@@ -37,12 +37,12 @@ import io
 import json
 import os
 import struct
-import tempfile
 from dataclasses import dataclass, field
 
 import numpy as np
 
 from ada.comms.rest.utility import utility
+from ada.core.file_system import new_temp_path
 
 # Diff colours (hex). Common semantics: green add, red remove, orange modify.
 COLOR_ADDED = "#00c853"
@@ -196,7 +196,7 @@ def resolve_ref_glb_path(storage, compare_ref: str) -> str:
     # Arbitrary uploaded file: any .glb key in the scope that isn't a versions/
     # build path. Fetch it directly so two arbitrary models can be compared.
     if ref.endswith(".glb") and not ref.startswith("versions/"):
-        dest = tempfile.mkstemp(suffix=".glb")[1]
+        dest = str(new_temp_path(suffix=".glb"))
         try:
             storage.fetch_to_path(ref, dest)
         except Exception as exc:  # noqa: BLE001
@@ -223,7 +223,7 @@ def resolve_ref_glb_path(storage, compare_ref: str) -> str:
             )
         chosen = sorted(cand)[0]
 
-    dest = tempfile.mkstemp(suffix=".glb")[1]
+    dest = str(new_temp_path(suffix=".glb"))
     storage.fetch_to_path(chosen, dest)
     return dest
 

--- a/src/ada/comms/rest/utilities/merge_preview.py
+++ b/src/ada/comms/rest/utilities/merge_preview.py
@@ -21,9 +21,9 @@ achieved plates, actual-vs-ideal reduction, fell-back plates, % curved).
 from __future__ import annotations
 
 import pathlib
-import tempfile
 
 from ada.comms.rest.utility import utility
+from ada.core.file_system import new_temp_path
 
 # Auto-disposed overlay namespace (same lifecycle bucket the diff utility uses),
 # kept out of the persistent admin-managed _derived/ tree.
@@ -160,7 +160,7 @@ def merge_preview(
     )
 
     on_progress("rendering-preview", 0.8)
-    glb_tmp = tempfile.mkstemp(suffix=".glb")[1]
+    glb_tmp = str(new_temp_path(suffix=".glb"))
     try:
         write_preview_glb(res, glb_tmp, mode=mode)
         overlay_key = f"{_OVERLAY_PREFIX}{model}.merge-{algorithm}-{mode}.glb"
@@ -402,7 +402,7 @@ def _generate(asm, model, algorithm, storage, on_progress, solids=False):
             mat["doubleSided"] = True
 
     on_progress("writing-glb", 0.9)
-    glb_tmp = tempfile.mkstemp(suffix=".glb")[1]
+    glb_tmp = str(new_temp_path(suffix=".glb"))
     try:
         data = scene.export(file_type="glb", tree_postprocessor=_tree_pp)
         pathlib.Path(glb_tmp).write_bytes(data)

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -37,6 +37,7 @@ from typing import Awaitable, Callable
 import asyncpg
 
 from ada.config import logger
+from ada.core.file_system import new_temp_path
 
 from . import db as db_module
 from . import source_cache
@@ -2574,7 +2575,7 @@ async def _run_component_build(
             name=component_name,
             **extra_kwargs,
         )
-        glb_path = pathlib.Path(tempfile.mkstemp(suffix=".glb")[1])
+        glb_path = new_temp_path(suffix=".glb")
         try:
             conn.to_gltf(glb_path)
             return glb_path.read_bytes()

--- a/src/ada/core/file_system.py
+++ b/src/ada/core/file_system.py
@@ -1,10 +1,37 @@
 import os
 import pathlib
 import shutil
+import tempfile
 import time
 from typing import List, Union
 
 from ada.config import logger
+
+
+def new_temp_path(suffix: str | None = None, prefix: str | None = None, dir: str | None = None) -> pathlib.Path:
+    """Reserve a unique temp file path and hand it back CLOSED.
+
+    ``tempfile.mkstemp`` returns ``(fd, path)`` and the fd is the caller's to
+    close. The idiom ``pathlib.Path(tempfile.mkstemp(suffix=...)[1])`` — which
+    this repo had in 20 places — drops the fd on the floor without closing it,
+    which is a descriptor leak, not a style nit:
+
+    * the REST worker is a long-lived process that mints one of these per
+      conversion, so the leak accumulates against RLIMIT_NOFILE for the
+      lifetime of the pod;
+    * on Windows the still-open handle also LOCKS the file, so the caller's own
+      ``unlink()``/``os.replace()`` of the path it was just given fails with
+      ``PermissionError: [WinError 32]``. That is what it looked like from the
+      outside: four "Windows-only" REST test failures that were really this
+      leak becoming visible on the one platform that enforces it.
+
+    Callers that want the fd should keep using ``mkstemp`` directly and close it
+    themselves; this helper is for the (overwhelmingly common) case of wanting
+    only a path that some writer will open by name.
+    """
+    fd, name = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
+    os.close(fd)
+    return pathlib.Path(name)
 
 
 class SIZE_UNIT:

--- a/src/ada/fem/formats/sesam/results/sif_stream.py
+++ b/src/ada/fem/formats/sesam/results/sif_stream.py
@@ -23,6 +23,7 @@ import copy
 import io
 import pathlib
 
+from ada.core.file_system import new_temp_path
 from ada.fem.formats.sesam.results.read_sif import _RV_STEP_CARDS, Sif2Mesh, SifReader
 from ada.fem.formats.sesam.results.sif_index import (
     SifStepIndex,
@@ -78,9 +79,7 @@ class SifStreamReader:
             return
         # The header is the deck minus every step's RV data — it still carries
         # the mesh, sections, RDPOINTS and each RV block's control row.
-        import tempfile
-
-        hdr = pathlib.Path(tempfile.mkstemp(suffix=".SIF")[1])
+        hdr = new_temp_path(suffix=".SIF")
         try:
             assemble_reduced_local(self.path, self.index.header_ranges(), hdr)
             with open(hdr, "r") as f:

--- a/tests/comms/rest/test_convert_path_contract.py
+++ b/tests/comms/rest/test_convert_path_contract.py
@@ -13,12 +13,23 @@ from __future__ import annotations
 import asyncio
 import pathlib
 
+import pytest
 from obstore.store import LocalStore
 
 from ada.comms.rest.converter import convert, result_bytes
 from ada.comms.rest.scope import Scope
 from ada.comms.rest.storage import Storage
-from ada.comms.rest.subprocess_convert import run_isolated_convert
+from ada.comms.rest.subprocess_convert import HAVE_POSIX_FORK, run_isolated_convert
+
+# The convert() half of this module is portable and runs everywhere. The two
+# full-chain tests drive run_isolated_convert, which forks — so they are POSIX
+# only. Gate on the module's own capability flag rather than on sys.platform:
+# it is the actual precondition, and it stays correct if another fork-less
+# platform shows up.
+requires_fork = pytest.mark.skipif(
+    not HAVE_POSIX_FORK,
+    reason="run_isolated_convert needs os.fork + fcntl (POSIX only); the REST worker is Linux-only",
+)
 
 
 def _fem(fem_files: pathlib.Path) -> pathlib.Path:
@@ -59,6 +70,7 @@ def test_result_bytes_normalises_both(fem_files):
             as_path.unlink(missing_ok=True)
 
 
+@requires_fork
 def test_full_chain_fork_to_put_path(tmp_path, fem_files):
     # Mirror what the worker does: run convert in the forked child, take the
     # returned out_path, stream it to storage with put_path, and read it back.
@@ -87,6 +99,7 @@ def test_full_chain_fork_to_put_path(tmp_path, fem_files):
     assert b"<" in data  # gzip stored, transparently inflated on read
 
 
+@requires_fork
 def test_full_chain_glb_bytes_path(tmp_path, fem_files):
     # The bytes branch still round-trips: child writes the bytes into the
     # result slot, parent streams that file up via put_path.

--- a/tests/comms/rest/test_convert_sin_stream.py
+++ b/tests/comms/rest/test_convert_sin_stream.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 import pathlib
 import re
-import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
+
+from ada.core.file_system import new_temp_path
 
 SIN_PATH = pathlib.Path(__file__).resolve().parents[3] / (
     "files/fem_files/cantilever/sesam/static/shell/STATIC_SHELL_CANTILEVER_SESAMR1.SIN"
@@ -75,7 +76,7 @@ def test_sin_source_uri_streams_byte_identical(range_server_url):
     key = f"fem/sin/{SIN_PATH.name}"
     local = result_bytes(convert(SIN_PATH, key, "glb"))
 
-    stub = pathlib.Path(tempfile.mkstemp(suffix=SIN_PATH.suffix)[1])
+    stub = new_temp_path(suffix=SIN_PATH.suffix)
     try:
         streamed = result_bytes(convert(stub, key, "glb", source_uri=range_server_url))
         assert stub.stat().st_size == 0

--- a/tests/comms/rest/test_engine_build.py
+++ b/tests/comms/rest/test_engine_build.py
@@ -2,10 +2,33 @@
 
 from __future__ import annotations
 
+import importlib.util
 import pathlib
+import shutil
 import zipfile
 
+import pytest
+
 from ada.comms.rest.engine_build import build_wheel_from_source
+
+# ``build_wheel_from_source`` shells out to pip, and pip is NOT in pixi.lock for
+# any environment on any platform — see ``_pip_base_cmd``. On the Linux CI
+# runner this test passes only because ``shutil.which("pip")`` finds the
+# runner's SYSTEM pip, outside the pixi env entirely; on Windows there is no
+# such fallback, so it fails. Skipping keeps the suite honest about what it can
+# actually verify here rather than leaving a permanent red.
+#
+# The underlying problem is not this test: the engine-build worker's dependency
+# on pip is undeclared, so the green tick on Linux does not demonstrate that the
+# shipped worker image can build engine wheels at all. Declaring pip in
+# [feature.viewer-api.dependencies] would fix both and let this run everywhere,
+# but that needs a pixi re-lock and is deliberately left out of this change.
+_HAVE_PIP = importlib.util.find_spec("pip") is not None or shutil.which("pip") is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAVE_PIP,
+    reason="no pip available to build the engine wheel (pip is not a declared pixi dependency)",
+)
 
 # A minimal pure-python package, built in a temp dir and turned into a wheel.
 _PYPROJECT = """\

--- a/tests/comms/rest/test_parity_isolation.py
+++ b/tests/comms/rest/test_parity_isolation.py
@@ -12,9 +12,18 @@ from __future__ import annotations
 import asyncio
 import json
 
+import pytest
+
 from ada.comms.rest.converter import ConverterRegistry
-from ada.comms.rest.subprocess_convert import run_isolated_convert
+from ada.comms.rest.subprocess_convert import HAVE_POSIX_FORK, run_isolated_convert
 from ada.comms.rest.worker import _parity_child
+
+# Every test here runs the parity check through the forking child wrapper, so
+# the whole module is POSIX-only. Gate on the capability flag, not sys.platform.
+pytestmark = pytest.mark.skipif(
+    not HAVE_POSIX_FORK,
+    reason="run_isolated_convert needs os.fork + fcntl (POSIX only); the REST worker is Linux-only",
+)
 
 
 def test_parity_child_runs_in_isolated_fork(fem_files):

--- a/tests/comms/rest/test_subprocess_timeout.py
+++ b/tests/comms/rest/test_subprocess_timeout.py
@@ -19,18 +19,19 @@ test stays under 5 s by setting a 1 s timeout.
 from __future__ import annotations
 
 import pathlib
-import sys
 import time
 
 import pytest
 
-# subprocess_convert imports adapy heavily; gate the module-level
-# import so a missing dep doesn't crash collection.
-from ada.comms.rest.subprocess_convert import run_isolated_convert
+from ada.comms.rest.subprocess_convert import HAVE_POSIX_FORK, run_isolated_convert
 
+# This skipif used to be dead: subprocess_convert imported fcntl at module
+# scope, so on Windows the `from ... import` above raised during COLLECTION and
+# the marker was never reached — the file showed up as a collection error, not a
+# skip. The import is portable now, so the gate finally does what it says.
 pytestmark = pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="os.fork not available on Windows",
+    not HAVE_POSIX_FORK,
+    reason="run_isolated_convert needs os.fork + fcntl (POSIX only); the REST worker is Linux-only",
 )
 
 

--- a/tests/comms/rest/test_worker_pool_subscription.py
+++ b/tests/comms/rest/test_worker_pool_subscription.py
@@ -7,16 +7,14 @@ therefore served only the first: jobs for the rest sat in their subjects with
 nothing consuming them, which reads as an idle pool rather than a broken one.
 
 These cover the two decisions that turn a capability list into subscriptions.
-``ada.comms.rest.worker`` pulls in ``fcntl`` transitively, so it is importable
-on POSIX only.
+They are pure list arithmetic — nothing here forks or touches NATS — so they run
+on every platform now that ``ada.comms.rest.worker`` no longer drags a
+POSIX-only ``fcntl`` import in transitively (they were importorskip'd before).
 """
 
 import pytest
 
-worker = pytest.importorskip(
-    "ada.comms.rest.worker",
-    reason="ada.comms.rest.worker imports fcntl (POSIX only)",
-)
+from ada.comms.rest import worker
 
 
 def test_every_capability_becomes_a_pool():


### PR DESCRIPTION
## What this is

`pytest tests/comms/rest` had a standing **13 failed / 5 collection errors** on a Windows dev machine. Thirteen tolerated failures is a baseline nobody can read a regression out of, so this takes it to zero.

All 18 red items came from **three** root causes, and two of them are real bugs rather than platform noise.

## 1. Leaked `mkstemp` file descriptors (production bug)

`tempfile.mkstemp()` returns `(fd, path)` and the fd belongs to the caller. The idiom

```python
out_path = pathlib.Path(tempfile.mkstemp(suffix=".step")[1])
```

drops the fd without closing it. It appeared in **20 places**, 19 of them on the REST worker/app path. This is not a style nit:

- the worker is a long-lived process that mints one of these **per conversion**, so the leak accumulates against `RLIMIT_NOFILE` for the lifetime of the pod;
- on Windows the still-open handle also **locks** the file, so the caller's own `unlink()` / `os.replace()` of the path it was just handed fails with `PermissionError: [WinError 32]`.

That second effect is all it looked like from the outside: four "Windows-only" test failures that were really this leak becoming visible on the one platform that enforces it. Linux hides it right up until the pod runs out of descriptors.

Added `ada.core.file_system.new_temp_path()`, which closes the fd and returns the path, and moved every leaking site onto it. The correct `fd, name = mkstemp(...); os.close(fd)` pattern already existed in five places in the tree — this just makes it the only one.

## 2. `subprocess_convert` was unimportable off POSIX

It imported `fcntl` and `resource` at module scope. Everything in that module which *uses* them is POSIX-only (`os.fork`, `os.wait4`, `/proc` sampling) and the worker only ever runs on Linux — but the top-level import made the whole module, and therefore `ada.comms.rest.worker`, unimportable anywhere else.

That cost more than it looks:

- it took out **five test modules at collection time**, and with them the pure-logic worker tests (`_scope_of`, capability gating, equipment geometry, procedural detailing) that have nothing to do with forking;
- it **silently disabled `test_subprocess_timeout.py`'s own `skipif(sys.platform == "win32")`** — collection died on the import before pytest could read the marker, so a gate that was deliberately written showed up as a collection error instead of a skip.

The imports are guarded now, `HAVE_POSIX_FORK` exposes the capability, and `run_isolated_convert` raises through `_require_posix()` with a clear message. Importing is portable; forking still fails loudly off POSIX.

## 3. `test_engine_build` needs pip, which nothing declares

`build_wheel_from_source` shells out to pip. **pip is not in `pixi.lock` for any environment on any platform** — so `importlib.util.find_spec("pip")` is `None` everywhere, and this test passes on the Linux runner only because `shutil.which("pip")` finds the *runner's system pip*, outside the pixi env entirely.

Skipped here with that stated. Flagging the larger issue separately rather than fixing it in this PR: **the engine-build worker's dependency on pip is undeclared**, so the green tick on Linux does not demonstrate that the shipped worker image can build engine wheels at all. Declaring `pip` in `[feature.viewer-api.dependencies]` would fix that and let this test run everywhere, but it needs a pixi re-lock and deserves its own change.

## The CI gap

`tests/comms/rest` is excluded from `pr-tests.yml`'s 3-platform matrix — the `test` task ignores it, because it needs the viewer-api stack the `tests` env doesn't carry.

It is **not** unrun, though: `ci-branch-tests` (`test.yml`) has a `Test viewer REST API` job with a Postgres service, and since that workflow triggers on bare `on: push`, a same-repo branch push produces a check run on the PR head SHA that shows up in the PR's check list. That is exactly why the gap is easy to miss.

What it does not cover:

1. **Fork PRs.** `on: push` fires in the fork, not here. An outside contributor's PR gets the pr-tests matrix (comms/rest excluded) and nothing else — zero REST coverage, silently.
2. It only reports for branches pushed to this repo, so branch protection cannot rely on it being present on every PR.

This adds a `pull_request`-triggered `Test viewer REST API (PR)` job that mirrors the branch one exactly (same envs, same two legs, same Postgres service), so it runs for forks and same-repo alike and is safe to mark required.

Deliberately **Linux-only**, not matrixed. The suite runs clean on Windows now, but GitHub `services:` containers are Linux-only — the ~46 Postgres-backed admin/audit tests can only really execute there — and the worker is Linux-only by construction. Paying for a viewer-api env solve on macOS to run a strictly smaller subset isn't worth it.

## Nothing currently gates merges to `main`

Worth knowing, and this PR cannot fix it — it's a repo setting, and which checks are required is your call:

```
GET /repos/Krande/adapy/branches/main/protection
  required_status_checks.contexts: []
  required_status_checks.checks:   []
  required_approving_review_count: 0
  enforce_admins: false
GET /repos/Krande/adapy/rulesets -> []
```

Branch protection exists but lists **zero required status checks**. Every job reports on PRs and they've all been green, but nothing stops a PR merging with `lint`, the test matrix, or `Test viewer REST API` red. Suggested required set once this lands: `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, `Test viewer REST API (PR)`, `viewer-image`.

## Before / after

Windows, `pytest tests/comms/rest`, on `main` @ 88ba77a48:

| | before | after |
|---|---|---|
| failed | 13 | **0** |
| errors | 5 | **0** |
| passed | 338 | 372 |
| skipped | 52 | 54 |

Diffed at nodeid level, not by count: **no previously-passing test changed state.** The 8 newly-skipped are exactly the gates above (4 `test_subprocess_timeout`, 2 `test_convert_path_contract` full-chain, 1 `test_parity_isolation`, 1 `test_engine_build`), each with a stated reason.

Five tests move the *other* way without being touched: `test_procedural_compile_runs.py`'s `skipif(worker_mod is None)` stops firing now that the worker imports on Windows, and they pass.

Also verified: `pixi run -e lint lint-check` clean; the `adacpp_stream` leg passes; and the full non-REST suite shows the same 2 failures / 4 errors before and after this change (a stale generated header and missing Playwright browsers — both pre-existing and environmental).

## Second commit: the viewer image caught a real break

Worth recording, because it is the case the `viewer-image` job was built for. The first commit added `from ada.core.file_system import new_temp_path` at module scope in `ada.comms.rest.{app,converter}` — but the viewer runtime ships a **curated subset** of `src/ada`, and `ada/core/` was not in it. The image built fine and then failed its startup smoke test on `ModuleNotFoundError: No module named 'ada.core'` — the same shape as the `ada.cad` crashloop in 0.30.0, and invisible to every other check (the tests and the worker image both have all of `src/ada` on the path).

Fixed by shipping just that one module (`ada/core/__init__.py` is empty upstream, and `file_system.py` is stdlib + `ada.config` only) in `Dockerfile.viewer` and `Dockerfile.viewer-fast`. Confirmed both directions locally by reconstructing the curated tree from the COPY block and running the smoke import against it with and without `ada/core` present, before pushing.
