### PR TITLE
fix: SIN pointer-table truncation, .SIN deep links, and an additive plugin API (1.1.0)

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -177,21 +177,34 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         # Plugin backends, the same two ways the worker finds them:
-        # ADA_WORKER_PRELOAD (explicit, fatal on failure — a process that exists
-        # BECAUSE of those imports should not start half-configured) and the
-        # ``ada.plugins`` entry-point group (per-plugin isolated).
+        # ADA_WORKER_PRELOAD (explicit) and the ``ada.plugins`` entry-point group.
         #
         # The API never needed this while every plugin job went to a worker: it
         # only had to ROUTE by capability, which it reads off worker heartbeats.
         # It needs it now because a viewer with no queue runs those jobs itself
         # (see `local_jobs`), and it can only run a plugin it has imported.
+        #
+        # Both are per-module isolated HERE, which is the opposite of the worker,
+        # and deliberately so. A worker exists BECAUSE of its preload, so a failed
+        # import there means the pool would sit on the queue answering nothing —
+        # better to die loudly. The API exists to serve the viewer; plugin jobs are
+        # one endpoint out of dozens. Letting an ImportError out of the lifespan
+        # would take the whole viewer down — a crashloop, no storage browser, no
+        # scene, no way to even see the error — because one optional plugin backend
+        # could not find one of its dependencies. So: log it with the module name
+        # and carry on. The failure then degrades to what it actually is, "that
+        # capability is missing", and shows up as a 501 from the plugin-job
+        # endpoint rather than as an API that will not start.
         preload = os.environ.get("ADA_WORKER_PRELOAD", "").strip()
         if preload:
             import importlib as _importlib
 
             for mod_name in (m.strip() for m in preload.split(",") if m.strip()):
                 logger.info("api: preloading %s", mod_name)
-                _importlib.import_module(mod_name)
+                try:
+                    _importlib.import_module(mod_name)
+                except Exception:
+                    logger.exception("api: preloading %s failed (non-fatal); its plugin jobs will 501", mod_name)
         try:
             from ada.plugins import discover_plugins
 

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -31,6 +31,7 @@ from ada.core.file_system import new_temp_path
 
 from . import auth as auth_module
 from . import db as db_module
