### PR TITLE
fix(occ): name OCCT's own alerts when a BOPAlgo run fails

### DIFF
--- a/src/ada/occ/backend.py
+++ b/src/ada/occ/backend.py
@@ -21,6 +21,46 @@ if TYPE_CHECKING:
     from ada.geom.points import Point
 
 
+def _bop_alert_names(algo) -> list[str]:
+    """The type names of the failure alerts OCCT recorded for a BOPAlgo run.
+
+    ``HasErrors()`` is only a boolean summary — the *reason* lives in the
+    algorithm's ``Message_Report`` as a list of typed alerts
+    (``BOPAlgo_AlertTooFewArguments``, ``BOPAlgo_AlertIntersectionFailed``,
+    ``BOPAlgo_AlertNullInputShapes``, ...). Reporting only the summary collapses
+    every distinct OCCT failure into one opaque string, which is how a plain
+    operand-count precondition read as a geometry-kernel bug in #263.
+
+    The list cannot simply be iterated: pythonocc exposes ``Message_ListOfAlert``
+    without its ``Message_ListIteratorOfListOfAlert``, so ``for a in alerts``
+    raises ``NameError``. Copy the list and drain the copy, which leaves the
+    algorithm's own report untouched.
+
+    Best-effort by construction: a diagnostic must never replace the failure it
+    is describing, so any problem reading the report yields no names rather than
+    an exception from the error path.
+    """
+    try:
+        from OCC.Core.Message import Message_Fail, Message_ListOfAlert
+
+        pending = Message_ListOfAlert()
+        pending.Assign(algo.GetReport().GetAlerts(Message_Fail))
+        names = []
+        while len(pending):
+            names.append(pending.First().DynamicType().Name())
+            pending.RemoveFirst()
+        return names
+    except Exception:  # noqa: BLE001 - diagnostics must not mask the real failure
+        return []
+
+
+def _bop_error(op: str, algo_name: str, algo) -> RuntimeError:
+    """The ``RuntimeError`` for a failed BOPAlgo run, naming OCCT's own alerts."""
+    alerts = _bop_alert_names(algo)
+    detail = f" [{', '.join(alerts)}]" if alerts else ""
+    return RuntimeError(f"{op}: {algo_name} reported errors{detail}")
+
+
 class OccBackend:
     """Backend backed by pythonocc-core. Native CPython only.
 
@@ -962,7 +1002,7 @@ class OccBackend:
             mv.SetFuzzyValue(tolerance)
         mv.Perform()
         if mv.HasErrors():
-            raise RuntimeError("make_volumes_from_faces: BOPAlgo_MakerVolume reported errors")
+            raise _bop_error("make_volumes_from_faces", "BOPAlgo_MakerVolume", mv)
         return list(self._TopologyExplorer(mv.Shape()).solids())
 
     def merge_cells(self, solids: list[ShapeHandle], tolerance: float = 0.0) -> list[ShapeHandle]:
@@ -999,7 +1039,7 @@ class OccBackend:
             cb.SetFuzzyValue(tolerance)
         cb.Perform()
         if cb.HasErrors():
-            raise RuntimeError("merge_cells: BOPAlgo_CellsBuilder reported errors")
+            raise _bop_error("merge_cells", "BOPAlgo_CellsBuilder", cb)
         # Take each operand's region into the result (mirrors Topology::Merge's
         # per-operand AddToResult with an empty avoid-list).
         for s in solids:
@@ -1028,7 +1068,7 @@ class OccBackend:
             builder.SetFuzzyValue(tolerance)
         builder.Perform()
         if builder.HasErrors():
-            raise RuntimeError("non_manifold_merge: BOPAlgo_Builder reported errors")
+            raise _bop_error("non_manifold_merge", "BOPAlgo_Builder", builder)
         return builder.Shape()
 
     def free_faces(self, solids: list[ShapeHandle]) -> list[ShapeHandle]:
@@ -1160,7 +1200,7 @@ class OccBackend:
             builder.SetRunParallel(True)
             builder.Perform()
             if builder.HasErrors():
-                raise RuntimeError("imprint_planar_faces: BOPAlgo_Builder reported errors")
+                raise _bop_error("imprint_planar_faces", "BOPAlgo_Builder", builder)
             res = builder.Shape()
 
         # Index every unique sub-shape. The map's hasher keys on TShape+Location

--- a/tests/core/cad/test_bop_error_diagnostics.py
+++ b/tests/core/cad/test_bop_error_diagnostics.py
@@ -1,0 +1,80 @@
+"""A failed BOPAlgo run must name OCCT's own alerts, not just say "reported errors".
+
+``BOPAlgo_Options.HasErrors()`` is a boolean summary; the reason is a list of typed
+alerts on the algorithm's ``Message_Report``. Raising only the summary makes every
+distinct OCCT failure — a wrong operand count, a failed intersection, a null shape —
+produce the identical string, so a report of one cannot be triaged without a
+debugger. That is how the operand-count precondition fixed in #263 was first read as
+a geometry-kernel problem.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.occ.backend import _bop_alert_names, _bop_error
+
+
+class _Exploding:
+    """An algorithm whose report cannot be read at all."""
+
+    def GetReport(self):
+        raise RuntimeError("no report available")
+
+
+def test_alert_names_never_raise_from_the_error_path():
+    # A diagnostic must not replace the failure it is describing.
+    assert _bop_alert_names(_Exploding()) == []
+
+
+def test_error_without_alerts_keeps_the_bare_message():
+    err = _bop_error("merge_cells", "BOPAlgo_CellsBuilder", _Exploding())
+
+    assert str(err) == "merge_cells: BOPAlgo_CellsBuilder reported errors"
+    assert isinstance(err, RuntimeError)
+
+
+def _cells_builder(n_operands: int):
+    pytest.importorskip("OCC")
+    from OCC.Core.BOPAlgo import BOPAlgo_CellsBuilder
+    from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+    from OCC.Core.TopTools import TopTools_ListOfShape
+
+    cb = BOPAlgo_CellsBuilder()
+    args = TopTools_ListOfShape()
+    for i in range(n_operands):
+        args.Append(BRepPrimAPI_MakeBox(1.0, 1.0, 1.0).Shape())
+    cb.SetArguments(args)
+    cb.Perform()
+    return cb
+
+
+@pytest.mark.parametrize("n_operands", [0, 1])
+def test_too_few_arguments_is_named_in_the_message(n_operands):
+    # CellsBuilder is a general fuse of >= 2 operands. This is the exact failure
+    # behind #263 — and the name is what makes it self-evidently a precondition
+    # rather than bad geometry.
+    cb = _cells_builder(n_operands)
+    assert cb.HasErrors()
+
+    assert _bop_alert_names(cb) == ["BOPAlgo_AlertTooFewArguments"]
+    assert str(_bop_error("merge_cells", "BOPAlgo_CellsBuilder", cb)) == (
+        "merge_cells: BOPAlgo_CellsBuilder reported errors [BOPAlgo_AlertTooFewArguments]"
+    )
+
+
+def test_reading_the_report_leaves_it_intact():
+    # The alert list is drained from a copy; a second read must still work, and the
+    # algorithm's own error state must be unchanged.
+    cb = _cells_builder(1)
+
+    assert _bop_alert_names(cb) == ["BOPAlgo_AlertTooFewArguments"]
+    assert _bop_alert_names(cb) == ["BOPAlgo_AlertTooFewArguments"]
+    assert cb.HasErrors()
+
+
+def test_successful_run_reports_no_alerts():
+    cb = _cells_builder(2)
+
+    assert not cb.HasErrors()
+    assert _bop_alert_names(cb) == []


