### PR TITLE
feat: accept and manage published dataset blobs under assets/

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -978,14 +978,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         scope_obj: Scope = Depends(_scope_from_path),
         user: User = Depends(auth_module.current_user),
     ) -> JSONResponse:
-        from .converter import is_derived_key, is_versions_artefact_key
+        from .converter import (
+            is_derived_key,
+            is_published_asset_key,
+            is_versions_artefact_key,
+        )
 
         clean = key.lstrip("/")
         if not clean:
             raise HTTPException(status_code=400, detail="empty key")
         if is_derived_key(clean):
             raise HTTPException(status_code=403, detail="cannot write to _derived/")
-        if not is_versions_artefact_key(clean) and not await _is_accepted_source(clean):
+        # ``versions/`` (CI-pushed build outputs) and ``assets/`` (published datasets) are stored
+        # blobs, not conversion inputs, so the accepted-source extension whitelist does not apply
+        # to them. Two predicates rather than one because they part company on deletability — see
+        # is_published_asset_key. The is_derived_key guard above applies to both.
+        if (
+            not is_versions_artefact_key(clean)
+            and not is_published_asset_key(clean)
+            and not await _is_accepted_source(clean)
+        ):
             raise HTTPException(status_code=415, detail=f"unsupported file type: {clean}")
 
         # Reject before reading the body so a multi-GB upload doesn't
@@ -1034,10 +1046,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # ── User-level file management (personal scope only) ────────────
     # Regular users manage their own files; shared/project scopes stay
     # admin-managed (project scopes mix the CI versions/ tree with
-    # regular files and get their own treatment later). CI version
-    # blobs and the bake cache are protected even inside the personal
-    # scope — deleting a source still cascades its derived blobs via
-    # the shared storage_ops helpers.
+    # regular files), with one carve-out: a project member may DELETE a
+    # published dataset blob under ``assets/`` in that project, because
+    # such a publish targets the project scope and would otherwise be
+    # irreversible for everyone but an admin. See _member_may_delete.
+    # CI version blobs and the bake cache are protected even inside the
+    # personal scope — deleting a source still cascades its derived
+    # blobs via the shared storage_ops helpers.
 
     def _require_personal(scope_obj: Scope) -> None:
         if scope_obj.kind != "user":
@@ -1047,6 +1062,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
 
     def _reject_protected_key(key: str) -> None:
+        # Note the absence of is_published_asset_key here, and keep it absent.
+        # ``assets/`` blobs are exempt from the upload extension whitelist the same way
+        # ``versions/`` blobs are, but they are user-published rather than CI-pushed, so
+        # whoever wrote one has to be able to remove it. Adding the prefix here would make
+        # every published dataset a one-way door: writable once, never deletable, not even
+        # by its publisher in their own personal scope.
         from .converter import is_derived_key, is_versions_artefact_key
 
         if is_derived_key(key) or is_versions_artefact_key(key):
@@ -1055,6 +1076,30 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 detail="versions/ and _derived/ keys are admin-managed",
             )
 
+    def _member_may_delete(scope_obj: Scope, key: str) -> bool:
+        """The one carve-out from "non-personal scopes are admin-managed".
+
+        A published dataset is written into the scope it describes, which is
+        usually a shared project scope rather than the publisher's personal one.
+        Without this, a project-scoped publish is irreversible for everyone
+        except an admin, which is the exact failure mode ``assets/`` exists to
+        avoid. Membership is not re-checked here: ``_scope_from_path`` has
+        already run ``scope.can_access``, which for a project scope is a
+        ``project_members`` lookup, so reaching this code at all means the
+        caller is a member of this project.
+
+        Delete only — deliberately NOT extended to rename / move-to-folder.
+        Those take a *destination* key, so allowing them would let a member move
+        bytes out of ``assets/`` and land arbitrary content at an unvalidated
+        key in a shared scope, bypassing the upload extension gate that only
+        exempts the prefix itself. They also rewrite the key, and the key is the
+        published dataset's identity and provenance; the correct fix for a wrong
+        key is to delete and publish again, which this allows.
+        """
+        from .converter import is_published_asset_key
+
+        return scope_obj.kind == "project" and is_published_asset_key(key)
+
     @api.delete("/scopes/{scope}/blobs/{key:path}")
     async def api_scope_blob_delete(
         key: str,
@@ -1062,8 +1107,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         scope_obj: Scope = Depends(_scope_from_path),
         user: User = Depends(auth_module.current_user),
     ) -> JSONResponse:
