### PR TITLE
fix: resolve a part's absolute placement once, not once per element

### DIFF
--- a/src/ada/api/beams/base_bm.py
+++ b/src/ada/api/beams/base_bm.py
@@ -14,7 +14,12 @@ from ada.api.transforms import Placement
 from ada.base.physical_objects import BackendGeom
 from ada.base.units import Units
 from ada.core.utils import Counter
-from ada.core.vector_utils import is_between_endpoints, unit_vector, vector_length
+from ada.core.vector_utils import (
+    is_between_endpoints,
+    is_identity_rot_matrix,
+    unit_vector,
+    vector_length,
+)
 from ada.fem.concept.constraints import DofType
 from ada.geom import Geometry
 from ada.geom.direction import Direction
@@ -520,7 +525,7 @@ class Beam(BackendGeom):
 
         ident = Placement()
         abs_place = self.placement.get_absolute_placement(include_rotations=True)
-        if not np.allclose(abs_place.rot_matrix, ident.rot_matrix):
+        if not is_identity_rot_matrix(abs_place.rot_matrix):
             moved = abs_place.transform_array_from_other_place(np.asarray([p1, p2]), ident)
             return moved[0], moved[1]
         return abs_place.origin + p1, abs_place.origin + p2

--- a/src/ada/api/beams/geom_beams.py
+++ b/src/ada/api/beams/geom_beams.py
@@ -8,6 +8,7 @@ import ada.geom.curves
 import ada.geom.solids as geo_so
 import ada.geom.surfaces as geo_su
 from ada.core.vector_transforms import transform_csys_to_csys
+from ada.core.vector_utils import is_identity_rot_matrix
 from ada.geom import Geometry
 from ada.geom.booleans import BooleanOperation
 from ada.geom.curves import Circle, Edge
@@ -32,7 +33,7 @@ def straight_beam_to_geom(beam: Beam | PipeSegStraight, is_solid=True) -> Geomet
         ident_place = ada.Placement()
         place_abs = beam.placement.get_absolute_placement(include_rotations=True)
 
-        if not np.allclose(place_abs.rot_matrix, ident_place.rot_matrix):
+        if not is_identity_rot_matrix(place_abs.rot_matrix):
             ori_vectors = place_abs.transform_array_from_other_place(
                 np.asarray([xvec, yvec, up]), ident_place, ignore_translation=True
             )

--- a/src/ada/api/beams/justification.py
+++ b/src/ada/api/beams/justification.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import numpy as np
 
+from ada.core.vector_utils import is_identity_rot_matrix, vectors_are_close
 from ada.sections.categories import BaseTypes
 
 if TYPE_CHECKING:
@@ -126,14 +127,15 @@ class OffsetHelper:
     def __init__(self, beam: Beam):
         self.beam = beam
 
-    def _local_axes_in_absolute(self, place_abs: "Placement" = None):
+    def _local_axes_in_absolute(self, place_abs: "Placement" = None, ident_place: "Placement" = None):
         """
         Returns (xvec, yvec, up) expressed in the absolute/global system,
         respecting self.placement rotations (same logic as exporter).
 
         ``place_abs`` optionally supplies the beam's precomputed absolute
         placement so callers that already resolved it (the shared COG/length
-        path) don't walk the ancestry again.
+        path) don't walk the ancestry again. ``ident_place`` likewise supplies
+        the global reference frame, which is the same object for every beam.
         """
         from ada import Placement
 
@@ -142,12 +144,13 @@ class OffsetHelper:
         up = self.beam.up
 
         if self.beam.placement is not None:
-            ident_place = Placement()
+            if ident_place is None:
+                ident_place = Placement()
             if place_abs is None:
                 place_abs = self.beam.placement.get_absolute_placement(include_rotations=True)
 
             # Only transform if rotation differs
-            if not np.allclose(place_abs.rot_matrix, ident_place.rot_matrix):
+            if not is_identity_rot_matrix(place_abs.rot_matrix):
                 ori_vectors = place_abs.transform_array_from_other_place(
                     np.asarray([xvec, yvec, up]), ident_place, ignore_translation=True
                 )
@@ -157,20 +160,24 @@ class OffsetHelper:
 
         return xvec, yvec, up
 
-    def _point_to_absolute(self, p: np.ndarray, place_abs: "Placement" = None) -> np.ndarray:
+    def _point_to_absolute(
+        self, p: np.ndarray, place_abs: "Placement" = None, ident_place: "Placement" = None
+    ) -> np.ndarray:
         """
         Transforms a point p from the beam's local system into absolute/global,
         using self.placement. If identity, returns p unchanged.
 
-        ``place_abs`` optionally supplies the beam's precomputed absolute
-        placement (see _local_axes_in_absolute).
+        ``place_abs`` and ``ident_place`` optionally supply the beam's
+        precomputed absolute placement and the shared global reference frame
+        (see _local_axes_in_absolute).
         """
         from ada import Placement
 
         if self.beam.placement is None:
             return p
 
-        ident_place = Placement()
+        if ident_place is None:
+            ident_place = Placement()
         if place_abs is None:
             place_abs = self.beam.placement.get_absolute_placement(include_rotations=True)
 
@@ -313,7 +320,7 @@ class OffsetHelper:
         off1 = off1 + add_local
         off2 = off2 + add_local
 