+from . import local_jobs
 from .auth import User
 from .config import Settings, load_settings
 from .converter import (
@@ -48,7 +49,6 @@ from .converter import (
     merge_option_into,
     supported_targets_for,
 )
-from . import local_jobs
 from .handlers import dispatch
 from .queue import JobQueue
 from .scope import Scope

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -48,6 +48,7 @@ from .converter import (
     merge_option_into,
     supported_targets_for,
 )
+from . import local_jobs
 from .handlers import dispatch
 from .queue import JobQueue
 from .scope import Scope
@@ -175,6 +176,29 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        # Plugin backends, the same two ways the worker finds them:
+        # ADA_WORKER_PRELOAD (explicit, fatal on failure — a process that exists
+        # BECAUSE of those imports should not start half-configured) and the
+        # ``ada.plugins`` entry-point group (per-plugin isolated).
+        #
+        # The API never needed this while every plugin job went to a worker: it
+        # only had to ROUTE by capability, which it reads off worker heartbeats.
+        # It needs it now because a viewer with no queue runs those jobs itself
+        # (see `local_jobs`), and it can only run a plugin it has imported.
+        preload = os.environ.get("ADA_WORKER_PRELOAD", "").strip()
+        if preload:
+            import importlib as _importlib
+
+            for mod_name in (m.strip() for m in preload.split(",") if m.strip()):
+                logger.info("api: preloading %s", mod_name)
+                _importlib.import_module(mod_name)
+        try:
+            from ada.plugins import discover_plugins
+
+            discover_plugins()
+        except Exception:
+            logger.exception("api: ada.plugins discovery failed (non-fatal)")
+
         # Connect to NATS lazily; a missing URL just disables the queue.
         if queue.enabled:
             try:
@@ -2423,6 +2447,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # Job status is identified by a globally unique job_id, so the
         # URL doesn't carry a scope. We still enforce that the caller
         # could access the job's recorded scope before returning it.
+        #
+        # In-process plugin jobs first: they exist whether or not a queue does,
+        # and their ids are namespaced so they can never collide with a queued
+        # job's. Checking them before the `queue.enabled` gate is what lets one
+        # polling loop in the frontend serve both paths.
+        local = local_jobs.registry.get(job_id)
+        if local is not None:
+            local_scope = Scope(kind=local.scope_kind, id=local.scope_id)
+            if not await scope_can_access(user, local_scope, getattr(request.app.state, "db_pool", None)):
+                raise HTTPException(status_code=403, detail="forbidden")
+            return JSONResponse(local.as_json())
         if not queue.enabled:
             raise HTTPException(status_code=503, detail="conversion disabled (no NATS configured)")
         job = await queue.get(job_id)
@@ -2781,8 +2816,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         ``derived_key`` and the plugin writes its sidecar bundle under its reserved
         prefix (``derived_prefix``). Poll via ``GET /api/convert/{job_id}``.
         """
-        if not queue.enabled:
-            raise HTTPException(status_code=503, detail="plugin jobs disabled (no NATS configured)")
         body = await request.json()
         options = body.get("options") or {}
         if not isinstance(options, dict):
@@ -2818,6 +2851,27 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     if isinstance(cap, str) and cap.strip():
                         target_capability = cap.strip().lower()
                     break
+
+        # No queue: run it here, in a thread, and hand back a job id the status
+        # endpoint below can serve. A single-node viewer (the examples, a laptop)
+        # otherwise has no way to run a plugin job at all — the button was dead in
+        # exactly the setup that puts the model in front of you. The plugin sees an
+        # identical contract either way, so nothing about it knows which path ran.
+        if not queue.enabled:
+            try:
+                local = local_jobs.start_plugin_job(
+                    plugin_id=plugin_id,
+                    options=options,
+                    derived_prefix=body.get("derived_prefix"),
+                    derived_key=derived_key,
+                    storage=storage,
+                    scope=scope_obj,
+                )
+            except LookupError as exc:
+                # The plugin's backend is not importable in THIS process. With a
+                # worker that is the pool's problem; here it is the answer.
+                raise HTTPException(status_code=501, detail=str(exc)) from exc
+            return JSONResponse({"job_id": local.job_id, "derived_key": derived_key})
 
         job = await queue.enqueue(
             source_key,

--- a/src/ada/comms/rest/handlers.py
+++ b/src/ada/comms/rest/handlers.py
@@ -62,7 +62,7 @@ _EXT_TO_TYPE: dict[str, FileTypeDC] = {
 # conversion" branch fires; the actual format is recoverable from the
 # filename extension if needed.
 #
-# .sif and .rmed land here so the FEA picker buttons in the storage
+# .sif, .sin and .rmed land here so the FEA picker buttons in the storage
 # browser are reachable. FileTypeDC has no FEA-specific value, so
 # they ride on IFC like the other convertable sources; the frontend
 # discriminates off the extension (isFEAResult / isStreamingFEAResult)
@@ -82,6 +82,7 @@ _CONVERTABLE_AS_IFC: frozenset[str] = frozenset(
         ".dae",
         ".off",
         ".sif",
+        ".sin",
         ".rmed",
     }
 )

--- a/src/ada/comms/rest/local_jobs.py
+++ b/src/ada/comms/rest/local_jobs.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+import json
 import logging
 import threading
 import time
@@ -83,12 +84,49 @@ class LocalJobRegistry:
     #: finished jobs — a running job is never evicted out from under its poller.
     MAX_JOBS = 200
 
+    #: ...which is why MAX_JOBS alone does not bound anything: a job that never
+    #: reaches a terminal state is never evictable, so N stuck jobs hold N entries
+    #: (and N daemon threads) forever and the cap silently stops applying. A
+    #: plugin that deadlocks on a lock, blocks on a socket with no timeout, or
+    #: loops on bad input does exactly that, and nothing else in this module can
+    #: notice: the thread cannot be killed and the job has no deadline.
+    #:
+    #: Past this age a job is declared stuck. Its cancel_event is set — a plugin
+    #: that observes it between units of work stops burning CPU, the same
+    #: cooperative contract the worker's cancel poller uses — and it goes terminal,
+    #: so its poller gets an answer instead of "running" until the process dies,
+    #: and the cap can reclaim it. Well above the minutes-to-an-hour a real check
+    #: takes, because the cost of being wrong here is abandoning a legitimate run.
+    MAX_RUNTIME_S = 6 * 60 * 60
+
     def __init__(self) -> None:
         self._jobs: dict[str, LocalJob] = {}
         self._lock = threading.Lock()
 
+    def _sweep_locked(self) -> None:
+        """Declare over-age running jobs stuck. Caller holds ``_lock``."""
+        now = time.time()
+        for job in self._jobs.values():
+            if job.status != STATUS_RUNNING or (now - job.started_at) <= self.MAX_RUNTIME_S:
+                continue
+            logger.warning(
+                "local plugin job %s (%s) has run for %.0fs (limit %ds) — abandoning it",
+                job.job_id,
+                job.plugin_id,
+                now - job.started_at,
+                self.MAX_RUNTIME_S,
+            )
+            job.cancel_event.set()
+            # STATUS_ERROR, not a status of its own: the frontend polls one loop
+            # for both paths and only knows what the queue spells. The nuance
+            # goes in `stage`, which is free text either way.
+            job.status = STATUS_ERROR
+            job.stage = "timeout"
+            job.error = f"job exceeded the {self.MAX_RUNTIME_S}s in-process limit and was abandoned"
+
     def add(self, job: LocalJob) -> None:
         with self._lock:
+            self._sweep_locked()
             self._jobs[job.job_id] = job
             if len(self._jobs) > self.MAX_JOBS:
                 for jid, j in list(self._jobs.items()):
@@ -99,6 +137,11 @@ class LocalJobRegistry:
 
     def get(self, job_id: str) -> LocalJob | None:
         with self._lock:
+            # Sweeping on read, not only on write, is what makes the deadline
+            # reachable at all: a server that runs one job and never another gets
+            # no `add` to sweep from, and polling is the one thing that is
+            # guaranteed to happen while someone is waiting on the answer.
+            self._sweep_locked()
             return self._jobs.get(job_id)
 
     def cancel(self, job_id: str) -> bool:
@@ -128,7 +171,29 @@ def _resolve_entrypoint(plugin_id: str) -> Any:
             f"not in a worker."
         )
     mod_name, _, attr = str(entry).partition(":")
-    return getattr(importlib.import_module(mod_name), attr)
+    try:
+        if not attr:
+            raise ValueError(f"{entry!r} is not in 'module:callable' form")
+        return getattr(importlib.import_module(mod_name), attr)
+    except Exception as exc:
+        # A registered plugin whose entrypoint does not import is a different
+        # failure from an unregistered one, but it has the same answer here, so it
+        # gets the same exception type. The worker turns this into a job error and
+        # keeps serving; in-process there is no job yet, so it has to become the
+        # response — and if it escapes as the raw ImportError/AttributeError it
+        # becomes a bare 500 that names neither the plugin nor the entrypoint.
+        #
+        # The message carries the entrypoint string (already public: it rides in
+        # the spec `GET /api/plugins` returns) and the exception TYPE, but not the
+        # exception text — that is the one part that can quote a private module
+        # path or a filesystem layout back to whoever called the endpoint. The
+        # traceback goes to the log, where the person who can act on it is.
+        logger.exception("local plugin job: entrypoint %r for plugin %r failed to resolve", entry, plugin_id)
+        raise LookupError(
+            f"plugin {plugin_id!r} advertises job_entrypoint {entry!r}, which this process could not "
+            f"import ({type(exc).__name__}) — see the server log for the traceback. Running jobs "
+            f"in-process needs the plugin importable HERE, not in a worker."
+        ) from exc
 
 
 def start_plugin_job(
@@ -142,7 +207,8 @@ def start_plugin_job(
 ) -> LocalJob:
     """Run a plugin job in a thread and return its handle immediately.
 
-    Raises before returning if the plugin is not importable here — a 500 the
+    Raises ``LookupError`` before returning if the plugin is not resolvable here
+    (unregistered, or registered but its entrypoint will not import) — a 501 the
     caller can read beats a job id that reports an error two polls later.
     """
     fn = _resolve_entrypoint(plugin_id)
@@ -194,15 +260,33 @@ def start_plugin_job(
             if accepts_cancel:
                 kwargs["cancel_event"] = job.cancel_event
             result = fn(options, **kwargs)
+            if job.status != STATUS_RUNNING:
+                # The registry already ruled on this job (age sweep) and a poller
+                # may have read that verdict. Whatever the call finally returned,
+                # the job is over — do not walk a terminal state back to `done`.
+                return
             if job.cancel_event.is_set():
                 job.status = STATUS_CANCELLED
                 job.stage = "cancelled"
                 return
-            job.result = result if isinstance(result, dict) else {"result": result}
+            # Store the summary at `derived_key`, which is what the worker does
+            # with the same return value. The caller was handed that key in the
+            # POST response and fetches the JSON from it once the job reports
+            # done, so without this write the two paths are identical right up to
+            # the part where one of them produces an answer: the plugin runs, and
+            # its result sits in a dict nothing can read (`as_json` does not
+            # return it, by design — it is a blob, not a status field).
+            payload = result if isinstance(result, dict) else {"result": result}
+            job.stage = "upload"
+            job.progress = 0.95
+            sync_storage.put_bytes(derived_key, json.dumps(payload).encode("utf-8"), content_encoding="gzip")
+            job.result = payload
             job.status = STATUS_DONE
             job.stage = "done"
             job.progress = 1.0
         except Exception as exc:  # noqa: BLE001 — the job's failure is data, not ours
+            if job.status != STATUS_RUNNING:
+                return
             if job.cancel_event.is_set():
                 job.status = STATUS_CANCELLED
                 job.stage = "cancelled"

--- a/src/ada/comms/rest/local_jobs.py
+++ b/src/ada/comms/rest/local_jobs.py
@@ -1,0 +1,220 @@
+"""In-process plugin jobs, for a viewer running without a worker pool.
+
+A plugin's on-demand backend job normally goes onto NATS and is picked up by a
+capability worker. That is the right shape for a deployment: the checks are long,
+CPU-heavy and want their own pods.
+
+It is the wrong shape for one person running the viewer on their laptop. There is
+no NATS, so ``/api/plugins/{id}/jobs`` answered 503 and the plugin's "run" button
+was dead — in the exact setup the examples put you in, where you have the SIN
+open, the plugin installed, and nothing between you and the answer but a message
+saying the queue is disabled.
+
+So: when no queue is configured, run the job HERE, in a thread, and report it
+through a job id the existing ``GET /api/convert/{job_id}`` endpoint can serve.
+The plugin sees the same contract either way — the same ``job_entrypoint``, the
+same sync storage facade, the same ``on_progress`` and ``cancel_event`` — so
+nothing about a plugin has to know which mode it is in.
+
+Deliberately NOT a queue. One dict, one executor, no persistence, no retries, no
+cross-process anything. A single-node convenience with the failure modes of one:
+jobs die with the process, and a second job runs concurrently with the first
+rather than queueing behind it. Anything that wants more than that wants NATS,
+which is the thing this stands in for rather than replaces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import logging
+import threading
+import time
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Terminal + running states, spelled the way the queue spells them so the
+#: frontend polling loop cannot tell the two paths apart.
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_ERROR = "error"
+STATUS_CANCELLED = "cancelled"
+
+
+@dataclass
+class LocalJob:
+    job_id: str
+    plugin_id: str
+    scope_kind: str
+    scope_id: str | None
+    derived_key: str
+    status: str = STATUS_RUNNING
+    stage: str = "queued"
+    progress: float = 0.0
+    error: str | None = None
+    result: dict[str, Any] | None = None
+    started_at: float = field(default_factory=time.time)
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+
+    def as_json(self) -> dict[str, Any]:
+        """The shape ``GET /api/convert/{job_id}`` returns for a queued job."""
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "stage": self.stage,
+            "progress": self.progress,
+            "error": self.error,
+            "derived_key": self.derived_key,
+            "scope_kind": self.scope_kind,
+            "scope_id": self.scope_id,
+        }
+
+
+class LocalJobRegistry:
+    """Every in-process job this server has run. Bounded, and never persisted."""
+
+    #: Jobs are tiny (a dict and a status string) but unbounded growth in a
+    #: long-lived dev server is still a leak. Oldest-first eviction, and only of
+    #: finished jobs — a running job is never evicted out from under its poller.
+    MAX_JOBS = 200
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, LocalJob] = {}
+        self._lock = threading.Lock()
+
+    def add(self, job: LocalJob) -> None:
+        with self._lock:
+            self._jobs[job.job_id] = job
+            if len(self._jobs) > self.MAX_JOBS:
+                for jid, j in list(self._jobs.items()):
+                    if j.status != STATUS_RUNNING:
+                        del self._jobs[jid]
+                    if len(self._jobs) <= self.MAX_JOBS:
+                        break
+
+    def get(self, job_id: str) -> LocalJob | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def cancel(self, job_id: str) -> bool:
+        job = self.get(job_id)
+        if job is None or job.status != STATUS_RUNNING:
+            return False
+        job.cancel_event.set()
+        return True
+
+
+#: Module-level so the two endpoints (`POST .../jobs`, `GET /convert/{id}`) share
+#: one registry without threading it through app state.
+registry = LocalJobRegistry()
+
+
+def _resolve_entrypoint(plugin_id: str) -> Any:
+    """Import the callable a plugin advertises as its ``job_entrypoint``."""
+    from ada.plugins import plugin_backend_spec
+
+    spec = plugin_backend_spec(plugin_id)
+    entry = (spec or {}).get("job_entrypoint")
+    if not spec or not entry:
+        raise LookupError(
+            f"plugin {plugin_id!r} is not registered in this process or advertises no "
+            f"job_entrypoint — is its backend on ADA_WORKER_PRELOAD / an ada.plugins "
+            f"entry point? Running jobs in-process needs the plugin importable HERE, "
+            f"not in a worker."
+        )
+    mod_name, _, attr = str(entry).partition(":")
+    return getattr(importlib.import_module(mod_name), attr)
+
+
+def start_plugin_job(
+    *,
+    plugin_id: str,
+    options: dict[str, Any],
+    derived_prefix: str | None,
+    derived_key: str,
+    storage: Any,
+    scope: Any,
+) -> LocalJob:
+    """Run a plugin job in a thread and return its handle immediately.
+
+    Raises before returning if the plugin is not importable here — a 500 the
+    caller can read beats a job id that reports an error two polls later.
+    """
+    fn = _resolve_entrypoint(plugin_id)
+    loop = asyncio.get_running_loop()
+
+    # The same synchronous storage view the worker hands a plugin, so the
+    # entrypoint's `storage.get_bytes(...)` / `put_bytes(...)` work unchanged.
+    from ada.comms.rest.worker import _SyncStorageFacade
+
+    sync_storage = _SyncStorageFacade(storage, scope, loop)
+
+    job = LocalJob(
+        job_id=f"local-{uuid.uuid4().hex[:16]}",
+        plugin_id=plugin_id,
+        scope_kind=getattr(scope, "kind", "shared"),
+        scope_id=getattr(scope, "id", None),
+        derived_key=derived_key,
+    )
+    registry.add(job)
+
+    def _on_progress(stage: str, frac: float) -> None:
+        # Called from the job thread. Plain assignment: these are only ever read
+        # by the polling endpoint, and a torn read of a float progress bar is not
+        # a correctness problem worth a lock on every tick.
+        job.stage = str(stage)
+        try:
+            job.progress = max(0.0, min(1.0, float(frac)))
+        except (TypeError, ValueError):
+            pass
+
+    # Only pass cancel_event to an entrypoint that accepts it, so a plugin whose
+    # signature predates the kwarg keeps working.
+    try:
+        sig = inspect.signature(fn)
+        accepts_cancel = "cancel_event" in sig.parameters or any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+    except (TypeError, ValueError):
+        accepts_cancel = False
+
+    def _run() -> None:
+        try:
+            kwargs: dict[str, Any] = {
+                "storage": sync_storage,
+                "scope": scope,
+                "on_progress": _on_progress,
+                "derived_prefix": derived_prefix,
+            }
+            if accepts_cancel:
+                kwargs["cancel_event"] = job.cancel_event
+            result = fn(options, **kwargs)
+            if job.cancel_event.is_set():
+                job.status = STATUS_CANCELLED
+                job.stage = "cancelled"
+                return
+            job.result = result if isinstance(result, dict) else {"result": result}
+            job.status = STATUS_DONE
+            job.stage = "done"
+            job.progress = 1.0
+        except Exception as exc:  # noqa: BLE001 — the job's failure is data, not ours
+            if job.cancel_event.is_set():
+                job.status = STATUS_CANCELLED
+                job.stage = "cancelled"
+                return
+            logger.exception("local plugin job %s (%s) failed", job.job_id, plugin_id)
+            job.status = STATUS_ERROR
+            job.error = f"{type(exc).__name__}: {exc}"
+            job.stage = "error"
+            logger.debug("local plugin job traceback:\n%s", traceback.format_exc())
+
+    # A plain daemon thread rather than the default executor: a capacity check
+    # runs for minutes to an hour, and parking that on the loop's shared pool
+    # would starve every other threadpool user for the duration.
+    threading.Thread(target=_run, name=f"local-plugin-job-{plugin_id}", daemon=True).start()
+    return job

