### PR TITLE
fix(queue): write the audit row before a worker can see the job

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -2898,6 +2898,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             },
             derived_key=derived_key,
             target_capability=target_capability,
+            # Hold the publish until the audit row exists. A plugin_job is short
+            # (tens of ms — often just the cached-blob short circuit), which is
+            # well inside the time this handler takes to get its INSERT in, and
+            # the worker's terminal write is UPDATE ... WHERE job_id with no
+            # upsert. Publishing first is what strands a row at "queued" with no
+            # message and no KV entry left to recover it from.
+            publish=False,
         )
         # Register as a first-class audit task (row keyed by job_id). Without this
         # the worker's mark_audit_running/_audit_done no-op, /my-jobs shows nothing,
@@ -2913,6 +2920,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             status="queued",
             job_id=job.job_id,
         )
+        await queue.publish(job)
         return JSONResponse({"job_id": job.job_id, "derived_key": derived_key})
 
     # Settings whose key begins with this prefix are readable by ANY

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -267,6 +267,7 @@ class JobQueue:
         derived_key: str | None = None,
         target_capability: str | None = None,
         force_rebuild: bool = False,
+        publish: bool = True,
     ) -> Job:
         # ``derived_key`` lets callers pin an explicit produced-blob
         # path. The convert flow leaves it None and lets
@@ -322,10 +323,29 @@ class JobQueue:
         # (component_build) lost the record and the worker saw the
         # job_id from NATS but couldn't look it up.
         await self._put(job)
-        cap = (target_capability or self.DEFAULT_CAPABILITY).strip().lower()
+        # ``publish=False`` hands the caller the persisted Job without letting a
+        # worker see it yet, so the caller can write its audit row first.
+        if publish:
+            await self.publish(job)
+        return job
+
+    async def publish(self, job: Job) -> None:
+        """Hand an already-persisted job to its pool's subject.
+
+        Split out of :meth:`enqueue` so a caller that ALSO records the job in
+        Postgres can insert that row BEFORE any worker can see the message. The
+        worker's audit writes are ``UPDATE audit_log ... WHERE job_id = $1``
+        (:func:`db.mark_audit_running`, :func:`db.update_audit_by_job`) with no
+        upsert — they silently affect zero rows when the row is not there yet.
+        A job the worker finishes in tens of milliseconds (a ``plugin_job``, or
+        anything hitting the cached-derived-blob short circuit) can outrun the
+        API's INSERT, and the row is then created as ``queued`` and stays there
+        forever: no message left in the work queue, and the KV entry gone once
+        the terminal-status cleanup sweep runs.
+        """
+        cap = (job.target_capability or self.DEFAULT_CAPABILITY).strip().lower()
         subject = f"{self._cfg.subject}.{cap}"
         await self._js.publish(subject, job.job_id.encode("utf-8"))
