### PR TITLE
chore: bump deputy to v0.5.3 and trigger pr-review on labeled

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -22,7 +22,7 @@ name: Review Pull Request
 
 on:
   pull_request_target:
-    types: [opened, synchronize, edited, unlabeled]
+    types: [opened, synchronize, edited, labeled, unlabeled]
     branches: [main, develop]
 
 permissions:
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install deputy
         # deputy pins gitpython<3.1.60 itself from v0.5.2 — do not re-add it here.
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.2"
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.3"
 
       - name: Review the PR (checks + sticky comment); fails if a check fails
         run: deputy pr-review

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -18,7 +18,7 @@ name: Review Pull Request
 # pull_request_target so the job (and GITHUB_TOKEN) can comment and label even
 # on fork PRs. It checks out the BASE ref only and never runs any PR-head code.
 #
-# Pinned to deputy @v0.5.2.
+# Pinned to deputy @v0.5.3.
 
 on:
   pull_request_target:

--- a/.github/workflows/tag-on-pr-merge.yaml
+++ b/.github/workflows/tag-on-pr-merge.yaml
@@ -22,7 +22,7 @@ name: Create Tag on PR Merge
 #   * Do not enable "Do not allow bypassing the above settings" in branch
 #     protection, or the deploy-key push is rejected and no tag is created.
 #
-# Pinned to deputy @v0.5.2.
+# Pinned to deputy @v0.5.3.
 
 on:
   pull_request_target:

--- a/.github/workflows/tag-on-pr-merge.yaml
+++ b/.github/workflows/tag-on-pr-merge.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install deputy
         # deputy pins gitpython<3.1.60 itself from v0.5.2 — do not re-add it here.
-        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.2"
+        run: pip install "deputy @ git+https://github.com/Krande/deputy.git@v0.5.3"
 
       - name: Tag + release per the PR's release label
         run: deputy tag-on-merge


### PR DESCRIPTION
Bumps the [deputy](https://github.com/Krande/deputy) pin from v0.5.2 to v0.5.3 in `.github/workflows/pr-review.yaml` and `.github/workflows/tag-on-pr-merge.yaml`, and adds `labeled` to the pr-review trigger.

**Why v0.5.3.** v0.5.2 had a silent-release bug: deputy's own default label could sit alongside an explicitly applied `release-*` label, leaving the PR with two release labels — and two labels cut no release at all, silently, while the tag job still reported success. v0.5.3 treats the default as a *fallback*: when an explicit `release-*` label supersedes it, deputy removes its own.

**Why the `labeled` trigger.** That tidy-up only happens when pr-review actually runs. Without `labeled` in the trigger list, removing and re-adding a label never re-runs the review, so the stale default label survives and the green check is misleading. The pin bump alone cannot fix this — the trigger change has to ship with it.

No library code changes, so this PR is labelled `release-skip`.
