### PR TITLE
chore(ci): bump deputy to v0.5.2 and drop the inline gitpython pin

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -18,7 +18,7 @@ name: Review Pull Request
 # pull_request_target so the job (and GITHUB_TOKEN) can comment and label even
 # on fork PRs. It checks out the BASE ref only and never runs any PR-head code.
 #
-# Pinned to deputy @v0.4.0.
+# Pinned to deputy @v0.5.2.
 
 on:
   pull_request_target:
@@ -49,15 +49,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install deputy
-        # TEMPORARY PIN (2026-08-25): GitPython 3.1.60 removed
-        # `git.Actor.name_email_regex`. python-semantic-release reads that
-        # attribute unconditionally at config load
-        # (semantic_release/cli/config.py:294 in the 8.5.1 that deputy pins), so
-        # with 3.1.60 every `semantic-release` subcommand dies with AttributeError
-        # and no release is cut. deputy v0.4.0 leaves gitpython unconstrained, so a
-        # fresh install resolves 3.1.60. Drop this pin once python-semantic-release
-        # guards the attribute, or once deputy pins gitpython upstream.
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0" "gitpython<3.1.60"
+        # deputy pins gitpython<3.1.60 itself from v0.5.2 — do not re-add it here.
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.2"
 
       - name: Review the PR (checks + sticky comment); fails if a check fails
         run: deputy pr-review

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -49,7 +49,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install deputy
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0"
+        # TEMPORARY PIN (2026-08-25): GitPython 3.1.60 removed
+        # `git.Actor.name_email_regex`. python-semantic-release reads that
+        # attribute unconditionally at config load
+        # (semantic_release/cli/config.py:294 in the 8.5.1 that deputy pins), so
+        # with 3.1.60 every `semantic-release` subcommand dies with AttributeError
+        # and no release is cut. deputy v0.4.0 leaves gitpython unconstrained, so a
+        # fresh install resolves 3.1.60. Drop this pin once python-semantic-release
+        # guards the attribute, or once deputy pins gitpython upstream.
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0" "gitpython<3.1.60"
 
       - name: Review the PR (checks + sticky comment); fails if a check fails
         run: deputy pr-review

--- a/.github/workflows/tag-on-pr-merge.yaml
+++ b/.github/workflows/tag-on-pr-merge.yaml
@@ -22,7 +22,7 @@ name: Create Tag on PR Merge
 #   * Do not enable "Do not allow bypassing the above settings" in branch
 #     protection, or the deploy-key push is rejected and no tag is created.
 #
-# Pinned to deputy @v0.4.0.
+# Pinned to deputy @v0.5.2.
 
 on:
   pull_request_target:
@@ -61,15 +61,8 @@ jobs:
           git config user.email "semantic-release@users.noreply.github.com"
 
       - name: Install deputy
-        # TEMPORARY PIN (2026-08-25): GitPython 3.1.60 removed
-        # `git.Actor.name_email_regex`. python-semantic-release reads that
-        # attribute unconditionally at config load
-        # (semantic_release/cli/config.py:294 in the 8.5.1 that deputy pins), so
-        # with 3.1.60 every `semantic-release` subcommand dies with AttributeError
-        # and no release is cut. deputy v0.4.0 leaves gitpython unconstrained, so a
-        # fresh install resolves 3.1.60. Drop this pin once python-semantic-release
-        # guards the attribute, or once deputy pins gitpython upstream.
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0" "gitpython<3.1.60"
+        # deputy pins gitpython<3.1.60 itself from v0.5.2 — do not re-add it here.
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.2"
 
       - name: Tag + release per the PR's release label
         run: deputy tag-on-merge

--- a/.github/workflows/tag-on-pr-merge.yaml
+++ b/.github/workflows/tag-on-pr-merge.yaml
@@ -61,7 +61,15 @@ jobs:
           git config user.email "semantic-release@users.noreply.github.com"
 
       - name: Install deputy
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0"
+        # TEMPORARY PIN (2026-08-25): GitPython 3.1.60 removed
+        # `git.Actor.name_email_regex`. python-semantic-release reads that
+        # attribute unconditionally at config load
+        # (semantic_release/cli/config.py:294 in the 8.5.1 that deputy pins), so
+        # with 3.1.60 every `semantic-release` subcommand dies with AttributeError
+        # and no release is cut. deputy v0.4.0 leaves gitpython unconstrained, so a
+        # fresh install resolves 3.1.60. Drop this pin once python-semantic-release
+        # guards the attribute, or once deputy pins gitpython upstream.
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.4.0" "gitpython<3.1.60"
 
       - name: Tag + release per the PR's release label
         run: deputy tag-on-merge


### PR DESCRIPTION
Bumps the pinned `deputy` from `v0.4.0` to `v0.5.2` and removes the inline
`"gitpython<3.1.60"` constraint from the install line.

`deputy v0.5.2` carries that constraint itself, in both `[project].dependencies`
and `[tool.pixi.package.run-dependencies]`, so installing it alongside deputy is
now redundant. A one-line note stays on the install step so it does not get
re-added.

### What changed in deputy between the two tags

| | |
|---|---|
| `v0.5.0` | Adds `[release].version_json`, an opt-in JSON-aware version bump for npm manifests. `run_release` defaults to an empty list, so a repo that does not declare the key behaves exactly as before. |
| `v0.5.1` | `gitops-update` now matches a manifest's existing list indentation instead of reformatting it. Only affects the `gitops-update` command, which this workflow does not run. |
| `v0.5.2` | Adds the `gitpython` pin. |

No change to `pr-review` or `tag-on-merge` behaviour, no config keys removed,
and the `deputy.toml` schema only gained one optional key.

### Verification

`pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.2"`
resolves `gitpython 3.1.59`, semantic-release's config module imports, and
`deputy 0.5.2` loads.

Note that `pr-review.yaml` runs on `pull_request_target`, so the check on this
PR executes the workflow definition from the **base** branch — it does not
exercise the new install line. That is verified after merge.

Labelled `release-skip`: CI-only, nothing to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