-        is_varying = not np.allclose(off1, off2)
+        is_varying = not vectors_are_close(off1, off2)
         avg = 0.5 * (off1 + off2)
 
         return CurveOffsetResult(
@@ -338,16 +345,23 @@ class OffsetHelper:
         beam's absolute placement is resolved a single time here and threaded
         into the helpers rather than re-walking the ancestry in each.
         """
+        from ada import Placement
+
         place_abs = None
+        ident_place = Placement()
         if self.beam.placement is not None:
             place_abs = self.beam.placement.get_absolute_placement(include_rotations=True)
 
         # Endpoints of the *beam line* in absolute/global coordinates
-        p1_abs = np.asarray(self._point_to_absolute(self.beam.n1.p.copy(), place_abs=place_abs), dtype=float)
-        p2_abs = np.asarray(self._point_to_absolute(self.beam.n2.p.copy(), place_abs=place_abs), dtype=float)
+        p1_abs = np.asarray(
+            self._point_to_absolute(self.beam.n1.p.copy(), place_abs=place_abs, ident_place=ident_place), dtype=float
+        )
+        p2_abs = np.asarray(
+            self._point_to_absolute(self.beam.n2.p.copy(), place_abs=place_abs, ident_place=ident_place), dtype=float
+        )
 
         # Local beam basis expressed in absolute/global coords (placement rotation applied)
-        axes = self._local_axes_in_absolute(place_abs=place_abs)
+        axes = self._local_axes_in_absolute(place_abs=place_abs, ident_place=ident_place)
         x_abs = np.asarray(axes[0], dtype=float)
         y_abs = np.asarray(axes[1], dtype=float)
         up_abs = np.asarray(axes[2], dtype=float)

--- a/src/ada/api/plates/base_pl.py
+++ b/src/ada/api/plates/base_pl.py
@@ -10,7 +10,7 @@ from ada.api.nodes import Node
 from ada.base.physical_objects import BackendGeom
 from ada.base.units import Units
 from ada.config import Config, logger
-from ada.core.vector_utils import poly2d_center_of_gravity
+from ada.core.vector_utils import is_identity_rot_matrix, poly2d_center_of_gravity
 from ada.geom import Geometry
 from ada.geom.direction import Direction
 from ada.geom.points import Point
@@ -195,9 +195,7 @@ class Plate(BackendGeom):
         if not self.placement.is_identity():
             ident_place = Placement()
             place_abs = self.placement.get_absolute_placement(include_rotations=True)
-            place_abs_rot_mat = place_abs.rot_matrix
-            ident_rot_mat = ident_place.rot_matrix
-            if not np.allclose(place_abs_rot_mat, ident_rot_mat):
+            if not is_identity_rot_matrix(place_abs.rot_matrix):
                 new_vectors = place_abs.transform_array_from_other_place(
                     np.asarray([normal, xdir]), ident_place, ignore_translation=True
                 )

--- a/src/ada/api/transforms.py
+++ b/src/ada/api/transforms.py
@@ -10,7 +10,12 @@ import pyquaternion as pq
 
 import ada
 from ada.core.vector_transforms import normal_to_points_in_plane, transform_3x3
-from ada.core.vector_utils import calc_xvec, calc_yvec, unit_vector
+from ada.core.vector_utils import (
+    calc_xvec,
+    calc_yvec,
+    is_exact_identity_rot_matrix,
+    unit_vector,
+)
 from ada.geom.direction import Direction
 from ada.geom.placement import XV, YV, ZV, Axis2Placement3D, O
 from ada.geom.points import Point
@@ -44,6 +49,21 @@ class Rotation:
         return res
 
 
+def _fingerprints_match(a: tuple, b: tuple) -> bool:
+    """Identity-compare two ancestry fingerprints.
+
+    ``is`` rather than ``==`` on purpose: the members are ndarrays, whose
+    ``==`` is elementwise, and object identity is exactly the guarantee wanted
+    here (see :meth:`Placement._ancestry_fingerprint`).
+    """
+    if len(a) != len(b):
+        return False
+    for x, y in zip(a, b):
+        if x is not y:
+            return False
+    return True
+
+
 class Placement:
     def __init__(self, origin: Iterable | Point = None, xdir=None, ydir=None, zdir=None, scale=1.0, parent=None):
         from ada.api.computed_placement import ComputedPlacement
@@ -71,6 +91,7 @@ class Placement:
 
         self._is_identity: bool = None
         self._computed_placement: ComputedPlacement = None
+        self._abs_memo: dict[bool, tuple[tuple, Placement]] | None = None
 
     def _init_computed_placement(self):
         """Lazy initialization of computed placement."""
@@ -154,16 +175,104 @@ class Placement:
             zdir=matrix[2, :3],
         )
 
+    def _is_local_identity(self) -> bool:
+        """``True`` when this placement contributes nothing to an ancestry accumulation.
+
+        That is: a zero origin and an identity rotation. Both are exact no-ops
+        in IEEE-754 arithmetic (``0.0 + x == x`` and ``R @ I == R``), which is
+        what lets :meth:`get_absolute_placement` skip the walk outright rather
+        than merely shorten it.
+
+        The rotation test leans on ``Direction`` being value-interned: a
+        placement built from the global axes holds *the* ``XV()``/``YV()``/``ZV()``
+        objects, so three pointer comparisons settle it. The far more common
+        case -- no direction given at all, i.e. the default ``Placement()``
+        every element gets -- is settled without resolving the directions.
+        """
+        origin = self._origin
+        if getattr(origin, "shape", None) != (3,):
+            return False
+        if origin[0] != 0.0 or origin[1] != 0.0 or origin[2] != 0.0:
+            return False
+        if self._xdir is None and self._ydir is None and self._zdir is None:
+            return True
+        return self.xdir is XV() and self.ydir is YV() and self.zdir is ZV()
+
     def get_absolute_placement(self, include_rotations=False) -> Placement:
+        """This placement accumulated through its owner's ancestry.
+
+        Treat the result as read-only. It was already free to be ``self`` (an
+        unparented placement is its own absolute placement), and the fast paths
+        below widen that: elements sharing a container can be handed the same
+        resolved object.
+        """
         if self.parent is None:
             return self
+
+        # Every element in a part walks the same ancestry to reach the same
+        # answer. An element whose own placement is the local identity adds a
+        # zero origin and multiplies by an identity rotation, so the accumulation
+        # below collapses -- to the last bit -- onto its container's. Resolve
+        # that once for the container instead of once per element.
+        if self._is_local_identity():
+            container = self.parent.parent
+            container_placement = getattr(container, "placement", None) if container is not None else None
+            # The collapse only holds if the container's placement walks the
+            # container's own ancestry. A placement assigned through the
+            # ``placement`` setter is left unparented, and then resolves to
+            # itself rather than to an accumulation -- walk in that case.
+            if container_placement is not None and container_placement.parent is container:
+                absolute = container_placement.get_absolute_placement(include_rotations)
+                if include_rotations:
+                    return absolute
+                # Without rotations only the origin accumulates: the result
+                # carries this placement's own axes, not the container's.
+                return Placement(origin=absolute.origin, xdir=self.xdir, ydir=self.ydir, zdir=self.zdir)
+
+        return self._resolve_absolute_placement(include_rotations)
+
+    def _ancestry_fingerprint(self, ancestry: list) -> tuple | None:
+        """Every object :meth:`_resolve_absolute_placement` reads, for cache validation.
+
+        A placement's rotation is fixed at construction -- ``rot_matrix`` is
+        already a ``cached_property``, so the codebase relies on this -- which
+        means a placement's *object identity* pins its rotation. ``origin`` is
+        the one piece with a setter, so it is recorded separately.
+
+        Returns ``None`` -- meaning "do not cache" -- if any origin on the chain
+        is not a :class:`~ada.geom.points.Point`. Point is immutable and
+        interned, so recording the object is enough to notice any change; a
+        plain ndarray origin could be written through in place behind us, and
+        no fingerprint could catch that.
+        """
+        origin = self._origin
+        if type(origin) is not Point:
+            return None
+        fingerprint = [origin]
+        for ancestor in ancestry:
+            ancestor_placement = ancestor.placement
+            ancestor_origin = ancestor_placement._origin
+            if type(ancestor_origin) is not Point:
+                return None
+            fingerprint.append(ancestor_placement)
+            fingerprint.append(ancestor_origin)
+        return tuple(fingerprint)
+
+    def _resolve_absolute_placement(self, include_rotations: bool) -> Placement:
+        ancestry = self.parent.get_ancestors(include_self=False)
+        fingerprint = self._ancestry_fingerprint(ancestry)
+
+        memo = self._abs_memo
+        if memo is not None and fingerprint is not None:
+            cached = memo.get(include_rotations)
+            if cached is not None and _fingerprints_match(cached[0], fingerprint):
+                return cached[1]
 
         current_location = self.origin.copy()
 
         if include_rotations:
             # Accumulate rotation matrices instead of quaternions
             accumulated_rot_matrix = self.rot_matrix.copy()
-            ancestry = self.parent.get_ancestors(include_self=False)
 
             for ancestor in ancestry:
                 current_location += ancestor.placement.origin
@@ -171,19 +280,25 @@ class Placement:
                 accumulated_rot_matrix = ancestor.placement.rot_matrix @ accumulated_rot_matrix
 
             # Extract direction vectors directly from the final rotation matrix
-            return Placement(
+            result = Placement(
                 origin=current_location,
                 xdir=accumulated_rot_matrix[0],
                 ydir=accumulated_rot_matrix[1],
                 zdir=accumulated_rot_matrix[2],
             )
+        else:
+            # For non-rotation case, just accumulate origins
+            for ancestor in ancestry:
+                current_location += ancestor.placement.origin
 
-        # For non-rotation case, just accumulate origins
-        ancestry = self.parent.get_ancestors(include_self=False)
-        for ancestor in ancestry:
-            current_location += ancestor.placement.origin
+            result = Placement(origin=current_location, xdir=self.xdir, ydir=self.ydir, zdir=self.zdir)
 
-        return Placement(origin=current_location, xdir=self.xdir, ydir=self.ydir, zdir=self.zdir)
+        if fingerprint is not None:
+            if memo is None:
+                memo = self._abs_memo = {}
+            memo[include_rotations] = (fingerprint, result)
+
+        return result
 
     def rotate(self, axis: Iterable[float], angle: float) -> Placement:
         """Rotate the placement around an axis. Returns a new placement."""
@@ -241,6 +356,17 @@ class Placement:
         # Fallback to original implementation
         return np.array([self.xdir, self.ydir, self.zdir])
 
+    @cached_property
+    def rot_matrix_inv(self):
+        """Inverse of :attr:`rot_matrix`, resolved once per placement.
+
+        One placement is the reference frame for every element transformed
+        against it, so the inverse of a single small constant matrix was being
+        recomputed once per element. Cached on the same grounds as
+        ``rot_matrix`` itself: a placement's rotation is fixed once built.
+        """
+        return np.linalg.inv(self.rot_matrix)
+
     def get_matrix4x4(self):
         t = np.array([[self.origin[0]], [self.origin[1]], [self.origin[2]]])
         Rt = np.hstack([self.rot_matrix, t])
@@ -269,7 +395,14 @@ class Placement:
     def transform_array_from_other_place(
         self, arr: np.ndarray, other_place: Placement, ignore_translation=False
     ) -> np.ndarray:
-        rotation_mat = self.rot_matrix @ np.linalg.inv(other_place.rot_matrix)
+        other_rot_matrix = other_place.rot_matrix
+        if is_exact_identity_rot_matrix(other_rot_matrix):
+            # inv(I) is I and ``M @ I`` is bit-exact M, so both are pure cost.
+            # Transforming out of the global frame is the overwhelmingly common
+            # case, and it took the inverse of the identity every single time.
+            rotation_mat = self.rot_matrix
+        else:
+            rotation_mat = self.rot_matrix @ other_place.rot_matrix_inv
 
         if ignore_translation:
             transformed_vec = arr @ rotation_mat.T

--- a/src/ada/cadit/gxml/write/write_beams.py
+++ b/src/ada/cadit/gxml/write/write_beams.py
@@ -87,6 +87,7 @@ def add_straight_beam(beam: Beam, xml_root: ET.Element, sw: SatWriter = None):
     import numpy as np
 
     from ada import Placement
+    from ada.core.vector_utils import is_identity_rot_matrix
 
     structure_elem = ET.SubElement(xml_root, "structure")
     straight_beam = ET.SubElement(structure_elem, "straight_beam", {"name": beam.name})
@@ -99,7 +100,7 @@ def add_straight_beam(beam: Beam, xml_root: ET.Element, sw: SatWriter = None):
     if beam.placement.is_identity() is False:
         ident_place = Placement()
         place_abs = beam.placement.get_absolute_placement(include_rotations=True)
-        if not np.allclose(place_abs.rot_matrix, ident_place.rot_matrix):
+        if not is_identity_rot_matrix(place_abs.rot_matrix):
             ori_vectors = place_abs.transform_array_from_other_place(
                 np.asarray([xvec, yvec, up]), ident_place, ignore_translation=True
             )

--- a/src/ada/core/vector_utils.py
+++ b/src/ada/core/vector_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from math import isfinite
 from typing import TYPE_CHECKING, Iterable
 
 import numpy as np
@@ -276,6 +277,64 @@ def _unit_vector_cached(vec_tup: tuple[float, ...]) -> tuple[float, ...]:
     if np.isnan(norm_arr).any():
         raise VectorNormalizeError(f'Error trying to normalize vector "{arr}"')
     return tuple(norm_arr)
+
+
+# ---------------------------------------------------------------------------
+# Small fixed-size comparisons.
+#
+# ``np.allclose`` costs ~12 us on a 3x3 no matter how trivially it answers: the
+# array protocol, the rtol/atol broadcast and the boolean reduction all pay full
+# dispatch price on nine numbers. The placement/transform paths run these
+# comparisons once per element, so the dispatch - not the arithmetic - is what
+# shows up in a profile. Written out as plain Python floats the same predicates
+# are ~20x cheaper.
+#
+# The semantics are numpy's, deliberately, so these are drop-in: the tolerance
+# is asymmetric (``rtol`` scales the *second* argument), non-finite values
+# compare by equality only, and NaN is never close to anything.
+# ---------------------------------------------------------------------------
+
+_IDENTITY_ROWS = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+
+
+def scalars_are_close(x: float, y: float, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    """``np.isclose(x, y, rtol, atol)`` for a single pair of Python floats."""
+    if x == y:  # also the inf == inf case numpy special-cases
+        return True
+    if not (isfinite(x) and isfinite(y)):
+        return False
+    return abs(x - y) <= atol + rtol * abs(y)
+
+
+def vectors_are_close(a: Iterable[float], b: Iterable[float], rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    """``np.allclose(a, b, rtol, atol)`` for two 3-component vectors."""
+    a0, a1, a2 = a
+    b0, b1, b2 = b
+    return (
+        scalars_are_close(a0, b0, rtol, atol)
+        and scalars_are_close(a1, b1, rtol, atol)
+        and scalars_are_close(a2, b2, rtol, atol)
+    )
+
+
+def is_identity_rot_matrix(rot_matrix: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    """``np.allclose(rot_matrix, np.identity(3), rtol, atol)`` for a 3x3 rotation."""
+    rows = rot_matrix.tolist()
+    for row, ident_row in zip(rows, _IDENTITY_ROWS):
+        for value, ident in zip(row, ident_row):
+            if not scalars_are_close(value, ident, rtol, atol):
+                return False
+    return True
+
+
+def is_exact_identity_rot_matrix(rot_matrix: np.ndarray) -> bool:
+    """``True`` only when the 3x3 holds the identity to the last bit.
+
+    Used to skip work that is provably a no-op rather than to decide geometry:
+    inverting the identity returns it unchanged and multiplying by it is exact,
+    so a caller that takes this branch gets bit-identical numbers out.
+    """
+    return rot_matrix.tolist() == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
 
 def unit_vector(vector: np.ndarray | list | tuple) -> Direction:

--- a/tests/core/api/test_absolute_placement_equivalence.py
+++ b/tests/core/api/test_absolute_placement_equivalence.py
@@ -1,0 +1,491 @@
+"""Differential test for the fast paths in ``Placement.get_absolute_placement``.
+
+``get_absolute_placement`` used to walk the owner's whole ancestry on every
+call, re-summing the same origins and re-multiplying the same rotation
+matrices once per element rather than once per placement. It now collapses
+that walk when the element's own placement is the local identity, and memoises
+the accumulation behind an object-identity fingerprint of everything it read.
+
+Both are only legitimate if they are *exactly* equivalent, so this file keeps
+the pre-optimisation algorithm around verbatim as ``_reference_absolute`` and
+asserts bit-for-bit equality against it over a deliberately degeneracy-biased
+spread: zero and signed-zero origins, subnormal and astronomically large
+coordinates, axis-aligned and anti-aligned frames, near-parallel axes, mixed
+units, and nesting from one to six levels deep. Bit-for-bit and not
+``approx``: a wrong answer here has historically been a wrong *unit* or a
+transposed frame, and a loose assertion would wave both through.
+
+The second half covers invalidation. A cache that survived a mutation to an
+ancestor's transform would be a far worse bug than the cost it saves, so every
+route that can change the answer -- an origin reassigned, a placement
+replaced, an element or an intermediate part re-parented -- is exercised as
+read / mutate / read and re-checked against the reference.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import numpy as np
+import pytest
+
+import ada
+from ada import Direction, Placement, Point
+from ada.core.vector_utils import (
+    is_exact_identity_rot_matrix,
+    is_identity_rot_matrix,
+    scalars_are_close,
+    vectors_are_close,
+)
+
+
+def _reference_absolute(place: Placement, include_rotations: bool) -> Placement:
+    """The pre-optimisation ``get_absolute_placement``, transcribed unchanged."""
+    if place.parent is None:
+        return place
+
+    current_location = place.origin.copy()
+
+    if include_rotations:
+        accumulated_rot_matrix = place.rot_matrix.copy()
+        ancestry = place.parent.get_ancestors(include_self=False)
+
+        for ancestor in ancestry:
+            current_location += ancestor.placement.origin
+            accumulated_rot_matrix = ancestor.placement.rot_matrix @ accumulated_rot_matrix
+
+        return Placement(
+            origin=current_location,
+            xdir=accumulated_rot_matrix[0],
+            ydir=accumulated_rot_matrix[1],
+            zdir=accumulated_rot_matrix[2],
+        )
+
+    ancestry = place.parent.get_ancestors(include_self=False)
+    for ancestor in ancestry:
+        current_location += ancestor.placement.origin
+
+    return Placement(origin=current_location, xdir=place.xdir, ydir=place.ydir, zdir=place.zdir)
+
+
+def _assert_identical(actual: Placement, expected: Placement, ctx: str) -> None:
+    """Bit-for-bit, via the raw doubles -- not ``allclose``."""
+    for attr in ("origin", "xdir", "ydir", "zdir"):
+        got = np.asarray(getattr(actual, attr), dtype=float)
+        want = np.asarray(getattr(expected, attr), dtype=float)
+        assert got.tobytes() == want.tobytes(), f"{ctx}: {attr} {got!r} != {want!r}"
+    assert actual.rot_matrix.tobytes() == expected.rot_matrix.tobytes(), f"{ctx}: rot_matrix"
+
+
+def _check(place: Placement, ctx: str) -> None:
+    for include_rotations in (False, True):
+        expected = _reference_absolute(place, include_rotations)
+        actual = place.get_absolute_placement(include_rotations=include_rotations)
+        _assert_identical(actual, expected, f"{ctx} include_rotations={include_rotations}")
+        # ... and again, so a memo that answers a second call cannot drift.
+        actual_again = place.get_absolute_placement(include_rotations=include_rotations)
+        _assert_identical(actual_again, expected, f"{ctx} (repeat) include_rotations={include_rotations}")
+
+
+# --------------------------------------------------------------------------
+# input spread
+# --------------------------------------------------------------------------
+
+DEGENERATE_ORIGINS = [
+    None,
+    (0, 0, 0),
+    (-0.0, 0.0, -0.0),
+    (5e-324, 0, 0),  # smallest subnormal
+    (1e-15, -1e-15, 1e-15),
+    (1e12, -1e12, 1e12),
+    (1e150, 0, 0),  # far outside any physical model extent
+    (0.001, 0.002, 0.003),
+    (-5.5, 3.25, -0.125),
+    (1000.0, 0.0, 0.0),
+]
+
+DEGENERATE_AXES = [
+    None,
+    ((1, 0, 0), (0, 1, 0), (0, 0, 1)),  # explicit global frame
+    ((1, 0, 0), None, (0, 0, 1)),
+    ((0, 0, 1), None, (1, 0, 0)),
+    ((-1, 0, 0), None, (0, 0, 1)),  # anti-aligned
+    ((0, 1, 0), None, (0, 0, -1)),
+    ((1, 1, 0), None, (0, 0, 1)),
+    ((1, 1e-14, 0), None, (0, 0, 1)),  # near-parallel to global X
+    ((1, 0, 0), None, (0, 1e-14, 1)),  # near-degenerate up
+]
+
+
+def _placement(origin, axes) -> Placement:
+    if axes is None:
+        return Placement(origin=origin)
+    xdir, ydir, zdir = axes
+    return Placement(origin=origin, xdir=xdir, ydir=ydir, zdir=zdir)
+
+
+def _build(depth: int, origin, axes, units="m") -> tuple[ada.Assembly, ada.Part, ada.Beam, ada.Beam, ada.Plate]:
+    """Nest ``depth`` parts, alternating the awkward placement with a plain one."""
+    a = ada.Assembly("A", units=units)
+    node = a
+    for level in range(depth):
+        placement = _placement(origin, axes) if level % 2 == 0 else Placement()
+        part = ada.Part(f"P{level}", placement=placement)
+        node.add_part(part)
+        node = part
+
+    plain = ada.Beam("plain", (0, 0, 0), (1, 0, 0), "IPE300")
+    node.add_beam(plain)
+    placed = ada.Beam("placed", (0, 0, 0), (0, 0, 1), "IPE300", placement=_placement(origin, axes))
+    node.add_beam(placed)
+    plate = ada.Plate("pl", [(0, 0), (1, 0), (1, 1), (0, 1)], 0.01)
+    node.add_plate(plate)
+    return a, node, plain, placed, plate
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 6])
+@pytest.mark.parametrize("origin_idx", range(len(DEGENERATE_ORIGINS)))
+@pytest.mark.parametrize("axes_idx", range(len(DEGENERATE_AXES)))
+def test_degenerate_placements_match_the_reference_bit_for_bit(depth, origin_idx, axes_idx):
+    origin = DEGENERATE_ORIGINS[origin_idx]
+    axes = DEGENERATE_AXES[axes_idx]
+    _, part, plain, placed, plate = _build(depth, origin, axes)
+
+    ctx = f"depth={depth} origin={origin} axes={axes}"
+    _check(part.placement, f"{ctx} part")
+    _check(plain.placement, f"{ctx} plain-beam")
+    _check(placed.placement, f"{ctx} placed-beam")
+    _check(plate.placement, f"{ctx} plate")
+
+
+def _random_origin(rng: random.Random):
+    scale = rng.choice([5e-324, 1e-12, 1e-6, 1e-3, 1.0, 1e3, 1e9, 1e15])
+    return tuple(rng.uniform(-1, 1) * scale for _ in range(3))
+
+
+def _random_axes(rng: random.Random):
+    roll = rng.random()
+    if roll < 0.25:
+        return None
+    if roll < 0.55:
+        return rng.choice(
+            [
+                ((1, 0, 0), (0, 1, 0), (0, 0, 1)),
+                ((1, 0, 0), None, (0, 0, 1)),
+                ((0, 1, 0), None, (0, 0, 1)),
+                ((0, 0, 1), None, (1, 0, 0)),
+                ((-1, 0, 0), None, (0, 0, 1)),
+                ((0, -1, 0), None, (0, 0, -1)),
+            ]
+        )
+    axis = [rng.uniform(-1, 1) for _ in range(3)]
+    norm = math.sqrt(sum(c * c for c in axis)) or 1.0
+    axis = [c / norm for c in axis]
+    rotated = Placement.from_axis_angle(axis, rng.uniform(-360.0, 360.0))
+    return (tuple(rotated.xdir), tuple(rotated.ydir), tuple(rotated.zdir))
+
+
+def test_randomised_hierarchies_match_the_reference_bit_for_bit():
+    rng = random.Random(20240607)
+    for case in range(400):
+        depth = rng.randint(1, 4)
+        units = rng.choice(["m", "mm"])
+        a = ada.Assembly(f"R{case}", units=units)
+        node = a
+        for level in range(depth):
+            node.add_part(ada.Part(f"P{level}", placement=_placement(_random_origin(rng), _random_axes(rng))))
+            node = node.parts[f"P{level}"]
+
+        plain = ada.Beam("plain", (0, 0, 0), (rng.uniform(0.1, 10), 0, 0), "IPE300")
+        node.add_beam(plain)
+        placed = ada.Beam(
+            "placed",
+            (0, 0, 0),
+            (0, rng.uniform(0.1, 10), 0),
+            "IPE300",
+            placement=_placement(_random_origin(rng), _random_axes(rng)),
+        )
+        node.add_beam(placed)
+
+        _check(node.placement, f"case={case} part")
+        _check(plain.placement, f"case={case} plain-beam")
+        _check(placed.placement, f"case={case} placed-beam")
+
+
+# --------------------------------------------------------------------------
+# invalidation
+# --------------------------------------------------------------------------
+
+
+def test_mutating_an_ancestor_origin_invalidates_the_resolved_placement():
+    a = ada.Assembly("A")
+    outer = ada.Part("outer", placement=Placement(origin=(1, 2, 3)))
+    a.add_part(outer)
+    inner = ada.Part("inner", placement=Placement(origin=(10, 0, 0)))
+    outer.add_part(inner)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300")
+    inner.add_beam(bm)
+
+    _check(bm.placement, "before")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [11.0, 2.0, 3.0]
+
+    outer.placement.origin = Point(5, 5, 5)
+    _check(bm.placement, "after ancestor origin change")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [15.0, 5.0, 5.0]
+
+
+def test_replacing_an_ancestor_placement_invalidates_the_resolved_placement():
+    """The ``placement`` setter leaves the new placement unparented.
+
+    An unparented placement resolves to *itself* rather than to an
+    accumulation, so an element must not be allowed to defer to its
+    container's answer in that state. Nested two deep on purpose: with the
+    container sitting directly under the assembly, the container's own origin
+    is the whole answer and a wrong deferral would coincide with the right one.
+    """
+    a = ada.Assembly("A")
+    outer = ada.Part("outer", placement=Placement(origin=(1, 2, 3)))
+    a.add_part(outer)
+    inner = ada.Part("inner", placement=Placement(origin=(10, 0, 0)))
+    outer.add_part(inner)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300")
+    inner.add_beam(bm)
+
+    _check(bm.placement, "before")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [11.0, 2.0, 3.0]
+
+    inner.placement = Placement(origin=(20, 0, 0))
+    assert inner.placement.parent is None  # the setter does not re-parent
+    _check(bm.placement, "after ancestor placement replaced")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [21.0, 2.0, 3.0]
+
+    # ... and once the new placement IS parented, the collapse is live again.
+    inner.placement.parent = inner
+    _check(bm.placement, "after ancestor placement re-parented")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [21.0, 2.0, 3.0]
+
+
+def test_reparenting_an_element_invalidates_the_resolved_placement():
+    a = ada.Assembly("A")
+    left = ada.Part("left", placement=Placement(origin=(1, 0, 0)))
+    right = ada.Part("right", placement=Placement(origin=(0, 7, 0)))
+    a.add_part(left)
+    a.add_part(right)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300")
+    left.add_beam(bm)
+
+    _check(bm.placement, "in left")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [1.0, 0.0, 0.0]
+
+    right.add_beam(bm)
+    _check(bm.placement, "in right")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [0.0, 7.0, 0.0]
+
+
+def test_reparenting_an_intermediate_part_invalidates_the_resolved_placement():
+    a = ada.Assembly("A")
+    top = ada.Part("top", placement=Placement(origin=(100, 0, 0)))
+    a.add_part(top)
+    middle = ada.Part("middle", placement=Placement(origin=(0, 3, 0)))
+    top.add_part(middle)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300")
+    middle.add_beam(bm)
+
+    _check(bm.placement, "under top")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [100.0, 3.0, 0.0]
+
+    a.add_part(middle)  # middle moves out from under top
+    _check(bm.placement, "under assembly")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [0.0, 3.0, 0.0]
+
+
+def test_replacing_the_elements_own_placement_invalidates_the_resolved_placement():
+    a = ada.Assembly("A")
+    part = ada.Part("part", placement=Placement(origin=(1, 2, 3)))
+    a.add_part(part)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300")
+    part.add_beam(bm)
+
+    _check(bm.placement, "identity own placement")
+    bm.placement = Placement(origin=(0.5, 0, 0))
+    bm.placement.parent = bm
+    _check(bm.placement, "own placement replaced")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [1.5, 2.0, 3.0]
+
+    bm.placement.origin = Point(0, 0, 7)
+    _check(bm.placement, "own origin mutated")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [1.0, 2.0, 10.0]
+
+
+def test_an_ndarray_origin_is_never_memoised():
+    """A raw ndarray origin is writable, so it must not be cached behind us."""
+    a = ada.Assembly("A")
+    part = ada.Part("part", placement=Placement(origin=(1, 2, 3)))
+    a.add_part(part)
+    bm = ada.Beam("bm", (0, 0, 0), (1, 0, 0), "IPE300", placement=Placement(origin=(1, 0, 0)))
+    part.add_beam(bm)
+
+    part.placement.origin = np.array([4.0, 0.0, 0.0])
+    _check(bm.placement, "ndarray ancestor origin")
+    assert bm.placement.get_absolute_placement().origin.tolist() == [5.0, 0.0, 0.0]
+
+    part.placement.origin[0] = 40.0  # in-place write a fingerprint could not see
+    assert bm.placement.get_absolute_placement().origin.tolist() == [41.0, 0.0, 0.0]
+
+
+def test_cog_is_unchanged_by_the_fast_paths():
+    """End-to-end: the COG of a nested, partly rotated model."""
+    a = ada.Assembly("A")
+    for i in range(3):
+        area = ada.Part(f"area{i}", placement=Placement(origin=(i * 10.0, 0, 0)))
+        a.add_part(area)
+        deck = ada.Part(f"deck{i}", placement=Placement.from_axis_angle([0, 0, 1], 30.0, origin=(0, 0, 4.0)))
+        area.add_part(deck)
+        for j in range(4):
+            deck.add_beam(ada.Beam(f"bm{i}_{j}", (j, 0, 0), (j + 1, 0, 0), "IPE300"))
+
+    cog = a.calculate_cog()
+    expected = np.zeros(3)
+    total = 0.0
+    for bm in a.get_all_physical_objects(by_type=ada.Beam):
+        place_abs = _reference_absolute(bm.placement, True)
+        start = place_abs.transform_array_from_other_place(np.asarray([bm.n1.p]), Placement())[0]
+        end = place_abs.transform_array_from_other_place(np.asarray([bm.n2.p]), Placement())[0]
+        mass = bm.section.properties.Ax * float(np.linalg.norm(end - start)) * bm.material.model.rho
+        expected += 0.5 * (start + end) * mass
+        total += mass
+
+    assert np.asarray(cog.p).tobytes() == (expected / total).tobytes()
+
+
+# --------------------------------------------------------------------------
+# the numpy-semantics helpers
+# --------------------------------------------------------------------------
+
+_EDGE_SCALARS = [
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    1e-9,
+    1e-8,
+    1.1e-8,
+    1e-5,
+    5e-324,
+    1e-300,
+    1e300,
+    1.0 + 1e-9,
+    1.0 + 1e-5,
+    1.0 - 1e-5,
+    math.inf,
+    -math.inf,
+    math.nan,
+]
+
+
+@pytest.mark.parametrize("x", _EDGE_SCALARS)
+@pytest.mark.parametrize("y", _EDGE_SCALARS)
+def test_scalars_are_close_matches_numpy(x, y):
+    assert scalars_are_close(x, y) == bool(np.isclose(x, y))
+
+
+@pytest.mark.parametrize("magnitude", [1e-9, 1e-6, 1e-3, 1.0, 1e3, 1e6, 1e12])
+def test_scalars_are_close_matches_numpy_on_the_tolerance_boundary(magnitude):
+    """Straddle the boundary in both argument orders.
+
+    ``np.isclose`` scales ``rtol`` by the SECOND argument only, so the
+    predicate is asymmetric. Separations pitched either side of the boundary
+    resolve differently depending on which value carries the tolerance, which
+    is what pins the asymmetry down rather than merely the tolerance size.
+    """
+    boundary = 1e-08 + 1e-05 * magnitude
+    for scale in (0.5, 0.9, 0.999999, 1.0, 1.000001, 1.0000001, 1.1, 2.0):
+        separation = boundary * scale
+        for x, y in (
+            (magnitude, magnitude + separation),
+            (magnitude + separation, magnitude),
+            (-magnitude, -magnitude - separation),
+            (-magnitude - separation, -magnitude),
+            (magnitude, -magnitude),
+        ):
+            assert scalars_are_close(x, y) == bool(np.isclose(x, y)), (x, y)
+            assert vectors_are_close((x, x, x), (y, y, y)) == bool(np.allclose((x, x, x), (y, y, y)))
+
+
+def test_vectors_are_close_matches_numpy_over_a_random_spread():
+    rng = np.random.default_rng(11)
+    pool = np.array(_EDGE_SCALARS)
+    for _ in range(4000):
+        if rng.random() < 0.5:
+            a = rng.choice(pool, 3)
+            b = rng.choice(pool, 3)
+        else:
+            a = rng.normal(size=3) * 10.0 ** rng.integers(-12, 12)
+            b = a + rng.normal(size=3) * 10.0 ** rng.integers(-14, 2)
+        assert vectors_are_close(a, b) == bool(np.allclose(a, b))
+
+
+def test_is_identity_rot_matrix_matches_numpy_over_a_random_spread():
+    rng = np.random.default_rng(12)
+    identity = np.identity(3)
+    assert is_identity_rot_matrix(identity)
+    for _ in range(4000):
+        m = identity + rng.normal(size=(3, 3)) * 10.0 ** rng.integers(-14, 2)
+        assert is_identity_rot_matrix(m) == bool(np.allclose(m, identity))
+    for scale in (0.0, 1e-12, 1e-9, 1e-8, 1e-6, 1e-4):
+        m = identity + scale
+        assert is_identity_rot_matrix(m) == bool(np.allclose(m, identity))
+
+
+def test_is_exact_identity_rot_matrix_is_exact():
+    identity = np.identity(3)
+    assert is_exact_identity_rot_matrix(identity)
+    assert is_exact_identity_rot_matrix(Placement().rot_matrix)
+    nudged = identity.copy()
+    nudged[0, 1] = 5e-324
+    assert not is_exact_identity_rot_matrix(nudged)
+    assert is_identity_rot_matrix(nudged)  # still "close", just not exact
+    assert not is_exact_identity_rot_matrix(Placement(xdir=(0, 1, 0), zdir=(0, 0, 1)).rot_matrix)
+
+
+def test_identity_shortcut_in_transform_matches_the_explicit_inverse():
+    """The skipped ``inv(I)`` / ``@ I`` must be bit-for-bit no-ops."""
+    rng = np.random.default_rng(13)
+    identity_place = Placement()
+    for _ in range(500):
+        axis = rng.normal(size=3)
+        axis = axis / np.linalg.norm(axis)
+        place = Placement.from_axis_angle(axis.tolist(), float(rng.uniform(-360, 360)), origin=rng.normal(size=3))
+        arr = rng.normal(size=(4, 3)) * 10.0 ** rng.integers(-6, 6)
+
+        explicit = (arr - identity_place.origin) @ (
+            place.rot_matrix @ np.linalg.inv(identity_place.rot_matrix)
+        ).T + place.origin
+        assert place.transform_array_from_other_place(arr, identity_place).tobytes() == explicit.tobytes()
+
+        explicit_no_translation = arr @ (place.rot_matrix @ np.linalg.inv(identity_place.rot_matrix)).T
+        assert (
+            place.transform_array_from_other_place(arr, identity_place, ignore_translation=True).tobytes()
+            == explicit_no_translation.tobytes()
+        )
+
+
+def test_rot_matrix_inv_matches_a_direct_inverse():
+    rng = np.random.default_rng(14)
+    for _ in range(200):
+        axis = rng.normal(size=3)
+        axis = axis / np.linalg.norm(axis)
+        place = Placement.from_axis_angle(axis.tolist(), float(rng.uniform(-360, 360)))
+        assert place.rot_matrix_inv.tobytes() == np.linalg.inv(place.rot_matrix).tobytes()
+
+
+def test_local_identity_detection():
+    assert Placement()._is_local_identity()
+    assert Placement(origin=(0, 0, 0))._is_local_identity()
+    assert Placement(origin=(0, 0, 0), xdir=(1, 0, 0), ydir=(0, 1, 0), zdir=(0, 0, 1))._is_local_identity()
+    assert Placement(origin=(-0.0, 0.0, -0.0))._is_local_identity()
+    assert not Placement(origin=(5e-324, 0, 0))._is_local_identity()
+    assert not Placement(origin=(1, 0, 0))._is_local_identity()
+    assert not Placement(xdir=(0, 1, 0), zdir=(0, 0, 1))._is_local_identity()
+    assert not Placement(origin=Direction(0, 0))._is_local_identity()  # 2D origin


