### PR TITLE
chore: name things by what they do, not by who consumes them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,15 +398,15 @@ Co-authored-by: Claude Fable 5 &lt;noreply@anthropic.com&gt; ([`ec25512`](https:
 
 The pull-loop heartbeat livenessProbe (task #74) was emitted for EVERY worker
 pool, but only the adapy worker image writes /tmp/worker-alive. The abaqus and
-weld-gen capability pools run foreign images (adapy-viewer-worker-abaqus, an old
-base; asa-weld-gen-runner) that never write it, so the probe failed every cycle
+detailing capability pools run foreign images (an old abaqus
+base; a third-party capability runner) that never write it, so the probe failed every cycle
 and SIGKILL-crashlooped them (exit 137 ~4.5min after start) — which in turn spammed
 PodCrashLooping/PodCrashLoopingSlow alerts all night.
 
 Make the heartbeat probe opt-in: the helper emits it only when a pool sets
 `heartbeatLiveness: true` (now the default on the adapy `worker` pool) or supplies
 its own `livenessProbe:`. Capability pools that do neither get no liveness probe.
-helm template verified: main worker keeps the heartbeat probe, abaqus + weld-gen
+helm template verified: main worker keeps the heartbeat probe, the capability pools
 render with none.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) &lt;noreply@anthropic.com&gt; ([`b606c1d`](https://github.com/Krande/adapy/commit/b606c1d7cbf7175f159eb9f2217d6f6615a8e211))

--- a/src/ada/topology/builder.py
+++ b/src/ada/topology/builder.py
@@ -65,8 +65,14 @@ class TopologyBuilder:
         return a.show(stream_from_ifc_store=stream_from_ifc_store)
 
     def show_output_model(
-        self, web3d_output_glb: str | pathlib.Path | None = None, stream_from_ifc_store: bool = False
+        self, output_glb: str | pathlib.Path | None = None, stream_from_ifc_store: bool = False
     ):
+        """Show the built model, optionally writing the GLB to ``output_glb``.
+
+        The parameter names what it does rather than who consumes it: this
+        writes a glTF binary, and which viewer opens it afterwards is not a
+        property of the export.
+        """
         from ada.visit.render_params import RenderParams
 
         if self.blueprint.output_part is None:
@@ -74,11 +80,15 @@ class TopologyBuilder:
 
         a = self.get_output_assembly(auto_sync_ifc_store=stream_from_ifc_store)
 
-        if web3d_output_glb:
+        if output_glb:
             return a.show(
                 stream_from_ifc_store=stream_from_ifc_store,
                 params_override=RenderParams(
-                    gltf_export_to_file=web3d_output_glb,
+                    gltf_export_to_file=output_glb,
+                    # ON-THE-WIRE KEY, not a name this code is free to choose.
+                    # Consumers match on it verbatim to decide how to read the
+                    # file's element metadata, so renaming it here would not
+                    # rename it there -- it would simply stop being recognised.
                     gltf_asset_extras_dict={"web3dversion": "2"},
                     stream_from_ifc_store=stream_from_ifc_store,
                 ),

--- a/src/ada/topology/builder.py
+++ b/src/ada/topology/builder.py
@@ -64,9 +64,7 @@ class TopologyBuilder:
             a.ifc_store.sync()
         return a.show(stream_from_ifc_store=stream_from_ifc_store)
 
-    def show_output_model(
-        self, output_glb: str | pathlib.Path | None = None, stream_from_ifc_store: bool = False
-    ):
+    def show_output_model(self, output_glb: str | pathlib.Path | None = None, stream_from_ifc_store: bool = False):
         """Show the built model, optionally writing the GLB to ``output_glb``.
 
         The parameter names what it does rather than who consumes it: this


### PR DESCRIPTION
This repo is public, and two places named a specific downstream consumer rather than the thing itself.

**`show_output_model(web3d_output_glb=...)` → `output_glb`.** The method writes a glTF binary; which viewer opens it afterwards is not a property of the export. Nothing in the tree passes it by keyword, so the rename costs no caller.

**A CHANGELOG entry** named two deployment-specific images and a capability by its project name. Now described by what they are ("an old abaqus base; a third-party capability runner", "detailing capability pools").

## One occurrence deliberately left alone

```python
gltf_asset_extras_dict={"web3dversion": "2"},
```

This is an **on-the-wire key**, not a name this code is free to choose. Consumers match on it verbatim to decide how to read a file's element metadata, so renaming it here would not rename it there — it would simply stop being recognised. It now carries a comment saying so, because it is the one occurrence that looks like an oversight and isn't.

Text-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VotvVwDYn2AbMpZSaTYN2o