### PR TITLE
feat(external-models): the panel, the binding, and the fixes found running it

### DIFF
--- a/deploy/helm/adapy-viewer/templates/_helpers.tpl
+++ b/deploy/helm/adapy-viewer/templates/_helpers.tpl
@@ -194,6 +194,14 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- include "adapy-viewer.databaseEnv" $ctx | nindent 12 }}
+          {{- /* Whole-secret env for a pool, for values that must not appear in
+               a values file: credentials for a bucket the worker reads that is
+               NOT the viewer's own storage. Keys are used verbatim, so the
+               secret must already name them as the variables the code reads. */}}
+          {{- with $w.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if eq $ctx.Values.storage.kind "local" }}
           volumeMounts:
             - name: data

--- a/deploy/helm/adapy-viewer/values.yaml
+++ b/deploy/helm/adapy-viewer/values.yaml
@@ -72,6 +72,11 @@ worker:
   ##   ADA_STEP_STREAM_WORKER_SOFT_MEM_MB   idle-recycle threshold (0 disables)
   ##   ADA_STEP_STREAM_WORKER_HARD_MEM_MB   mid-solid kill + requeue-once threshold (0 disables)
   extraEnv: {}
+  ## envFrom sources for this pool (e.g. [{secretRef: {name: my-secret}}]).
+  ## For values that cannot live in a values file — credentials for a bucket
+  ## the worker reads that is not the viewer's own storage. Keys are consumed
+  ## verbatim, so the secret must name them as the variables the code reads.
+  extraEnvFrom: []
   ## Non-root, matching the viewer/API container. The conversion stack only needs a
   ## writable tmpdir (/tmp, world-writable) and a cache HOME — the worker image points
   ## HOME at a uid-10001-owned dir, so root is not required. (No fsGroup: the S3 storage

