### PR TITLE
chore(ci): profile PRs without pull_request_target

### DIFF
--- a/.github/workflows/pr-profiling-comment.yml
+++ b/.github/workflows/pr-profiling-comment.yml
@@ -1,0 +1,83 @@
+name: PR Profiling Comment
+
+# The trusted half of the profiling split (see pr-profiling.yml for why it is
+# split at all). Posting a comment needs `pull-requests: write`, which is exactly
+# the permission the job running a fork's code must not have.
+#
+# `workflow_run` runs in the BASE repository's context, and always uses the copy
+# of this file on the DEFAULT branch — a PR cannot change what runs here, not
+# even a PR that edits this file. Nothing from the artifact is executed: the
+# markdown is posted verbatim as a comment body, and the PR number is validated
+# before use.
+
+on:
+  workflow_run:
+    workflows: ["PR Profiling"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    name: Post profiling comment
+    runs-on: ubuntu-latest
+    # A failed or cancelled profiling run has nothing worth posting. The event
+    # guard keeps this from firing on a re-run dispatched some other way.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download the profiling output
+        uses: actions/download-artifact@v7
+        with:
+          # The artifact belongs to a different workflow's run, so it has to be
+          # named explicitly — the default would look in this run.
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: profiling-results-*
+          merge-multiple: true
+          path: output
+
+      - name: Resolve the PR this belongs to
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -eu
+          # Everything in the artifact was produced by a job running a fork's
+          # code, so it is attacker-controlled. Strip the PR number to digits,
+          # then confirm that PR's head really is the commit that was profiled —
+          # without that check, a fork could name any number here and have the
+          # comment posted onto somebody else's PR.
+          if [ ! -f output/pr-number.txt ]; then
+            echo "::error::no pr-number.txt in the profiling artifact"
+            exit 1
+          fi
+          NUM="$(tr -cd '0-9' < output/pr-number.txt | head -c 12)"
+          if [ -z "$NUM" ]; then
+            echo "::error::pr-number.txt carried no digits"
+            exit 1
+          fi
+          ACTUAL="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUM}" --jq .head.sha)"
+          if [ "$ACTUAL" != "$RUN_HEAD_SHA" ]; then
+            # Also the benign case: the PR was pushed to while profiling ran, so
+            # these results describe superseded code. Declining to post is the
+            # right answer to both.
+            echo "::error::PR #${NUM} head is ${ACTUAL}, but this run profiled ${RUN_HEAD_SHA} — refusing to comment."
+            exit 1
+          fi
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Post Comment
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: output/profiling_comment.md
+          pr-number: ${{ steps.pr.outputs.number }}
+          comment-tag: profiling-results
+          mode: upsert
+          create-if-not-exists: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-profiling.yml
+++ b/.github/workflows/pr-profiling.yml
@@ -1,7 +1,27 @@
 name: PR Profiling
 
+# Runs the profiling suite against a PR's own code, and does nothing else: no
+# write permissions, no secrets, no comment. Posting the result needs
+# `pull-requests: write`, so it lives in pr-profiling-comment.yml, which runs in
+# the base repository's context instead.
+#
+# This was one `pull_request_target` workflow that checked out the PR head and
+# commented itself. That is the "pwn request" shape — a fork's code executing
+# with the base repo's GITHUB_TOKEN, secrets and default-branch cache scope,
+# where editing any profiled file is enough to read them. actions/checkout@v7
+# began refusing it outright (see its `allow-unsafe-pr-checkout` input), which is
+# how it surfaced: every fork PR's profiling job failed at the checkout step.
+#
+# The split below is the shape GitHub documents for this. Untrusted code runs
+# here under `pull_request`, whose token is read-only and scoped to the PR; the
+# result reaches the trusted half as an artifact, which is read as data and
+# never executed.
+#
+# Do NOT restore `pull_request_target`, and do NOT set
+# `allow-unsafe-pr-checkout: true` — either one reopens the hole.
+
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -14,16 +34,22 @@ concurrency:
   group: pr-profiling-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   profile:
     name: Profile and Track Performance
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
     steps:
       - uses: actions/checkout@v7
         with:
+          # The PR head rather than the merge commit, so the profiled SHA is the
+          # one the report and artifact name refer to. Safe to check out here in
+          # a way it was not under pull_request_target: this job holds nothing
+          # worth stealing.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
@@ -36,6 +62,12 @@ jobs:
           cache: true
 
       - name: Restore Profiling History
+        # Note the scope change that came with `pull_request`: a fork PR's cache
+        # is isolated to that PR and can no longer be written to the default
+        # branch's scope. `restore-keys` still reaches the base branch's entries,
+        # and the authoritative main-branch baseline lives in the profiling_data
+        # branch (see main-profiling.yml), not here — so the worst case is a
+        # first run with no per-PR history rather than a lost baseline.
         uses: actions/cache@v6
         with:
           path: output/profiling_history.json
@@ -58,23 +90,18 @@ jobs:
           path: output/profiling_history.json
           key: profiling-history-${{ github.event.pull_request.number }}-${{ github.run_id }}
 
+      - name: Record the PR number for the comment workflow
+        # `workflow_run` does not carry the PR number when the head repo is a
+        # fork — `workflow_run.pull_requests` comes back empty — so it travels in
+        # the artifact. The consumer treats this as untrusted input and verifies
+        # it against the run's head SHA before commenting on anything.
+        run: |
+          set -eu
+          mkdir -p output
+          echo "${{ github.event.pull_request.number }}" > output/pr-number.txt
+
       - name: Upload Profiling Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: profiling-results-${{ github.event.pull_request.head.sha }}
           path: output/
-          # Alternatively list files explicitly if we don't want everything in output/
-          # path: |
-          #   output/profiling_report.html
-          #   output/profiling_data.prof
-          #   output/top_20_stats.json
-          #   output/profiling_comment.md
-
-      - name: Post Comment
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          file-path: output/profiling_comment.md
-          comment-tag: profiling-results
-          mode: upsert
-          create-if-not-exists: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every fork PR's profiling job has been failing at checkout since `actions/checkout@v7`, which refuses to check out fork code from a `pull_request_target` workflow without `allow-unsafe-pr-checkout: true`. Most recently on #280.

Refusing is correct. The job ran a fork's code with the base repo's `GITHUB_TOKEN`, `pull-requests: write`, secrets and default-branch cache scope — editing any profiled file was enough to reach them. Setting the flag would silence the error and keep the hole, so this splits the workflow instead.

## The split

**`pr-profiling.yml`** still runs the PR's own code, now under `pull_request`: read-only token, no secrets, no write permissions. It ends by uploading its `output/` directory.

**`pr-profiling-comment.yml`** (new) picks that up on `workflow_run` and posts the comment. `workflow_run` runs in the base repo's context using the **default branch's** copy of the file, so a PR cannot change what runs there — not even a PR that edits this file.

The artifact is read as data and never executed.

## Trusting the PR number

`workflow_run.pull_requests` is empty when the head repo is a fork, so the PR number travels inside the artifact — which is written by a job running untrusted code. It is stripped to digits, then checked against the run's `head_sha` before anything is posted. Without that, a fork could name any number and land the comment on somebody else's PR.

That check also declines to post when the PR was pushed to mid-run, since those results describe superseded code.

## Scope

Only `pr-profiling.yml` was affected. `pr-review.yaml` and `tag-on-pr-merge.yaml` are also `pull_request_target`, but both check out the base branch and never the PR head — which is why deputy's checks have been passing on fork PRs throughout.

## Note on caching

A fork PR's cache is now isolated to that PR rather than the default branch's scope. `restore-keys` still reaches base-branch entries, and the authoritative main baseline lives in the `profiling_data` branch (`main-profiling.yml`), not the cache — so the worst case is a first run without per-PR history, not a lost baseline.

`release-skip`: CI configuration only, no package change.