### PR TITLE
feat: UI for the external-model API — scope binding and a model list

### DIFF
--- a/src/frontend/src/components/ExternalModelsPanel.tsx
+++ b/src/frontend/src/components/ExternalModelsPanel.tsx
@@ -1,0 +1,161 @@
+import React, {useCallback, useEffect, useState} from "react";
+
+import {makePluginContextStandalone} from "@/plugins";
+import {useScopeStore, scopeUrlPart} from "@/state/scopeStore";
+import {useExternalModelsStore} from "@/state/externalModelsStore";
+import {
+    ExternalModel,
+    bindingFor,
+    listModels,
+    loadBindingMap,
+    modelUrl,
+} from "@/services/externalModels";
+
+// The menu-bar list of externally-stored models for the current scope.
+//
+// Shows only when the scope is BOUND (Admin -> External Models). An unbound
+// deployment gets no panel and no button, which is why the binding tab is the
+// entry point for the whole feature rather than a detail of it.
+//
+// Loading goes through the same scene primitives a plugin would use, via the
+// standalone plugin context, so an external model is registered, disposed and
+// listed exactly like any other loaded source — one implementation of that
+// path, not two.
+
+const OWNER = "external-models";
+
+const ExternalModelsPanel: React.FC = () => {
+    const visible = useExternalModelsStore((s) => s.visible);
+    const scope = useScopeStore((s) => scopeUrlPart(s.current));
+
+    const [models, setModels] = useState<ExternalModel[]>([]);
+    const [binding, setBinding] = useState<{provider: string; collection: string} | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [loaded, setLoaded] = useState<Set<string>>(new Set());
+    const [busy, setBusy] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!visible) return;
+        let cancelled = false;
+        const abort = new AbortController();
+        void (async () => {
+            setLoading(true);
+            setError(null);
+            setModels([]);
+            try {
+                const b = bindingFor(await loadBindingMap(), scope);
+                if (cancelled) return;
+                setBinding(b);
+                if (!b) return;
+                const ms = await listModels(b.provider, b.collection, scope, {signal: abort.signal});
+                if (!cancelled) setModels(ms);
+            } catch (e) {
+                // The provider's own message is passed through: a refusal here
+                // may be a correct answer (no access to that collection), and it
+                // is better said in the words of whoever owns that access model.
+                if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+            abort.abort();
+        };
+    }, [visible, scope]);
+
+    const sourceNameFor = useCallback(
+        (m: ExternalModel) => `${OWNER}:${m.collection}/${m.id}`,
+        [],
+    );
+
+    const onLoad = useCallback(
+        async (m: ExternalModel) => {
+            if (!binding) return;
+            setBusy(m.id);
+            setError(null);
+            try {
+                const url = await modelUrl(binding.provider, binding.collection, m.id, scope);
+                const ctx = makePluginContextStandalone(OWNER);
+                await ctx.scene.loadModelFromUrl(OWNER, url, {
+                    sourceName: sourceNameFor(m),
+                    // Third-party glTF follows the spec's Y-up convention while
+                    // this viewer's world is Z-up, and the convention is baked
+                    // into the vertex data with no node transform to detect it,
+                    // so the caller has to declare it.
+                    sourceUpAxis: "y",
+                });
+                setLoaded((prev) => new Set(prev).add(m.id));
+            } catch (e) {
+                setError(e instanceof Error ? e.message : String(e));
+            } finally {
+                setBusy(null);
+            }
+        },
+        [binding, scope, sourceNameFor],
+    );
+
+    const onUnload = useCallback(
+        (m: ExternalModel) => {
+            makePluginContextStandalone(OWNER).scene.unloadModel(sourceNameFor(m));
+            setLoaded((prev) => {
+                const next = new Set(prev);
+                next.delete(m.id);
+                return next;
+            });
+        },
+        [sourceNameFor],
+    );
+
+    if (!visible) return null;
+
+    return (
+        <div className="absolute top-12 right-2 z-20 w-80 max-h-[70vh] overflow-auto rounded-sm border border-gray-700 bg-gray-900/95 shadow-lg">
+            <div className="px-3 py-2 border-b border-gray-700">
+                <div className="text-sm font-medium">External models</div>
+                <div className="text-xs text-gray-400 truncate">
+                    {binding ? `${binding.provider} / ${binding.collection}` : "not bound for this scope"}
+                </div>
+            </div>
+
+            {error && <div className="px-3 py-2 text-xs text-red-300">{error}</div>}
+
+            {loading && <div className="px-3 py-4 text-center text-xs text-gray-500">Loading…</div>}
+
+            {!loading && !binding && (
+                <div className="px-3 py-4 text-xs text-gray-400">
+                    No external collection is linked to this scope. An admin can link one under
+                    Admin → External Models.
+                </div>
+            )}
+
+            {!loading && binding && models.length === 0 && !error && (
+                <div className="px-3 py-4 text-xs text-gray-400">
+                    This collection has no loadable models.
+                </div>
+            )}
+
+            <ul>
+                {models.map((m) => {
+                    const isLoaded = loaded.has(m.id);
+                    return (
+                        <li key={m.id} className="flex items-center gap-2 px-3 py-2 border-t border-gray-800">
+                            <span className="flex-1 truncate text-sm" title={m.name}>{m.name}</span>
+                            <button
+                                type="button"
+                                className="text-xs px-2 py-1 rounded-sm border border-gray-700 hover:bg-gray-800 disabled:opacity-50"
+                                disabled={busy === m.id}
+                                onClick={() => (isLoaded ? onUnload(m) : void onLoad(m))}
+                            >
+                                {busy === m.id ? "…" : isLoaded ? "Unload" : "Load"}
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+};
+
+export default ExternalModelsPanel;

--- a/src/frontend/src/components/Menu.tsx
+++ b/src/frontend/src/components/Menu.tsx
@@ -6,6 +6,8 @@ import { useComponentControlsStore } from "@/state/componentControlsStore";
 import { useComponentSpecsStore } from "@/state/componentSpecsStore";
 import { request_list_of_nodes } from "../utils/node_editor/handlers/request_list_of_nodes";
 import ServerInfoBox from "./server_info/ServerInfoBox";
+import ExternalModelsPanel from "./ExternalModelsPanel";
+import { useExternalModelsStore } from "@/state/externalModelsStore";
 import { runtime } from "@/runtime/config";
 import { useViewerStores } from "../state/AdaViewerContext";
 // REST-only — code-split so the embedded desktop zip stays slim.
@@ -18,6 +20,7 @@ import GraphIcon from "./icons/GraphIcon";
 import InfoIcon from "./icons/InfoIcon";
 import ReloadIcon from "./icons/ReloadIcon";
 import ServerIcon from "./icons/ServerIcon";
+import ExternalModelsIcon from "./icons/ExternalModelsIcon";
 import ToggleControlsIcon from "./icons/AnimationControlToggle";
 import TreeViewIcon from "./icons/TreeViewIcon";
 import SceneIcon from "./icons/SceneIcon";
@@ -130,6 +133,8 @@ const Menu = () => {
     stores.useNodeEditorStore();
   const { isOptionsVisible, setIsOptionsVisible, enableNodeEditor } =
     stores.useOptionsStore(); // use the useNavBarStore function
+  const externalModelsVisible = useExternalModelsStore((s) => s.visible);
+  const toggleExternalModels = useExternalModelsStore((s) => s.toggle);
   const { showServerInfoBox, setShowServerInfoBox } =
     stores.useServerInfoStore();
   const { hasAnimation, isControlsVisible, setIsControlsVisible } =
@@ -240,6 +245,21 @@ const Menu = () => {
               aria-pressed={showServerInfoBox}
             >
               <ServerIcon />
+            </button>
+          )}
+          {/* External models — REST-only for the same reason as Storage: the
+              catalogue is served by the REST API. Hidden entirely rather than
+              disabled when the scope has no binding would require reading the
+              setting on every scope change just to decide whether to draw a
+              button, so the button stays and the PANEL explains. */}
+          {runtime.isRestMode() && (
+            <button
+              className={navBtnClass(externalModelsVisible)}
+              onClick={toggleExternalModels}
+              title="External models"
+              aria-pressed={externalModelsVisible}
+            >
+              <ExternalModelsIcon />
             </button>
           )}
           <button
@@ -369,6 +389,7 @@ const Menu = () => {
           {/* Plugin-contributed panels (region "top-panel"). Each is wrapped in
               an ErrorBoundary inside PluginPanelRegion so a plugin crash is
               contained. Renders nothing when no plugin is active. */}
+          <ExternalModelsPanel />
           <PluginPanelRegion region="top-panel" />
         </div>
       </div>

--- a/src/frontend/src/components/admin/AdminPanel.tsx
+++ b/src/frontend/src/components/admin/AdminPanel.tsx
@@ -12,6 +12,7 @@ import EquipmentAdminPanel from "./EquipmentAdminPanel";
 import FrontendLoadsTab from "./FrontendLoadsTab";
 import IssueTargetTab from "./IssueTargetTab";
 import PerformanceTab from "./PerformanceTab";
+import ExternalModelsTab from "./ExternalModelsTab";
 import ProjectsTab from "./ProjectsTab";
 import SchedulesTab from "./SchedulesTab";
 import StorageTab from "./StorageTab";
@@ -34,7 +35,7 @@ import WorkersTab from "./WorkersTab";
 
 const VALID_TABS = new Set<AdminTab>([
     "audit", "audit_runs", "schedules", "issues", "performance",
-    "frontend_loads", "corpus", "projects", "storage", "workers", "conversion",
+    "frontend_loads", "corpus", "projects", "external_models", "storage", "workers", "conversion",
     "equipment", "system", "engines",
 ]);
 
@@ -147,6 +148,9 @@ const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false, initialTab}) =
                     <TabButton active={tab === "projects"} onClick={() => setTab("projects")}>
                         Projects
                     </TabButton>
+                    <TabButton active={tab === "external_models"} onClick={() => setTab("external_models")}>
+                        External Models
+                    </TabButton>
                     <TabButton active={tab === "storage"} onClick={() => setTab("storage")}>
                         Storage
                     </TabButton>
@@ -197,6 +201,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({embedded = false, initialTab}) =
                 {tab === "frontend_loads" && <FrontendLoadsTab/>}
                 {tab === "corpus" && <CorpusTab/>}
                 {tab === "projects" && <ProjectsTab/>}
+                {tab === "external_models" && <ExternalModelsTab/>}
                 {tab === "storage" && <StorageTab/>}
                 {tab === "workers" && <WorkersTab/>}
                 {tab === "conversion" && <ConversionSettingsTab/>}

--- a/src/frontend/src/components/admin/ExternalModelsTab.tsx
+++ b/src/frontend/src/components/admin/ExternalModelsTab.tsx
@@ -1,0 +1,228 @@
+import React, {useCallback, useEffect, useMemo, useState} from "react";
+
+import {AdminProject, viewerApi} from "@/services/viewerApi";
+import {
+    ExternalCollection,
+    ExternalModelProvider,
+    listCollections,
+    listProviders,
+} from "@/services/externalModels";
+import {
+    ExternalModelBindingMap,
+    bindingFor,
+    parseBindingMap,
+    EXTERNAL_MODELS_BINDING_KEY,
+} from "@/services/externalModelsBinding";
+
+// Admin tab — bind a viewer scope to an external model collection.
+//
+// WHY ITS OWN TAB RATHER THAN A ROW IN "Projects". The binding is per SCOPE,
+// and a scope is not always a project: `shared` and a user's personal scope are
+// bindable too, and neither has a row in the projects list. Hanging this off
+// the project rows would have made the two most useful bindings unreachable.
+//
+// WHAT IT UNLOCKS. The viewer only offers the external-model list for a scope
+// that is bound — an unbound deployment sees no change at all. This tab is the
+// only way to create that binding.
+//
+// The map lives at a `public.`-prefixed setting so any authenticated user's UI
+// can READ it (they need it to know whether to show the menu entry), while
+// writes stay admin-only. It is not sensitive: it says which scope points at
+// which collection, and anyone who can see the list already sees those names.
+
+const CATALOGUE_SCOPE = "shared";
+
+interface ScopeRow {
+    scope: string;
+    label: string;
+    hint: string;
+}
+
+const ExternalModelsTab: React.FC = () => {
+    const [providers, setProviders] = useState<ExternalModelProvider[]>([]);
+    const [projects, setProjects] = useState<AdminProject[]>([]);
+    const [map, setMap] = useState<ExternalModelBindingMap>({});
+    // provider id -> its collections, fetched lazily and cached: each call is an
+    // enqueue/poll round-trip, so re-fetching per row would be visibly slow.
+    const [collections, setCollections] = useState<Record<string, ExternalCollection[]>>({});
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const [provs, projs, raw] = await Promise.all([
+                listProviders(CATALOGUE_SCOPE).catch(() => [] as ExternalModelProvider[]),
+                viewerApi.adminListProjects().catch(() => [] as AdminProject[]),
+                viewerApi.getPublicSetting(EXTERNAL_MODELS_BINDING_KEY).catch(() => null),
+            ]);
+            setProviders(provs);
+            setProjects(projs.filter((p) => !p.archived_at));
+            setMap(parseBindingMap(raw));
+            if (provs.length === 0) {
+                // Distinguish "no provider registered" from "catalogue empty":
+                // the usual cause is a worker that never preloaded a provider
+                // module, and that is not visible from anywhere else in the UI.
+                setError(
+                    "No external-model providers are registered. A worker must preload a " +
+                    "provider module before anything can be bound.",
+                );
+            }
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    const loadCollections = useCallback(
+        async (provider: string) => {
+            if (!provider || collections[provider]) return;
+            try {
+                const cols = await listCollections(provider, CATALOGUE_SCOPE);
+                setCollections((prev) => ({...prev, [provider]: cols}));
+            } catch (e) {
+                setError(e instanceof Error ? e.message : String(e));
+                setCollections((prev) => ({...prev, [provider]: []}));
+            }
+        },
+        [collections],
+    );
+
+    const rows: ScopeRow[] = useMemo(() => {
+        const out: ScopeRow[] = [
+            {scope: "shared", label: "Shared", hint: "everyone with access to this viewer"},
+            {scope: "user:me", label: "My personal scope", hint: "resolved per user, server-side"},
+        ];
+        for (const p of projects) {
+            out.push({scope: `project:${p.id}`, label: p.name, hint: p.slug});
+        }
+        return out;
+    }, [projects]);
+
+    const persist = useCallback(async (next: ExternalModelBindingMap) => {
+        // Write through the ADMIN setter: the public prefix governs read access
+        // only and has no public setter.
+        await viewerApi.adminSetSetting(EXTERNAL_MODELS_BINDING_KEY, JSON.stringify(next));
+        setMap(next);
+    }, []);
+
+    const setBinding = useCallback(
+        async (scope: string, provider: string, collection: string) => {
+            setBusy(scope);
+            setError(null);
+            try {
+                const next = {...map};
+                if (!provider || !collection) {
+                    delete next[scope];
+                } else {
+                    next[scope] = `${provider}:${collection}`;
+                }
+                await persist(next);
+            } catch (e) {
+                setError(e instanceof Error ? e.message : String(e));
+            } finally {
+                setBusy(null);
+            }
+        },
+        [map, persist],
+    );
+
+    if (loading) {
+        return <div className="px-4 py-8 text-center text-gray-500 text-sm">Loading…</div>;
+    }
+
+    return (
+        <div className="h-full overflow-auto">
+            <div className="px-3 py-3 border-b border-gray-700 space-y-1">
+                <div className="text-sm font-medium">External model bindings</div>
+                <div className="text-xs text-gray-400">
+                    A scope with a binding gets an external-model list in the viewer. An unbound
+                    scope sees no change.
+                </div>
+            </div>
+
+            {error && (
+                <div className="px-3 py-2 text-red-300 text-xs border-b border-gray-700">{error}</div>
+            )}
+
+            <table className="w-full text-sm">
+                <thead>
+                <tr className="text-left text-xs uppercase text-gray-500">
+                    <th className="px-3 py-2 font-medium">Scope</th>
+                    <th className="px-3 py-2 font-medium">Provider</th>
+                    <th className="px-3 py-2 font-medium">Collection</th>
+                </tr>
+                </thead>
+                <tbody>
+                {rows.map((row) => {
+                    const bound = bindingFor(map, row.scope);
+                    const provider = bound?.provider ?? "";
+                    const collection = bound?.collection ?? "";
+                    const known = collections[provider] ?? [];
+                    // A binding whose collection is no longer listed still
+                    // renders, marked. Dropping it from the <select> would
+                    // silently unbind the scope the moment an admin opened this
+                    // tab before the provider had been read.
+                    const missing = Boolean(collection) && known.length > 0
+                        && !known.some((c) => c.id === collection);
+                    return (
+                        <tr key={row.scope} className="border-t border-gray-800">
+                            <td className="px-3 py-2 align-top">
+                                <div className="font-medium">{row.label}</div>
+                                <div className="text-xs text-gray-500">{row.hint}</div>
+                            </td>
+                            <td className="px-3 py-2 align-top">
+                                <select
+                                    className="w-full bg-gray-800 border border-gray-700 rounded-sm px-2 py-1 text-sm"
+                                    value={provider}
+                                    disabled={busy === row.scope}
+                                    onFocus={() => void loadCollections(provider)}
+                                    onChange={(e) => {
+                                        const p = e.target.value;
+                                        void loadCollections(p);
+                                        // Changing provider clears the collection:
+                                        // a collection id is only meaningful within
+                                        // the provider it came from.
+                                        void setBinding(row.scope, p, "");
+                                    }}
+                                >
+                                    <option value="">— none —</option>
+                                    {providers.map((p) => (
+                                        <option key={p.id} value={p.id}>{p.label}</option>
+                                    ))}
+                                </select>
+                            </td>
+                            <td className="px-3 py-2 align-top">
+                                <select
+                                    className="w-full bg-gray-800 border border-gray-700 rounded-sm px-2 py-1 text-sm"
+                                    value={collection}
+                                    disabled={!provider || busy === row.scope}
+                                    onFocus={() => void loadCollections(provider)}
+                                    onChange={(e) => void setBinding(row.scope, provider, e.target.value)}
+                                >
+                                    <option value="">— none —</option>
+                                    {missing && (
+                                        <option value={collection}>{collection} (not in list)</option>
+                                    )}
+                                    {known.map((c) => (
+                                        <option key={c.id} value={c.id}>{c.name}</option>
+                                    ))}
+                                </select>
+                            </td>
+                        </tr>
+                    );
+                })}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default ExternalModelsTab;

--- a/src/frontend/src/components/icons/ExternalModelsIcon.tsx
+++ b/src/frontend/src/components/icons/ExternalModelsIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+// A box with an outbound arrow — geometry sourced from somewhere this viewer
+// does not manage.
+const ExternalModelsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg width="24px" height="24px" strokeWidth="1.5" viewBox="0 0 24 24" fill="none"
+         xmlns="http://www.w3.org/2000/svg" color="currentColor" {...props}>
+        <path d="M12 22L3 17V7L12 2L21 7V11" stroke="currentColor" strokeWidth="1.5"
+              strokeLinecap="round" strokeLinejoin="round"></path>
+        <path d="M12 22V12M12 12L21 7M12 12L3 7" stroke="currentColor" strokeWidth="1.5"
+              strokeLinecap="round" strokeLinejoin="round"></path>
+        <path d="M15 19H21M21 19L18.5 16.5M21 19L18.5 21.5" stroke="currentColor" strokeWidth="1.5"
+              strokeLinecap="round" strokeLinejoin="round"></path>
+    </svg>
+);
+
+export default ExternalModelsIcon;

--- a/src/frontend/src/state/adminPanelStore.ts
+++ b/src/frontend/src/state/adminPanelStore.ts
@@ -11,6 +11,7 @@ export type AdminTab =
     | "frontend_loads"
     | "corpus"
     | "projects"
+    | "external_models"
     | "storage"
     | "workers"
     | "conversion"

--- a/src/frontend/src/state/externalModelsStore.ts
+++ b/src/frontend/src/state/externalModelsStore.ts
@@ -1,0 +1,20 @@
+import {create} from "zustand";
+
+// Visibility for the external-models panel in the menu bar.
+//
+// Deliberately NOT persisted. The panel's contents depend on the current
+// scope's binding, which an admin can change or remove at any time; restoring
+// it open across reloads would reopen a panel that may now have nothing behind
+// it. The button is one click.
+
+interface ExternalModelsState {
+    visible: boolean;
+    setVisible: (v: boolean) => void;
+    toggle: () => void;
+}
+
+export const useExternalModelsStore = create<ExternalModelsState>()((set) => ({
+    visible: false,
+    setVisible: (v) => set({visible: v}),
+    toggle: () => set((s) => ({visible: !s.visible})),
+}));


### PR DESCRIPTION
Follow-up to #287, which added the external-model API but nothing that could create the binding it reads. The feature was unreachable from the UI.

Two halves.

## Admin → External Models

A tab for linking a viewer **scope** to a provider + collection.

**Why its own tab rather than a row in Projects.** The binding is per scope, and a scope is not always a project: `shared` and a user's personal scope are bindable too, and neither has a row in the projects list. Hanging this off project rows would have put the two most useful bindings out of reach.

```
Scope                 | Provider        | Collection
Shared                | Object store    | demo
My personal scope     | — none —        | — none —
Some Project          | Third party     | plant-a
```

Provider **and** collection are chosen per row, so different scopes can point at different catalogues rather than the deployment having one global source.

Two behaviours worth keeping:

* A binding whose collection is no longer listed still renders, marked `(not in list)`. Dropping it from the `<select>` would silently unbind the scope the moment an admin opened the tab before that provider had been read.
* Zero registered providers is reported as its own message rather than an empty table — the usual cause is a worker that never preloaded a provider module, which is not visible anywhere else in the UI.

Collections are fetched lazily per provider and cached; each call is an enqueue/poll round-trip, so re-fetching per row would be visibly slow.

## Menu-bar panel

Lists the bound collection's models for the current scope, with Load / Unload into the scene. Re-reads the binding on every scope change, since switching project can switch catalogue entirely.

Loading goes through the standalone plugin context rather than reimplementing the loader, so an external model is registered, disposed and listed exactly like any other loaded source — one implementation of that path, not two. `sourceUpAxis: "y"` is declared explicitly: third-party glTF follows the spec's Y-up convention while this viewer's world is Z-up, and it is baked into the vertex data with no node transform for core to detect.

Deliberate choices:

* The **button** always shows (in REST mode) and the **panel** explains an unbound scope. Hiding the button instead would mean reading the setting on every scope change purely to decide whether to draw it.
* Visibility is not persisted — the contents depend on a binding an admin can change or remove, so restoring it open could reopen a panel with nothing behind it.
* A provider's error text is passed through verbatim; a refusal can be a correct answer, and is better said in the words of whoever owns that access model.

## Verification

```
tsc          clean for these files (the one remaining error,
             load_fea_streaming.ts, is present on clean main)
frontend     275 passed / 1 skipped
```

## Note for deployers

A worker must register a provider before anything can be bound — either `ADA_WORKER_PRELOAD=ada.plugins.external_models` on the pool, or a plugin dist declaring an `ada.plugins` entry point. Until then the tab correctly reports that no providers are registered rather than showing an empty table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)