--- a/src/ada/plugins/external_models/adapy_plugin.py
+++ b/src/ada/plugins/external_models/adapy_plugin.py
@@ -114,13 +114,23 @@ def run_job(
         raise ValueError("action 'model_url' requires a 'model_id' option")
     expires = int(options.get("expires_in_seconds") or 900)
     url = cat.model_download_url(collection, model_id, expires_in_seconds=expires)
+
+    # A provider whose URL carries its own signature needs no headers; one whose
+    # fetch must be authenticated returns them. getattr rather than a required
+    # Protocol method, so a provider written before this keeps working.
+    headers: dict[str, str] = {}
+    getter = getattr(cat, "model_download_headers", None)
+    if callable(getter):
+        headers = dict(getter(collection, model_id) or {})
+
     _progress(action, 0.9)
-    # The URL is presigned and short-lived; it is the payload, so it necessarily
-    # reaches the browser. Never logged.
+    # URL and headers are short-lived credentials; they are the payload, so they
+    # necessarily reach the browser. Never logged.
     return {
         "action": action,
         "provider": provider,
         "collection": collection,
         "model_id": model_id,
         "url": url,
+        "headers": headers,
     }

--- a/src/ada/plugins/external_models/catalog.py
+++ b/src/ada/plugins/external_models/catalog.py
@@ -44,6 +44,16 @@ __all__ = [
 # bucket" — otherwise a stray README.md shows up in the dropdown as a model.
 MODEL_SUFFIXES = (".glb", ".gltf")
 
+# Optional per-collection sidecar mapping model id -> display label, so a
+# catalogue can show a meaningful name where the object key is an opaque
+# identifier (an E3D ref, say). One GET per listing regardless of model count,
+# which is why it is a single file rather than per-object metadata: S3 listings
+# do not carry user metadata, so that shape would cost one HEAD per model.
+#
+# Absent, unreadable or malformed is NOT an error -- every model simply falls
+# back to its filename, which is what an unlabelled collection should look like.
+LABELS_FILENAME = "_labels.json"
+
 
 @dataclass(frozen=True)
 class Collection:
@@ -62,6 +72,10 @@ class ExternalModel:
     collection: str
     key: str
     size: int | None = None
+    # True when `name` came from the collection's label manifest rather than
+    # from the filename. Lets a UI show that a name is curated instead of
+    # derived, and lets a scan job find what is still unlabelled.
+    labelled: bool = False
 
 
 @runtime_checkable
@@ -203,10 +217,35 @@ class S3ExternalModelCatalog:
                 seen.add(head)
         return [Collection(id=c, name=c) for c in sorted(seen)]
 
+    def _labels(self, collection: str) -> dict[str, str]:
+        """The collection's id -> label map, or empty.
+
+        Every failure mode here is deliberately silent: a collection with no
+        manifest is the normal case, and a malformed one should degrade to
+        filenames rather than break the listing it decorates.
+        """
+        import json
+
+        import obstore as obs
+
+        try:
+            raw = obs.get(self._store, f"{collection}/{LABELS_FILENAME}").bytes()
+        except Exception:
+            return {}
+        try:
+            parsed = json.loads(bytes(raw).decode("utf-8"))
+        except Exception:
+            logger.warning("external-models: %s/%s is not valid JSON", collection, LABELS_FILENAME)
+            return {}
+        if not isinstance(parsed, dict):
+            return {}
+        return {str(k): str(v) for k, v in parsed.items() if isinstance(v, (str, int, float))}
+
     def list_models(self, collection: str) -> list[ExternalModel]:
         collection = collection.strip("/")
         if not collection:
             return []
+        labels = self._labels(collection)
         models: list[ExternalModel] = []
         for key in self._list_keys(f"{collection}/"):
             rest = key[len(collection) + 1 :]
@@ -214,14 +253,19 @@ class S3ExternalModelCatalog:
             # collection. Ignoring it beats flattening it into a bogus name.
             if "/" in rest:
                 continue
-            if not rest.lower().endswith(MODEL_SUFFIXES):
+            if rest == LABELS_FILENAME or not rest.lower().endswith(MODEL_SUFFIXES):
                 continue
+            model_id = _model_name(rest)
+            label = labels.get(model_id)
             models.append(
                 ExternalModel(
-                    id=_model_name(rest),
-                    name=_model_name(rest),
+                    id=model_id,
+                    # The id stays the filename-derived value: it addresses the
+                    # object and must not move when someone edits a label.
+                    name=label or model_id,
                     collection=collection,
                     key=key,
+                    labelled=label is not None,
                 )
             )
         return sorted(models, key=lambda m: m.name)

--- a/src/ada/plugins/external_models/catalog.py
+++ b/src/ada/plugins/external_models/catalog.py
@@ -223,12 +223,19 @@ class S3ExternalModelCatalog:
         Every failure mode here is deliberately silent: a collection with no
         manifest is the normal case, and a malformed one should degrade to
         filenames rather than break the listing it decorates.
+
+        THE IMPORT IS INSIDE THE TRY for that reason. Left outside it, an
+        environment without obstore raised straight through `list_models` --
+        which is a listing failing because its DECORATION is unavailable, and
+        the opposite of what this docstring promises. It also broke the test
+        fake, which overrides `_list_keys` precisely so it can exercise the
+        key-walking without a bucket or the dependency.
         """
         import json
 
-        import obstore as obs
-
         try:
+            import obstore as obs
+
             raw = obs.get(self._store, f"{collection}/{LABELS_FILENAME}").bytes()
         except Exception:
             return {}

--- a/src/ada/plugins/external_models/catalog.py
+++ b/src/ada/plugins/external_models/catalog.py
@@ -75,6 +75,15 @@ class ExternalModelCatalog(Protocol):
 
     def model_download_url(self, collection: str, model_id: str, *, expires_in_seconds: int = 900) -> str: ...
 
+    # OPTIONAL, and intentionally not part of the Protocol's required surface: a
+    # provider whose download URL carries its own signature needs nothing here,
+    # while one whose fetch must be authenticated (a direct-read client against a
+    # vendor API, say) returns the headers the browser should send. Absent means
+    # "no headers", so an object-store provider implements nothing.
+    #
+    # Resolved with getattr at the call site rather than declared here, so a
+    # provider written before this existed keeps satisfying the Protocol.
+
 
 def _model_name(key: str) -> str:
     base = key.rsplit("/", 1)[-1]

--- a/src/frontend/src/components/ExternalModelsPanel.tsx
+++ b/src/frontend/src/components/ExternalModelsPanel.tsx
@@ -123,8 +123,11 @@ const ExternalModelsPanel: React.FC = () => {
 
     if (!visible) return null;
 
+    // text-gray-100 is not decoration: the panel sets a dark background but
+    // inherited nothing for the foreground, so model names rendered dark on dark
+    // and were effectively invisible.
     return (
-        <div className="absolute top-12 right-2 z-20 w-80 max-h-[70vh] overflow-auto rounded-sm border border-gray-700 bg-gray-900/95 shadow-lg">
+        <div className="absolute top-12 right-2 z-20 w-80 max-h-[70vh] overflow-auto rounded-sm border border-gray-700 bg-gray-900/95 text-gray-100 shadow-lg">
             <div className="px-3 py-2 border-b border-gray-700">
                 <div className="text-sm font-medium">External models</div>
                 <div className="text-xs text-gray-400 truncate">
@@ -154,10 +157,10 @@ const ExternalModelsPanel: React.FC = () => {
                     const isLoaded = loaded.has(m.id);
                     return (
                         <li key={m.id} className="flex items-center gap-2 px-3 py-2 border-t border-gray-800">
-                            <span className="flex-1 truncate text-sm" title={m.name}>{m.name}</span>
+                            <span className="flex-1 truncate text-sm text-gray-100" title={m.name}>{m.name}</span>
                             <button
                                 type="button"
-                                className="text-xs px-2 py-1 rounded-sm border border-gray-700 hover:bg-gray-800 disabled:opacity-50"
+                                className="text-xs px-2 py-1 rounded-sm border border-gray-700 text-gray-200 hover:bg-gray-800 disabled:opacity-50"
                                 disabled={busy === m.id}
                                 onClick={() => (isLoaded ? onUnload(m) : void onLoad(m))}
                             >

--- a/src/frontend/src/components/ExternalModelsPanel.tsx
+++ b/src/frontend/src/components/ExternalModelsPanel.tsx
@@ -6,6 +6,7 @@ import {useExternalModelsStore} from "@/state/externalModelsStore";
 import {
     ExternalModel,
     bindingFor,
+    catalogueNonce,
     listModels,
     loadBindingMap,
     modelUrl,
@@ -48,7 +49,13 @@ const ExternalModelsPanel: React.FC = () => {
                 if (cancelled) return;
                 setBinding(b);
                 if (!b) return;
-                const ms = await listModels(b.provider, b.collection, scope, {signal: abort.signal});
+                // Fresh each time the panel opens or the scope changes: core
+                // caches an identical request indefinitely, so without this the
+                // list could never reflect a changed catalogue.
+                const ms = await listModels(b.provider, b.collection, scope, {
+                    signal: abort.signal,
+                    refresh: catalogueNonce(),
+                });
                 if (!cancelled) setModels(ms);
             } catch (e) {
                 // The provider's own message is passed through: a refusal here

--- a/src/frontend/src/components/ExternalModelsPanel.tsx
+++ b/src/frontend/src/components/ExternalModelsPanel.tsx
@@ -76,10 +76,16 @@ const ExternalModelsPanel: React.FC = () => {
             setBusy(m.id);
             setError(null);
             try {
-                const url = await modelUrl(binding.provider, binding.collection, m.id, scope);
+                const {url, headers} = await modelUrl(
+                    binding.provider, binding.collection, m.id, scope,
+                );
                 const ctx = makePluginContextStandalone(OWNER);
                 await ctx.scene.loadModelFromUrl(OWNER, url, {
                     sourceName: sourceNameFor(m),
+                    // Empty for a presigned URL; populated for a provider whose
+                    // fetch must be authenticated. Passing them through means the
+                    // panel works for both without branching on provider.
+                    headers: Object.keys(headers).length ? headers : undefined,
                     // Third-party glTF follows the spec's Y-up convention while
                     // this viewer's world is Z-up, and the convention is baked
                     // into the vertex data with no node transform to detect it,

--- a/src/frontend/src/components/admin/ExternalModelsTab.tsx
+++ b/src/frontend/src/components/admin/ExternalModelsTab.tsx
@@ -4,6 +4,7 @@ import {AdminProject, viewerApi} from "@/services/viewerApi";
 import {
     ExternalCollection,
     ExternalModelProvider,
+    catalogueNonce,
     listCollections,
     listProviders,
 } from "@/services/externalModels";
@@ -52,6 +53,10 @@ const ExternalModelsTab: React.FC = () => {
     // would write an incomplete binding, which `setBinding` correctly treats as
     // "unbind", so the control snapped straight back to none.
     const [pendingProvider, setPendingProvider] = useState<Record<string, string>>({});
+    // Cache-busting token, refreshed on mount and on demand. Without it the
+    // catalogue reads cache-hit forever and this tab cannot show a deployment
+    // whose provider configuration changed after the first ever read.
+    const [nonce, setNonce] = useState(catalogueNonce);
     const [error, setError] = useState<string | null>(null);
 
     const refresh = useCallback(async () => {
@@ -59,7 +64,9 @@ const ExternalModelsTab: React.FC = () => {
         setError(null);
         try {
             const [provs, projs, raw] = await Promise.all([
-                listProviders(CATALOGUE_SCOPE).catch(() => [] as ExternalModelProvider[]),
+                listProviders(CATALOGUE_SCOPE, {refresh: nonce}).catch(
+                    () => [] as ExternalModelProvider[],
+                ),
                 viewerApi.adminListProjects().catch(() => [] as AdminProject[]),
                 viewerApi.getPublicSetting(EXTERNAL_MODELS_BINDING_KEY).catch(() => null),
             ]);
@@ -80,7 +87,7 @@ const ExternalModelsTab: React.FC = () => {
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [nonce]);
 
     useEffect(() => {
         void refresh();
@@ -90,14 +97,14 @@ const ExternalModelsTab: React.FC = () => {
         async (provider: string) => {
             if (!provider || collections[provider]) return;
             try {
-                const cols = await listCollections(provider, CATALOGUE_SCOPE);
+                const cols = await listCollections(provider, CATALOGUE_SCOPE, {refresh: nonce});
                 setCollections((prev) => ({...prev, [provider]: cols}));
             } catch (e) {
                 setError(e instanceof Error ? e.message : String(e));
                 setCollections((prev) => ({...prev, [provider]: []}));
             }
         },
-        [collections],
+        [collections, nonce],
     );
 
     const rows: ScopeRow[] = useMemo(() => {
@@ -147,9 +154,23 @@ const ExternalModelsTab: React.FC = () => {
         <div className="h-full overflow-auto">
             <div className="px-3 py-3 border-b border-gray-700 space-y-1">
                 <div className="text-sm font-medium">External model bindings</div>
-                <div className="text-xs text-gray-400">
-                    A scope with a binding gets an external-model list in the viewer. An unbound
-                    scope sees no change.
+                <div className="flex items-center gap-2">
+                    <div className="text-xs text-gray-400 flex-1">
+                        A scope with a binding gets an external-model list in the viewer. An unbound
+                        scope sees no change.
+                    </div>
+                    <button
+                        type="button"
+                        className="text-xs px-2 py-1 rounded-sm border border-gray-700 hover:bg-gray-800"
+                        onClick={() => {
+                            // New token AND drop the collection cache: both are
+                            // keyed on the old one.
+                            setCollections({});
+                            setNonce(catalogueNonce());
+                        }}
+                    >
+                        Refresh
+                    </button>
                 </div>
             </div>
 

--- a/src/frontend/src/components/admin/ExternalModelsTab.tsx
+++ b/src/frontend/src/components/admin/ExternalModelsTab.tsx
@@ -47,6 +47,11 @@ const ExternalModelsTab: React.FC = () => {
     const [collections, setCollections] = useState<Record<string, ExternalCollection[]>>({});
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState<string | null>(null);
+    // Provider chosen for a scope but not yet persisted, because a binding needs
+    // BOTH halves. Without this the provider <select> appears dead: choosing one
+    // would write an incomplete binding, which `setBinding` correctly treats as
+    // "unbind", so the control snapped straight back to none.
+    const [pendingProvider, setPendingProvider] = useState<Record<string, string>>({});
     const [error, setError] = useState<string | null>(null);
 
     const refresh = useCallback(async () => {
@@ -163,7 +168,9 @@ const ExternalModelsTab: React.FC = () => {
                 <tbody>
                 {rows.map((row) => {
                     const bound = bindingFor(map, row.scope);
-                    const provider = bound?.provider ?? "";
+                    // A persisted binding wins; otherwise show what the operator
+                    // just picked and has not finished.
+                    const provider = bound?.provider ?? pendingProvider[row.scope] ?? "";
                     const collection = bound?.collection ?? "";
                     const known = collections[provider] ?? [];
                     // A binding whose collection is no longer listed still
@@ -186,11 +193,16 @@ const ExternalModelsTab: React.FC = () => {
                                     onFocus={() => void loadCollections(provider)}
                                     onChange={(e) => {
                                         const p = e.target.value;
+                                        setPendingProvider((prev) => ({...prev, [row.scope]: p}));
                                         void loadCollections(p);
-                                        // Changing provider clears the collection:
-                                        // a collection id is only meaningful within
-                                        // the provider it came from.
-                                        void setBinding(row.scope, p, "");
+                                        // Only touch storage when the scope was
+                                        // already bound: switching provider
+                                        // invalidates the old collection (an id is
+                                        // only meaningful within its provider), and
+                                        // clearing to none means unbind. Choosing a
+                                        // provider for an UNBOUND scope writes
+                                        // nothing until a collection follows.
+                                        if (bound) void setBinding(row.scope, "", "");
                                     }}
                                 >
                                     <option value="">— none —</option>
@@ -206,6 +218,7 @@ const ExternalModelsTab: React.FC = () => {
                                     disabled={!provider || busy === row.scope}
                                     onFocus={() => void loadCollections(provider)}
                                     onChange={(e) => void setBinding(row.scope, provider, e.target.value)}
+                                    title={provider ? undefined : "Choose a provider first"}
                                 >
                                     <option value="">— none —</option>
                                     {missing && (

--- a/src/frontend/src/components/conversion/ConversionProgress.tsx
+++ b/src/frontend/src/components/conversion/ConversionProgress.tsx
@@ -376,9 +376,13 @@ const basename = (key: string) => key.split("/").pop() ?? key;
 // Conversion rows WITHOUT an outer box — the top (newest) job plus a "+N"
 // expansion for the rest. Composed inside UnifiedToast so conversion and
 // scene-load share one toast box.
+/** A job plus the key it is stored under. The two differ (`sourceKey` vs
+ *  `${sourceKey}::${target}`) and only the latter can address the entry. */
+type ToastJob = ConversionJob & {storeKey: string};
+
 const ConversionRows: React.FC<{
-    jobs: ConversionJob[];
-    onClearJob: (sourceKey: string) => void;
+    jobs: ToastJob[];
+    onClearJob: (storeKey: string) => void;
 }> = ({jobs, onClearJob}) => {
     const [expanded, setExpanded] = useState(false);
     if (jobs.length === 0) return null;
@@ -393,7 +397,7 @@ const ConversionRows: React.FC<{
         <div className="space-y-1">
             <JobRow
                 job={top}
-                onCancel={() => onClearJob(top.sourceKey)}
+                onCancel={() => onClearJob(top.storeKey)}
                 showCancel={true}
             />
             {extras.length > 0 && (
@@ -422,7 +426,7 @@ const ConversionRows: React.FC<{
                                 >
                                     <JobRow
                                         job={j}
-                                        onCancel={() => onClearJob(j.sourceKey)}
+                                        onCancel={() => onClearJob(j.storeKey)}
                                         showCancel={true}
                                     />
                                 </div>
@@ -479,8 +483,8 @@ const LoadRow: React.FC<{name: string; job?: ConversionJob}> = ({name, job}) => 
 // second LoadQueueToast box) makes the "Loading" counter replace the
 // conversion counter in place instead of popping a separate toast.
 const UnifiedToast: React.FC<{
-    conversionJobs: ConversionJob[];
-    onClearJob: (sourceKey: string) => void;
+    conversionJobs: ToastJob[];
+    onClearJob: (storeKey: string) => void;
     loadName: string | null;
     loadJob?: ConversionJob;
     loadQueued: LoadTask[];
@@ -691,19 +695,26 @@ const ConversionProgress = () => {
     // traceback + copy button is reachable. Excluded from the conversion rows:
     // (a) the conversion/bake job driving the current scene load, and (b) the
     // model-load GLB-download job — both surface on the single load row.
+    // `storeKey` is carried, not dropped. The store is keyed by
+    // `${sourceKey}::${target}` (see serverPipeline / useRestoreInflightJobs) and
+    // `job.sourceKey` is the bare key — so dismissing by sourceKey deletes
+    // nothing and the toast stays on screen forever, which is exactly what it
+    // did. The key that addresses the entry has to reach the button.
     const inProgress = Object.entries(jobs)
         .filter(([k, j]) =>
             (j.status === "queued" || j.status === "running") &&
             k !== MODEL_LOAD_KEY &&
             !(loadCurrentName && k.startsWith(loadCurrentName + "::")))
-        .map(([, j]) => j);
+        .map(([k, j]) => ({...j, storeKey: k}));
     // Load-row progress: the conversion/bake job still feeding the load if one is
     // running, else the GLB download job — so the bar runs queue→convert→upload→load.
     const loadJob =
         (loadCurrentName
             ? Object.entries(jobs).find(([k]) => k.startsWith(loadCurrentName + "::"))?.[1]
             : undefined) ?? (modelLoadActive ? modelLoadJob : undefined);
-    const errored = Object.values(jobs).filter((j) => j.status === "error" && j.sourceKey !== MODEL_LOAD_KEY);
+    const errored = Object.entries(jobs)
+        .filter(([, j]) => j.status === "error" && j.sourceKey !== MODEL_LOAD_KEY)
+        .map(([k, j]) => ({...j, storeKey: k}));
     const allVisible = [...inProgress, ...errored];
     const visibleSweeps = Object.entries(sweeps);
 
@@ -753,7 +764,7 @@ const ConversionProgress = () => {
             />
             {errored.map((job) => (
                 <div
-                    key={job.sourceKey}
+                    key={job.storeKey}
                     className="bg-gray-800 text-gray-100 rounded-sm shadow-lg px-3 py-2 text-xs border border-gray-700"
                 >
                     <div className="flex justify-between items-center mb-1">
@@ -765,7 +776,7 @@ const ConversionProgress = () => {
                     <ErrorRow
                         sourceKey={job.sourceKey}
                         message={job.error || "(no error message)"}
-                        onClear={() => clearJob(job.sourceKey)}
+                        onClear={() => clearJob(job.storeKey)}
                     />
                 </div>
             ))}

--- a/src/frontend/src/components/viewer/sceneHelpers/setupCameraControlsHandlers.ts
+++ b/src/frontend/src/components/viewer/sceneHelpers/setupCameraControlsHandlers.ts
@@ -13,6 +13,7 @@ import {selectChildLevel, selectParentLevel, selectSibling} from "@/utils/tree_v
 import {useCellBuilderStore, needsPreviewCompile} from "@/state/cellBuilderStore";
 import {frameCells} from "@/utils/scene/frameCells";
 import {requestRender} from "@/state/perfStore";
+import {useModelState} from "@/state/modelState";
 
 export function setupCameraControlsHandlers(
     scene: THREE.Scene,
@@ -145,7 +146,21 @@ export function setupCameraControlsHandlers(
 
     window.addEventListener("keydown", handleKeyDown);
 
+    // An emptied scene returns the camera to its starting pose. Subscribed to
+    // the model state rather than hooked into the unload handlers because there
+    // are several ways to unload -- the Scene panel's x, a plugin's
+    // `ctx.scene.unloadModel`, a scene-wide clear -- and this is the one place
+    // that sees all of them. Only the transition INTO empty resets, so a user
+    // who framed a detail and unloaded nothing keeps their view.
+    let wasLoaded = useModelState.getState().loadedSourceNames.size > 0;
+    const unsubscribeLoaded = useModelState.subscribe((state) => {
+        const isLoaded = state.loadedSourceNames.size > 0;
+        if (wasLoaded && !isLoaded) resetCameraHome(camera, controls);
+        wasLoaded = isLoaded;
+    });
+
     return () => {
+        unsubscribeLoaded();
         window.removeEventListener("keydown", handleKeyDown);
         if (scopeEl) {
             if (onEnter) scopeEl.removeEventListener("mouseenter", onEnter);
@@ -203,6 +218,49 @@ export const frameBox = (
         controls.setLookAt(newPosition.x, newPosition.y, newPosition.z, center.x, center.y, center.z, true);
         camera.updateProjectionMatrix();
     }
+};
+
+/** The pose `setupCamera` starts every viewer at, and the clipping it starts
+ *  with. Kept here beside the code that overwrites them. */
+const HOME_POSITION = new THREE.Vector3(-5, 5, 5);
+const HOME_TARGET = new THREE.Vector3(0, 0, 0);
+const HOME_NEAR = 0.1;
+const HOME_FAR = 10000;
+
+/** Put the camera back where the viewer started.
+ *
+ * WHY THIS IS NEEDED AT ALL. `zoomToAll` returns early on a scene with no
+ * meshes -- correctly, since there is nothing to frame -- so unloading the last
+ * model leaves the camera wherever the user had dragged it, and "fit all" then
+ * does nothing because there is still nothing to fit. The viewer is empty and
+ * unrecoverable except by reloading the page.
+ *
+ * NEAR AND FAR ARE RESET TOO, and that is the part that is easy to miss.
+ * `applyAdaptiveClipping` scales them to the model being framed, so after a
+ * large model they are left wide -- and the next small model loads clipped into
+ * invisibility, which reads as "the load failed" rather than "the clipping is
+ * stale". Position without clipping would be a half reset. */
+export const resetCameraHome = (
+    camera: THREE.PerspectiveCamera,
+    controls: OrbitControls | CameraControls,
+) => {
+    camera.near = HOME_NEAR;
+    camera.far = HOME_FAR;
+    camera.position.copy(HOME_POSITION);
+    camera.updateProjectionMatrix();
+    if (controls instanceof CameraControls) {
+        // setLookAt with no transition already applies the pose; CameraControls'
+        // own update() takes a frame delta and is driven by the render loop.
+        void controls.setLookAt(
+            HOME_POSITION.x, HOME_POSITION.y, HOME_POSITION.z,
+            HOME_TARGET.x, HOME_TARGET.y, HOME_TARGET.z,
+            false,
+        );
+    } else {
+        controls.target.copy(HOME_TARGET);
+        controls.update();
+    }
+    requestRender();
 };
 
 export const zoomToAll = (scene: THREE.Scene, camera: THREE.PerspectiveCamera, controls: OrbitControls | CameraControls) => {

--- a/src/frontend/src/services/externalModels.ts
+++ b/src/frontend/src/services/externalModels.ts
@@ -183,8 +183,8 @@ export async function modelUrl(
   modelId: string,
   scope: ScopeUrl,
   opts?: { expiresInSeconds?: number; signal?: AbortSignal },
-): Promise<string> {
-  const out = await runAction<{ url: string }>(
+): Promise<{ url: string; headers: Record<string, string> }> {
+  const out = await runAction<{ url: string; headers?: Record<string, string> }>(
     {
       action: "model_url",
       provider,
@@ -196,7 +196,10 @@ export async function modelUrl(
     opts?.signal,
   );
   if (!out.url) throw new ExternalModelsError("provider returned no url");
-  return out.url;
+  // Headers are empty for a provider whose URL carries its own signature, and
+  // populated for one whose fetch must be authenticated. Returning them beside
+  // the URL is what lets a single call site serve both without knowing which.
+  return { url: out.url, headers: out.headers ?? {} };
 }
 
 // --- scope binding ----------------------------------------------------------

--- a/src/frontend/src/services/externalModels.ts
+++ b/src/frontend/src/services/externalModels.ts
@@ -78,6 +78,22 @@ interface JobOptions {
   refresh?: string;
 }
 
+/** Derived summaries are stored GZIPPED above a size threshold, so a small
+ *  payload arrives as plain JSON and a large one does not. Decoding blindly as
+ *  text works until a catalogue grows — the first big collection fails with
+ *  `Unexpected token '\x1f'`, which reads like a corrupt response rather than a
+ *  compressed one. Sniff the magic number instead of guessing from size. */
+async function decodeSummary(buf: ArrayBuffer): Promise<string> {
+  const bytes = new Uint8Array(buf);
+  if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) {
+    const stream = new Blob([buf]).stream().pipeThrough(
+      new DecompressionStream("gzip"),
+    );
+    return await new Response(stream).text();
+  }
+  return new TextDecoder().decode(buf);
+}
+
 const POLL_INTERVAL_MS = 800;
 const POLL_TIMEOUT_MS = 60_000;
 
@@ -123,7 +139,7 @@ async function runAction<T>(
   // derived_key too, but the enqueue's is the one core wrote the options hash
   // into, so it is the authoritative one for a cache-hit.
   const buf = await viewerApi.getBlob(scope, derived_key);
-  const text = new TextDecoder().decode(buf);
+  const text = await decodeSummary(buf);
   try {
     return JSON.parse(text) as T;
   } catch {
@@ -204,6 +220,11 @@ export async function modelUrl(
       collection,
       model_id: modelId,
       expires_in_seconds: opts?.expiresInSeconds,
+      // ALWAYS bust the cache. The result is a short-lived signed URL, so a
+      // cache hit returns one minted for an earlier request — which the store
+      // then rejects as expired. Unlike the listing actions this is never
+      // cacheable, so the token is unconditional rather than a caller's choice.
+      refresh: catalogueNonce(),
     },
     scope,
     opts?.signal,

--- a/src/frontend/src/services/externalModels.ts
+++ b/src/frontend/src/services/externalModels.ts
@@ -138,14 +138,27 @@ async function runAction<T>(
  *  is present is a deployment choice. */
 export async function listProviders(
   scope: ScopeUrl,
-  signal?: AbortSignal,
+  opts?: { refresh?: string; signal?: AbortSignal },
 ): Promise<ExternalModelProvider[]> {
   const out = await runAction<{ providers: ExternalModelProvider[] }>(
-    { action: "list_providers" },
+    { action: "list_providers", refresh: opts?.refresh },
     scope,
-    signal,
+    opts?.signal,
   );
   return out.providers ?? [];
+}
+
+/** A cache-busting token for one read of the catalogue.
+ *
+ *  Core hashes a job's `options` into its source key, so an identical request
+ *  cache-hits a finished job FOREVER — which means a UI that never varies its
+ *  options can never observe a configuration change. A deployment switched from
+ *  the stub to a real bucket kept serving the stub's fixtures indefinitely.
+ *
+ *  One token per mount (or per explicit refresh), reused across that view's
+ *  calls: fresh data when a view opens, and the cache still absorbs re-renders. */
+export function catalogueNonce(): string {
+  return Date.now().toString(36);
 }
 
 export async function listCollections(

--- a/tests/plugins/test_external_models.py
+++ b/tests/plugins/test_external_models.py
@@ -331,7 +331,8 @@ def test_unlabelled_model_falls_back_to_its_filename():
 
 def test_partial_manifest_labels_only_what_it_names():
     cat = _LabelledS3(
-        ["plant/a.glb", "plant/b.glb"], {"a": "Alpha"},
+        ["plant/a.glb", "plant/b.glb"],
+        {"a": "Alpha"},
     )
     got = {m.id: (m.name, m.labelled) for m in cat.list_models("plant")}
     assert got == {"a": ("Alpha", True), "b": ("b", False)}

--- a/tests/plugins/test_external_models.py
+++ b/tests/plugins/test_external_models.py
@@ -18,6 +18,7 @@ from ada.plugins.external_models import (
 )
 from ada.plugins.external_models.adapy_plugin import run_job
 from ada.plugins.external_models.catalog import (
+    LABELS_FILENAME,
     Collection,
     ExternalModel,
     ExternalModelCatalog,
@@ -291,3 +292,53 @@ def test_run_job_defaults_to_the_demo_provider():
     register()
     out = run_job({"action": "list_collections"})
     assert out["provider"] == DEMO_PROVIDER_ID
+
+
+# --- label manifest -----------------------------------------------------------
+
+
+class _LabelledS3(S3ExternalModelCatalog):
+    """Exercises the label path without obstore or a bucket."""
+
+    def __init__(self, keys, labels=None):
+        self._keys = keys
+        self._labels_data = labels
+
+    def _list_keys(self, prefix: str = "") -> list[str]:
+        return [k for k in self._keys if k.startswith(prefix)]
+
+    def _labels(self, collection: str):
+        return self._labels_data or {}
+
+
+def test_label_from_the_manifest_replaces_the_displayed_name():
+    cat = _LabelledS3(["plant/$X100-PIPE.glb"], {"$X100-PIPE": "X100 Piping"})
+    m = cat.list_models("plant")[0]
+    assert m.name == "X100 Piping"
+    assert m.labelled is True
+    # The id must NOT move: it addresses the object, so a renamed label would
+    # otherwise break every existing binding and load.
+    assert m.id == "$X100-PIPE"
+    assert m.key == "plant/$X100-PIPE.glb"
+
+
+def test_unlabelled_model_falls_back_to_its_filename():
+    cat = _LabelledS3(["plant/$X100-PIPE.glb"], {})
+    m = cat.list_models("plant")[0]
+    assert m.name == "$X100-PIPE"
+    assert m.labelled is False
+
+
+def test_partial_manifest_labels_only_what_it_names():
+    cat = _LabelledS3(
+        ["plant/a.glb", "plant/b.glb"], {"a": "Alpha"},
+    )
+    got = {m.id: (m.name, m.labelled) for m in cat.list_models("plant")}
+    assert got == {"a": ("Alpha", True), "b": ("b", False)}
+
+
+def test_the_manifest_is_not_itself_listed_as_a_model():
+    # It lives beside the models and is not one; listing it would offer an
+    # unloadable entry named after the file.
+    cat = _LabelledS3([f"plant/{LABELS_FILENAME}", "plant/a.glb"], {})
+    assert [m.id for m in cat.list_models("plant")] == ["a"]


### PR DESCRIPTION
Seven commits behind the External models panel, all found by running it against a real object-store catalogue. Opened separately from the upload work (#291), which stacks on top of this.

- **per-provider fetch headers, and worker `extraEnvFrom`** — a provider whose URL carries its own signature needs no headers; one whose fetch must be authenticated returns them. Resolved with `getattr` so a provider written before this keeps satisfying the Protocol.
- **bust the job cache, or the UI can never see a config change** — core hashes a job's options into its source key, so an identical request cache-hits a finished job forever. A deployment switched from the stub to a real bucket kept serving the stub's fixtures indefinitely.
- **the panel rendered dark text on its dark background** — unreadable, and only in the deployed shell.
- **gunzip derived summaries, never cache a signed URL** — a cached URL is one minted for an earlier request, which the store then rejects as expired.
- **the provider dropdown erased the binding it was setting** — selecting a provider cleared the collection that had just been chosen.
- **per-collection label manifest** — a display name for a model whose id is filename-derived, without moving the id, which addresses the object.
- **dismissable job toasts, and a camera that comes home on an empty scene**

Reviewable on its own; #291 adds upload on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VotvVwDYn2AbMpZSaTYN2o