### PR DESCRIPTION
> Titled `fix:` rather than `perf:` because the PR-title gate accepts only `fix:`/`feat:`/`chore:`, and `chore:` would not cut a release. This is a performance change; no behaviour changes (see the bit-exactness section).

## What was slow

`Placement.get_absolute_placement` walks the owner's entire ancestry on every
call. Elements that share a container therefore re-sum the same origins and
re-multiply the same rotation matrices once per element instead of once per
placement. Each of those results is then handed to
`transform_array_from_other_place`, which inverts the identity matrix again,
and compared against the identity through `np.allclose`.

Profiling `Part.calculate_cog` on a 2,940-beam / 140-plate model (4 areas x 5
decks, three to four levels deep, half the decks rotated), cProfile:

| | calls | cumulative |
|---|---|---|
| `np.allclose` -> `np.isclose` | 5,880 | 0.134 s |
| `transform_array_from_other_place` | 7,049 | 0.169 s |
| `np.linalg.inv` (on the identity, repeatedly) | 7,049 | 0.061 s |
| `get_absolute_placement` | 3,080 | 0.138 s |
| **total** | 1,532,512 | **0.784 s** |

All of it is per-call dispatch overhead on nine numbers, not arithmetic.

## The change

Three fast paths, each **exact** rather than approximate.

