### PR TITLE
fix(frontend): give dependency pre-bundling the same esnext target as the build

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -24,6 +24,23 @@ export default defineConfig({
             // pre-bundle for the workspace symlink). Enabled set is in plugins.json.
         },
     },
+    // Dependency PRE-BUNDLING is a separate esbuild pass from the build below,
+    // with its own target — `build.target` does not reach it. Without this,
+    // `vite --force` lowers node_modules for vite's default browser list
+    // (es2020/edge88/firefox78/chrome87/safari14 + vite's two `supported`
+    // overrides) and the pinned esbuild 0.28.1 dies on a dependency's
+    // destructured function parameter:
+    //
+    //   ERROR Transforming destructuring to the configured target environment
+    //   is not supported yet
+    //
+    // Same root cause as `build.target` below and the same answer: the viewer
+    // already requires a modern WebGL2 browser, so nothing needs lowering.
+    optimizeDeps: {
+        esbuildOptions: {
+            target: 'esnext',
+        },
+    },
     build: {
         outDir: path.resolve(__dirname, 'dist'), // Output directory outside of 'src'
         sourcemap: false,


### PR DESCRIPTION
`npm run dev` fails before serving anything:

```
ERROR Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
is not supported yet
  node_modules/@xyflow/system/dist/esm/index.js
```

## Why only `dev`

Dependency pre-bundling is a **separate esbuild pass** from the production build, with its own target — `build.target` does not reach it. `build.target: 'esnext'` was already set (with a comment explaining exactly this class of failure), so `build` was fixed and `dev` was not. `dev` is `vite --force`, which re-runs pre-bundling on every start, so it fails every time rather than intermittently.

With no `optimizeDeps.esbuildOptions.target`, vite falls back to its default browser list, and the esbuild pinned in `overrides` (0.28.1, a security pin) refuses to lower a dependency's destructured function parameter for it. The "+ 2 overrides" in the message are vite's own `supported` flags.

## Reproduced against the pinned binary

```
$ esbuild @xyflow/system/dist/esm/index.js --bundle \
    --target=es2020,edge88,firefox78,chrome87,safari14
✘ [ERROR] Transforming destructuring to the configured target environment … is not supported yet

$ esbuild @xyflow/system/dist/esm/index.js --bundle --target=esnext
  nul  193.9kb
⚡ Done in 21ms
```

Worth noting that every environment in that target list supports destructuring **natively**, so nothing needed lowering to begin with — this is esbuild 0.28 declining a transform it should not have attempted. Raising the target sidesteps it rather than fixing esbuild, which is the same trade `build.target` already made.

## Scope

Dev server only. `build.target` and `vite.config.serve.ts` are untouched, so no shipped artefact changes — hence `release-skip`.