### PR TITLE
feat: external-model UI — development branch

### DIFF
--- a/src/frontend/src/components/admin/ExternalModelsTab.tsx
+++ b/src/frontend/src/components/admin/ExternalModelsTab.tsx
@@ -47,6 +47,11 @@ const ExternalModelsTab: React.FC = () => {
     const [collections, setCollections] = useState<Record<string, ExternalCollection[]>>({});
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState<string | null>(null);
+    // Provider chosen for a scope but not yet persisted, because a binding needs
+    // BOTH halves. Without this the provider <select> appears dead: choosing one
+    // would write an incomplete binding, which `setBinding` correctly treats as
+    // "unbind", so the control snapped straight back to none.
+    const [pendingProvider, setPendingProvider] = useState<Record<string, string>>({});
     const [error, setError] = useState<string | null>(null);
 
     const refresh = useCallback(async () => {
@@ -163,7 +168,9 @@ const ExternalModelsTab: React.FC = () => {
                 <tbody>
                 {rows.map((row) => {
                     const bound = bindingFor(map, row.scope);
-                    const provider = bound?.provider ?? "";
+                    // A persisted binding wins; otherwise show what the operator
+                    // just picked and has not finished.
+                    const provider = bound?.provider ?? pendingProvider[row.scope] ?? "";
                     const collection = bound?.collection ?? "";
                     const known = collections[provider] ?? [];
                     // A binding whose collection is no longer listed still
@@ -186,11 +193,16 @@ const ExternalModelsTab: React.FC = () => {
                                     onFocus={() => void loadCollections(provider)}
                                     onChange={(e) => {
                                         const p = e.target.value;
+                                        setPendingProvider((prev) => ({...prev, [row.scope]: p}));
                                         void loadCollections(p);
-                                        // Changing provider clears the collection:
-                                        // a collection id is only meaningful within
-                                        // the provider it came from.
-                                        void setBinding(row.scope, p, "");
+                                        // Only touch storage when the scope was
+                                        // already bound: switching provider
+                                        // invalidates the old collection (an id is
+                                        // only meaningful within its provider), and
+                                        // clearing to none means unbind. Choosing a
+                                        // provider for an UNBOUND scope writes
+                                        // nothing until a collection follows.
+                                        if (bound) void setBinding(row.scope, "", "");
                                     }}
                                 >
                                     <option value="">— none —</option>
@@ -206,6 +218,7 @@ const ExternalModelsTab: React.FC = () => {
                                     disabled={!provider || busy === row.scope}
                                     onFocus={() => void loadCollections(provider)}
                                     onChange={(e) => void setBinding(row.scope, provider, e.target.value)}
+                                    title={provider ? undefined : "Choose a provider first"}
                                 >
                                     <option value="">— none —</option>
                                     {missing && (


### PR DESCRIPTION
Accumulating branch for the external-model feature. Opened as a **draft** deliberately: it collects iteration commits and should be reviewed as one change when the feature settles, rather than as a stream of small PRs.

Builds of this branch deploy to an internal viewer, so each commit here is exercised against a real catalogue before it is proposed for `main`.

## Landed already (merged separately)

* **#287** — the external-model API: a provider registry in core, a built-in object-store provider, and the viewer-side client
* **#288** — the UI: an admin tab binding a scope to a provider/collection, and a menu-bar model list

## In this branch

* **Provider dropdown erased the binding it was setting.** `setBinding(scope, provider, "")` treats an empty collection as *unbind*, so choosing a provider deleted the binding, persisted the emptied map, and let the control revert to none — a full server round-trip per selection, landing exactly where it started. A binding needs both halves, so a provider chosen alone now lives in component state until a collection follows.

## Review notes

* The catalogue path was never at fault in the above: `list_providers` and the derived-blob read both returned 200 throughout.
* Squash on merge; the intermediate commits are iteration, not history worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)