**1. Collapse the walk for identity placements.** An element whose own
placement is the local identity adds a zero origin and multiplies by an
identity rotation. `0.0 + x == x` and `R @ I == R` are exact in IEEE-754, so
the accumulation collapses -- to the last bit -- onto the container's, and the
container's is resolved once and memoised.

*Invalidation* is the crux, so the memo validates itself rather than trusting
a hook at every mutation site: it records the object identity of every
placement and every origin it read, and re-checks them with `is` on each hit.
A reassigned origin, a replaced placement, a re-parented element or a
re-parented intermediate part all change one of those objects (or the chain
length) and force a recompute. This rests on two properties the codebase
already relies on: `rot_matrix` is a `cached_property`, so a placement's
rotation is fixed at construction and its object identity pins it; and `Point`
is immutable and value-interned, so recording the object is enough to notice
a change. Where an origin is *not* a `Point` -- the setter accepts a raw
ndarray, which could be written through in place -- nothing is memoised at
all, because no fingerprint could catch that.

One guard worth calling out: the `placement` setter leaves the new placement
unparented, and an unparented placement resolves to *itself* rather than to an
accumulation. The collapse only applies when the container's placement is
actually parented to the container; otherwise the walk runs.

**2. `np.allclose` on 3x3 / 3-vectors -> plain floats.** `scalars_are_close`,
`vectors_are_close`, `is_identity_rot_matrix` in `ada.core.vector_utils`,
deliberately reproducing numpy's semantics so they are drop-in: asymmetric
tolerance (`rtol` scales the *second* argument), equality-only comparison for
non-finite values, NaN close to nothing. ~12 us -> ~0.6 us on a 3x3.