### PR DESCRIPTION
## The problem

`BOPAlgo_Options.HasErrors()` is a **boolean summary**. The actual reason lives in the algorithm's `Message_Report` as a list of typed alerts — `BOPAlgo_AlertTooFewArguments`, `BOPAlgo_AlertNullInputShapes`, `BOPAlgo_AlertIntersectionFailed`, and so on.

All four BOPAlgo call sites in `OccBackend` threw that list away:

```python
if cb.HasErrors():
    raise RuntimeError("merge_cells: BOPAlgo_CellsBuilder reported errors")
```

So every distinct OCCT failure — wrong operand count, null input shape, failed intersection — produced the **same** string. A report of one cannot be triaged without attaching a debugger.

This is not hypothetical. The precondition fixed in #263 (`BOPAlgo_CellsBuilder` is a general fuse of >= 2 operands, and errors rather than no-ops on one) surfaced only as:

```
merge_cells: BOPAlgo_CellsBuilder reported errors
```

which reads as bad geometry. OCCT had recorded `BOPAlgo_AlertTooFewArguments` the whole time — a name that says outright it is a precondition, not a geometry problem.

## The change

A module-level `_bop_alert_names(algo)` reads the failure alerts, and `_bop_error(op, algo_name, algo)` builds the `RuntimeError`. The four sites — `make_volumes_from_faces`, `merge_cells`, `non_manifold_merge`, `imprint_planar_faces` — use it.

Messages gain a bracketed alert list and are otherwise unchanged:

```
merge_cells: BOPAlgo_CellsBuilder reported errors [BOPAlgo_AlertTooFewArguments]
merge_cells: BOPAlgo_CellsBuilder reported errors [BOPAlgo_AlertNullInputShapes]
```

Both of those are copied from an actual run, not composed by hand — the second by feeding a default-constructed `TopoDS_Solid` alongside two good boxes. **The message now discriminates between two failures that were previously indistinguishable.**

Two details worth knowing:

- **The list cannot be iterated.** pythonocc exposes `Message_ListOfAlert` without its `Message_ListIteratorOfListOfAlert`, so `for a in alerts` raises `NameError` (`len()` and `First()` do work). The helper copies the list with `Assign` and drains the copy, which leaves the algorithm's own report untouched — asserted by a test that reads the alerts twice and checks `HasErrors()` afterwards.
- **It is best-effort by construction.** A diagnostic must never replace the failure it is describing, so any problem reading the report yields no names and the bare message, rather than throwing from the error path. Covered by a test using an algorithm whose `GetReport()` raises.

Behaviour on the success path is untouched: the helper is only reached after `HasErrors()`.

## Not covered here

`AdacppBackend.merge_cells` delegates to C++, which does its own `HasErrors()` check and raises a `std::runtime_error` with the same generic text — the alert list is discarded on the native side, before Python sees it, so this change cannot reach it. #263 already appends operand count and tolerance there, which covers the precondition case. Surfacing the alerts natively is the mirror change and belongs in the extension.

## Tests

`tests/core/cad/test_bop_error_diagnostics.py` — 6 tests:

- `BOPAlgo_AlertTooFewArguments` is named, for 0 and 1 operands (parametrized)
- reading the report leaves it intact and re-readable
- a successful (2-operand) run reports no alerts
- an unreadable report yields no names rather than raising
- the message with no alerts is byte-identical to the old one

The OCC-dependent tests `importorskip("OCC")`, matching the convention in this directory.

`tests/core/cad`: **60 passed, 1 skipped** before, **66 passed, 1 skipped** after. black / ruff / isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
