### PR TITLE
fix(restore-jobs): end the poll when the server no longer knows the job

### DIFF
--- a/src/frontend/src/hooks/useRestoreInflightJobs.ts
+++ b/src/frontend/src/hooks/useRestoreInflightJobs.ts
@@ -19,7 +19,7 @@
 // before auth is ready — guarded by the scope's truthiness.
 
 import {useEffect} from "react";
-import {viewerApi} from "@/services/viewerApi";
+import {viewerApi, ApiError} from "@/services/viewerApi";
 import {useConversionStore} from "@/state/conversionStore";
 import {useScopeStore, scopeUrlPart} from "@/state/scopeStore";
 import {runtime} from "@/runtime/config";
@@ -30,6 +30,7 @@ const MAX_POLL_ATTEMPTS = 60 * 30; // ~45 min ceiling, generous for big bakes.
 async function pollUntilTerminal(
     jobId: string,
     storeKey: string,
+    scopeUrl: string,
     signal: {aborted: boolean},
 ): Promise<void> {
     const store = useConversionStore.getState();
@@ -55,9 +56,35 @@ async function pollUntilTerminal(
                 status.status === "cancelled"
             ) return;
         } catch (err) {
-            // Network blip — log and keep polling; the next tick
-            // typically succeeds. Don't poison the toast with a
-            // false error state.
+            // A 404 is not a blip: the job is GONE server-side. Its status
+            // row lives in the queue's KV, which expires, while the audit row
+            // that /my-jobs reads does not -- so a job whose KV entry aged out
+            // (or was never written) leaves an audit row stuck at `queued`
+            // forever. Treating that as a blip polls it for the full
+            // MAX_POLL_ATTEMPTS ceiling and the toast never resolves; worse,
+            // the row survives reload, so it comes back on every refresh.
+            // Mark it terminal here and cancel the row, exactly as the wasm-
+            // branch below does for its own orphans.
+            if (err instanceof ApiError && err.status === 404) {
+                const prev = useConversionStore.getState().jobs[storeKey];
+                if (prev) {
+                    store.setJob(storeKey, {
+                        ...prev,
+                        status: "cancelled",
+                        error: "job is no longer known to the server",
+                    });
+                }
+                void viewerApi
+                    .auditLocalUpdate(scopeUrl, jobId, {
+                        status: "cancelled",
+                        error: "job no longer known to the server",
+                    })
+                    .catch(() => {});
+                return;
+            }
+            // Anything else is a genuine blip — log and keep polling; the next
+            // tick typically succeeds. Don't poison the toast with a false
+            // error state.
             // eslint-disable-next-line no-console
             console.warn(`[restore-jobs] poll ${jobId} blip`, err);
         }
@@ -136,7 +163,7 @@ export function useRestoreInflightJobs(): void {
                     error: j.error,
                     startedAt: Date.now(),
                 });
-                void pollUntilTerminal(j.job_id, storeKey, cancel);
+                void pollUntilTerminal(j.job_id, storeKey, scopeUrl, cancel);
             }
         })();
 


### PR DESCRIPTION
A restored job whose status row is gone polled for the full ~45 min ceiling and never resolved, because every poll failure was treated as a network blip.

The two records have different lifetimes. `/api/convert/{job_id}` reads the queue's KV, which expires; `/my-jobs` reads the audit row, which does not. So a job whose KV entry aged out — or was never written — leaves an audit row at `queued` that nothing can advance. `useRestoreInflightJobs` re-seeds it on every mount, so the toast reappears on **every hard refresh**, permanently, for work that finished (or never started) long ago.

A 404 from that endpoint is not a blip, it is the answer: the job is gone. Mark the store entry terminal and best-effort cancel the audit row, the same way the `wasm-` branch already handles its own orphans. Every other error keeps the existing keep-polling behaviour, so a real network wobble still doesn't poison the toast with a false error.

### How it was found

A deployed viewer showed a stuck `_synthetic/plugin_job/external-models/<hash>` toast on every refresh:

```
NATS stream:  msgs=0, all six consumers pending=0   -> nothing running
KV row:       ABSENT                                 -> status endpoint 404s
audit_log:    status = queued                        -> /my-jobs keeps returning it
```

It was one of six catalogue jobs fired by a single page load; the other five finished in 23–53 ms. So the enqueue/audit-write race that stranded it is rare — this change stops a rare race from becoming a permanent toast.

### Testing

Typecheck is clean (`tsc --noEmit` reports the same single pre-existing error in `load_fea_streaming.ts` before and after).

Not unit-tested: `pollUntilTerminal` closes over the `viewerApi` singleton and the zustand store, and reshaping it for injection would be a larger change than the fix. The 404 it keys on is asserted by the endpoint itself, which raises `HTTPException(status_code=404, detail=f"job {job_id} not found")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VotvVwDYn2AbMpZSaTYN2o