**3. Stop inverting the identity.** `transform_array_from_other_place` skips
both the inverse and the multiply when the reference frame is exactly the
identity, and otherwise takes the inverse from a new `rot_matrix_inv` cached
property -- cached on the same grounds as `rot_matrix` itself.

After, same profile: **0.381 s**, 828,951 calls. `np.allclose` and
`np.linalg.inv` are gone from the path; the 3,080 ancestry resolutions become
memo hits totalling 0.017 s.

## Measurement

Every measurement is its own subprocess with a freshly built model, so nothing
the change caches can amortise over repeats the real workload does not have.
Runs alternate **ABBA** and **BAAB**; both directions are reported, because if
they disagreed in sign the number would be measuring the ordering. Medians,
n=32 per variant (8 reps of each pattern).

**Representative model** (elements have default placements; containers are
translated and half of them rotated):

| | base | patched | ABBA | BAAB |
|---|---|---|---|---|
| COG | 0.4364 s | 0.2079 s | **-51.6%** | **-52.5%** |
| model build + COG | 0.7483 s | 0.5232 s | -30.6% | -30.6% |
| model build alone | 0.3112 s | 0.3140 s | +0.0% | +0.8% |

**Adversarial model** -- every element carries its own non-identity placement,
so the collapse never fires and its checks are pure overhead. Same element
count:

| | base | patched | ABBA | BAAB |
|---|---|---|---|---|
| COG | 0.4347 s | 0.2955 s | -32.1% | -32.3% |
| model build + COG | 0.7832 s | 0.6440 s | -17.8% | -17.7% |

**IFC export**, which crosses the same helpers outside the COG path (n=20):
-9.5% / -8.6%. Consistent in sign but below what is worth claiming as proven,
so: no regression, not a win.

The COG value was identical across all runs of every configuration.

## Correctness

`tests/core/api/test_absolute_placement_equivalence.py` keeps the
pre-optimisation algorithm verbatim as `_reference_absolute` and asserts
**bit-for-bit** equality against it -- comparing raw doubles, not `approx`,
because a wrong answer here has historically been a wrong unit or a transposed
frame and a loose assertion would wave both through.

The spread is degeneracy-biased: `None`/zero/signed-zero origins, the smallest
subnormal, 1e-15 and 1e150 coordinates, explicit global frames, anti-aligned
axes, axes near-parallel to the reference, mixed m/mm units, nesting one to
six deep, containers alternating awkward and plain placements, plus 400
randomised hierarchies. Then read/mutate/read coverage of every invalidation
route, and a numpy-parity scan of the new predicates over inf/-inf/NaN/
subnormals and separations straddling the tolerance boundary in both argument
orders.