--- a/src/ada/fem/formats/sesam/results/case_names.py
+++ b/src/ada/fem/formats/sesam/results/case_names.py
@@ -53,9 +53,7 @@ def combination_label(components: dict[int, float], names: dict[int, str]) -> st
     """
     if not components:
         return ""
-    return " + ".join(
-        f"{_factor(f)}\u00b7{names.get(n) or f'case {n}'}" for n, f in sorted(components.items())
-    )
+    return " + ".join(f"{_factor(f)}\u00b7{names.get(n) or f'case {n}'}" for n, f in sorted(components.items()))
 
 
 def _text_records(sin_file: Any, card: str) -> dict[int, str]:

--- a/src/ada/fem/formats/sesam/results/case_names.py
+++ b/src/ada/fem/formats/sesam/results/case_names.py
@@ -1,0 +1,58 @@
+"""What a Sesam deck calls its result cases.
+
+A step in the viewer is labelled with its VALUE — "1", "2", "3" — because that is
+all the artefact pipeline knows about it. The deck knows more: it names its load
+cases (`girder_local`, `unit_acc_x`, `deck`), and those names are how an engineer
+recognises which case they are looking at. "Case 3" is an index; "Case 3
+(unit_acc_x)" is a load case.
+
+The names were already reachable — codecheck's viewer export reads exactly these
+records when it writes its own case labels — but only after a code check had run.
+Anything that wanted them BEFORE one (a picker for choosing which cases to check)
+had nothing but the numbers.
+
+Two records, in the precedence codecheck established:
+
+* ``TDRESREF`` names a RESULT case, and wins where present.
+* ``TDLOAD`` names a LOAD case, and fills in where the deck named no result case
+  — which is the common shape for a static deck, where the two coincide.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["result_case_names"]
+
+
+def _load_case_names(sin_file: Any) -> dict[int, str]:
+    """Map load case number → name from ``TDLOAD``."""
+    if "TDLOAD" not in sin_file.type_blocks:
+        return {}
+    out: dict[int, str] = {}
+    for prefix, text in sin_file.iter_text_records("TDLOAD"):
+        if not prefix or not text:
+            continue
+        out[int(round(prefix[0]))] = str(text).strip()
+    return out
+
+
+def result_case_names(sin_file: Any) -> dict[int, str] | None:
+    """``{case number: name}`` for a Sesam deck, or ``None`` when it names none.
+
+    Takes the open file rather than a reader: these are text records, and the
+    file iterates them directly without the reader's numeric-record machinery.
+    """
+    from ada.fem.formats.sesam.results.read_sin import read_result_names
+
+    if sin_file is None or not getattr(sin_file, "type_blocks", None):
+        return None
+
+    try:
+        # Load cases first, so the result-case pass overwrites them rather than
+        # the other way round.
+        names = _load_case_names(sin_file)
+        names.update({k: str(v).strip() for k, v in read_result_names(sin_file).items() if v})
+    except Exception:  # a deck we cannot read here is a deck with no names
+        return None
+    return {k: v for k, v in names.items() if v} or None

--- a/src/ada/fem/formats/sesam/results/case_names.py
+++ b/src/ada/fem/formats/sesam/results/case_names.py
@@ -6,12 +6,12 @@ cases (`girder_local`, `unit_acc_x`, `lcc1`), and those names are how an enginee
 recognises which case they are looking at. "Case 3" is an index; "Case 3
 (unit_acc_x)" is a load case.
 
-The names were already reachable — codecheck's viewer export reads exactly these
-records when it writes its own case labels — but only after a code check had run.
+The names were already reachable — a downstream code-check tool reads exactly
+these records when it writes its own case labels — but only after a check had run.
 Anything that wanted them BEFORE one (a picker for choosing which cases to check)
 had nothing but the numbers.
 
-Two records, in the precedence codecheck established:
+Two records, in the precedence those consumers established:
 
 * ``TDRESREF`` names a RESULT case, and wins where present.
 * ``TDLOAD`` names a LOAD case, and fills in where the deck named no result case

--- a/src/ada/fem/formats/sesam/results/case_names.py
+++ b/src/ada/fem/formats/sesam/results/case_names.py
@@ -2,7 +2,7 @@
 
 A step in the viewer is labelled with its VALUE — "1", "2", "3" — because that is
 all the artefact pipeline knows about it. The deck knows more: it names its load
-cases (`girder_local`, `unit_acc_x`, `deck`), and those names are how an engineer
+cases (`girder_local`, `unit_acc_x`, `lcc1`), and those names are how an engineer
 recognises which case they are looking at. "Case 3" is an index; "Case 3
 (unit_acc_x)" is a load case.
 
@@ -16,24 +16,59 @@ Two records, in the precedence codecheck established:
 * ``TDRESREF`` names a RESULT case, and wins where present.
 * ``TDLOAD`` names a LOAD case, and fills in where the deck named no result case
   — which is the common shape for a static deck, where the two coincide.
+
+``RDRESCMB`` defines the COMBINATIONS on top of those, and names nothing: a
+combination's name, when it has one, is in ``TDRESREF`` like any other result
+case. What ``RDRESCMB`` adds is the recipe — which basic cases at which factors —
+and :func:`combination_label` renders it for a caller that wants to show how a
+case is built up. That is supporting detail, not the case's name.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["result_case_names"]
+__all__ = ["combination_label", "result_case_names", "selectable_result_cases"]
 
 
-def _load_case_names(sin_file: Any) -> dict[int, str]:
-    """Map load case number → name from ``TDLOAD``."""
-    if "TDLOAD" not in sin_file.type_blocks:
+def _factor(value: float) -> str:
+    """A load factor as an engineer writes it: ``1.2``, not ``1.2000000476``."""
+    # The SIN stores factors as float32, so the double they widen to is never
+    # exactly the decimal that was typed. Round before formatting or every
+    # factor carries eight digits of float noise.
+    return f"{round(float(value), 4):g}"
+
+
+def combination_label(components: dict[int, float], names: dict[int, str]) -> str:
+    """Describe a combination by its recipe: ``1.2·girder_local + 1.1·deck``.
+
+    ``components`` is ``{basic case: factor}`` as ``read_result_combinations``
+    returns it; ``names`` is what the basic cases are called. A basic case with
+    no name of its own appears as ``case 5`` — better than dropping the term,
+    which would silently misdescribe the combination.
+
+    Ordered by case number rather than by factor, so the same basics always read
+    in the same order across combinations and two of them can be compared by eye.
+    Never truncated: this is the detail view of a case, not its label.
+    """
+    if not components:
+        return ""
+    return " + ".join(
+        f"{_factor(f)}\u00b7{names.get(n) or f'case {n}'}" for n, f in sorted(components.items())
+    )
+
+
+def _text_records(sin_file: Any, card: str) -> dict[int, str]:
+    """``{case number: text}`` from one TD* card, or empty when it has none."""
+    if card not in sin_file.type_blocks:
         return {}
     out: dict[int, str] = {}
-    for prefix, text in sin_file.iter_text_records("TDLOAD"):
+    for prefix, text in sin_file.iter_text_records(card):
         if not prefix or not text:
             continue
-        out[int(round(prefix[0]))] = str(text).strip()
+        name = str(text).strip()
+        if name:
+            out[int(round(prefix[0]))] = name
     return out
 
 
@@ -43,16 +78,53 @@ def result_case_names(sin_file: Any) -> dict[int, str] | None:
     Takes the open file rather than a reader: these are text records, and the
     file iterates them directly without the reader's numeric-record machinery.
     """
-    from ada.fem.formats.sesam.results.read_sin import read_result_names
-
     if sin_file is None or not getattr(sin_file, "type_blocks", None):
         return None
-
     try:
         # Load cases first, so the result-case pass overwrites them rather than
         # the other way round.
-        names = _load_case_names(sin_file)
-        names.update({k: str(v).strip() for k, v in read_result_names(sin_file).items() if v})
+        names = _text_records(sin_file, "TDLOAD")
+        names.update(_text_records(sin_file, "TDRESREF"))
     except Exception:  # a deck we cannot read here is a deck with no names
         return None
-    return {k: v for k, v in names.items() if v} or None
+    return names or None
+
+
+def selectable_result_cases(sin_file: Any) -> list[dict] | None:
+    """Every result case the deck offers, named, or ``None`` when it offers none.
+
+    Distinct from the manifest's field STEPS, which are the cases actually stored
+    as RV* records. On a "smart load combination" deck those are only the basic
+    cases: the design cases — the ones anyone runs a check for — are defined by
+    ``RDRESCMB`` and stored nowhere, so a picker built from steps offers exactly
+    the cases the engineer does not want and omits the two they do.
+
+    A combination carries ``makeup``, its recipe over the basic cases. It is
+    supporting detail for a UI to show on demand, deliberately kept out of
+    ``name``: the case is called ``lcc1``, and a label that spelled out five
+    weighted terms instead would be unreadable everywhere a case is listed.
+    """
+    from ada.fem.formats.sesam.results.read_sin import read_result_combinations
+
+    if sin_file is None or not getattr(sin_file, "type_blocks", None):
+        return None
+    names = result_case_names(sin_file) or {}
+    try:
+        combinations = read_result_combinations(sin_file)
+    except Exception:
+        combinations = {}
+    numbers = sorted(set(names) | set(combinations))
+    if not numbers:
+        return None
+    out: list[dict] = []
+    for n in numbers:
+        entry: dict = {"n": n}
+        if names.get(n):
+            entry["name"] = names[n]
+        if n in combinations:
+            entry["combination"] = True
+            makeup = combination_label(combinations[n], names)
+            if makeup:
+                entry["makeup"] = makeup
+        out.append(entry)
+    return out

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -440,6 +440,7 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     # ``sin_file`` may be a local path or an s3://, http(s):// URI — let
     # open_sin pick the backend. Don't Path()-mangle a URI; use the
     # source's display name (basename) for the FEAResult / convert path.
+    from ada.fem.formats.sesam.results.case_names import result_case_names
     from ada.fem.formats.sesam.results.sets import manifest_groups
 
     sin = open_sin(sin_file)
@@ -453,6 +454,10 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     # not carrying them here means the only way to get them back is a second full
     # parse of the file, which on a 400 MB SIN is not a thing to do for a picker.
     result.sesam_groups = manifest_groups(reader)
+    # And what the deck calls its result cases. Same reasoning as the sets: read
+    # from records this parse already walked, and unreachable afterwards without
+    # opening the file again.
+    result.sesam_case_names = result_case_names(sin)
     return result
 
 
@@ -675,6 +680,16 @@ class SinStreamReader:
             self._reader = SinReader(sin=self.sin)
             self._reader._load_static()
         return manifest_groups(self._reader)
+
+    def try_step_names(self):
+        """What the deck calls each result case, for the manifest's steps.
+
+        Straight off the open file — these are text records, not the numeric
+        blocks the reader indexes, so no reader needs to exist for them.
+        """
+        from ada.fem.formats.sesam.results.case_names import result_case_names
+
+        return result_case_names(self.sin)
 
 
 __all__ = [

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -440,7 +440,10 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     # ``sin_file`` may be a local path or an s3://, http(s):// URI — let
     # open_sin pick the backend. Don't Path()-mangle a URI; use the
     # source's display name (basename) for the FEAResult / convert path.
-    from ada.fem.formats.sesam.results.case_names import result_case_names
+    from ada.fem.formats.sesam.results.case_names import (
+        result_case_names,
+        selectable_result_cases,
+    )
     from ada.fem.formats.sesam.results.sets import manifest_groups
 
     sin = open_sin(sin_file)
@@ -458,6 +461,7 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     # from records this parse already walked, and unreachable afterwards without
     # opening the file again.
     result.sesam_case_names = result_case_names(sin)
+    result.sesam_result_cases = selectable_result_cases(sin)
     return result
 
 
@@ -690,6 +694,17 @@ class SinStreamReader:
         from ada.fem.formats.sesam.results.case_names import result_case_names
 
         return result_case_names(self.sin)
+
+    def try_result_cases(self):
+        """Every result case the deck OFFERS, which is not the same as its steps.
+
+        A "smart load combination" deck stores only its basic cases as RV*
+        records, so the manifest's steps miss the combinations — which are the
+        design cases anyone actually checks.
+        """
+        from ada.fem.formats.sesam.results.case_names import selectable_result_cases
+
+        return selectable_result_cases(self.sin)
 
 
 __all__ = [

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -435,8 +435,6 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     millions-of-RVNODDIS-rows decks won't fit under the 4 GiB
     worker budget.
     """
