### PR TITLE
fix(plugins): repaint plugin panels when the theme changes

### DIFF
--- a/src/frontend/src/__tests__/plugins/pluginThemeLiveness.test.ts
+++ b/src/frontend/src/__tests__/plugins/pluginThemeLiveness.test.ts
@@ -1,0 +1,74 @@
+// The plugin slot hosts must SUBSCRIBE to the theme, not snapshot it.
+//
+// `effectivePluginTheme(useThemeStore.getState())` reads the store without
+// subscribing. Core's own chrome does not care: it paints from the `--ada-*`
+// CSS variables, which the store writes to the document element, so the browser
+// applies a theme switch immediately. A plugin panel handed the token OBJECT has
+// no such luck — it keeps whatever values were current at its last render.
+//
+// The hosts subscribed to the viewer stores and to the plugin-visibility store,
+// and never to the theme. So switching theme repainted core and left every
+// plugin panel on the old palette until something unrelated re-rendered it.
+//
+// Asserted on the source rather than by mounting: the defect is "a subscription
+// is missing", which is a property of the source. A behavioural version would
+// need a DOM and a mounted host to restate what one read of the file settles.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const read = (rel: string) => readFileSync(resolve(root, rel), "utf8");
+
+test("both plugin slot hosts subscribe to the theme store", () => {
+  const src = read("src/plugins/PluginSlots.tsx");
+  assert.ok(
+    src.includes('import { usePluginTheme } from "@/state/themeStore";'),
+    "PluginSlots must import usePluginTheme",
+  );
+  assert.equal(
+    src.split("const theme = usePluginTheme();").length - 1,
+    2,
+    "both hosts must subscribe — the panel region and the top-bar buttons — " +
+      "or one of them repaints late",
+  );
+});
+
+test("every slot-host context carries the subscribed theme", () => {
+  const src = read("src/plugins/PluginSlots.tsx");
+  const calls = src.match(/makePluginContext\([^;]*?\)/g) ?? [];
+  assert.ok(calls.length >= 4, `expected several makePluginContext calls, saw ${calls.length}`);
+  for (const call of calls) {
+    assert.ok(
+      call.includes("theme"),
+      `${call} drops the subscribed theme, so that panel keeps a stale palette`,
+    );
+  }
+});
+
+test("makePluginContext still works without a theme, for callers outside React", () => {
+  const src = read("src/plugins/context.ts");
+  assert.ok(
+    src.includes("theme?: PluginTheme"),
+    "the theme argument must stay optional — the sidecar-loader run-point and " +
+      "url-param dispatch build contexts with no React tree to subscribe in",
+  );
+  assert.ok(
+    src.includes("theme ?? effectivePluginTheme(useThemeStore.getState())"),
+    "the snapshot must remain the fallback",
+  );
+});
+
+test("usePluginTheme subscribes to exactly the fields the theme derives from", () => {
+  const src = read("src/state/themeStore.ts");
+  const start = src.indexOf("export function usePluginTheme");
+  assert.ok(start >= 0, "usePluginTheme must exist");
+  const hook = src.slice(start, src.indexOf("}", start));
+  // Anything effectivePluginTheme reads must be subscribed, or a change to it
+  // silently does not repaint; anything else would re-render on unrelated writes.
+  for (const field of ["preset", "customBg", "customText", "bgOpacity"]) {
+    assert.ok(hook.includes(`s.${field}`), `usePluginTheme must subscribe to ${field}`);
+  }
+});

--- a/src/frontend/src/plugins/PluginSlots.tsx
+++ b/src/frontend/src/plugins/PluginSlots.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 import ErrorBoundary from "@/components/common/ErrorBoundary";
 import { useViewerStores } from "@/state/AdaViewerContext";
