### PR TITLE
chore(ci): gate the committed viewer bundle on where its strings came from

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -148,6 +148,59 @@ jobs:
         - name: Run streaming-path tests (ada-cpp backend)
           run: pixi run -e viewer-api-tests-adacpp test-rest-adacpp
 
+    # The committed viewer bundle (src/ada/visit/rendering/resources/index.zip) is a compiled
+    # binary shipped as package data inside every wheel, and it is the one file in the tree that a
+    # text diff cannot show you: a pull request that rebuilt it on a machine with out-of-tree plugin
+    # overlays enabled absorbed the compiled source of packages from other repositories, and the
+    # diff read `Bin 776265 -> 1002877 bytes`. Nobody reviews that.
+    #
+    # This asserts every UI string in the blob traces back to src/frontend. It needs node_modules
+    # for the corpus (vendored strings are legitimately in the bundle and absent from src/), which
+    # is why it installs first and why it is its own job rather than a step bolted onto a pixi one.
+    bundle-provenance:
+        name: Viewer bundle provenance
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v7
+          with:
+            ref: ${{ github.event.pull_request.head.sha || github.ref }}
+            # The scope check below diffs against the PR base, which needs real history.
+            fetch-depth: 0
+
+        # Only the bundle, the frontend sources it is checked against, or the checker itself can
+        # change the answer. Done inline rather than as an `on: pull_request: paths:` filter so the
+        # job always reports a status and can be a required check.
+        - name: Does this PR touch the bundle or its corpus?
+          id: scope
+          env:
+            BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          run: |
+            CHANGED="$(git diff --name-only "$BASE_SHA"...HEAD || true)"
+            if echo "$CHANGED" | grep -qE '^(src/frontend/|src/ada/visit/rendering/resources/index\.zip$|tools/(check_bundle_provenance\.py|bundle_provenance_baseline\.txt)$)'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "Neither the bundle nor src/frontend changed; nothing to re-verify."
+            fi
+
+        - uses: actions/setup-node@v7
+          if: steps.scope.outputs.run == 'true'
+          with:
+            node-version: '20'   # matches the frontend-build stage of deploy/Dockerfile.viewer
+            cache: npm
+            cache-dependency-path: src/frontend/package-lock.json
+
+        # --ignore-scripts because the corpus only needs the packages' source text on disk; no
+        # postinstall output is read, and skipping them keeps this the cheap job it should be.
+        - name: Install frontend dependencies
+          if: steps.scope.outputs.run == 'true'
+          working-directory: src/frontend
+          run: npm ci --no-audit --no-fund --ignore-scripts
+
+        - name: Check bundle provenance
+          if: steps.scope.outputs.run == 'true'
+          run: python3 tools/check_bundle_provenance.py -v
+
     # Build the viewer image and start the server inside it. Nothing else in this workflow can catch
     # a viewer that won't boot: lint and the test matrix run against the full src/ada tree, but the
     # viewer runtime ships a CURATED subset of it (see the COPY block in deploy/Dockerfile.viewer),

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,17 @@ src/frontend/public/wasm/
 adacpp-src/
 
 .claude/