-        return job
 
     async def _capability_for_ext(self, source_key: str, engine: str | None = None) -> str:
         """Look up the capability tag of the online worker pool that should handle this job.

--- a/tests/comms/rest/test_plugin_job_audit_race.py
+++ b/tests/comms/rest/test_plugin_job_audit_race.py
@@ -30,12 +30,15 @@ os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-race
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from ada.comms.rest import db as db_module  # noqa: E402
 from ada.comms.rest import worker as worker_module  # noqa: E402
 from ada.comms.rest.app import create_app  # noqa: E402
-from ada.comms.rest.config import AuthConfig, LocalConfig, QueueConfig, Settings  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
 from ada.comms.rest.queue import JobQueue  # noqa: E402
-
 
 # ---------------------------------------------------------------- fake DB ---
 #

--- a/tests/comms/rest/test_plugin_job_audit_race.py
+++ b/tests/comms/rest/test_plugin_job_audit_race.py
@@ -1,0 +1,279 @@
+"""The enqueue-then-audit ordering loses the worker's terminal status.
+
+``POST /api/plugins/{plugin_id}/jobs`` publishes the job to NATS *first* and
+only then inserts the ``audit_log`` row that records it as ``queued``
+(``app.py``: ``job = await queue.enqueue(...)`` then ``await _audit(...,
+status="queued")``).
+
+The worker's terminal write is a bare ``UPDATE audit_log ... WHERE job_id = $1``
+(``db.update_audit_by_job``) with no upsert — it silently affects zero rows when
+the row is not there yet. A plugin_job that the worker finishes in tens of
+milliseconds (the cached-derived-blob short circuit in ``worker._process_one``
+is a single storage HEAD) can therefore complete *before* the API's INSERT
+lands, and the row is then created as ``queued`` and stays that way forever:
+``duration_ms`` NULL, ``error`` NULL, no NATS message left, no KV entry (the KV
+row went terminal and the 15-minute cleanup sweep dropped it).
+
+These tests drive the interleaving directly instead of relying on timing luck:
+the fake JetStream ``publish`` runs the worker's audit transitions inline, which
+is exactly "the worker won the race".
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-race-storage-"))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as db_module  # noqa: E402
+from ada.comms.rest import worker as worker_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import AuthConfig, LocalConfig, QueueConfig, Settings  # noqa: E402
+from ada.comms.rest.queue import JobQueue  # noqa: E402
+
+
+# ---------------------------------------------------------------- fake DB ---
+#
+# Just enough of ``audit_log`` to reproduce the two statements that matter:
+# the INSERT the API issues and the ``WHERE job_id`` UPDATEs the worker issues.
+
+
+class FakeAuditTable:
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+        self.missed_updates: list[str] = []
+
+    def run(self, sql: str, args: tuple):
+        s = " ".join(sql.split())
+        if s.startswith("INSERT INTO audit_log"):
+            self.rows.append(
+                {
+                    "user_sub": args[0],
+                    "action": args[3],
+                    "key": args[4],
+                    "target_format": args[5],
+                    "status": args[6],
+                    "error": args[7],
+                    "duration_ms": args[8],
+                    "job_id": args[9],
+                    "audit_run_id": args[11],
+                }
+            )
+            return None
+        if s.startswith("UPDATE audit_log SET status = 'running'"):
+            for r in self.rows:
+                if r["job_id"] == args[0] and r["status"] == "queued":
+                    r["status"] = "running"
+                    return None
+            self.missed_updates.append(f"running:{args[0]}")
+            return None
+        if s.startswith("UPDATE audit_log SET status = $2"):
+            for r in self.rows:
+                if r["job_id"] == args[0]:
+                    r["status"] = args[1]
+                    r["error"] = args[2] if args[2] is not None else r["error"]
+                    r["duration_ms"] = args[3] if args[3] is not None else r["duration_ms"]
+                    return {"audit_run_id": r["audit_run_id"]}
+            # This is the bug's fingerprint: a terminal write with nothing to
+            # write it to.
+            self.missed_updates.append(f"terminal:{args[0]}")
+            return None
+        raise AssertionError(f"unmodelled SQL: {s[:120]}")
+
+
+class _NullTx:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeConn:
+    def __init__(self, table: FakeAuditTable) -> None:
+        self._t = table
+
+    def transaction(self):
+        return _NullTx()
+
+    async def fetchrow(self, sql, *args):
+        return self._t.run(sql, args)
+
+    async def execute(self, sql, *args):
+        self._t.run(sql, args)
+
+
+class _AcquireCtx:
+    def __init__(self, table: FakeAuditTable) -> None:
+        self._t = table
+
+    async def __aenter__(self):
+        return FakeConn(self._t)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakePool:
+    def __init__(self, table: FakeAuditTable) -> None:
+        self.table = table
+
+    async def execute(self, sql, *args):
+        self.table.run(sql, args)
+
+    def acquire(self):
+        return _AcquireCtx(self.table)
+
+    async def close(self):
+        return None
+
+
+# ------------------------------------------------------------- fake queue ---
+
+
+class FakeKV:
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    async def put(self, key, value):
+        self.store[key] = value
+
+    async def get(self, key):
+        from nats.js.errors import KeyNotFoundError
+
+        if key not in self.store:
+            raise KeyNotFoundError()
+        return type("Entry", (), {"value": self.store[key]})()
+
+    async def keys(self):
+        return list(self.store)
+
+
+class FakeJS:
+    """``publish`` is the race knob: ``on_publish`` runs in the exact window
+    between the NATS publish and the API's audit INSERT."""
+
+    def __init__(self, on_publish) -> None:
+        self.published: list[tuple[str, str]] = []
+        self._on_publish = on_publish
+
+    async def publish(self, subject, payload):
+        job_id = payload.decode("utf-8")
+        self.published.append((subject, job_id))
+        if self._on_publish is not None:
+            await self._on_publish(job_id)
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            # Non-empty so ``queue.enabled`` is True and the endpoint takes the
+            # NATS path rather than the in-process ``local_jobs`` one.
+            url="nats://test-not-dialled",
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+def _build(monkeypatch, tmp_path, on_publish):
+    table = FakeAuditTable()
+    pool = FakePool(table)
+    holder: dict = {"pool": pool}
+
+    async def _hook(job_id):
+        if on_publish is not None:
+            await on_publish(holder["pool"], job_id)
+
+    async def fake_connect(self):
+        self._js = FakeJS(_hook)
+        self._kv = FakeKV()
+
+    async def fake_list_workers(self):
+        return []
+
+    monkeypatch.setattr(JobQueue, "connect", fake_connect)
+    monkeypatch.setattr(JobQueue, "list_workers", fake_list_workers)
+
+    app = create_app(_settings(tmp_path))
+    return app, table, pool
+
+
+async def _worker_finishes_the_job(pool, job_id):
+    """What the worker does on the fast path: no source download, the derived
+    blob is already there, so ``_process_one`` short-circuits straight to
+    ``_audit_done(..., "done", ...)``."""
+    import time
+
+    await worker_module._audit_done(pool, job_id, "done", None, time.monotonic() - 0.03)
+
+
+def test_worker_terminal_write_before_the_audit_insert_strands_the_row(monkeypatch, tmp_path):
+    """The failing case. The worker completes between publish and INSERT; its
+    UPDATE hits nothing, and the row is then born ``queued`` and never moves."""
+    app, table, pool = _build(monkeypatch, tmp_path, _worker_finishes_the_job)
+
+    with TestClient(app) as client:
+        client.app.state.db_pool = pool
+        r = client.post("/api/plugins/external-models/jobs", json={"options": {"catalogue": "a"}})
+
+    assert r.status_code == 200, r.text
+    assert len(table.rows) == 1
+    row = table.rows[0]
+
+    # The row the operator sees in Postgres, and the toast restores from
+    # /api/scopes/{scope}/my-jobs, forever.
+    assert row["status"] == "done", (
+        f"audit row stranded at {row['status']!r} (duration_ms={row['duration_ms']!r}, "
+        f"error={row['error']!r}); lost worker writes: {table.missed_updates}"
+    )
+
+
+def test_worker_terminal_write_after_the_audit_insert_is_recorded(monkeypatch, tmp_path):
+    """The control: this is what the five siblings did. Same code, the only
+    difference is that the INSERT won."""
+    captured: list = []
+
+    async def defer(pool, job_id):
+        captured.append((pool, job_id))
+
+    app, table, pool = _build(monkeypatch, tmp_path, defer)
+
+    with TestClient(app) as client:
+        client.app.state.db_pool = pool
+        r = client.post("/api/plugins/external-models/jobs", json={"options": {"catalogue": "b"}})
+        assert r.status_code == 200, r.text
+
+    # ...and only now does the worker land.
+    import asyncio
+
+    asyncio.run(_worker_finishes_the_job(*captured[0]))
+
+    assert table.rows[0]["status"] == "done"
+    assert table.missed_updates == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
A `plugin_job` could finish before its own audit row existed, leaving the row at `queued` **forever** with no way to advance it. The toast then resurrects it on every hard refresh.