+import { usePluginTheme } from "@/state/themeStore";
 import { makePluginContext } from "./context";
 import { usePluginUiStore } from "./pluginUiStore";
 import {
@@ -40,8 +41,11 @@ export const PluginPanelRegion: React.FC<{ region: PluginRegion; excludeTabs?: b
   const stores = useViewerStores();
   // Subscribe to visibility so a top-bar toggle re-renders this region.
   const visible = usePluginUiStore((s) => s.visible);
+  // ...and to the theme, so a theme switch repaints plugin panels with core's
+  // own chrome rather than a render or two later.
+  const theme = usePluginTheme();
 
-  const baseCtx = makePluginContext("", stores);
+  const baseCtx = makePluginContext("", stores, theme);
   const panels = getPanelsForRegion(region, baseCtx).filter(
     ({ panel }) => !excludeTabs || !panel.asTab,
   );
@@ -52,7 +56,7 @@ export const PluginPanelRegion: React.FC<{ region: PluginRegion; excludeTabs?: b
       {panels
         .filter(({ panel }) => !panel.topBarButton || visible[panel.id])
         .map(({ pluginId, panel }) => {
-          const ctx = makePluginContext(pluginId, stores);
+          const ctx = makePluginContext(pluginId, stores, theme);
           return (
             <ErrorBoundary
               key={panel.id}
@@ -94,8 +98,9 @@ export const PluginTopBarButtons: React.FC<{ navBtnClass: (active: boolean) => s
   const stores = useViewerStores();
   const visible = usePluginUiStore((s) => s.visible);
   const toggle = usePluginUiStore((s) => s.toggle);
+  const theme = usePluginTheme();
 
-  const baseCtx = makePluginContext("", stores);
+  const baseCtx = makePluginContext("", stores, theme);
   const panels = getPanelsForRegion("top-panel", baseCtx).filter(
     ({ panel }) => panel.topBarButton,
   );
@@ -115,7 +120,7 @@ export const PluginTopBarButtons: React.FC<{ navBtnClass: (active: boolean) => s
               toggle(panel.id);
               if (btn.onClick) {
                 try {
-                  btn.onClick(makePluginContext(pluginId, stores));
+                  btn.onClick(makePluginContext(pluginId, stores, theme));
                 } catch (err) {
                   disablePlugin(pluginId, `top-bar onClick threw: ${String(err)}`);
                 }

--- a/src/frontend/src/plugins/context.ts
+++ b/src/frontend/src/plugins/context.ts
@@ -10,6 +10,7 @@ import { requestRender } from "@/state/perfStore";
 import { scopeUrlPart, useScopeStore } from "@/state/scopeStore";
 import { useColorStore } from "@/state/colorLegendStore";
 import { effectivePluginTheme, useThemeStore } from "@/state/themeStore";
+import type { PluginTheme } from "./registry";
 import {
   getActiveFeaMesh,
   getActiveFeaSelectedRangeIds,
@@ -122,7 +123,11 @@ function makeSceneHandle(): SceneHandle {
 /** Build a plugin context bound to a specific plugin id. Stores are the live
  * viewer singletons (via the provider's shape); scope + api are read lazily so
  * the context stays valid across scope switches without rebuilding. */
-export function makePluginContext(pluginId: string, stores: AdaViewerStores): AdaPluginContext {
+export function makePluginContext(
+  pluginId: string,
+  stores: AdaViewerStores,
+  theme?: PluginTheme,
+): AdaPluginContext {
   const log = (level: PluginLogLevel, msg: string, ...args: unknown[]) => {
     const line = `[plugin:${pluginId}] ${msg}`;
     if (level === "error") console.error(line, ...args);
@@ -136,11 +141,16 @@ export function makePluginContext(pluginId: string, stores: AdaViewerStores): Ad
     stores,
     scene: makeSceneHandle(),
     scope: () => scopeUrlPart(useScopeStore.getState().current),
-    // Snapshot the active theme tokens. makePluginContext is rebuilt on every
-    // slot-host render, so a theme switch (which re-renders subscribers) re-reads
-    // the current values; plugin panels that also want live updates can read the
-    // `--ada-*` CSS vars this mirrors.
-    theme: effectivePluginTheme(useThemeStore.getState()),
+    // A React caller passes the SUBSCRIBED theme (`usePluginTheme`), which is
+    // what makes a plugin panel repaint on a theme switch. The fallback is a
+    // snapshot, for the callers that have no React tree to subscribe in — the
+    // sidecar-loader run-point and url-param dispatch below.
+    //
+    // This used to be the snapshot unconditionally, justified by "the slot host
+    // re-renders on a theme switch". It does not: the hosts subscribed to the
+    // viewer stores and the plugin-visibility store, never to the theme, so a
+    // panel kept whatever tokens were current at its last unrelated render.
+    theme: theme ?? effectivePluginTheme(useThemeStore.getState()),
     log,
   };
 }

--- a/src/frontend/src/state/themeStore.ts
+++ b/src/frontend/src/state/themeStore.ts
@@ -113,6 +113,27 @@ export function effectivePluginTheme(
     return {...effectivePanelTheme(s), ...SEMANTIC_TOKENS};
 }
 
+/** The plugin theme, as a SUBSCRIPTION rather than a snapshot.
+ *
+ * `effectivePluginTheme(useThemeStore.getState())` reads the store without
+ * subscribing, so a component using it repaints only when something else
+ * happens to re-render it. Core's own chrome does not notice, because it paints
+ * from the `--ada-*` CSS variables, which the store writes to the document
+ * element and the browser applies immediately. A plugin panel handed the token
+ * OBJECT has no such luck: it keeps whatever values were current at its last
+ * render, so switching theme repaints core and leaves plugin panels behind.
+ *
+ * The four fields below are exactly the ones `effectivePluginTheme` derives
+ * from, and all four are primitives — so this subscribes precisely, with no
+ * equality function and no re-render on unrelated store writes. */
+export function usePluginTheme(): PluginTheme {
+    const preset = useThemeStore((s) => s.preset);
+    const customBg = useThemeStore((s) => s.customBg);
+    const customText = useThemeStore((s) => s.customText);
+    const bgOpacity = useThemeStore((s) => s.bgOpacity);
+    return effectivePluginTheme({preset, customBg, customText, bgOpacity});
+}
+
 function applyPanelThemeVars(theme: PanelTheme): void {
     const root = document.documentElement.style;
     root.setProperty("--ada-panel-bg", theme.bg);

--- a/src/frontend/src/viewer-core/app.ts
+++ b/src/frontend/src/viewer-core/app.ts
@@ -59,6 +59,10 @@ export {
   PANEL_CHROME,
   SEMANTIC_TOKENS,
   THEME_PRESETS,
+  // The subscribing counterpart of `effectivePluginTheme`. A shell or panel
+  // that paints from the token OBJECT needs this to repaint on a theme
+  // switch; one that paints from the `--ada-*` CSS variables does not.
+  usePluginTheme,
   useThemeStore,
 } from "@/state/themeStore";
 export type { PanelTheme, ThemePresetId } from "@/state/themeStore";


### PR DESCRIPTION
Switching theme repaints core instantly and leaves every plugin panel on the old palette until something unrelated re-renders it.

## Why core does not notice

Core paints from the `--ada-*` CSS variables, which the theme store writes onto the document element. The browser applies those the moment they change, with no React involved.

A plugin panel handed the token **object** through `ctx.theme` has no such luck — it keeps whatever values were current when it last rendered. And `makePluginContext` built that object with:

```ts
theme: effectivePluginTheme(useThemeStore.getState()),
```

`getState()` does not subscribe. The comment justified it by saying the slot host re-renders on a theme switch — which was not true. Both hosts subscribed to the viewer stores and to the plugin-visibility store, and neither ever subscribed to the theme.

## The fix

`usePluginTheme()` is the subscribing counterpart. It reads exactly the four fields `effectivePluginTheme` derives from — `preset`, `customBg`, `customText`, `bgOpacity` — all primitives, so it subscribes precisely: no equality function, and no re-render on unrelated store writes.

Both slot hosts call it and pass the result into `makePluginContext`. The argument is **optional** and still falls back to the snapshot, because two callers have no React tree to subscribe in: the sidecar-loader run-point and url-param dispatch.

It is exported on the `@/viewer-core` facade too, so a UI shell painting from the token object gets the same liveness. A panel painting from the CSS variables never needed either and is unaffected.

## Scope

This fixes the liveness half for **every** plugin at once. Two related things are deliberately untouched:

- adapy's own tree panel still carries hardcoded colour classes rather than using `PANEL_CHROME`. Separate change, no dependency either way.
- Plugins that already work around this by reading `var(--ada-…)` keep working unchanged — `registry.ts` blesses both shapes, and this does not alter which is preferred.

## Testing

4 new tests, all passing; 13 existing plugin tests still pass. They assert the **source**, because the defect is a missing subscription — a behavioural version would need a DOM and a mounted host to restate what one read of the file settles.

Two pre-existing failures on this branch are unrelated and reproduce identically with the change stashed: `load_fea_streaming.ts(1272,25)` under `tsc`, and `viewerCoreFacade.test.ts`, which compares path separators and so fails only on Windows.