+
+# Out-of-tree plugin overlays. A local build can drop extra plugin packages in
+# here and point ADA_PLUGINS_EXTRA at them (src/frontend/scripts/gen-plugin-registry.mjs);
+# those belong to their own repositories and must never be committed to this one.
+# The in-repo plugins are re-included by name, so adding a genuine one here is a
+# one-line change and an overlay is not something `git add -A` can sweep up.
+#
+# NOTE this is a different mitigation from tools/check_bundle_provenance.py, not
+# a substitute for it: in the incident that prompted both, no overlay directory
+# was ever committed — the tracked index.zip was rebuilt around one. This rule
+# would not have caught that.
+src/frontend/packages/plugins/*
+!src/frontend/packages/plugins/demo/
+!src/frontend/packages/plugins/ui-alt/

--- a/tools/bundle_provenance_baseline.txt
+++ b/tools/bundle_provenance_baseline.txt
@@ -1,0 +1,80 @@
+# Baselined orphans for tools/check_bundle_provenance.py.
+#
+# WHAT AN ENTRY HERE MEANS
+# ------------------------
+# The check asserts that every UI-looking string in the committed viewer bundle
+# also occurs somewhere in src/frontend. A few legitimately do not, because the
+# bundler ASSEMBLED them and no single place in the tree ever spells them out:
+#
+#   * prose or a class list that the source builds by concatenating fragments,
+#     or that JSX writes across several lines and the bundler joins;
+#   * text the source writes with an escape or an HTML entity, which the bundler
+#     emits decoded;
+#   * a run of minified code that the string regex mistakes for a literal.
+#
+# Every line below was traced to a real source location before it was added, and
+# the location is named in the comment above it. That is the bar.
+#
+# ADDING A LINE IS A DECISION, NOT A FORMALITY
+# --------------------------------------------
+# This file is the only thing standing between "the bundle contains a string
+# from another repository" and a green check. Do not add an entry to make CI
+# pass. Add one only after you have opened the file and line the string is
+# assembled from and can write that reference down here. If you cannot find the
+# source, the finding is real: the bundle was built somewhere it should not have
+# been, and the fix is to rebuild it, not to edit this file.
+#
+# Entries are compared whitespace-normalised, so trailing spaces in a class
+# fragment below are not load-bearing here (they are in the source).
+#
+# Regenerate the candidate list with:
+#     python tools/check_bundle_provenance.py -v --limit 500
+
+# --- JSX text nodes: written across lines, with `&amp;` for the ampersand.
+# The bundler joins the lines and decodes the entity, so the tree contains
+# "CAD &amp; FEA file conversion" split over two lines and never the result.
+# src/frontend/src/components/convert/ConvertPage.tsx:49
+CAD & FEA file conversion
+# src/frontend/src/components/convert/ConvertPage.tsx:79
+Uploads & conversions
+
+# --- Prose concatenated with `+` across two source lines.
+# src/frontend/src/components/admin/StorageTab.tsx:659-660
+Delete every cached derived product (GLB / FEA blob set) in this scope. Sources are preserved.
+
+# --- Vendored strings written with a backslash-escaped apostrophe.
+# node_modules holds `Draggable\'s` and `Couldn\'t`; the bundler re-quotes them
+# with double quotes and drops the backslash, so the emitted text differs from
+# every byte sequence on disk. Both are dependency internals, not our copy.
+# node_modules/react-draggable/build/cjs/DraggableCore.js:326
+Draggable's offsetParent must be a DOM Node.
+# node_modules/three/examples/jsm/loaders/GLTFLoader.js:3442
+THREE.GLTFLoader: Couldn't load texture
+
+# --- Tailwind class lists concatenated from `+`-joined fragments.
+# In each case the source spells out the pieces and the bundler folds the
+# constant fragments into one literal.
+# src/frontend/src/components/storage/StorageBrowser.tsx:1598-1599
+flex flex-col overflow-auto focus:outline-hidden focus-visible:ring-1 focus-visible:ring-blue-500/40 rounded-sm 
+# src/frontend/src/components/admin/FileTreeView.tsx:587-588
+flex items-center gap-1.5 px-2 py-1 rounded cursor-pointer select-none hover:bg-gray-800/80 
+# src/frontend/src/components/InViewerPanelHost.tsx:60-61
+flex items-center gap-2 bg-gray-800 text-gray-100 px-3 py-2 border-b border-gray-700 shrink-0
+# src/frontend/src/components/common/InlineNameInput.tsx:35-36
+flex-1 min-w-0 bg-gray-800 border border-blue-500 rounded-sm px-1 py-0.5 text-xs text-gray-100 focus:outline-hidden
+# src/frontend/src/components/admin/CorpusTab.tsx:1245-1246
+md:w-72 md:shrink-0 md:flex-none md:border-r md:border-b-0 flex-1 min-h-0 border-b border-gray-800 overflow-auto 
+# src/frontend/src/components/admin/AuditRunsTab.tsx:1266-1267
+md:w-80 md:shrink-0 md:flex-none md:border-r md:border-b-0 flex-1 min-h-0 border-b border-gray-800 overflow-auto 
+# src/frontend/src/components/info_box_scene/LoadedModelsSection.tsx:92-93
+shrink-0 px-1.5 py-0.5 rounded-sm cursor-pointer text-gray-400 hover:text-red-300 hover:bg-gray-700 disabled:opacity-50
+
+# --- Not string literals at all: minified code between two quoted keys.
+# The bundle contains the type guards
+#     ore=n=>"id"in n&&"position"in n&&!("source"in n)&&!("target"in n)
+# and STRING_RE matches the operators BETWEEN the closing quote of one key and
+# the opening quote of the next. Widening the regex to exclude these would cost
+# real coverage; naming them is cheaper and honest. Emitted by the minifier from
+# @xyflow/react's node/edge predicates.
+in n&&!(
+in n)&&!(

--- a/tools/check_bundle_provenance.py
+++ b/tools/check_bundle_provenance.py
@@ -1,0 +1,226 @@
+"""Assert the committed viewer bundle was built from this repository, and only this repository.
+
+``src/ada/visit/rendering/resources/index.zip`` is a compiled frontend bundle
+committed as a binary and shipped as package data, so it goes out inside every
+published wheel. It is also the one file in the tree that nobody reads in review.
+
+Those two facts met: a bundle rebuilt on a machine with plugin overlays enabled
+(``ADA_PLUGINS_EXTRA`` set, out-of-tree packages dropped into
+``src/frontend/packages/plugins/``) silently absorbed the compiled source of
+packages that live in other repositories — their ids, their design system, their
+user-visible strings — and a text diff of the pull request showed nothing but
+``Bin 776265 -> 1002877 bytes``.
+
+The check
+---------
+Extract the bundle, collect every UI-looking string literal in it, and assert
+each one occurs somewhere in this repository's frontend inputs. A string with no
+source here did not come from here.
+
+The corpus deliberately includes ``node_modules``: vendored strings from
+dependencies are legitimately in the bundle and absent from ``src``. Without it
+a clean bundle reports hundreds of false orphans, which is the difference
+between a check people trust and one they learn to skip. That is why this must
+run after ``npm ci``.
+
+Measured on the two real blobs — the committed bundle and the polluted one, with
+the same corpus (a full ``npm ci`` tree, 10,338 files):
+
+    committed  5,606 strings      0 orphans  (14 baselined, see below)
+    polluted   7,631 strings  1,694 orphans
+
+The threshold is zero new orphans, not a count. Fourteen strings in the clean
+bundle are ASSEMBLED by the bundler and so appear nowhere in the tree verbatim;
+they are pinned by exact text in ``tools/bundle_provenance_baseline.txt``, each
+with the source line it is assembled from. Pinning by text rather than by number
+keeps the gate at "nothing new" instead of letting it decay into a budget.
+
+The orphan list is the diagnostic: it names the panels, buttons and tooltips
+that came from outside, which is exactly what a reviewer needs in order to act.
+
+Rejected alternative, recorded so it is not re-proposed: gating on
+``window.FRONTEND_SHA`` ending in ``-dirty``. Both blobs are ``-dirty`` —
+unavoidably, since writing ``index.zip`` dirties the very tree the build is
+measuring — so that gate would fail every legitimate bundle.
+
+Note this is NOT what a ``.gitignore`` on the overlay directory would catch. In
+the real incident no overlay directory was ever committed; the tracked bundle
+was rebuilt around one. Ignoring the overlay is worth doing, but it addresses a
+different mistake.
+
+Usage:
+    python tools/check_bundle_provenance.py
+    python tools/check_bundle_provenance.py --bundle path/to/index.zip -v
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BUNDLE = ROOT / "src" / "ada" / "visit" / "rendering" / "resources" / "index.zip"
+BASELINE = Path(__file__).resolve().parent / "bundle_provenance_baseline.txt"
+FRONTEND = ROOT / "src" / "frontend"
+
+CORPUS_ROOTS = ("src", "packages", "index.html", "node_modules")
+CORPUS_SUFFIXES = {
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".css",
+    ".html",
+    ".json",
+    ".md",
+}
+
+# A UI-looking string: starts with a letter, made of characters a label, tooltip
+# or message would use. Narrow on purpose — minified identifiers, base64 and hex
+# would swamp the signal and every one of them would be a false orphan.
+STRING_RE = re.compile(r"""["'`]([A-Za-z][A-Za-z0-9 ._:/()\-+%#'&,?!]{3,119})["'`]""")
+HEXISH_RE = re.compile(r"^[0-9a-fA-F]+$")
+_WS_RE = re.compile(r"\s+")
+
+
+def _norm(s: str) -> str:
+    return _WS_RE.sub(" ", s).strip()
+
+
+def bundle_strings(bundle: Path) -> set[str]:
+    with zipfile.ZipFile(bundle) as z:
+        names = z.namelist()
+        if names != ["index.html"]:
+            raise SystemExit(
+                f"error: {bundle} should contain exactly one member named index.html, "
+                f"found {names}.\nA changed shape means the build changed; look before "
+                f"relaxing this."
+            )
+        text = z.read("index.html").decode("utf-8", "replace")
+    return {s for s in STRING_RE.findall(text) if not HEXISH_RE.match(s)}
+
+
+def corpus_files() -> list[Path]:
+    out: list[Path] = []
+    for rel in CORPUS_ROOTS:
+        p = FRONTEND / rel
+        if p.is_file():
+            out.append(p)
+        elif p.is_dir():
+            out += [f for f in p.rglob("*") if f.is_file() and f.suffix in CORPUS_SUFFIXES]
+    return out
+
+
+def find_orphans(wanted: set[str], files: list[Path]) -> set[str]:
+    """Strings with no occurrence anywhere in the corpus.
+
+    Streams the corpus and discards matches as they are found, rather than
+    concatenating it — node_modules is large, and the remaining set collapses
+    quickly, so this stays fast without holding the corpus in memory.
+    """
+    # Whitespace is normalised on both sides. The source wraps long class lists
+    # and long prose across several lines, so a verbatim comparison would report
+    # strings that ARE in the tree merely because the tree wrapped them
+    # differently.
+    remaining = {s: _norm(s) for s in wanted}
+    for f in files:
+        if not remaining:
+            break
+        try:
+            text = _norm(f.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        remaining = {s: n for s, n in remaining.items() if n not in text}
+    return set(remaining)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bundle", type=Path, default=BUNDLE)
+    ap.add_argument(
+        "--frontend", type=Path, default=None, help="src/frontend to use as the corpus (default: this checkout)"
+    )
+    ap.add_argument("-v", "--verbose", action="store_true")
+    ap.add_argument("--limit", type=int, default=40, help="how many orphans to print")
+    args = ap.parse_args()
+
+    global FRONTEND
+    if args.frontend:
+        FRONTEND = args.frontend.resolve()
+
+    if not args.bundle.is_file():
+        print(f"error: {args.bundle} not found", file=sys.stderr)
+        return 1
+    if not (FRONTEND / "node_modules").is_dir():
+        print(
+            "error: src/frontend/node_modules is missing. The corpus needs it, or every "
+            "vendored string reads as an orphan. Run `npm ci` in src/frontend first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    strings = bundle_strings(args.bundle)
+    files = corpus_files()
+    if args.verbose:
+        print(f"bundle strings: {len(strings)}   corpus files: {len(files)}")
+
+    orphans = find_orphans(strings, files)
+
+    # A handful of strings are ASSEMBLED by the bundler and so never appear
+    # verbatim in the tree: `+`-concatenated class lists and prose, JSX text
+    # nodes split over lines, HTML entities the bundler decodes. They are
+    # baselined by exact text rather than by count, so the gate stays "no NEW
+    # orphan" instead of degrading into a threshold nobody revisits. See the
+    # header of the baseline file for the bar an entry has to clear.
+    #
+    # Compared whitespace-normalised, like the corpus scan above: several of these
+    # entries end in a significant trailing space (a class fragment meant to be
+    # concatenated), and a text file whose meaning depends on invisible trailing
+    # whitespace is a file the next editor silently breaks.
+    baseline = set()
+    if BASELINE.is_file():
+        baseline = {
+            _norm(ln)
+            for ln in BASELINE.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.startswith("#")
+        }
+    matched = {_norm(s) for s in orphans} & baseline
+    stale = baseline - matched
+    orphans = {s for s in orphans if _norm(s) not in baseline}
+    if stale and args.verbose:
+        print(f"note: {len(stale)} baseline entries no longer orphaned; prune them")
+
+    if not orphans:
+        print(
+            f"OK: all {len(strings)} bundle strings trace to this repository "
+            f"({len(baseline)} baselined as bundler-assembled)."
+        )
+        return 0
+
+    shown = sorted(orphans)[: args.limit]
+    print(
+        f"\nFAIL: {len(orphans)} of {len(strings)} strings in {args.bundle.name} do not "
+        f"occur anywhere in src/frontend.\n",
+        file=sys.stderr,
+    )
+    for s in shown:
+        print(f"  {s!r}", file=sys.stderr)
+    if len(orphans) > len(shown):
+        print(f"  … and {len(orphans) - len(shown)} more", file=sys.stderr)
+    print(
+        "\nThe bundle was almost certainly rebuilt with out-of-tree plugins overlaid.\n"
+        "Rebuild it from a clean checkout with no plugin environment variables set,\n"
+        "or restore the committed blob:\n"
+        "    git checkout origin/main -- src/ada/visit/rendering/resources/index.zip",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`src/ada/visit/rendering/resources/index.zip` is a compiled frontend bundle committed as a binary and shipped as package data inside every wheel. It is consumed by exactly one code path — `RendererReact` in `src/ada/visit/rendering/renderer_react.py`, the offline single-file-HTML viewer — and it is the one file in the tree that a text diff cannot show you.

A pull request rebuilt that bundle on a machine with out-of-tree plugin overlays enabled. The blob absorbed the compiled source of packages belonging to other repositories: their ids, their design system, their user-visible strings. The diff read `Bin 776265 -> 1002877 bytes`. Nobody reviews a binary.

## The check

`tools/check_bundle_provenance.py` extracts the bundle, collects every UI-looking string literal in it, and asserts each one occurs somewhere in `src/frontend`. A string with no source here did not come from here.

The corpus deliberately includes `node_modules` — vendored strings are legitimately in the bundle and absent from `src/`, and without them a clean bundle reports hundreds of false orphans, which is the difference between a check people trust and one they learn to skip. That is why it runs after `npm ci`.

Measured on the two real blobs against the same corpus (10,338 files):

| bundle | strings | orphans |
| --- | ---: | ---: |
| committed (`main`) | 5,606 | **0** (14 baselined) |
| the polluted one | 7,631 | **1,694** |

The orphan list is the diagnostic, not just a verdict: it names the panels, buttons and tooltips that came from outside, which is what a reviewer needs in order to act.

## Why there is a baseline, and what it costs to add to it

Fourteen strings in the committed bundle are *assembled* by the bundler and so appear nowhere in the tree verbatim. Every one was traced to a real source line before it was added, and that line is written down next to it in `tools/bundle_provenance_baseline.txt`:

- **2** JSX text nodes split across lines with `&amp;`, which the bundler joins and decodes (`ConvertPage.tsx`).
- **9** class lists and one tooltip that the source builds by `+`-concatenating fragments (`StorageBrowser`, `FileTreeView`, `InViewerPanelHost`, `InlineNameInput`, `CorpusTab`, `AuditRunsTab`, `LoadedModelsSection`, `StorageTab`).
- **2** dependency messages written with a backslash-escaped apostrophe (`react-draggable`, `three`'s `GLTFLoader`), which the bundler re-quotes without the backslash.
- **2** runs of minified code — `in n&&!(` and `in n)&&!(` — that the string regex matches *between* two quoted object keys in a type guard. Widening the regex to exclude these would cost real coverage; naming them is cheaper and honest.

Entries are pinned by exact text rather than by count, so the gate stays "no **new** orphan" instead of degrading into a budget. The baseline header states the bar plainly: adding a line is a decision, not a formality, and if you cannot find the source of a string, the finding is real.

## CI

New `bundle-provenance` job in `pr-tests.yml`. It is scoped to PRs that touch the bundle, its corpus, or the checker itself, and the scope test is inline rather than an `on: pull_request: paths:` filter so the job always reports a status and can be made a required check. `npm ci --ignore-scripts` with the npm cache keeps it cheap.

## Two things deliberately *not* done

- **Gating on `window.FRONTEND_SHA` ending in `-dirty`.** Both blobs are `-dirty` — unavoidably, since writing `index.zip` dirties the very tree the build is measuring — so that gate would fail every legitimate bundle. Recorded in the module docstring so it is not re-proposed.
- **Treating the `.gitignore` rule as the fix.** It is here because it is cheap, but it is a *different* mitigation: in this incident no overlay directory was ever committed — the tracked bundle was rebuilt around one. Ignoring the overlay would not have caught this. The in-repo plugins are re-included by name so adding a genuine one stays a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mdyz12Wh4LQgzdAN1DYneo