-    from ada.fem.formats.sesam.results.read_sif import Sif2Mesh
-
     # ``sin_file`` may be a local path or an s3://, http(s):// URI — let
     # open_sin pick the backend. Don't Path()-mangle a URI; use the
     # source's display name (basename) for the FEAResult / convert path.
@@ -444,6 +442,7 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
         result_case_names,
         selectable_result_cases,
     )
+    from ada.fem.formats.sesam.results.read_sif import Sif2Mesh
     from ada.fem.formats.sesam.results.sets import manifest_groups
 
     sin = open_sin(sin_file)

--- a/src/ada/fem/formats/sesam/results/read_sin.py
+++ b/src/ada/fem/formats/sesam/results/read_sin.py
@@ -440,12 +440,20 @@ def read_sin_file(sin_file: str | pathlib.Path, *, step: int | None = None) -> "
     # ``sin_file`` may be a local path or an s3://, http(s):// URI — let
     # open_sin pick the backend. Don't Path()-mangle a URI; use the
     # source's display name (basename) for the FEAResult / convert path.
+    from ada.fem.formats.sesam.results.sets import manifest_groups
+
     sin = open_sin(sin_file)
     name_path = sin.path if sin.path is not None else pathlib.Path(str(sin_file))
     reader = SinReader(sin=sin, step=step)
     reader.load()
     s2m = Sif2Mesh(reader)
-    return s2m.convert(name_path)
+    result = s2m.convert(name_path)
+    # The deck's named sets travel with the result. They are decoded from records
+    # this reader has already parsed, and the reader is discarded on return — so
+    # not carrying them here means the only way to get them back is a second full
+    # parse of the file, which on a 400 MB SIN is not a thing to do for a picker.
+    result.sesam_groups = manifest_groups(reader)
+    return result
 
 
 def iter_sin_step_results(sin_file: str | pathlib.Path, steps, *, forces_elements: set[int] | None = None):
@@ -655,7 +663,18 @@ class SinStreamReader:
         return None
 
     def try_groups(self):