-        _require_personal(scope_obj)
         clean = key.lstrip("/")
+        if not _member_may_delete(scope_obj, clean):
+            _require_personal(scope_obj)
         if not clean:
             raise HTTPException(status_code=400, detail="empty key")
         _reject_protected_key(clean)
@@ -1677,7 +1723,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         Returns 503 on local-backed deployments — operator must provide
         an S3-compatible backend with CORS configured for browser PUTs.
         """
-        from .converter import is_derived_key, is_versions_artefact_key
+        from .converter import (
+            is_derived_key,
+            is_published_asset_key,
+            is_versions_artefact_key,
+        )
 
         if not storage.supports_presigned_uploads:
             raise HTTPException(
@@ -1690,7 +1740,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=400, detail="key required")
         if is_derived_key(key):
             raise HTTPException(status_code=403, detail="cannot write to _derived/")
-        if not is_versions_artefact_key(key) and not await _is_accepted_source(key):
+        # ``versions/`` (CI-pushed build outputs) and ``assets/`` (published datasets) are stored
+        # blobs, not conversion inputs, so the accepted-source extension whitelist does not apply
+        # to them. Two predicates rather than one because they part company on deletability — see
+        # is_published_asset_key. The is_derived_key guard above applies to both.
+        if not is_versions_artefact_key(key) and not is_published_asset_key(key) and not await _is_accepted_source(key):
             raise HTTPException(status_code=415, detail=f"unsupported file type: {key}")
         try:
             url = await storage.presigned_put_url(scope_obj, key, expires_in_seconds=3600)
@@ -1731,7 +1785,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         succeeds; if it doesn't, the file lands but no audit / convert
         happens (storage list still surfaces it).
         """
-        from .converter import is_derived_key, is_versions_artefact_key
+        from .converter import (
+            is_derived_key,
+            is_published_asset_key,
+            is_versions_artefact_key,
+        )
 
         body = await request.json()
         key = (body.get("key") or "").strip().lstrip("/")
@@ -1739,7 +1797,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=400, detail="key required")
         if is_derived_key(key):
             raise HTTPException(status_code=403, detail="cannot write to _derived/")
-        if not is_versions_artefact_key(key) and not await _is_accepted_source(key):
+        # ``versions/`` (CI-pushed build outputs) and ``assets/`` (published datasets) are stored
+        # blobs, not conversion inputs, so the accepted-source extension whitelist does not apply
+        # to them. Two predicates rather than one because they part company on deletability — see
+        # is_published_asset_key. The is_derived_key guard above applies to both.
+        if not is_versions_artefact_key(key) and not is_published_asset_key(key) and not await _is_accepted_source(key):
             raise HTTPException(status_code=415, detail=f"unsupported file type: {key}")
         meta = await storage.head(scope_obj, key)
         if meta is None:

--- a/src/ada/comms/rest/converter.py
+++ b/src/ada/comms/rest/converter.py
@@ -504,6 +504,15 @@ def is_derived_key(key: str) -> bool:
 # hidden?", and storage.list(skip_prefixes=...) uses the same tuple to avoid ENUMERATING them —
 # a listing that skipped a different set than it filtered would be a silent correctness bug (a real
 # file vanishing from the browser), so the two must not drift.