## The race

The ordering was publish-then-record:

```
queue.py:324  await self._put(job)                     # KV row, status=queued
queue.py:327  await self._js.publish(subject, job_id)  # ← worker can now see it
                ...PubAck return trip, pool acquire, INSERT round trip...
app.py:2906   await _audit(..., status="queued", ...)  # ← row is finally born
```

`js.publish` waits for the PubAck, so the message is durable and the pull consumer notified **before** the API resumes. A worker that finishes inside that window issues `UPDATE audit_log ... WHERE job_id = $1`, which matches zero rows. `db.update_audit_by_job` returns `None` and `worker._audit_done` discards it — no log, no retry. The handler's INSERT then creates the row as `queued`, and nothing will ever move it.

`db.py:421` even documents the hole — *"No-op when the row is missing (job predates the migration, or the enqueue-time audit insert failed)"* — it just never considered **hasn't happened yet**.

## Why it's reachable at all

The cached short-circuit at `worker.py:3221` writes the terminal audit and **returns before `mark_audit_running`**. Such a job makes exactly one DB write, issued within a storage HEAD of message delivery.

That matches the production row exactly: stranded at `queued`, never `running`, one of six catalogue jobs from a single page load whose five siblings finished in 23–53 ms (a HEAD, not real work).

The KV row's absence is what proves the worker *did* run it — `purge_completed_jobs` only removes entries whose status is terminal, and the bucket has no TTL. This is not a lost message; it's a lost bookkeeping write.

## The fix

Persist-intent-then-dispatch: split `publish()` out of `enqueue()` so the caller can insert its audit row first. `job.target_capability` is set in both routing branches, so the split is behaviour-preserving for routing.

Residual risk: a process death in the ~1 ms between INSERT and publish leaves a `queued` row *with* a live KV entry — strictly rarer than the window already firing, and recoverable, because the row exists and cancel works.

## Relation to #295

#295 makes a 404 from `/api/convert/{job_id}` terminal, so a stranded row stops resurrecting. That's the symptom. This is the cause — it stops the row being created.

## Not fixed here

The same enqueue-then-audit ordering exists at six other call sites in `app.py` (2017, 2105, 2302, 2410, 6159, 6253). The audit-run dispatcher ones matter most: a lost `queued` row means `_bump_audit_run_counter` never fires for that cell and the sweep hangs at `running` forever, since the finish check is `ok + failed + skipped >= total`. Worth a follow-up rather than widening this change.

Also worth a follow-up: `db.update_audit_by_job` returning `None` on a zero-row UPDATE is silently discarded. One `logger.warning` there would have made this a log grep instead of an investigation.

## Testing

`tests/comms/rest`: **403 passed, 46 skipped.**

The new test drives the real endpoint through `create_app` + `TestClient` with the real `JobQueue.enqueue` and the real audit write path, against a fake JetStream whose `publish` runs the worker's audit transitions inline — that *is* "the worker won the race", with no timing luck. It fails on HEAD and passes with the fix. Its sibling control (worker landing after the response, which is what the five surviving jobs did) passes both ways, so the test isolates the ordering rather than the plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VotvVwDYn2AbMpZSaTYN2o