-        return None
+        """The deck's named sets, for the manifest's ``groups`` block.
+
+        Reads through the persistent reader, which already holds the parsed
+        ``TDSETNAM`` / ``GSETMEMB`` records — the step-invariant blocks are read
+        once for the whole bake, so this costs nothing beyond the decode.
+        """
+        from ada.fem.formats.sesam.results.sets import manifest_groups
+
+        if self._reader is None:
+            self._reader = SinReader(sin=self.sin)
+            self._reader._load_static()
+        return manifest_groups(self._reader)
 
 
 __all__ = [

--- a/src/ada/fem/formats/sesam/results/sets.py
+++ b/src/ada/fem/formats/sesam/results/sets.py
@@ -1,0 +1,74 @@
+"""Sesam named sets, as the viewer manifest carries them.
+
+A Sesam result deck names its sets in ``TDSETNAM`` and lists their members in
+``GSETMEMB``. Both readers already parse those records — :class:`SifReader` for
+SIF text and :class:`SinReader` for the SIN binary, which inherits the same
+decoders — but nothing turned them into the ``groups`` block the bake writes into
+``fea.manifest.json``. Both stream readers' ``try_groups()`` returned ``None``,
+so a result deck reached the viewer with no sets at all, and the FEM-bake path's
+comment ("readers without the method (SIF/SIN/RMED) contribute nothing") was a
+statement of the gap rather than of a design.
+
+That is what this closes. It matters beyond the Groups picker: a set is how you
+say WHICH PART of a model an operation applies to — scoping a capacity check to
+``Pl_H000``, isolating a deck — and without the names reaching the browser, every
+such control had to be a text box you typed a name into from memory.
+
+Member ids are the deck's own element and node numbers, prefixed the way the
+frontend's draw-range lookup expects (``EL`` / ``P``). They need no remapping:
+``GSETMEMB``'s numbers are the same ``GELMNT1`` element numbers and ``GNODE``
+node numbers the baked mesh is keyed by.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["manifest_groups"]
+
+
+def manifest_groups(reader: Any) -> list[dict[str, Any]] | None:
+    """Named sets from a Sesam reader, shaped for ``manifest["groups"]``.
+
+    ``None`` when the deck names no sets — the manifest omits the key entirely
+    rather than carrying an empty list, so the frontend's "does this result have
+    groups at all" test stays a simple presence check.
+
+    A set may carry BOTH node (``ISTYPE`` 1) and element (``ISTYPE`` 2) records.
+    Those become two entries rather than one, because they are two different
+    things to the viewer: an element set can be isolated in the 3D view, a node
+    set names vertices that carry no triangles and can only be listed. Collapsing
+    them would make one of the two silently unusable.
+    """
+    try:
+        members_by_set = reader.get_gsetmemb()
+        names = reader.get_tdsetnam_map()
+    except (AttributeError, NotImplementedError):
+        return None
+    if not members_by_set or not names:
+        return None
+
+    groups: list[dict[str, Any]] = []
+    for set_id, by_type in members_by_set.items():
+        record = names.get(set_id)
+        if record is None:
+            # A set with members and no name. Nothing sensible to call it, and a
+            # made-up label in a picker is worse than an absence.
+            continue
+        name = str(record[-1]).strip()
+        if not name:
+            continue
+        for kind, prefix, ids in (
+            ("element", "EL", by_type.get("elset") or []),
+            ("node", "P", by_type.get("nset") or []),
+        ):
+            if not ids:
+                continue
+            groups.append(
+                {
+                    "name": name,
+                    "members": [f"{prefix}{int(i)}" for i in ids],
+                    "fe_object_type": kind,
+                }
+            )
+    return groups or None

--- a/src/ada/fem/formats/sesam/results/sets.py
+++ b/src/ada/fem/formats/sesam/results/sets.py
@@ -11,7 +11,7 @@ statement of the gap rather than of a design.
 
 That is what this closes. It matters beyond the Groups picker: a set is how you
 say WHICH PART of a model an operation applies to — scoping a capacity check to
-``Pl_H000``, isolating a deck — and without the names reaching the browser, every
+one plate group, isolating a deck — and without the names reaching the browser, every
 such control had to be a text box you typed a name into from memory.
 
 Member ids are the deck's own element and node numbers, prefixed the way the

--- a/src/ada/fem/formats/sesam/results/sif_stream.py
+++ b/src/ada/fem/formats/sesam/results/sif_stream.py
@@ -296,4 +296,14 @@ class SifStreamReader:
         return None
 
     def try_groups(self):
-        return None
+        """The deck's named sets, for the manifest's ``groups`` block.
+
+        The static reader carries the parsed ``TDSETNAM`` / ``GSETMEMB`` records;
+        a deck read without one (nothing has asked for geometry yet) simply has
+        no sets to report rather than forcing a read for them.
+        """
+        from ada.fem.formats.sesam.results.sets import manifest_groups
+
+        if self._static is None:
+            return None
+        return manifest_groups(self._static)

--- a/src/ada/fem/formats/sesam/results/sin_reader.py
+++ b/src/ada/fem/formats/sesam/results/sin_reader.py
@@ -409,14 +409,23 @@ def _decode_type_block(source: ByteSource, preamble_off: int, next_preamble: int
     # ((pointer_table_offset - payload) - 4*SLOT_STRIDE) / SLOT_STRIDE
     # = number of dim slots = 2 * NDIM
     dim_bytes = pointer_table_offset - payload - 4 * SLOT_STRIDE
-    if ptr_table_word > 0 and dim_bytes >= 0 and dim_bytes % (2 * SLOT_STRIDE) == 0:
+    # Is ptr_table_word usable at all? It names the first pointer's value field
+    # directly, so when it lands past the fixed header it is the best evidence in
+    # the block about where the table starts — better than any walk over the
+    # slots in between.
+    anchored = ptr_table_word > 0 and dim_bytes >= 0
+    if anchored and dim_bytes % (2 * SLOT_STRIDE) == 0:
         ndim = dim_bytes // (2 * SLOT_STRIDE)
         if ndim > 4:
             # Defensive — well-formed SIF types have ndim ≤ 2.
             ndim = 0
     else:
-        # ptr_table_word missing or implausible — fall back to the
-        # cap/pop heuristic so malformed/older SIN files still parse.
+        # The gap does not divide into (capacity, populated) pairs, so NDIM
+        # cannot be derived from it. That does NOT make the anchor wrong: some
+        # writers put an extra header slot between the dims and the table (a
+        # TDRESREF block observed with (cap=10, pop=10, 8) where TDLOAD in the
+        # same file has (cap=8, pop=8)). Deriving NDIM by walking instead is
+        # fine; throwing the anchor away with it is not.
         ndim = 0
 
     if ndim == 0:
@@ -434,7 +443,15 @@ def _decode_type_block(source: ByteSource, preamble_off: int, next_preamble: int
             if (dim_slot - 4) // 2 >= 4:
                 break
         ndim = (dim_slot - 4) // 2
-        pointer_table_offset = payload + dim_slot * SLOT_STRIDE
+        # Only when there was no anchor to keep. Where the walk stopped short of
+        # the anchor, it stopped on a header slot, and reading the table from
+        # there takes that slot's value as the first pointer — which is not one.
+        # It fails the NFIELD validity check, truncates the table to nothing, and
+        # the block reads as empty: present in the file, ten records deep, and
+        # invisible. That is how a deck's result-case names went missing while
+        # every other tool could see them.
+        if not anchored:
+            pointer_table_offset = payload + dim_slot * SLOT_STRIDE
 
     caps: list[int] = []
     dims: list[int] = []

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -1820,10 +1820,7 @@ def build_manifest(
         # Convert tuple → list for JSON-friendly shape.
         scalar_range = {k: list(v) for k, v in scalar_range.items()}
 
-        steps = [
-            _step_entry(i, v, _format_step_label(spec, i, v), step_names)
-            for i, v in enumerate(spec.step_values)
-        ]
+        steps = [_step_entry(i, v, _format_step_label(spec, i, v), step_names) for i, v in enumerate(spec.step_values)]
 
         fields_payload.append(
             {

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -712,6 +712,11 @@ class FEAResultStreamAdapter:
         # otherwise labelled with its value — "1", "2", "3" — which is an index,
         # where the deck's own `unit_acc_x` is a load case.
         self._step_names: dict[int, str] | None = getattr(result, "sesam_case_names", None)
+        # Every case the deck OFFERS — which is more than it stores. A "smart
+        # load combination" deck records the basic cases and defines the design
+        # cases as combinations of them, so a picker built from the steps offers
+        # the cases nobody checks and omits the ones they do.
+        self._result_cases: list[dict] | None = getattr(result, "sesam_result_cases", None)
 
         # Remap real node IDs → 0-based point indices. ElementBlock
         # stores arbitrary-id node references (1-based for RMED,
@@ -728,6 +733,9 @@ class FEAResultStreamAdapter:
 
     def try_step_names(self) -> dict[int, str] | None:
         return self._step_names
+
+    def try_result_cases(self) -> list[dict] | None:
+        return self._result_cases
 
     # ----- protocol -------------------------------------------------------
 
@@ -1778,6 +1786,7 @@ def build_manifest(
     fem_concepts: dict | None = None,
     groups: list[dict] | None = None,
     step_names: dict[int, str] | None = None,
+    result_cases: list[dict] | None = None,
     legacy_glb_url_template: str | None = None,
 ) -> dict:
     """Compose the manifest dict from the bake outputs.
@@ -2021,6 +2030,14 @@ def build_manifest(
     # no ADA_EXT, so the frontend feeds these into useSceneInfoStore directly).
     if groups:
         manifest["groups"] = groups
+    # Every result case the source OFFERS, which is more than its field steps
+    # list. A "smart load combination" deck stores only its basic cases as RV*
+    # records and defines the design cases as combinations of them, so a picker
+    # built from steps offers the cases nobody checks and omits the ones they do.
+    # Separate from `fields[].steps` rather than folded into it: a step is
+    # something the colour machinery can read, and a combination is not.
+    if result_cases:
+        manifest["result_cases"] = result_cases
     if legacy_glb_url_template is not None:
         manifest["legacy_glb"] = {"url_template": legacy_glb_url_template}
 
@@ -2559,6 +2576,12 @@ def bake_artefacts(
     except (AttributeError, NotImplementedError):
         step_names = None
 
+    # And every case it offers, stored or superposed.
+    try:
+        result_cases = reader.try_result_cases()
+    except (AttributeError, NotImplementedError):
+        result_cases = None
+
     manifest = build_manifest(
         src=src,
         source_sha256=source_sha256,
@@ -2584,6 +2607,7 @@ def bake_artefacts(
         fem_concepts=fem_concepts,
         groups=groups,
         step_names=step_names,
+        result_cases=result_cases,
         legacy_glb_url_template=legacy_glb_url_template,
     )
     manifest_path = out_dir / "fea.manifest.json"

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -705,8 +705,9 @@ class FEAResultStreamAdapter:
         # deck so the Scene > FEM panel can draw the glyph overlay.
         self._fem_concepts: dict | None = None
         # Optional FEM node/element sets as manifest group dicts ({name, members, fe_object_type}).
-        # Populated by the FEM reader so the Scene > FEM groups picker works for design models.
-        self._groups: list[dict] | None = None
+        # Populated by the FEM reader for design models, and carried on the result by
+        # the Sesam readers, which decode TDSETNAM / GSETMEMB while parsing the deck.
+        self._groups: list[dict] | None = getattr(result, "sesam_groups", None)
 
         # Remap real node IDs → 0-based point indices. ElementBlock
         # stores arbitrary-id node references (1-based for RMED,
@@ -2518,8 +2519,9 @@ def bake_artefacts(
     except (AttributeError, NotImplementedError):
         fem_concepts = None
 
-    # FEM node/element sets -> manifest groups (Scene > FEM groups picker). Readers without the
-    # method (SIF/SIN/RMED) contribute nothing.
+    # FEM node/element sets -> manifest groups (Scene > FEM groups picker, and the
+    # Outliner's Groups branch). Sesam decks (SIF/SIN) report their TDSETNAM /
+    # GSETMEMB sets; a reader without the method contributes nothing.
     try:
         groups = reader.try_groups()
     except (AttributeError, NotImplementedError):

--- a/src/ada/fem/results/artefacts.py
+++ b/src/ada/fem/results/artefacts.py
@@ -708,6 +708,10 @@ class FEAResultStreamAdapter:
         # Populated by the FEM reader for design models, and carried on the result by
         # the Sesam readers, which decode TDSETNAM / GSETMEMB while parsing the deck.
         self._groups: list[dict] | None = getattr(result, "sesam_groups", None)
+        # What the deck calls each result case, keyed by case number. A step is
+        # otherwise labelled with its value — "1", "2", "3" — which is an index,
+        # where the deck's own `unit_acc_x` is a load case.
+        self._step_names: dict[int, str] | None = getattr(result, "sesam_case_names", None)
 
         # Remap real node IDs → 0-based point indices. ElementBlock
         # stores arbitrary-id node references (1-based for RMED,
@@ -721,6 +725,9 @@ class FEAResultStreamAdapter:
 
     def try_groups(self) -> list[dict] | None:
         return self._groups
+
+    def try_step_names(self) -> dict[int, str] | None:
+        return self._step_names
 
     # ----- protocol -------------------------------------------------------
 
@@ -1770,6 +1777,7 @@ def build_manifest(
     lineage: dict | None = None,
     fem_concepts: dict | None = None,
     groups: list[dict] | None = None,
+    step_names: dict[int, str] | None = None,
     legacy_glb_url_template: str | None = None,
 ) -> dict:
     """Compose the manifest dict from the bake outputs.
@@ -1804,7 +1812,8 @@ def build_manifest(
         scalar_range = {k: list(v) for k, v in scalar_range.items()}
 
         steps = [
-            {"i": i, "value": float(v), "label": _format_step_label(spec, i, v)} for i, v in enumerate(spec.step_values)
+            _step_entry(i, v, _format_step_label(spec, i, v), step_names)
+            for i, v in enumerate(spec.step_values)
         ]
 
         fields_payload.append(
@@ -1878,7 +1887,7 @@ def build_manifest(
             scalar_range_payload["magnitude"] = list(roll_mag)
 
         steps = [
-            {"i": i, "value": float(v), "label": _format_step_label_simple(primary.n_steps, primary.name, v)}
+            _step_entry(i, v, _format_step_label_simple(primary.n_steps, primary.name, v), step_names)
             for i, v in enumerate(primary.step_values)
         ]
 
@@ -2089,6 +2098,22 @@ def build_history_payload(history: "HistoryRecords") -> dict:
             for s in history.series
         ],
     }
+
+
+def _step_entry(i: int, v: float, label: str, step_names: "dict[int, str] | None") -> dict:
+    """One step of a field, plus the deck's name for it when there is one.
+
+    `name` is additive and optional: every existing reader of `steps` keys off
+    `i` / `value` / `label`, so a manifest without it is unchanged. Keyed on the
+    step VALUE rather than the index because that is the deck's case number —
+    step 0 is case 1 — and the names come from the deck.
+    """
+    entry = {"i": i, "value": float(v), "label": label}
+    if step_names:
+        name = step_names.get(int(v))
+        if name:
+            entry["name"] = name
+    return entry
 
 
 def _format_step_label(spec: FieldSpec, i: int, v: float) -> str:
@@ -2527,6 +2552,13 @@ def bake_artefacts(
     except (AttributeError, NotImplementedError):
         groups = None
 
+    # What the deck calls each result case; a reader without the method leaves
+    # the steps labelled by value, as before.
+    try:
+        step_names = reader.try_step_names()
+    except (AttributeError, NotImplementedError):
+        step_names = None
+
     manifest = build_manifest(
         src=src,
         source_sha256=source_sha256,
@@ -2551,6 +2583,7 @@ def bake_artefacts(
         lineage=lineage,
         fem_concepts=fem_concepts,
         groups=groups,
+        step_names=step_names,
         legacy_glb_url_template=legacy_glb_url_template,
     )
     manifest_path = out_dir / "fea.manifest.json"

--- a/src/frontend/src/components/viewer/sceneHelpers/OrientationGizmo.ts
+++ b/src/frontend/src/components/viewer/sceneHelpers/OrientationGizmo.ts
@@ -142,7 +142,19 @@ export class OrientationGizmo extends HTMLElement {
         this.style.boxSizing = "border-box";
         this.style.width = `${this.options.size}px`;
         this.style.height = `${this.options.size}px`;
-        this.style.position = "fixed";
+        // Absolute, not fixed — anchored to the canvas container rather than the window.
+        //
+        // Fixed put it in the bottom-right of the BROWSER, which was the same place as
+        // the bottom-right of the canvas while the canvas was full-bleed. A UI that gives
+        // the 3D view its own grid area (the docked shell) puts the right dock over that
+        // corner, so the gizmo sat underneath it — glowing faintly through a translucent
+        // panel, and unclickable where they overlapped.
+        //
+        // ThreeCanvas's container is already `relative`, so absolute anchors to the
+        // viewport region in both UIs: unchanged in the classic full-bleed layout, and
+        // correctly beside the docks in a docked one. It follows a splitter drag for
+        // free, which a margin computed from the dock width would not.
+        this.style.position = "absolute";
         // Sit just below the menu/panel layer (z-10) so an open side panel —
         // e.g. the equipment/system catalog editor on mobile — covers the
         // gizmo where they overlap and its Save button stays clickable. The

--- a/src/frontend/src/hooks/useUrlParamLoad.ts
+++ b/src/frontend/src/hooks/useUrlParamLoad.ts
@@ -3,6 +3,7 @@ import {scopeUrlPart, useScopeStore} from "@/state/scopeStore";
 import {sceneRef} from "@/state/refs";
 import {runtime} from "@/runtime/config";
 import {dispatchPluginUrlParams} from "@/plugins/urlParams";
+import {isStreamingFEAResult} from "@/utils/scene/fileKinds";
 
 // Consume ``?scope=...&file=...`` query params on viewer mount.
 //
@@ -90,15 +91,30 @@ export function useUrlParamLoad(): void {
                 await new Promise((r) => setTimeout(r, SCENE_WAIT_INTERVAL_MS));
             }
             try {
-                const {overlay_file_in_scene} = await import(
-                    "@/utils/scene/handlers/overlay_file_in_scene"
-                );
-                // ``derivedParam`` (e.g. ``_derived/foo.step.glb``) is
-                // the explicit derived-blob hand-off from /convert's
-                // "View in 3D" button. Pass it through so the loader
-                // can fetch the blob directly without a second
-                // ``/convert`` round-trip to re-resolve the path.
-                await overlay_file_in_scene(fileParam, derivedParam ?? undefined);
+                // Streaming-FEA sources (.sin/.sif/.rmed/...) have no legacy GLB
+                // target — they load from their baked `_derived/<src>.fea/`
+                // artefacts. Routing them through overlay_file_in_scene made the
+                // deep link a no-op ("non-GLB source but conversion disabled")
+                // on any deployment without a conversion queue, even though the
+                // bake was already on storage. Go through the same load queue the
+                // storage browser uses, which picks the streaming loader for
+                // those and the overlay for everything else.
+                if (!derivedParam && isStreamingFEAResult(fileParam)) {
+                    const {load_fea_with_defaults} = await import(
+                        "@/utils/scene/handlers/load_fea_streaming"
+                    );
+                    await load_fea_with_defaults(fileParam);
+                } else {
+                    const {overlay_file_in_scene} = await import(
+                        "@/utils/scene/handlers/overlay_file_in_scene"
+                    );
+                    // ``derivedParam`` (e.g. ``_derived/foo.step.glb``) is
+                    // the explicit derived-blob hand-off from /convert's
+                    // "View in 3D" button. Pass it through so the loader
+                    // can fetch the blob directly without a second
+                    // ``/convert`` round-trip to re-resolve the path.
+                    await overlay_file_in_scene(fileParam, derivedParam ?? undefined);
+                }
             } catch (err) {
                 // eslint-disable-next-line no-console
                 console.warn("[useUrlParamLoad] load failed for", fileParam, err);

--- a/src/frontend/src/plugins/registry.ts
+++ b/src/frontend/src/plugins/registry.ts
@@ -18,7 +18,7 @@ import { registerUiShell, type UiShellSpec } from "./uiShells";
 // Bumped on a breaking change to any slot interface below. A plugin declares the
 // core range it was built against via `coreApiRange`; an out-of-range plugin is
 // skipped with a visible log rather than loaded half-way (Decision 5 / lifecycle).
-export const PLUGIN_API_VERSION = "1.0.0";
+export const PLUGIN_API_VERSION = "1.1.0";
 
 // The named mount regions core exposes in Phase 1. Deliberately small
 // (`fem-sidebar` covers the FEM simulation panel, `top-panel` the menu bar,
@@ -30,6 +30,67 @@ export type PluginRegion =
   | "scene-info"
   | "storage-detail"
   | "admin";
+
+// ---------------------------------------------------------------------------
+// Placement (1.1.0)
+//
+// A region names a HOST. It says which of core's containers mounts the panel,
+// which is all a panel needed while the UI was one fixed layout. A UI shell with
+// docks and modes needs the other half of the question — WHERE in its chrome, and
+// WHEN — and there was no way for a plugin to say it. A shell had to guess, which
+// in practice meant plugin panels piled into whichever single host the shell
+// happened to mount.
+//
+// These two fields are that answer, and they are deliberately thin: core does not
+// own docks or modes, it only carries the words between a plugin and the shell
+// that has them. A shell with no docks ignores `dock` and mounts by region as
+// before; core itself does exactly that.
+// ---------------------------------------------------------------------------
+
+/** Named regions of a shell's chrome. A shell that has no such thing ignores it. */
+export type PluginDockId = "left" | "right" | "bottom" | "float" | "overlay";
+
+/**
+ * A mode id. Core's own UI has no modes, so this is an open string: the four a
+ * shell ships (`inspect`/`results`/`build`/`convert` in the docked UI) and any a
+ * plugin contributes through `modes` are the same kind of thing, and core has no
+ * business ranking them.
+ */
+export type PluginModeId = string;
+
+/**
+ * A whole activity a plugin contributes — a mode, in a shell that has modes.
+ *
+ * The slot exists because a mode is the one contribution no other field can carry.
+ * A panel can say `modes: ["capacity"]`, but nothing tells the shell what
+ * "capacity" IS: its name, its glyph, where it sits in the switcher. Without that
+ * the shell would have to invent a label from an id, which is how you end up with
+ * a mode button reading "capacity-manager:capacity".
+ *
+ * Contributing one does not make it exist: a shell with no modes ignores this
+ * list, and the plugin's panels fall back to their region as they always did.
+ */
+export interface PluginModeSpec {
+  /** Globally unique, kebab-case. What a panel's `modes` names. */
+  id: PluginModeId;
+  /** Short name for the mode switcher. */
+  label: string;
+  /** One line: what you DO here. Tooltip / palette text. */
+  hint?: string;
+  /** Sort key among the shell's own modes; ties broken by id. */
+  order?: number;
+  /** The mode's glyph. A plugin ships the component — it cannot name one from a
+   * shell's icon registry, which it has never heard of. */
+  icon?: React.FC;
+  /**
+   * The mode's toolbar: the controls that belong to this activity and no other.
+   *
+   * A mode without one is a switcher entry that changes which panels are offered.
+   * With one, it is a place to work — which is the difference between a feature
+   * living in a panel and a feature having a home.
+   */
+  toolbar?: (ctx: AdaPluginContext) => React.ReactNode;
+}
 
 export type PluginLogLevel = "debug" | "info" | "warn" | "error";
 
@@ -170,6 +231,16 @@ export interface PanelSlot {
   // Local id; namespaced to `${pluginId}:${id}` on register.
   id: string;
   region: PluginRegion;
+  /**
+   * Which of the shell's docks this panel wants (1.1.0). Ignored by a shell with
+   * no docks — core's own UI mounts by `region` regardless.
+   */
+  dock?: PluginDockId;
+  /**
+   * Which modes offer this panel (1.1.0). Omitted means every mode. Names a
+   * shell's own mode or one this plugin contributed through `modes`.
+   */
+  modes?: readonly PluginModeId[];
   order?: number;
   activationPredicate?: ActivationPredicate;
   render: (ctx: AdaPluginContext) => React.ReactNode;
@@ -234,6 +305,9 @@ export interface PluginSpec {
   sceneColorFields?: SceneColorFieldProvider[];
   resultSidecarLoaders?: ResultSidecarLoader[];
   urlParamHandlers?: UrlParamHandler[];
+  // Whole activities (1.1.0). Consumed by a shell that has modes; ignored by one
+  // that does not, including core's own UI.
+  modes?: PluginModeSpec[];
   // Whole-UI contributions: a plugin may ship an entire alternative viewer UI
   // that core mounts INSTEAD of its own shell (see `./uiShells`). Orthogonal to
   // the slots above — a plugin can do either, both, or neither.
@@ -251,6 +325,7 @@ export interface RegisteredPlugin {
   sceneColorFields: SceneColorFieldProvider[];
   resultSidecarLoaders: ResultSidecarLoader[];
   urlParamHandlers: UrlParamHandler[];
+  modes: PluginModeSpec[];
   // Ids of the UI shells this plugin contributed (the shells themselves live in
   // the shell registry); kept for introspection / audit.
   uiShellIds: string[];
@@ -359,6 +434,11 @@ export function registerPlugin(spec: PluginSpec): void {
     sceneColorFields,
     resultSidecarLoaders,
     urlParamHandlers,
+    // NOT namespaced, unlike panels and colour fields. A mode id is user-facing —
+    // a panel writes `modes: ["capacity"]` and a shell may accept `?mode=capacity`
+    // — so it has to be the word the author chose. Collisions are the same
+    // first-writer-wins as everywhere else in this registry.
+    modes: spec.modes ?? [],
     uiShellIds,
   });
 }
@@ -401,6 +481,29 @@ function isActive(p: RegisteredPlugin, ctx: AdaPluginContext): boolean {
  * by whole-plugin + per-slot activation predicates against the given ctx. Each
  * entry carries its owning `pluginId` so core can build a per-plugin ctx + wrap
  * the render in an ErrorBoundary keyed on the plugin. */
+/**
+ * Every mode contributed by an enabled plugin, in switcher order.
+ *
+ * Context-free: a shell needs this to build its mode switcher, which exists before
+ * any model is loaded and long before a plugin context is worth constructing. So
+ * `activationPredicate` is NOT consulted — a mode is a place you can go, not a
+ * thing that comes and goes. A mode whose panels are all inactive is an empty
+ * mode, which is a smaller failure than a switcher button that appears and
+ * disappears under the pointer.
+ */
+export function getPluginModes(): Array<{ pluginId: string; mode: PluginModeSpec }> {
+  const out: Array<{ pluginId: string; mode: PluginModeSpec; order: number }> = [];
+  for (const p of _registry.values()) {
+    if (p.disabled) continue;
+    for (const mode of p.modes) {
+      if (!mode?.id) continue;
+      out.push({ pluginId: p.id, mode, order: mode.order ?? 0 });
+    }
+  }
+  out.sort((a, b) => a.order - b.order || a.mode.id.localeCompare(b.mode.id));
+  return out.map(({ pluginId, mode }) => ({ pluginId, mode }));
+}
+
 export function getPanelsForRegion(
   region: PluginRegion,
   ctx: AdaPluginContext,

--- a/src/frontend/src/plugins/registry.ts
+++ b/src/frontend/src/plugins/registry.ts
@@ -80,7 +80,7 @@ export type PluginModeId = string;
  * A panel can say `modes: ["capacity"]`, but nothing tells the shell what
  * "capacity" IS: its name, its glyph, where it sits in the switcher. Without that
  * the shell would have to invent a label from an id, which is how you end up with
- * a mode button reading "capacity-manager:capacity".
+ * a mode button reading "my-plugin:review".
  *
  * Contributing one does not make it exist: a shell with no modes ignores this
  * list, and the plugin's panels fall back to their region as they always did.

--- a/src/frontend/src/plugins/registry.ts
+++ b/src/frontend/src/plugins/registry.ts
@@ -47,8 +47,14 @@ export type PluginRegion =
 // before; core itself does exactly that.
 // ---------------------------------------------------------------------------
 
-/** Named regions of a shell's chrome. A shell that has no such thing ignores it. */
-export type PluginDockId = "left" | "right" | "bottom" | "float" | "overlay";
+/** Named regions of a shell's chrome. A shell that has no such thing ignores it.
+ *
+ * `right-aux` is a SECOND right-hand column, beside the first rather than tabbed
+ * into it. A panel you read WHILE reading another one — a detail view for the row
+ * selected in a table — belongs there: sharing one dock means the two take turns,
+ * and stacking them means scrolling between them. A shell with only one right
+ * column can treat it as `right`. */
+export type PluginDockId = "left" | "right" | "right-aux" | "bottom" | "float" | "overlay";
 
 /**
  * A mode id. Core's own UI has no modes, so this is an open string: the four a

--- a/src/frontend/src/plugins/registry.ts
+++ b/src/frontend/src/plugins/registry.ts
@@ -52,9 +52,18 @@ export type PluginRegion =
  * `right-aux` is a SECOND right-hand column, beside the first rather than tabbed
  * into it. A panel you read WHILE reading another one — a detail view for the row
  * selected in a table — belongs there: sharing one dock means the two take turns,
- * and stacking them means scrolling between them. A shell with only one right
- * column can treat it as `right`. */
-export type PluginDockId = "left" | "right" | "right-aux" | "bottom" | "float" | "overlay";
+ * and stacking them means scrolling between them. `right-aux2` is a third such
+ * column, for the case where reading one panel means comparing it against two
+ * others at once. A shell with fewer right columns than a plugin asks for can
+ * treat the extras as `right`. */
+export type PluginDockId =
+  | "left"
+  | "right"
+  | "right-aux"
+  | "right-aux2"
+  | "bottom"
+  | "float"
+  | "overlay";
 
 /**
  * A mode id. Core's own UI has no modes, so this is an open string: the four a

--- a/src/frontend/src/utils/scene/handlers/load_fea_streaming.ts
+++ b/src/frontend/src/utils/scene/handlers/load_fea_streaming.ts
@@ -95,6 +95,19 @@ export function setBeamSolidsVisible(visible: boolean): void {
     }
 }
 
+/**
+ * Does the loaded FEA model carry beam section geometry at all?
+ *
+ * `setBeamSolidsVisible` is a no-op without it — the bake only emits
+ * ``beam_solids_url`` for a reader with section + axis info per beam, and only
+ * when it was asked to. A UI that offers "beams as solid" needs to tell the two
+ * cases apart: a toggle that flips and changes nothing reads as broken, where a
+ * greyed one with a reason reads as a property of the model.
+ */
+export function hasBeamSolids(): boolean {
+    return active?.beamSolidMesh != null;
+}
+
 /** The active FEA mesh (a custom-batch THREE.Mesh carrying per-element
  *  ``drawRanges``), or null when no FEA model is loaded. Exposed so a plugin can
  *  drive element-level scene ops (isolate / highlight / attach overlays) off the

--- a/src/frontend/src/viewer-core/index.ts
+++ b/src/frontend/src/viewer-core/index.ts
@@ -61,6 +61,7 @@ export const VIEWER_CORE_API_VERSION = "1.0.0";
 export {
   disablePlugin,
   getPlugin,
+  getPluginModes,
   getRegisteredPlugins,
   PLUGIN_API_VERSION,
   registerPlugin,
@@ -69,6 +70,9 @@ export type {
   ActivationPredicate,
   AdaPluginContext,
   PanelSlot,
+  PluginDockId,
+  PluginModeId,
+  PluginModeSpec,
   PluginApiClient,
   PluginLogLevel,
   PluginRegion,

--- a/tests/comms/rest/test_local_plugin_jobs.py
+++ b/tests/comms/rest/test_local_plugin_jobs.py
@@ -1,0 +1,298 @@
+"""Hardening contract for the in-process plugin-job path (`local_jobs`).
+
+When no queue is configured the API runs a plugin's backend job itself, in a
+thread, instead of answering 503. That path is the one place where the API
+imports and executes plugin code, so its failure modes are the API's failure
+modes — and these tests pin the three that are not the plugin's own fault:
+
+* a plugin backend that will not import must not take the API down with it,
+  neither at startup (``ADA_WORKER_PRELOAD``) nor at request time
+  (``job_entrypoint``);
+* a job that never finishes must not hold its registry entry forever, because
+  a never-evictable entry defeats the whole cap;
+* a job that finishes must leave its summary where the caller was told to look
+  for it, which is the ``derived_key`` it got back from the POST.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+
+# Importing ada.comms.rest.app evaluates a module-level `create_app()` which
+# materializes a local Storage. Point it at a temp dir so the import succeeds in
+# environments without `./viewer-data`.
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ada.comms.rest import local_jobs
+from ada.comms.rest.app import create_app
+from ada.comms.rest.config import AuthConfig, LocalConfig, QueueConfig, Settings
+from ada.comms.rest.local_jobs import (
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_RUNNING,
+    LocalJob,
+    LocalJobRegistry,
+)
+from ada.plugins import register_plugin_backend
+
+
+def _settings(tmp_path) -> Settings:
+    """No queue URL — which is exactly the condition that routes a plugin job
+    into `local_jobs` instead of onto NATS."""
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+def _job(job_id: str, status: str = STATUS_RUNNING, age_s: float = 0.0) -> LocalJob:
+    job = LocalJob(
+        job_id=job_id,
+        plugin_id="test-plugin",
+        scope_kind="shared",
+        scope_id=None,
+        derived_key=f"_derived/{job_id}.json",
+        status=status,
+    )
+    job.started_at = time.time() - age_s
+    return job
+
+
+# --------------------------------------------------------------------------
+# A bad plugin must not be able to stop the API from starting
+# --------------------------------------------------------------------------
+
+
+def test_an_unimportable_preload_module_does_not_stop_the_api(monkeypatch, tmp_path):
+    """The worker dies on a failed preload on purpose — it exists because of it.
+
+    The API does not: plugin jobs are one endpoint out of dozens, so an
+    ImportError escaping the lifespan would trade "one capability is missing"
+    for "the viewer is down", which is the worse of the two by a distance.
+    """
+    mod_dir = tmp_path / "badmods"
+    mod_dir.mkdir()
+    (mod_dir / "adapy_test_boom_plugin.py").write_text(
+        "raise ImportError('a dependency this plugin needs is not installed')",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(mod_dir))
+    monkeypatch.setenv("ADA_WORKER_PRELOAD", "adapy_test_boom_plugin")
+    monkeypatch.delitem(sys.modules, "adapy_test_boom_plugin", raising=False)
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        # Startup completed, and the rest of the API is untouched by the failure.
+        assert client.get("/api/config").status_code == 200
+
+
+# --------------------------------------------------------------------------
+# A plugin whose entrypoint will not resolve answers, rather than 500-ing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plugin_id,entrypoint",
+    [
+        # Registered, but the module is not there at all.
+        ("adapy-test-badmod", "adapy_test_missing_module:run"),
+        # Module imports; the advertised callable is not in it.
+        ("adapy-test-badattr", "json:no_such_callable"),
+        # Not in "module:callable" form, so there is nothing to getattr.
+        ("adapy-test-nocolon", "json"),
+    ],
+)
+def test_an_unresolvable_entrypoint_is_a_501_not_a_500(tmp_path, plugin_id, entrypoint):
+    """501 is the same answer an unregistered plugin gets, and for the same
+    reason: this process cannot run that plugin. Letting the ImportError or
+    AttributeError out instead produced a bare 500 naming neither the plugin
+    nor the entrypoint — an unhandled exception, dressed as a server fault."""
+    register_plugin_backend(plugin_id, job_entrypoint=entrypoint)
+    app = create_app(_settings(tmp_path))
+    with TestClient(app, raise_server_exceptions=False) as client:
+        r = client.post(f"/api/plugins/{plugin_id}/jobs", json={"options": {}})
+    assert r.status_code == 501, r.text
+    detail = r.json()["detail"]
+    assert plugin_id in detail and entrypoint in detail
+
+
+def test_the_501_detail_does_not_echo_the_import_error_text(tmp_path):
+    """The exception TEXT is the part that quotes module paths and filesystem
+    layout back at whoever called the endpoint. The type is enough for the
+    caller; the traceback belongs in the log."""
+    register_plugin_backend("adapy-test-secretive", job_entrypoint="adapy_test_missing_module:run")
+    app = create_app(_settings(tmp_path))
+    with TestClient(app, raise_server_exceptions=False) as client:
+        r = client.post("/api/plugins/adapy-test-secretive/jobs", json={"options": {}})
+    assert r.status_code == 501
+    detail = r.json()["detail"]
+    assert "ModuleNotFoundError" in detail
+    assert "No module named" not in detail
+
+
+# --------------------------------------------------------------------------
+# The registry stays bounded even when nothing terminates
+# --------------------------------------------------------------------------
+
+
+def test_finished_jobs_are_evicted_oldest_first():
+    reg = LocalJobRegistry()
+    for i in range(reg.MAX_JOBS + 50):
+        reg.add(_job(f"j{i}", status=STATUS_DONE))
+    assert len(reg._jobs) == reg.MAX_JOBS
+    assert reg.get("j0") is None
+    assert reg.get(f"j{reg.MAX_JOBS + 49}") is not None
+
+
+def test_a_job_that_never_finishes_is_declared_stuck_and_becomes_evictable():
+    """The count cap only evicts terminal jobs, so before the age sweep a supply
+    of jobs that never finish grew the registry without limit — the cap looked
+    like a bound and was not one."""
+    reg = LocalJobRegistry()
+    for i in range(reg.MAX_JOBS + 50):
+        reg.add(_job(f"stuck{i}", status=STATUS_RUNNING, age_s=reg.MAX_RUNTIME_S + 60))
+    assert len(reg._jobs) == reg.MAX_JOBS
+
+
+def test_a_stuck_job_reports_a_terminal_status_to_its_poller():
+    """A poller has no other way out: the thread cannot be killed, so if the job
+    never goes terminal the caller polls "running" until the process dies."""
+    reg = LocalJobRegistry()
+    job = _job("stuck", status=STATUS_RUNNING, age_s=reg.MAX_RUNTIME_S + 1)
+    reg.add(job)
+
+    seen = reg.get("stuck")
+    assert seen is not None
+    assert seen.status == STATUS_ERROR
+    assert seen.as_json()["stage"] == "timeout"
+    # ...and the cooperative signal is raised, so a plugin that watches it stops
+    # burning CPU rather than running on unobserved.
+    assert job.cancel_event.is_set()
+
+
+def test_a_running_job_inside_the_limit_is_left_alone():
+    reg = LocalJobRegistry()
+    reg.add(_job("young", status=STATUS_RUNNING, age_s=5.0))
+    for i in range(reg.MAX_JOBS + 10):
+        reg.add(_job(f"done{i}", status=STATUS_DONE))
+    still = reg.get("young")
+    assert still is not None and still.status == STATUS_RUNNING
+
+
+# --------------------------------------------------------------------------
+# A finished job leaves its summary where the caller was told to look
+# --------------------------------------------------------------------------
+
+
+def _entrypoint(options, *, storage, scope, on_progress, derived_prefix, **_kw):
+    on_progress("working", 0.5)
+    return {"echoed": options.get("n"), "ok": True}
+
+
+def test_a_completed_job_writes_its_summary_to_derived_key(tmp_path):
+    """The POST hands back `derived_key` and the plugin's UI fetches the JSON
+    from it once the job reports done — the same contract the worker fulfils by
+    uploading the returned dict. In-process the return value used to stay in a
+    field nothing serves, so the job succeeded and its answer was unreachable."""
+    register_plugin_backend("adapy-test-echo", job_entrypoint=f"{__name__}:_entrypoint")
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        r = client.post("/api/plugins/adapy-test-echo/jobs", json={"options": {"n": 7}})
+        assert r.status_code == 200, r.text
+        job_id = r.json()["job_id"]
+        derived_key = r.json()["derived_key"]
+
+        status = None
+        for _ in range(200):
+            status = client.get(f"/api/convert/{job_id}").json()
+            if status["status"] != STATUS_RUNNING:
+                break
+            time.sleep(0.05)
+        assert status["status"] == STATUS_DONE, status
+
+        job = local_jobs.registry.get(job_id)
+        assert job is not None and job.result == {"echoed": 7, "ok": True}
+
+        # Fetched the way the plugin's UI fetches it, so the test pins the whole
+        # round trip rather than the storage layout underneath it.
+        blob_resp = client.get(f"/api/scopes/shared/blobs/{derived_key}")
+        assert blob_resp.status_code == 200, blob_resp.text
+        blob = blob_resp.content
+
+    # httpx already unwraps Content-Encoding: gzip; be tolerant if it did not.
+    if blob[:2] == b"\x1f\x8b":
+        blob = gzip.decompress(blob)
+    assert json.loads(blob) == {"echoed": 7, "ok": True}
+
+
+def _slow_entrypoint(options, *, storage, scope, on_progress, derived_prefix, cancel_event, **_kw):
+    _slow_entrypoint.started.set()
+    _slow_entrypoint.release.wait(30)
+    return {"late": True}
+
+
+_slow_entrypoint.started = threading.Event()
+_slow_entrypoint.release = threading.Event()
+
+
+def test_a_job_swept_mid_run_is_not_resurrected_when_it_finally_returns(tmp_path, monkeypatch):
+    """The sweep's verdict is one a poller may already have read. A late return
+    from the abandoned call must not walk that back to `done` and hand out a
+    result the caller was told did not exist."""
+    monkeypatch.setattr(LocalJobRegistry, "MAX_RUNTIME_S", 0.5)
+    register_plugin_backend("adapy-test-slow", job_entrypoint=f"{__name__}:_slow_entrypoint")
+    _slow_entrypoint.started.clear()
+    _slow_entrypoint.release.clear()
+
+    app = create_app(_settings(tmp_path))
+    try:
+        with TestClient(app) as client:
+            r = client.post("/api/plugins/adapy-test-slow/jobs", json={"options": {}})
+            assert r.status_code == 200, r.text
+            job_id = r.json()["job_id"]
+            assert _slow_entrypoint.started.wait(10)
+
+            time.sleep(0.7)  # past the patched MAX_RUNTIME_S
+            swept = client.get(f"/api/convert/{job_id}").json()
+            assert swept["status"] == STATUS_ERROR and swept["stage"] == "timeout"
+
+            _slow_entrypoint.release.set()
+            after = swept
+            for _ in range(200):
+                after = client.get(f"/api/convert/{job_id}").json()
+                if after["status"] != STATUS_ERROR:
+                    break
+                time.sleep(0.05)
+            assert after["status"] == STATUS_ERROR and after["stage"] == "timeout"
+    finally:
+        _slow_entrypoint.release.set()

--- a/tests/core/fem/formats/sesam/test_read_sin.py
+++ b/tests/core/fem/formats/sesam/test_read_sin.py
@@ -418,6 +418,29 @@ def test_result_case_names_from_the_deck(sin_file):
     assert result_case_names(None) is None
 
 
+def test_combination_label_describes_the_recipe():
+    """A combination's makeup, for a UI that offers it as supporting detail.
+
+    Not its name — the deck names combinations in TDRESREF like any other result
+    case (`lcc1`), and a label spelling out five weighted terms would be
+    unreadable everywhere a case is listed. This is what you show on demand.
+    """
+    from ada.fem.formats.sesam.results.case_names import combination_label
+
+    names = {1: "girder_local", 2: "deck", 8: "selfweight"}
+    # float32 widening noise must not reach the label.
+    assert (
+        combination_label({1: 1.2000000476837158, 2: 1.1}, names)
+        == "1.2·girder_local + 1.1·deck"
+    )
+    # Ordered by case number, not by factor, so two combinations line up by eye.
+    assert combination_label({8: 1.0, 1: 2.0}, names) == "2·girder_local + 1·selfweight"
+    # A basic case nobody named still appears — dropping it would misdescribe
+    # the combination.
+    assert combination_label({5: 1.0}, names) == "1·case 5"
+    assert combination_label({}, names) == ""
+
+
 def test_result_case_names_reach_the_manifest_steps():
     """`build_manifest` carries the names onto each step, additively.
 
@@ -432,3 +455,66 @@ def test_result_case_names_reach_the_manifest_steps():
         assert reader.try_step_names() == {1: "LC1"}
     finally:
         reader.close()
+
+
+def test_pointer_table_anchor_survives_an_extra_header_slot():
+    """``ptr_table_word`` is kept even when NDIM cannot be derived from the gap.
+
+    Some writers put an extra header slot between a block's dims and its pointer
+    table. The gap then does not divide into (capacity, populated) pairs, so NDIM
+    has to be found by walking the pairs instead — but the block still says
+    exactly where its table starts, and that anchor was being discarded along
+    with the failed NDIM derivation.
+
+    The cost was silent and total: the walk stops on the extra header slot, the
+    table is read from one slot early, that slot's value is taken as the first
+    pointer, it fails the NFIELD check, the table truncates to nothing, and a
+    block with ten records reads as empty. On the reference deck that block was
+    TDRESREF — so a model whose result cases every other tool could name came
+    back with no names at all.
+    """
+    import numpy as np
+
+    from ada.fem.formats.sesam.results.sin_reader import (
+        NAME_LEN,
+        SLOT_STRIDE,
+        _decode_type_block,
+        MmapSource,
+    )
+
+    # One synthetic block: 4 fixed header slots, (cap, pop), an EXTRA slot, then
+    # two pointers. Slot values live in the second u32 of each 8-byte slot.
+    preamble = 0
+    payload = preamble + 4 + NAME_LEN
+    header_slots = [0, 5, 41, 0, 2, 2, 8]  # [3] (ptr_table_word) filled in below
+    first_ptr_slot = len(header_slots)
+    ptr_value_off = payload + first_ptr_slot * SLOT_STRIDE + 4
+    header_slots[3] = ptr_value_off // SLOT_STRIDE
+
+    # Two records, each starting with its NFIELD word so the pointers validate.
+    rec_words = [200, 240]
+    slots = header_slots + [w + 1 for w in rec_words]
+
+    buf = bytearray(4 + NAME_LEN + len(slots) * SLOT_STRIDE)
+    buf[0:4] = (2051).to_bytes(4, "little")
+    buf[4 : 4 + NAME_LEN] = b"TDRESREF"
+    for i, value in enumerate(slots):
+        at = payload + i * SLOT_STRIDE + 4
+        buf[at : at + 4] = int(value).to_bytes(4, "little")
+    # Room for the records the pointers name, each with a valid NFIELD.
+    buf.extend(b"\x00" * (max(rec_words) * 4 + 64))
+    for w in rec_words:
+        buf[w * 4 : w * 4 + 4] = np.float32(5.0).tobytes()
+
+    block = _decode_type_block(MmapSource(memoryview(bytes(buf))), preamble)
+    assert block.name == "TDRESREF"
+    # The anchor wins: the table starts where the block said, not where the walk
+    # over (cap, pop) pairs stopped.
+    assert block.pointer_table_offset == ptr_value_off - 4
+    # Both records are reachable, and the extra header slot is not among them —
+    # read one slot early it would be pointer[0], and being invalid it would
+    # truncate the table to nothing. (Trailing zero slots are the reader's
+    # documented tolerance: a zero pointer is empty, not invalid.)
+    got = block.pointer_table.tolist()
+    assert got[:2] == [w + 1 for w in rec_words]
+    assert 8 not in got

--- a/tests/core/fem/formats/sesam/test_read_sin.py
+++ b/tests/core/fem/formats/sesam/test_read_sin.py
@@ -429,10 +429,7 @@ def test_combination_label_describes_the_recipe():
 
     names = {1: "girder_local", 2: "deck", 8: "selfweight"}
     # float32 widening noise must not reach the label.
-    assert (
-        combination_label({1: 1.2000000476837158, 2: 1.1}, names)
-        == "1.2·girder_local + 1.1·deck"
-    )
+    assert combination_label({1: 1.2000000476837158, 2: 1.1}, names) == "1.2·girder_local + 1.1·deck"
     # Ordered by case number, not by factor, so two combinations line up by eye.
     assert combination_label({8: 1.0, 1: 2.0}, names) == "2·girder_local + 1·selfweight"
     # A basic case nobody named still appears — dropping it would misdescribe
@@ -478,8 +475,8 @@ def test_pointer_table_anchor_survives_an_extra_header_slot():
     from ada.fem.formats.sesam.results.sin_reader import (
         NAME_LEN,
         SLOT_STRIDE,
-        _decode_type_block,
         MmapSource,
+        _decode_type_block,
     )
 
     # One synthetic block: 4 fixed header slots, (cap, pop), an EXTRA slot, then

--- a/tests/core/fem/formats/sesam/test_read_sin.py
+++ b/tests/core/fem/formats/sesam/test_read_sin.py
@@ -402,3 +402,33 @@ def test_sin_registered_in_stream_readers():
         assert any(s.support == "nodal" for s in specs), "no nodal field surfaced for the streaming bake"
     finally:
         reader.close()
+
+
+def test_result_case_names_from_the_deck(sin_file):
+    """The deck's own name for each result case, keyed by case number.
+
+    Without this the viewer labels a step by its VALUE — "1", "2", "3" — which
+    is an index where the deck has a load case. The cantilever fixture names one
+    result case via ``TDRESREF``; a deck that names none returns ``None`` rather
+    than an empty dict, so a caller can tell "no names" from "no cases".
+    """
+    from ada.fem.formats.sesam.results.case_names import result_case_names
+
+    assert result_case_names(sin_file) == {1: "LC1"}
+    assert result_case_names(None) is None
+
+
+def test_result_case_names_reach_the_manifest_steps():
+    """`build_manifest` carries the names onto each step, additively.
+
+    `name` sits BESIDE `i` / `value` / `label` rather than replacing any of
+    them: every existing reader keys off those three, so a manifest baked by an
+    adapy without this — or from a deck that names nothing — is unchanged.
+    """
+    from ada.fem.formats.sesam.results.read_sin import SinStreamReader, open_sin
+
+    reader = SinStreamReader(open_sin(SIN_PATH))
+    try:
+        assert reader.try_step_names() == {1: "LC1"}
+    finally:
+        reader.close()


### PR DESCRIPTION
Replaces #280, which is being closed. **All of the substantive work here is
@oleandor's** — every one of the eight feature commits is theirs, unchanged, and
carries its original authorship and a `(cherry picked from commit ...)` trailer
back to the branch it came from. What this PR changes is the packaging around
them, plus two follow-ups.

## Why #280 could not simply be merged

Its diff contained one line that no review reads:

```
src/ada/visit/rendering/resources/index.zip | Bin 776265 -> 1002877 bytes
```

That blob is the compiled viewer bundle, and it had been rebuilt on a machine
with plugin overlays enabled. It absorbed the compiled source of two out-of-tree
packages that have no counterpart anywhere in `src/frontend` — their ids, their
design system, and a user-visible tooltip. `pyproject.toml` lists the file under
`package-data`, so it would have shipped **inside every published wheel**, not
merely been committed to a public tree.

Measured with the checker in #285, against the same corpus (a full `npm ci`
tree, 10,338 files):

| bundle | strings | with no source in this repo |
| --- | ---: | ---: |
| committed `index.zip` on `main` | 5,606 | **0** |
| `index.zip` on #280's head | 7,631 | **1,694** |

## What this branch does differently

**The bundle is not reverted here — it is absent.** Rather than replay #280 and
then restore the blob, each commit was replayed with the bundle pinned to
`main`, so **no commit in this branch touches `index.zip` at all**:

```
$ git log --oneline origin/main..HEAD -- src/ada/visit/rendering/resources/index.zip
$ git diff origin/main --stat -- src/ada/visit/rendering/resources/index.zip
```

Both empty. A revert commit would have left the polluted object reachable in
this repository's object store forever, which for a public repo is most of the
problem still standing. This way it is never pushed.

Verified with #285's checker against this branch's bundle:

```
bundle strings: 5606   corpus files: 10338
OK: all 5606 bundle strings trace to this repository (14 baselined as bundler-assembled).
```

## The two follow-ups

**`fix(rest): make the in-process plugin-job path fail like a server, not a fault`**
— four hardening fixes on the no-queue plugin-job path, each a failure mode that
is not the plugin's own bug but surfaces as one. The sharpest: an unimportable
`ADA_WORKER_PRELOAD` module used to take the whole API down. The
fatal-on-failure rule belongs to the *worker*, where a pool that exists because
of its preload has nothing to offer without it; the API serves the viewer, and
plugin jobs are one endpoint out of dozens. An `ImportError` escaping the
lifespan traded "one capability is missing" for a crashloop with no storage
browser, no scene, and no way to read the error. Now logged per module with its
traceback, and the endpoint answers 501.

11 tests in `tests/comms/rest/test_local_plugin_jobs.py`; nine fail against the
code before that commit, and two pin eviction behaviour that was already
correct.

**`docs: keep private project names out of the public source`** — three comments
reached for a real example where a generic one says the same thing. adapy is
public and these strings ship in every wheel. Sesam record names (TDRESREF,
TDLOAD, RDRESCMB, …) and the DNV-RP-C201 references stay: those are published
third-party formats and standards.

## What is unchanged from #280

All fifteen source files, byte for byte:

- `.SIN` as a first-class streaming FEA source, in the listing and the deep link
- plugin API **1.1.0** — placement, docks and modes, `right-aux`, the gizmo
  anchored to the canvas, `getPluginModes` and the new types exported from
  `@/viewer-core`
- a SIN block's pointer table read from the anchor the block gives
- Sesam result-case names carried into the manifest; a result deck reporting its
  named sets
- running a plugin job in-process when there is no queue

## Verification

- `pixi run lint-check` — 1,379 files unchanged, all checks passed
- `pytest tests/core/fem/formats/sesam/test_read_sin.py` — **19 passed**
- `pytest tests/comms/rest/test_local_plugin_jobs.py` (`viewer-api-tests` env) —
  **11 passed**
- #285's provenance checker on this branch's bundle — **exit 0**
- The full diff grepped for internal project, package and host names — no hits

## Merge order

#285 adds the CI gate that makes this class of mistake impossible to repeat, and
is independent of this PR. Landing it first means this PR's own bundle check
runs in CI rather than only in the summary above.

Downstream: this bumps the plugin API to 1.1.0, so a UI shell consuming
`getPluginModes` must not be released ahead of the adapy release that carries
this.