Separately, the same bit-exact comparison was run as a cross-process diff of
this branch against `main` over 27,901 records / **400,213 double-precision
scalar comparisons**: zero mismatches. That diff is what caught the two bugs
in the first draft (the unparented-container case, and `include_rotations=False`
needing the element's own axes rather than the container's) -- both are now
pinned by tests, verified by mutating the implementation and watching them fail.

- `pixi run -e tests test`: 2,513 passed, 128 skipped. The one failure,
  `tests/full/frontend/test_web_client.py::test_basic_frontend`, is a
  websocket `ConnectionAbortedError`; it passes on this branch and on `main`
  when run on its own.
- `lint-check` (black --check, ruff check, isort --check-only): clean.
- No existing test weakened, skipped, xfailed or deleted.
- Placement/COG tests re-run under both CAD backends (`tests` / `tests-adacpp`,
  backend pinned explicitly): identical results.

## Noted, not fixed

`compute_orientation_vec` raises `AttributeError: 'numpy.ndarray' object has no
attribute 'get_normalized'` for a `Placement(xdir=..., ydir=None, zdir=None)`
whose derived y-vector goes through the `calc_yvec` branch without being
wrapped in `Direction`. Pre-existing on `main`, unrelated to this change, and
excluded from the generated spread so the diff stays comparable.