+#
+# DO NOT add PUBLISHED_ASSET_PREFIX ("assets/") to this tuple. It looks like it belongs — those
+# blobs are machine-published rather than hand-uploaded, and a scope can hold thousands of them —
+# but they are the *only* record of what has been published: clients project a browsable hierarchy
+# out of the key listing returned by GET /api/scopes/{scope}/files, because that route is the sole
+# index of the prefix (it returns no per-prefix filter and no pagination, so one listing is the
+# whole answer). Hiding them would not degrade such a client, it would silently blank it — every
+# published dataset would read as "never published" with no error anywhere. If the listing really
+# has to shrink, add a prefix filter to the route rather than making the keys invisible.
 HIDDEN_PREFIXES: tuple[str, ...] = (
     "_derived/",
     "_overlays/",
@@ -525,6 +534,35 @@ def is_versions_artefact_key(key: str) -> bool:
     still does.
     """
     return key.lstrip("/").startswith("versions/")
+
+
+# Prefix for published dataset blobs, written under an opaque
+# ``assets/<collection>/<subject>/<revision>/<file>`` convention. Core attaches no meaning to any
+# segment: they are opaque tokens owned by whoever publishes them.
+PUBLISHED_ASSET_PREFIX = "assets/"
+
+
+def is_published_asset_key(key: str) -> bool:
+    """``assets/<collection>/<subject>/<revision>/<file>`` blobs are published
+    datasets — index/manifest JSON and packed data files — rather than
+    conversion sources, so the supported-source extension whitelist doesn't
+    apply to them. The ``_derived/`` guard still does.
+
+    Deliberately a **separate** predicate from :func:`is_versions_artefact_key`
+    rather than one more prefix inside it, because the two differ on
+    *deletability*, not just on the write gate:
+
+    * ``versions/`` blobs are pushed by CI and are admin-managed for their
+      whole life — a user must not be able to remove a build output.
+    * These are published by a user, so whoever published them must be able to
+      remove them, including (especially) when they published the wrong bytes.
+
+    ``_reject_protected_key`` in :mod:`ada.comms.rest.app` reads
+    ``is_versions_artefact_key``, so folding ``assets/`` into it would buy the
+    write exemption at the cost of making every published dataset permanently
+    undeletable by its own publisher — a one-way door on every byte written.
+    """
+    return key.lstrip("/").startswith(PUBLISHED_ASSET_PREFIX)
 
 
 def is_supported_source(key: str) -> bool:

--- a/tests/comms/rest/test_published_asset_keys.py
+++ b/tests/comms/rest/test_published_asset_keys.py
@@ -1,0 +1,338 @@
+"""Published dataset blobs under the ``assets/`` prefix.
+
+Two coupled behaviours are pinned here, and the coupling is the point:
+
+* the three write gates (direct PUT, presign, upload-complete) accept an
+  ``assets/<collection>/<subject>/<revision>/<file>`` key whatever its
+  extension, exactly as they already accept ``versions/``; and
+* unlike ``versions/``, such a key stays *deletable* — by its publisher in
+  a personal scope, and by a project member in a project scope.
+
+If the write exemption were ever folded into ``is_versions_artefact_key``
+the first half of that would still pass and the second half would not,
+which is why the exemption is its own predicate.
+
+Same env shim + LocalStore staging as test_user_storage_ops.py, and the
+same non-admin principal via the User.local_dev monkeypatch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import tempfile
+import uuid
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import auth as auth_module  # noqa: E402
+from ada.comms.rest import db as db_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+from ada.comms.rest.converter import (  # noqa: E402
+    HIDDEN_PREFIXES,
+    PUBLISHED_ASSET_PREFIX,
+    is_published_asset_key,
+    is_versions_artefact_key,
+)
+from ada.comms.rest.scope import Scope  # noqa: E402
+from ada.comms.rest.storage import Storage  # noqa: E402
+
+USER_SUB = "demo-user"
+PROJECT_ID = str(uuid.UUID(int=0x5A55E75))
+
+# One published revision: an index document and a packed dataset. Neither
+# extension is an accepted conversion source, which is the whole reason the
+# prefix needs an exemption.
+ASSET_JSON = "assets/collection-a/subject-b/20260825T135553Z/assets.json"
+ASSET_DB = "assets/collection-a/subject-b/20260825T135553Z/data.db"
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+@pytest.fixture
+def app_client(tmp_path: pathlib.Path, monkeypatch):
+    """API client whose principal is a NON-admin user with a fixed sub."""
+    monkeypatch.setattr(
+        auth_module.User,
+        "local_dev",
+        classmethod(
+            lambda cls: cls(
+                sub=USER_SUB,
+                email="demo@x.invalid",
+                display_name="Demo",
+                groups=frozenset(),
+                is_admin=False,
+            )
+        ),
+    )
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def member_client(app_client: TestClient, monkeypatch):
+    """The same non-admin principal, now a member of one project scope.
+
+    ``scope.can_access`` resolves project membership through
+    ``db.is_project_member`` behind a pool it only checks for None, so a
+    sentinel pool plus a stubbed membership query gives a real project scope
+    without a database. The scope id is UUID-shaped so
+    ``_resolve_project_scope`` passes it straight through instead of trying a
+    slug lookup.
+    """
+
+    async def _is_member(pool, project_id: str, sub: str) -> bool:
+        return project_id == PROJECT_ID and sub == USER_SUB
+
+    monkeypatch.setattr(db_module, "is_project_member", _is_member)
+    app_client.app.state.db_pool = object()
+    return app_client
+
+
+@pytest.fixture
+def presigning_client(app_client: TestClient, monkeypatch):
+    """LocalStore cannot sign URLs and the presign route 503s before it reaches
+    any key check, so stub just enough of the S3 surface that the route gets as
+    far as the gates under test."""
+    monkeypatch.setattr(Storage, "supports_presigned_uploads", property(lambda self: True))
+
+    async def _fake_presign(self, scope, key, expires_in_seconds=3600):
+        return f"https://object-store.invalid/{scope.prefix()}/{key}"
+
+    monkeypatch.setattr(Storage, "presigned_put_url", _fake_presign)
+    return app_client
+
+
+def _storage(client: TestClient) -> Storage:
+    storage = client.app.state.__dict__.get("_test_storage")
+    if storage is None:
+        for route in client.app.routes:
+            ep = getattr(route, "endpoint", None)
+            if ep is None:
+                continue
+            cells = getattr(ep, "__closure__", None)
+            if not cells:
+                continue
+            for c in cells:
+                v = c.cell_contents
+                if v.__class__.__name__ == "Storage":
+                    storage = v
+                    break
+            if storage is not None:
+                break
+        client.app.state._test_storage = storage
+    return storage
+
+
+def _put(client: TestClient, key: str, data: bytes, scope: Scope | None = None) -> None:
+    """Stage a blob directly in storage, bypassing upload validation."""
+    scope = scope or Scope.user(USER_SUB)
+    asyncio.run(_storage(client).put_bytes(scope, key, data))
+
+
+def _keys(client: TestClient, scope: Scope | None = None) -> set[str]:
+    scope = scope or Scope.user(USER_SUB)
+    files = asyncio.run(_storage(client).list(scope))
+    return {f.key for f in files}
+
+
+# ── the predicate itself ────────────────────────────────────────────
+
+
+def test_predicates_are_disjoint_and_assets_are_not_hidden():
+    assert is_published_asset_key(ASSET_JSON)
+    assert is_published_asset_key("/" + ASSET_DB)  # leading slash tolerated
+    assert not is_published_asset_key("versions/main/abc123/model.glb")
+    assert not is_published_asset_key("models/assets/x.json")  # prefix, not substring
+    assert not is_versions_artefact_key(ASSET_JSON)
+
+    # A3: hiding the prefix would silently blank every consumer that projects a
+    # hierarchy out of the file listing, since that listing is the only index of
+    # the prefix. Keep it visible.
+    assert PUBLISHED_ASSET_PREFIX not in HIDDEN_PREFIXES
+
+
+# ── A1: the three write gates ───────────────────────────────────────
+
+
+def test_put_accepts_published_asset_extensions(app_client: TestClient):
+    """.json and .db are not accepted conversion sources; under assets/ they
+    are stored blobs and must be taken anyway."""
+    for key in (ASSET_JSON, ASSET_DB):
+        r = app_client.put(f"/api/scopes/user:me/blobs/{key}", content=b"payload")
+        assert r.status_code == 201, r.text
+        assert r.json()["key"] == key
+    assert {ASSET_JSON, ASSET_DB} <= _keys(app_client)
+
+
+def test_put_exemption_is_prefix_scoped_not_a_blanket_lift(app_client: TestClient):
+    """The same extensions outside assets/ (and outside versions/) still 415."""
+    for key in (
+        "notes/assets.json",
+        "data/store.db",
+        "assetsx/collection/subject/rev/assets.json",  # near-miss prefix
+        "nested/assets/collection/subject/rev/assets.json",  # not at the root
+    ):
+        r = app_client.put(f"/api/scopes/user:me/blobs/{key}", content=b"payload")
+        assert r.status_code == 415, f"{key}: {r.status_code} {r.text}"
+    assert not _keys(app_client)
+
+
+def test_derived_still_refused_on_direct_put(app_client: TestClient):
+    r = app_client.put("/api/scopes/user:me/blobs/_derived/x.ifc.glb", content=b"x")
+    assert r.status_code == 403, r.text
+
+
+def test_presign_accepts_assets_and_still_refuses_derived(presigning_client: TestClient):
+    r = presigning_client.post("/api/scopes/user:me/upload-url", json={"key": ASSET_DB})
+    assert r.status_code == 200, r.text
+    assert r.json()["key"] == ASSET_DB
+
+    r = presigning_client.post("/api/scopes/user:me/upload-url", json={"key": "notes/assets.json"})
+    assert r.status_code == 415, r.text
+
+    r = presigning_client.post("/api/scopes/user:me/upload-url", json={"key": "_derived/x.ifc.glb"})
+    assert r.status_code == 403, r.text
+
+
+def test_upload_complete_accepts_assets_and_still_refuses_derived(app_client: TestClient):
+    _put(app_client, ASSET_JSON, b"published")
+
+    r = app_client.post("/api/scopes/user:me/upload-complete", json={"key": ASSET_JSON})
+    assert r.status_code == 201, r.text
+    assert r.json()["size"] == len(b"published")
+
+    r = app_client.post("/api/scopes/user:me/upload-complete", json={"key": "notes/assets.json"})
+    assert r.status_code == 415, r.text
+
+    r = app_client.post("/api/scopes/user:me/upload-complete", json={"key": "_derived/x.ifc.glb"})
+    assert r.status_code == 403, r.text
+
+
+# ── A2: deletability ────────────────────────────────────────────────
+
+
+def test_published_asset_is_deletable_in_personal_scope(app_client: TestClient):
+    """Pins behaviour that holds *by omission*: ``_reject_protected_key`` knows
+    only ``_derived/`` and ``versions/``, so an ``assets/`` key already deletes
+    cleanly here. That is exactly why it needs a test — it would be lost the
+    moment somebody tidied the write exemption into ``is_versions_artefact_key``
+    or added the prefix to that predicate, and the loss would be silent. The
+    ``versions/`` half of the assertion is the contrast: same scope, same user,
+    still admin-managed."""
+    _put(app_client, ASSET_JSON, b"published")
+    _put(app_client, "versions/main/abc123/model.glb", b"ci")
+
+    r = app_client.delete(f"/api/scopes/user:me/blobs/{ASSET_JSON}")
+    assert r.status_code == 200, r.text
+    assert ASSET_JSON in r.json()["deleted"]
+
+    r = app_client.delete("/api/scopes/user:me/blobs/versions/main/abc123/model.glb")
+    assert r.status_code == 400, r.text
+
+    keys = _keys(app_client)
+    assert ASSET_JSON not in keys
+    assert "versions/main/abc123/model.glb" in keys
+
+
+def test_published_asset_is_deletable_in_a_project_scope_by_a_member(member_client: TestClient):
+    scope = Scope.project(PROJECT_ID)
+    _put(member_client, ASSET_JSON, b"published", scope=scope)
+    _put(member_client, "models/wall.ifc", b"regular", scope=scope)
+    _put(member_client, "versions/main/abc123/model.glb", b"ci", scope=scope)
+
+    r = member_client.delete(f"/api/scopes/project:{PROJECT_ID}/blobs/{ASSET_JSON}")
+    assert r.status_code == 200, r.text
+    assert ASSET_JSON in r.json()["deleted"]
+
+    # Everything else in a project scope is still admin-managed.
+    r = member_client.delete(f"/api/scopes/project:{PROJECT_ID}/blobs/models/wall.ifc")
+    assert r.status_code == 403, r.text
+
+    # versions/ is refused in a project scope too — the carve-out never applies
+    # to it, so the personal-scope gate answers first.
+    r = member_client.delete(f"/api/scopes/project:{PROJECT_ID}/blobs/versions/main/abc123/model.glb")
+    assert r.status_code == 403, r.text
+
+    keys = _keys(member_client, scope)
+    assert ASSET_JSON not in keys
+    assert {"models/wall.ifc", "versions/main/abc123/model.glb"} <= keys
+
+
+def test_carve_out_does_not_reach_a_project_the_caller_is_not_in(member_client: TestClient):
+    """The delete exemption rides on membership enforced upstream by
+    _scope_from_path; a non-member never gets far enough to use it."""
+    other = str(uuid.UUID(int=0xDEAD))
+    _put(member_client, ASSET_JSON, b"published", scope=Scope.project(other))
+
+    r = member_client.delete(f"/api/scopes/project:{other}/blobs/{ASSET_JSON}")
+    assert r.status_code == 403, r.text
+    assert ASSET_JSON in _keys(member_client, Scope.project(other))
+
+
+def test_carve_out_is_delete_only_and_not_shared_scope(member_client: TestClient):
+    """Rename / move-to-folder take a destination key, so they stay
+    personal-scope-only; and the carve-out is for project scopes, not for the
+    shared scope."""
+    scope = Scope.project(PROJECT_ID)
+    _put(member_client, ASSET_JSON, b"published", scope=scope)
+    _put(member_client, ASSET_DB, b"published", scope=Scope.shared())
+
+    r = member_client.post(
+        f"/api/scopes/project:{PROJECT_ID}/keys/rename",
+        json={
+            "old_key": ASSET_JSON,
+            "new_key": "assets/collection-a/subject-b/20260825T135553Z/other.json",
+        },
+    )
+    assert r.status_code == 403, r.text
+
+    r = member_client.post(
+        f"/api/scopes/project:{PROJECT_ID}/keys/move-to-folder",
+        json={"keys": [ASSET_JSON], "folder": "assets/collection-a/subject-b/20260826T090000Z"},
+    )
+    assert r.status_code == 403, r.text
+
+    r = member_client.delete(f"/api/scopes/shared/blobs/{ASSET_DB}")
+    assert r.status_code == 403, r.text
+
+    assert ASSET_JSON in _keys(member_client, scope)
+    assert ASSET_DB in _keys(member_client, Scope.shared())


### PR DESCRIPTION
## What

Published dataset blobs are written under an opaque
`assets/<collection>/<subject>/<revision>/<file>` convention. Core attaches no
meaning to any segment — they are tokens owned by whoever publishes them.

* **`converter.py`** — new `is_published_asset_key` (and `PUBLISHED_ASSET_PREFIX`)
  beside `is_versions_artefact_key`.
* **`app.py`** — all three write gates (direct PUT, presign, upload-complete)
  now exempt the prefix from the accepted-conversion-source extension
  whitelist, the same way they already exempt `versions/`. The `is_derived_key`
  guard above each of them is unchanged.
* **`app.py`** — a project member may `DELETE` a key under `assets/` in that
  project scope. Everything else in a non-personal scope stays admin-managed.
* **`converter.py`** — a comment on `HIDDEN_PREFIXES` recording why the prefix
  must never be added to it.

## Why the write gate needed changing

Measured with a deployment probe against a running viewer, personal scope,
cleaned up afterwards:

```
PUT    assets/<c>/<s>/<r>/probe.json   -> 415  unsupported file type
PUT    assets/<c>/<s>/<r>/probe.glb    -> 201
DELETE that same .glb                  -> 200
```

So the prefix itself was never blocked — only the extension rule was. `.glb`
stored fine because it is a registered conversion source; the index/manifest
JSON and packed data files that make a published dataset useful did not. **This
PR lifts an extension rule for one prefix; it does not open a new keyspace.**

## Why `assets/` is a distinct predicate from `versions/`

They agree on the write gate and disagree on deletability, and the disagreement
is the entire reason for two predicates:

* `versions/` blobs are pushed by CI and are admin-managed for their whole
  life — a user must not be able to remove a build output.
* `assets/` blobs are published by a user, so whoever published them has to be
  able to remove them, and especially when they published the wrong bytes.

`_reject_protected_key` reads `is_versions_artefact_key`. Folding `assets/` into
that predicate would have bought the write exemption at the price of a one-way
door: writable once, then permanently undeletable by its own publisher, even in
their own personal scope (`400 versions/ and _derived/ keys are admin-managed`).
Both the predicate docstring and a comment on `_reject_protected_key` say so, so
the omission does not read as an oversight to the next person tidying it.

## Deletability matrix

| key | personal scope | project scope (member) | shared scope |
|---|---|---|---|
| regular file | 200 (before and after) | 403 (before and after) | 403 (before and after) |
| `versions/…` | 400 (before and after) | 403 (before and after) | 403 (before and after) |
| `_derived/…` | 400 (before and after) | 403 (before and after) | 403 (before and after) |
| `assets/…` | 200 (before and after) | **403 → 200** | 403 (before and after) |

One cell changes. The personal-scope row already held — `_reject_protected_key`
only ever knew `_derived/` and `versions/` — but it held *by omission*, so it now
has a regression test.

Rename and move-to-folder are deliberately **not** part of the carve-out:

1. They take a *destination* key. A member could move bytes out of `assets/` and
   land arbitrary content at an unvalidated key in a shared scope, defeating the
   very extension gate that only the prefix is exempt from.
2. They rewrite the key, and the key *is* the published dataset's identity and
   provenance. The correct fix for a wrong key is delete-and-republish, which
   this PR makes possible.
3. It is the narrowest change that removes the one-way door.

Membership is not re-checked in the carve-out: `_scope_from_path` has already run
`scope.can_access`, which for a project scope is a `project_members` lookup, so
reaching the handler at all means the caller is a member. There is a test for the
non-member case anyway.

## Why `assets/` must never be added to `HIDDEN_PREFIXES`

Adding it is plausible one day — these are not hand-uploaded user files and a
scope may hold thousands of them. But `GET /api/scopes/{scope}/files` is the
*only* index of the prefix (no per-prefix filter, no pagination — one listing is
the whole answer), so any consumer that projects a browsable hierarchy out of it
would not degrade on hiding, it would silently blank: every published dataset
would read as "never published", with no error anywhere. The comment names the
reason, and a test asserts the prefix stays out of the tuple.

## Tested

New `tests/comms/rest/test_published_asset_keys.py`, 10 tests, built on the same
`TestClient` + `LocalStore` + non-admin-principal shape as
`test_user_storage_ops.py`:

* `assets/…/assets.json` and `assets/…/data.db` are accepted by the direct PUT
  (both 415 before this change);
* the same extensions elsewhere still 415, including the near-miss prefixes
  `assetsx/…` and `nested/assets/…` — the exemption is prefix-scoped, not a
  blanket lift;
* `_derived/` still 403s on all three write paths;
* `assets/` deletable in a personal scope while `versions/` in the same scope
  still 400s;
* `assets/` deletable in a project scope by a member, while a regular file and a
  `versions/` key in that same project scope still 403;
* a non-member of a project gets 403 and the blob survives;
* rename / move-to-folder in a project scope still 403, and the shared scope gets
  no carve-out.

`pytest tests/comms/rest` — **382 passed, 54 skipped** (372 passed, 54 skipped on
the same tree with the new file excluded, so nothing existing changed status; no
test was weakened, skipped, xfailed or removed).

`pixi run -e lint lint-check` — clean (black, ruff, isort all pass).
