### PR TITLE
feat(queue): let a worker connect without the right to administer JetStream

### DIFF
--- a/deploy/worker-trust.md
+++ b/deploy/worker-trust.md
@@ -1,0 +1,324 @@
+# Worker trust: authentication, admission, and capability qualification
+
+A design for **who is allowed to be a worker**, **what the API is willing to
+believe from one**, and **when a worker should decline to advertise a capability
+it is no longer fit to serve**.
+
+Written because we want to run workers *outside* the cluster — a workstation
+that joins a capability pool because it holds something no cluster node can (a
+licensed seat, a device, a dataset). But every problem below already exists for
+the in-cluster pools. The external worker does not introduce these gaps; it
+removes the network boundary that has been quietly standing in for all three
+controls.
+
+---
+
+## 1. What is trusted today
+
+`JobQueue.connect()` is `await nats.connect(self._cfg.url)` — **no credentials,
+no TLS, no accounts**. The chart deploys a plain `nats -js` on a ClusterIP
+service (`helm/adapy-viewer/templates/nats.yaml`). The only thing standing
+between an actor and the job queue is the ability to open a TCP connection to
+port 4222.
+
+Anything that can do that can:
+
+1. **Take other pools' jobs.** Subscribe to `ada.viewer.jobs.convert.<cap>` for
+   any capability. Jobs carry scope ids and storage keys.
+2. **Impersonate a plugin.** The worker registry is a KV bucket any client can
+   write. `_live_worker_specs()` in `app.py` unions `plugin_specs` from every
+   non-stale registry row, **keyed by slug, last writer wins**, with no check on
+   who wrote the row. Writing one row is enough to (a) put an arbitrary entry in
+   every user's `GET /api/plugins`, and (b) re-point an existing plugin id's
+   `worker_capability` at a pool the writer controls — after which
+   `POST /api/plugins/report-builder/jobs` routes that plugin's work, and the
+   options it carries, to the writer.
+3. **Falsify job outcomes.** Job status lives in the same KV bucket under the
+   job id. Any client can mark any job `done` and point `derived_key` wherever
+   it likes.
+4. **Administer JetStream.** Workers today call the same `connect()` the API
+   does, which does `add_stream` / `update_stream` and deletes legacy consumers.
+   So nothing in the current design even *distinguishes* a worker from an
+   administrator — there is no lesser privilege to grant.
+
+Separately, and independent of NATS: a worker holds **bucket-wide object store
+credentials**, because `Storage` talks to S3/Garage directly and there is no
+REST-mediated storage kind.
+
+### The three problems this splits into
+
+| | Question | Today |
+| --- | --- | --- |
+| **Authentication** | Is this connection a principal we know? | No |
+| **Authorization** | What may that principal do on the bus? | Everything |
+| **Admission** | What will the API *believe* from it? | Everything it says |
+
+They are separable, and the third is the one that actually stops the plugin
+hijack in (2): a legitimately-credentialed external worker could still *claim*
+`report-builder` if it can write the registry. Transport auth alone does not
+answer "what may this worker claim to be".
+
+## 2. Design A — one credential model, k8s included
+
+**Do not build an external-only auth path.** The in-cluster worker being trusted
+by network position is precisely what makes (2), (3) and (4) reachable from any
+compromised pod in the namespace, and a second mechanism for outsiders would
+leave that standing while doubling what we have to maintain. One model, and the
+k8s workers get credentials from a Secret exactly as the VM gets them from a
+file. The external worker is then not a special case — just a user with a
+narrower permission set.
+
+### Users and permissions
+
+Plain NATS `accounts`/`users` in the server config is sufficient at this scale;
+NKEY/JWT (`nsc`) buys per-worker expiry and rotation and is the better end state
+if the external fleet grows past a handful.
+
+```
+api            pub/sub  ada.viewer.jobs.convert.>          # publish jobs
+               JS API   full on ADA_VIEWER_JOBS + KV       # creates the stream
+               KV       read/write
+
+worker-internal
+               sub      ada.viewer.jobs.convert.>
+               JS API   $JS.API.CONSUMER.{CREATE,MSG.NEXT}.ADA_VIEWER_JOBS.>
+               KV       read/write
+
+worker-ext-01                                               # one per external host
+               sub      ada.viewer.jobs.convert.cad         # its pool, nothing else
+               JS API   $JS.API.CONSUMER.*.ADA_VIEWER_JOBS.ada-viewer-worker-cad
+               KV       write $KV.ada-viewer-jobs.__meta_worker__ext-01
+                        write $KV.ada-viewer-jobs.*          # job status — see residual risks
+                        read  $KV.ada-viewer-jobs.>
+```
+
+The subject layout makes this practical without inventing anything: pools are
+already `<subject>.<capability>` and durables are already
+`<durable>-<capability>` (`queue.py: pull_subscribe`), so both the data subject
+and the JetStream API subject can be pinned per capability as they stand.
+
+### Identity comes from the credential, not from `$HOSTNAME`
+
+`worker_id` is currently `os.environ["HOSTNAME"]` — self-asserted, and it is the
+KV key the registry row is written under. Pin that key in the credential's
+publish permission (`__meta_worker__ext-01` above) and the id becomes
+**authenticated by NATS with no adapy code at all**: a worker cannot write a row
+under a name it was not issued. This is worth doing even before admission
+(§3), because it is what makes an admission list keyed by worker id meaningful.
+
+### Code changes
+
+* ✅ `QueueConfig` gains `creds_file`, `user`, `password`, `token`,
+  `nkey_seed_file`, `tls_ca` (+ `ADA_VIEWER_NATS_*` env), and `connect()` passes
+  them through to `nats.connect()`. `nats-py` supports all of these directly.
+* ✅ **`connect(manage=False)` for workers.** Stream and consumer
+  *administration* moves behind a flag the API sets and the worker does not, so
+  worker credentials need no stream-admin rights. Without this, least privilege
+  was impossible: the worker's first act was `add_stream`.
+* Helm: optional `nats.auth` block writing a server config with the users above,
+  a Secret per worker deployment, and `ADA_VIEWER_NATS_CREDS` wired into the
+  worker/API pods. `nats.enabled=false` deployments pass their own URL and creds
+  through unchanged.
+
+All of it is backwards compatible: no creds configured => `nats.connect(url)`,
+which is exactly today's behaviour.
+
+## 3. Design B — admission: what the API will believe
+
+Authentication says *who is talking*. Admission says *what the API accepts from
+them*, and it is the control that stops plugin-id hijack.
+
+Add an admin-owned allowlist — an `app_settings` key, editable from the existing
+admin panel:
+
+```json
+{
+  "ext-01":          { "capabilities": ["cad"],  "plugins": ["cad-export"] },
+  "adapy-worker-*":  { "capabilities": ["*"],    "plugins": ["*"] },
+  "*":               { "capabilities": [],       "plugins": [] }
+}
+```
+
+`_live_worker_specs()` (and the sibling unions for `conversions`,
+`source_exts`, the procedural catalogs) filter each row's advertisements through
+the entry matching that worker id. A worker outside the list still appears in
+`GET /api/admin/workers` — so an admin can *see* an unknown worker and decide
+about it — but contributes nothing to `/api/plugins`, nothing to the upload
+picker, and cannot claim a plugin id that is not its own.
+
+Defaults matter more than the mechanism here:
+
+* **Absent setting => allow everything.** Existing deployments do not change
+  behaviour on upgrade, and nobody's cluster breaks because a doc was not read.
+* **Present setting => deny by default** for ids that match no entry. Once an
+  operator opts in, an unknown worker is inert rather than partially trusted.
+* The admin panel should show unadmitted workers prominently with an
+  **Admit** button that writes the entry — the enrollment flow is the thing that
+  makes this get used rather than turned off.
+
+Pair this with the KV key pinning from §2 and the two halves compose cleanly:
+**NATS decides which row you may write; admission decides what the API believes
+from that row.**
+
+## 4. Design C — capability qualification
+
+Today the only guard against a worker serving work it should not is the blunt
+env flag `ADA_WORKER_BASE_CONVERSIONS=false`, set by hand on each foreign pool.
+Its own comment in `worker.py` records why it exists: an extra-capability pool
+built from an independent adapy *"advertises the full base converter matrix, so
+it wins base conversion jobs it has no business running — and when that image is
+stale it produces outdated output (e.g. non-manifold meshes)."*
+
+That is a correctness property defended by remembering to set an env var. Invert
+it: **a worker advertises a capability only if it can show it is fit to serve
+it.**
+
+### Requirement documents
+
+Per capability, a small document naming what that capability's output depends
+on. Authored by whoever owns the capability, stored in `app_settings` (so it is
+editable without a redeploy) and republished by the API into the KV meta
+keyspace that already carries `worker_image_tag`:
+
+```json
+{
+  "base":     { "requires": { "ada-py": ">=0.51.0", "occt": ">=7.8.1",
+                              "ada-cpp": ">=0.3.0" },
+                "build_match": { "occt": "novtk_*" } },
+  "meshing":  { "requires": { "example-mesher": ">=1.4.0" } },
+  "cad":      { "requires": { "example-cad-bridge": ">=1.2.0" } }
+}
+```
+
+`build_match` is not decoration: adapy's own `pixi.toml` pins `occt` and
+`pythonocc-core` to the `novtk_*` build variant and requires the two to agree, so
+"right version, wrong build" is a real way to be unfit.
+
+### The gate, in two places
+
+**Worker side (the one that matters).** At registration and on each heartbeat,
+the worker compares its own environment against the document and **drops failing
+capabilities from the set it advertises *and subscribes to***. Filtering the UI
+alone would be useless — an unfit worker that still holds a consumer keeps
+winning jobs.
+
+The input already exists: `_capture_worker_packages()` reads `conda-meta/*.json`
+(name, version, build, channel) plus pip dists. It is currently called only when
+a DB pool *and* an image tag are present; make it unconditional and cache it —
+it cannot change within a process lifetime.
+
+The registry row gains a `withheld` field so the reason is visible instead of the
+capability merely being absent:
+
+```json
+"withheld": [{ "capability": "base",
+               "reason": "ada-py 0.44.1 does not satisfy >=0.51.0" }]
+```
+
+A capability silently missing is a support ticket; a capability that says why it
+withheld itself is a fixed deployment.
+
+**API side (defence in depth).** The union endpoints apply the same check
+against the packages the worker reported. This covers the worker running code
+too old to know about qualification — it cannot gate itself, so something must
+gate it — and the worker that simply lies, which is the same trust question as
+§3 and wants the same answer.
+
+### Fail-open or fail-closed
+
+Asymmetric, deliberately:
+
+* **No requirement entry for a capability => advertise it.** Backwards
+  compatible, and self-governing plugin capabilities need no central entry.
+* **Entry exists but a required package is missing or unparseable => withhold**,
+  with the reason. Silence about `cad` is fine; silence about `base` is not.
+
+Conda versions are not reliably PEP 440 (epochs, build strings), so compare with
+`packaging.version` where it parses and fall back to exact-string equality where
+it does not — never to "probably newer".
+
+### Beyond versions: an optional probe
+
+Version comparison answers *is my code current*. It does not answer *does my
+environment actually work* — and for a licence-holding worker that is the more
+common failure: a machine whose licence server is unreachable must not advertise
+its capability at
+all, whatever its package versions say.
+
+So let a capability register an optional `self_check() -> None` (raise to fail)
+run at boot and on a slow cadence, in the same registry as the requirements. For
+a CAD bridge it is a ping at the licence server. Version gate first; the probe hook is
+a small addition on the same seam.
+
+### What happens to `ADA_WORKER_BASE_CONVERSIONS`
+
+It stays, as a manual override — "I *can* serve base but I do not want to" is a
+legitimate operator choice that no automatic check should override. It stops
+being the mechanism correctness depends on.
+
+## 5. Rollout order
+
+Each step is independently shippable and backwards compatible.
+
+1. **`connect(manage=False)` for workers.** ✅ **Landed.** No behaviour change;
+   unlocks least privilege later.
+2. **Credentials plumbed through `QueueConfig`.** ✅ **Landed** (Python side;
+   see the chart gap below). Still optional — nothing changes until a
+   deployment sets them.
+3. **Turn auth on in the cluster**, all pools, api included. Now network
+   position grants nothing.
+4. **Capability qualification** (§4) — worker-side gate, `withheld` in the
+   registry, admin panel surfacing it. This one pays for itself immediately on
+   the *existing* extra-worker pools, external workers or not.
+5. **Admission list** (§3), default-allow until an operator opts in, with the
+   Admit button in the admin panel.
+6. **Only then** issue an external worker its credentials and admit it.
+
+Steps 1, 4 and 5 are worth doing even if the external worker never ships.
+
+### What landed in steps 1–2
+
+| | |
+| --- | --- |
+| `QueueConfig` | `creds_file`, `user`, `password`, `token`, `nkey_seed_file`, `tls_ca` — all defaulting to empty |
+| Env | `ADA_VIEWER_NATS_{CREDS,USER,PASSWORD,TOKEN,NKEY_SEED,TLS_CA}` |
+| `JobQueue.connect` | `connect(manage: bool = True, name: str | None = None)` |
+| API | `connect(manage=True, name="adapy-viewer-api")` — creates the stream and bucket, as before |
+| Worker | `connect(manage=False, name=f"adapy-worker-{worker_id}")` — creates nothing |
+| Escape hatch | `ADA_WORKER_MANAGE_STREAM=true` restores worker self-provisioning |
+
+Two details worth knowing before step 3:
+
+* **`manage=False` waits rather than provisions.** A worker that starts before
+  the API polls for the KV bucket for 60s and then fails with a message naming
+  the cause. Waiting on the bucket also covers the stream, because the managing
+  path creates the stream first and the bucket last — a coupling noted in the
+  code, since reordering it would produce a worker bound to a bucket with no
+  stream to subscribe on.
+* **The chart can already inject creds into workers but not into the API.**
+  Worker pools have `extraEnv` / `extraEnvFrom` (`_helpers.tpl`), so a Secret
+  reaches them with no chart change. `deployment.yaml` has no such hook, so
+  step 3 has to add one (or an explicit `nats.auth` block) before the API can
+  authenticate. Nothing else blocks turning auth on.
+* **Connections are now named.** `nats server report connections` shows
+  `adapy-viewer-api` and `adapy-worker-<id>` instead of `ip:port`, which is what
+  makes "which principal is this" answerable while rolling auth out.
+
+## 6. Residual risks
+
+* **Job-status KV cannot be scoped per worker.** Job ids are random, so a
+  credential able to update the job it is processing can update any job's status
+  (not read its blobs). Accepted for now. The clean fix is to move status
+  writes behind the API — worker → HTTPS with its own bearer — which is a
+  larger change and worth revisiting if the external fleet grows.
+* **Object store credentials on unmanaged machines.** Mint per-worker keys
+  scoped to the bucket, and to the one key prefix that worker writes where the
+  store supports prefix policies. The stronger answer is a REST-mediated storage kind
+  so an external worker holds a viewer bearer token instead of bucket keys —
+  the API already mints long-lived CLI tokens (`AuthConfig.cli_token_secret`),
+  so the identity infrastructure exists; the storage facade does not.
+* **A worker is still trusted with the data of the jobs it legitimately
+  receives.** Admission bounds *which* jobs those are; it cannot make the
+  content safe. Deciding which scopes an external host may see work from is a
+  policy question, not a mechanism one — and worth answering before the first
+  external worker is admitted to anything but its own capability.

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -215,7 +215,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # Connect to NATS lazily; a missing URL just disables the queue.
         if queue.enabled:
             try:
-                await queue.connect()
+                # manage=True: the API owns the JetStream topology
+                # (stream + KV bucket) and brings it forward on deploy.
+                # Workers connect with manage=False so their credentials
+                # need no stream-admin rights.
+                await queue.connect(manage=True, name="adapy-viewer-api")
                 logger.info("queue connected to %s", settings.queue.url)
             except Exception as exc:
                 logger.warning("queue connect failed (%s); convert endpoints will return 503", exc)

--- a/src/ada/comms/rest/config.py
+++ b/src/ada/comms/rest/config.py
@@ -41,6 +41,27 @@ class QueueConfig:
     subject: str
     kv_bucket: str
     durable: str
+    # --- credentials -------------------------------------------------
+    # All empty (the default) is an unauthenticated connection, which is
+    # what every deployment does today and what a `nats -js` server with
+    # no accounts block expects. Set at most one of creds_file /
+    # user+password / token / nkey_seed_file; they map straight onto the
+    # matching ``nats.connect()`` kwargs.
+    #
+    # The point of having them is least privilege: once the server has an
+    # accounts block, the API connects as a principal that may administer
+    # the stream and a worker as one that may only pull its own pool's
+    # subject. See ``deploy/worker-trust.md``.
+    creds_file: str = ""
+    user: str = ""
+    password: str = ""
+    token: str = ""
+    nkey_seed_file: str = ""
+    # PEM bundle for verifying the server certificate. Only needed when
+    # the server presents a cert signed by a private CA — with a public
+    # CA (or with plaintext) leave it empty and the default trust store /
+    # no-TLS path applies.
+    tls_ca: str = ""
 
 
 @dataclass(frozen=True)
@@ -128,6 +149,15 @@ def load_settings() -> Settings:
         subject=os.environ.get("ADA_VIEWER_NATS_SUBJECT", "ada.viewer.jobs.convert"),
         kv_bucket=os.environ.get("ADA_VIEWER_NATS_KV_BUCKET", "ada-viewer-jobs"),
         durable=os.environ.get("ADA_VIEWER_NATS_DURABLE", "ada-viewer-worker"),
+        creds_file=os.environ.get("ADA_VIEWER_NATS_CREDS", "").strip(),
+        user=os.environ.get("ADA_VIEWER_NATS_USER", "").strip(),
+        # Not stripped: a password may legitimately begin or end with
+        # whitespace, and silently trimming it turns a working secret
+        # into an auth failure nobody can explain.
+        password=os.environ.get("ADA_VIEWER_NATS_PASSWORD", ""),
+        token=os.environ.get("ADA_VIEWER_NATS_TOKEN", ""),
+        nkey_seed_file=os.environ.get("ADA_VIEWER_NATS_NKEY_SEED", "").strip(),
+        tls_ca=os.environ.get("ADA_VIEWER_NATS_TLS_CA", "").strip(),
     )
 
     auth_enabled = _bool(os.environ.get("ADA_VIEWER_AUTH_ENABLED"), default=False)

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -19,6 +19,7 @@ safe.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 import uuid
@@ -26,7 +27,12 @@ from dataclasses import asdict, dataclass
 
 import nats
 from nats.js.api import ConsumerConfig, RetentionPolicy, StreamConfig
-from nats.js.errors import BadRequestError, BucketNotFoundError, KeyNotFoundError
+from nats.js.errors import (
+    BadRequestError,
+    BucketNotFoundError,
+    KeyNotFoundError,
+    NotFoundError,
+)
 
 from ada.config import logger
 
@@ -148,11 +154,68 @@ class JobQueue:
     # routing view and the UI view agree on which pools are live.
     WORKER_STALE_AFTER_S = 60.0
 
-    async def connect(self) -> None:
+    # How long ``connect(manage=False)`` waits for the KV bucket the API
+    # is responsible for creating. A non-managing client that starts
+    # before the API has nothing to bind to; rather than fail on the
+    # first attempt (crash-loop on ordering alone) or wait forever (a
+    # worker that looks healthy but is bound to nothing), poll for a
+    # window that comfortably covers a rolling restart and then raise
+    # with a message that names the real cause.
+    _BIND_WAIT_SECONDS = 60.0
+    _BIND_POLL_SECONDS = 2.0
+
+    def _connect_options(self, name: str | None) -> dict:
+        """Build the ``nats.connect()`` kwargs for the configured credentials.
+
+        Everything is optional and everything defaults to absent, so a
+        server with no accounts block behaves exactly as it did before
+        these fields existed.
+        """
+        opts: dict = {}
+        if name:
+            # Shows up in `nats server report connections` / monitoring.
+            # Worth setting: during an auth rollout the useful question is
+            # "which principal is this connection", and an unnamed client
+            # answers it with an ip:port.
+            opts["name"] = name
+        cfg = self._cfg
+        if cfg.creds_file:
+            opts["user_credentials"] = cfg.creds_file
+        if cfg.nkey_seed_file:
+            opts["nkeys_seed"] = cfg.nkey_seed_file
+        if cfg.user:
+            opts["user"] = cfg.user
+        if cfg.password:
+            opts["password"] = cfg.password
+        if cfg.token:
+            opts["token"] = cfg.token
+        if cfg.tls_ca:
+            import ssl
+
+            ctx = ssl.create_default_context()
+            ctx.load_verify_locations(cafile=cfg.tls_ca)
+            opts["tls"] = ctx
+        return opts
+
+    async def connect(self, manage: bool = True, name: str | None = None) -> None:
+        """Connect, and when ``manage`` is set, create the stream and bucket.
+
+        ``manage=True`` is the API: it owns the JetStream topology and
+        brings it forward on deploy. ``manage=False`` is a worker: it
+        only ever *uses* the topology, so its credential needs no
+        stream-admin rights. That split is the prerequisite for granting
+        workers a narrower permission set than the API — until it existed
+        a worker's first act was ``add_stream``, which meant nothing in
+        the design distinguished a worker from an administrator.
+        """
         if not self.enabled:
             raise QueueDisabled("ADA_VIEWER_NATS_URL not set")
-        self._nc = await nats.connect(self._cfg.url)
+        self._nc = await nats.connect(self._cfg.url, **self._connect_options(name))
         self._js = self._nc.jetstream()
+
+        if not manage:
+            await self._bind_existing()
+            return
 
         # Stream — idempotent. Carries both the legacy bare subject
         # (so messages already in flight at the moment of upgrade
@@ -206,6 +269,37 @@ class JobQueue:
             self._kv = await self._js.create_key_value(bucket=self._cfg.kv_bucket, history=1)
         except BadRequestError:
             self._kv = await self._js.key_value(self._cfg.kv_bucket)
+
+    async def _bind_existing(self) -> None:
+        """Bind to the API-created KV bucket without creating anything.
+
+        Waiting on the bucket also covers the stream: ``connect(manage=True)``
+        creates the stream first and the bucket last, so a bucket that
+        exists implies a stream that exists. Keep that order if you touch
+        the managing path — a worker that binds the bucket then finds no
+        stream to ``pull_subscribe`` on is a much worse failure than
+        waiting a little longer here.
+        """
+        deadline = time.monotonic() + self._BIND_WAIT_SECONDS
+        while True:
+            try:
+                self._kv = await self._js.key_value(self._cfg.kv_bucket)
+                return
+            # BucketNotFoundError subclasses NotFoundError; the plain
+            # form also covers "the backing KV_<bucket> stream is absent".
+            except NotFoundError:
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        f"KV bucket {self._cfg.kv_bucket!r} does not exist after "
+                        f"{self._BIND_WAIT_SECONDS:.0f}s. It is created by the API on startup — "
+                        "either the API has not come up yet, or this client's credentials "
+                        "cannot see the bucket."
+                    ) from None
+                logger.info(
+                    "queue: waiting for KV bucket %s to be created by the API",
+                    self._cfg.kv_bucket,
+                )
+                await asyncio.sleep(self._BIND_POLL_SECONDS)
 
     async def close(self) -> None:
         if self._nc is not None:

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -121,6 +121,25 @@ MAX_DELIVERIES = 3
 IN_PROGRESS_REFRESH_SECONDS = 30
 
 
+def _bool_env(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _worker_id() -> str:
+    """This worker's registry key.
+
+    Self-asserted today: whatever ``$HOSTNAME`` says, which in k8s is the
+    pod name and off-cluster is whatever the operator exports. Once NATS
+    credentials pin the registry KV key (``__meta_worker__<id>``) the
+    server enforces the match and this becomes an authenticated identity
+    rather than a claim — see deploy/worker-trust.md.
+    """
+    return os.environ.get("HOSTNAME", "").strip() or f"local-{os.getpid()}"
+
+
 def _pool_capabilities(capabilities: list[str]) -> list[str]:
     """Capability pools this worker should subscribe to.
 
@@ -4090,8 +4109,18 @@ async def _run() -> None:
     storage = Storage.from_settings(settings)
     queue = JobQueue(settings.queue)
     logger.info("worker: connecting to NATS subject=%s", settings.queue.subject)
-    await queue.connect()
-    logger.info("worker: connected to NATS")
+    # A worker only ever *uses* the JetStream topology; the API creates
+    # it. Not administering it is what lets a worker be issued a
+    # credential with no stream-admin rights — the whole point of
+    # deploy/worker-trust.md. If the API has not started yet, connect()
+    # waits for the KV bucket rather than racing to create it.
+    #
+    # ADA_WORKER_MANAGE_STREAM=true restores the old self-provisioning
+    # behaviour for the one setup that needs it: a worker running against
+    # a bare NATS with no API in the picture at all.
+    manage = _bool_env("ADA_WORKER_MANAGE_STREAM", default=False)
+    await queue.connect(manage=manage, name=f"adapy-worker-{_worker_id()}")
+    logger.info("worker: connected to NATS (manage_stream=%s)", manage)
 
     # Optional importer hook: capability workers built FROM the base
     # image often need to populate the connection-spec registry (or
@@ -4138,7 +4167,7 @@ async def _run() -> None:
     # onto every audit_log row without threading through callers.
     global _WORKER_IMAGE_TAG
     _WORKER_IMAGE_TAG = image_tag or None
-    worker_id = os.environ.get("HOSTNAME", "").strip() or f"local-{os.getpid()}"
+    worker_id = _worker_id()
     capabilities = [c.strip() for c in os.environ.get("ADA_WORKER_CAPABILITIES", "base").split(",") if c.strip()]
     # An extra-capability pool builds FROM / runs an independent adapy and still
     # advertises the full base converter matrix, so it wins base conversion jobs (gxml->glb, ...)

--- a/tests/comms/rest/test_plugin_job_audit_race.py
+++ b/tests/comms/rest/test_plugin_job_audit_race.py
@@ -210,7 +210,7 @@ def _build(monkeypatch, tmp_path, on_publish):
         if on_publish is not None:
             await on_publish(holder["pool"], job_id)
 
-    async def fake_connect(self):
+    async def fake_connect(self, **kwargs):
         self._js = FakeJS(_hook)
         self._kv = FakeKV()
 

--- a/tests/comms/rest/test_procedural_catalog_cache.py
+++ b/tests/comms/rest/test_procedural_catalog_cache.py
@@ -91,7 +91,7 @@ def _wire(monkeypatch, *, doc: dict, live_fp: str):
     async def _fake_list_workers(self):
         return []
 
-    async def _fake_connect(self):
+    async def _fake_connect(self, **kwargs):
         return None
 
     fake_row = {

--- a/tests/comms/rest/test_procedural_compile_runs.py
+++ b/tests/comms/rest/test_procedural_compile_runs.py
@@ -474,7 +474,7 @@ def test_compile_opens_an_audit_row_for_the_run(monkeypatch, tmp_path: pathlib.P
 
     monkeypatch.setattr(JobQueue, "enqueue", _fake_enqueue)
     monkeypatch.setattr(JobQueue, "list_workers", lambda self: _noop())
-    monkeypatch.setattr(JobQueue, "connect", lambda self: _noop())
+    monkeypatch.setattr(JobQueue, "connect", lambda self, **kwargs: _noop())
     monkeypatch.setattr(db_module, "get_procedural_model", _get_model)
     monkeypatch.setattr(db_module, "insert_audit", _insert_audit)
 

--- a/tests/comms/rest/test_procedural_detailing.py
+++ b/tests/comms/rest/test_procedural_detailing.py
@@ -132,7 +132,7 @@ def test_external_detailing_engine_discovered_from_live_worker(monkeypatch, tmp_
     from ada.comms.rest.queue import JobQueue
 
     monkeypatch.setattr(JobQueue, "enabled", property(lambda self: True))
-    monkeypatch.setattr(JobQueue, "connect", lambda self: _async_none())
+    monkeypatch.setattr(JobQueue, "connect", lambda self, **kwargs: _async_none())
     monkeypatch.setattr(JobQueue, "list_workers", lambda self: _async_val(_live_worker_advertising_ext_detail()))
 
     app = create_app(_settings(tmp_path))
@@ -310,7 +310,7 @@ def test_external_detailing_compile_enqueues_chained_job(monkeypatch, tmp_path: 
         # the heartbeat, not from any hardcoded adapy seed).
         return _live_worker_advertising_ext_detail()
 
-    async def _fake_connect(self):
+    async def _fake_connect(self, **kwargs):
         return None
 
     fake_row = {

--- a/tests/comms/rest/test_queue_credentials.py
+++ b/tests/comms/rest/test_queue_credentials.py
@@ -1,0 +1,207 @@
+"""Credential plumbing and the manage/use split on ``JobQueue.connect``.
+
+Two properties are worth pinning down here.
+
+**Credentials are opt-in and absent by default.** Every deployment today
+connects to a `nats -js` with no accounts block, so an empty
+``QueueConfig`` must produce a ``nats.connect()`` call with no auth
+kwargs at all — adding one (even ``user=""``) would change how the
+server treats the connection.
+
+**Workers do not administer JetStream.** ``connect(manage=False)`` must
+not create the stream or the bucket; it binds what the API already made.
+That is the prerequisite for issuing a worker a credential without
+stream-admin rights (deploy/worker-trust.md) — while the worker's first
+act was ``add_stream``, no such credential could exist.
+"""
+
+import ssl
+
+import pytest
+from nats.js.errors import NotFoundError
+
+from ada.comms.rest.config import QueueConfig, load_settings
+from ada.comms.rest.queue import JobQueue
+
+
+def _cfg(**over) -> QueueConfig:
+    base = dict(url="nats://localhost:4222", stream="S", subject="subj", kv_bucket="kv", durable="d")
+    base.update(over)
+    return QueueConfig(**base)
+
+
+# --- connect option mapping -----------------------------------------
+
+
+def test_no_credentials_configured_sends_no_auth_kwargs():
+    assert JobQueue(_cfg())._connect_options(None) == {}
+
+
+def test_connection_name_is_passed_through():
+    assert JobQueue(_cfg())._connect_options("adapy-worker-ext-01") == {"name": "adapy-worker-ext-01"}
+
+
+@pytest.mark.parametrize(
+    "field,value,kwarg",
+    [
+        ("creds_file", "/secrets/worker.creds", "user_credentials"),
+        ("nkey_seed_file", "/secrets/worker.nk", "nkeys_seed"),
+        ("user", "worker-internal", "user"),
+        ("password", "hunter2", "password"),
+        ("token", "t0ken", "token"),
+    ],
+)
+def test_each_credential_form_maps_to_its_nats_kwarg(field, value, kwarg):
+    opts = JobQueue(_cfg(**{field: value}))._connect_options(None)
+    assert opts == {kwarg: value}
+
+
+def test_tls_ca_becomes_an_ssl_context(tmp_path):
+    # load_verify_locations rejects a file with no certificate in it, so
+    # the failure mode we assert on is "the CA was actually loaded",
+    # not "a context was constructed and the path ignored".
+    ca = tmp_path / "ca.pem"
+    ca.write_text("not a certificate")
+    with pytest.raises(ssl.SSLError):
+        JobQueue(_cfg(tls_ca=str(ca)))._connect_options(None)
+
+
+# --- manage split ----------------------------------------------------
+
+
+class _FakeJS:
+    """Records which JetStream admin calls were attempted."""
+
+    def __init__(self, *, bucket_exists=True):
+        self.calls: list[str] = []
+        self._bucket_exists = bucket_exists
+
+    async def add_stream(self, *a, **kw):
+        self.calls.append("add_stream")
+
+    async def update_stream(self, *a, **kw):
+        self.calls.append("update_stream")
+
+    async def delete_consumer(self, *a, **kw):
+        self.calls.append("delete_consumer")
+
+    async def create_key_value(self, *a, **kw):
+        self.calls.append("create_key_value")
+        return "kv-handle"
+
+    async def key_value(self, bucket):
+        self.calls.append("key_value")
+        if not self._bucket_exists:
+            raise NotFoundError()
+        return "kv-handle"
+
+
+class _FakeNC:
+    def __init__(self, js):
+        self._js = js
+
+    def jetstream(self):
+        return self._js
+
+
+def _patch_connect(monkeypatch, js) -> dict:
+    seen: dict = {}
+
+    async def fake_connect(url, **opts):
+        seen["url"] = url
+        seen["opts"] = opts
+        return _FakeNC(js)
+
+    monkeypatch.setattr("ada.comms.rest.queue.nats.connect", fake_connect)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_manage_true_provisions_the_topology(monkeypatch):
+    js = _FakeJS()
+    _patch_connect(monkeypatch, js)
+    q = JobQueue(_cfg())
+
+    await q.connect(manage=True)
+
+    assert "add_stream" in js.calls
+    assert "create_key_value" in js.calls
+
+
+@pytest.mark.asyncio
+async def test_manage_false_creates_nothing_and_binds_the_bucket(monkeypatch):
+    js = _FakeJS()
+    _patch_connect(monkeypatch, js)
+    q = JobQueue(_cfg())
+
+    await q.connect(manage=False)
+
+    assert js.calls == ["key_value"]
+
+
+@pytest.mark.asyncio
+async def test_manage_false_raises_a_named_cause_when_the_api_never_appears(monkeypatch):
+    js = _FakeJS(bucket_exists=False)
+    _patch_connect(monkeypatch, js)
+    q = JobQueue(_cfg())
+    # Collapse the wait so the test asserts on the give-up behaviour
+    # rather than on how long we are willing to wait for it.
+    monkeypatch.setattr(JobQueue, "_BIND_WAIT_SECONDS", 0.0)
+    monkeypatch.setattr(JobQueue, "_BIND_POLL_SECONDS", 0.0)
+
+    with pytest.raises(RuntimeError, match="created by the API"):
+        await q.connect(manage=False)
+
+    # Still no attempt to fix it by provisioning the bucket itself.
+    assert "create_key_value" not in js.calls
+
+
+@pytest.mark.asyncio
+async def test_credentials_reach_nats_connect(monkeypatch):
+    js = _FakeJS()
+    seen = _patch_connect(monkeypatch, js)
+    q = JobQueue(_cfg(creds_file="/secrets/ext-01.creds"))
+
+    await q.connect(manage=False, name="adapy-worker-ext-01")
+
+    assert seen["opts"] == {"name": "adapy-worker-ext-01", "user_credentials": "/secrets/ext-01.creds"}
+
+
+# --- settings --------------------------------------------------------
+
+
+def test_env_populates_the_credential_fields(monkeypatch):
+    monkeypatch.setenv("ADA_VIEWER_NATS_URL", "nats://nats:4222")
+    monkeypatch.setenv("ADA_VIEWER_NATS_CREDS", "  /secrets/worker.creds  ")
+    monkeypatch.setenv("ADA_VIEWER_NATS_USER", "worker-internal")
+    monkeypatch.setenv("ADA_VIEWER_NATS_TLS_CA", "/secrets/ca.pem")
+
+    queue = load_settings().queue
+
+    assert queue.creds_file == "/secrets/worker.creds"
+    assert queue.user == "worker-internal"
+    assert queue.tls_ca == "/secrets/ca.pem"
+
+
+def test_password_whitespace_is_preserved(monkeypatch):
+    # A secret generated by a password manager can legitimately end in a
+    # space; trimming it turns a working credential into an auth failure
+    # that looks like a server-side problem.
+    monkeypatch.setenv("ADA_VIEWER_NATS_PASSWORD", " s3cret ")
+    assert load_settings().queue.password == " s3cret "
+
+
+def test_credentials_default_to_absent(monkeypatch):
+    for var in (
+        "ADA_VIEWER_NATS_CREDS",
+        "ADA_VIEWER_NATS_USER",
+        "ADA_VIEWER_NATS_PASSWORD",
+        "ADA_VIEWER_NATS_TOKEN",
+        "ADA_VIEWER_NATS_NKEY_SEED",
+        "ADA_VIEWER_NATS_TLS_CA",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    queue = load_settings().queue
+
+    assert JobQueue(queue)._connect_options(None) == {}


### PR DESCRIPTION
A worker's first act is `add_stream`. That means nothing in the design
distinguishes a worker from an administrator, so there is no lesser privilege
to grant one — even if the NATS server had an accounts block, which it does
not: `connect()` is `nats.connect(url)`, no credentials, no TLS.

Anything that can reach port 4222 today can take another pool's jobs, write the
worker registry, falsify job outcomes, and reconfigure the stream.

## What this changes

Two things, both inert until a deployment opts in:

**`connect(manage=...)`.** The API keeps provisioning the stream and KV bucket;
a worker only uses them. `manage=False` waits for the bucket instead of racing
to create it, so worker-before-API startup still works and fails after 60s
naming the cause rather than crash-looping on ordering alone.
`ADA_WORKER_MANAGE_STREAM=true` restores the old behaviour for a worker run
against a bare NATS with no API in the picture.

**Credentials on `QueueConfig`** — creds file, user/password, token, nkey seed,
private-CA bundle — from `ADA_VIEWER_NATS_*`. All default to empty, and empty
produces the exact `nats.connect(url)` call as before. The password is
deliberately not stripped: a generated secret can legitimately end in a space,
and trimming it turns a working credential into an auth failure that looks like
a server problem.

Connections are also named now (`adapy-viewer-api`, `adapy-worker-<id>`),
because "which principal is this connection" is the question an auth rollout
keeps asking and `ip:port` does not answer it.

## Why now

`deploy/worker-trust.md` is added here and works through the whole picture. The
part worth reading even if the rest waits is in §1: `_live_worker_specs()`
unions `plugin_specs` from every non-stale registry row, **keyed by slug, last
writer wins, with no check on who wrote the row**. Writing one KV row is enough
to re-point an existing plugin id's `worker_capability` at a pool the writer
controls, after which `POST /api/plugins/<id>/jobs` routes that plugin's work —
and the options it carries — to the writer. Transport auth alone does not fix
that, which is why the doc separates authentication, authorization and
admission rather than treating them as one problem.

This PR is steps 1–2 of the rollout in §5. It is a prerequisite for the rest:
until a worker stops administering the stream, no narrower credential can exist.

## Testing

15 new tests in `tests/comms/rest/test_queue_credentials.py` covering the option
mapping (including that no credentials configured sends *no* auth kwargs), the
manage split, and the bind-wait give-up path.

Four existing `JobQueue.connect` test fakes needed their signature widened.
One of them (`test_plugin_job_audit_race`) failed loudly rather than silently,
which surfaced a pre-existing wrinkle left alone here: a swallowed connect
failure surfaces later as `'NoneType' object has no attribute 'put'` rather
than the intended 503.

## Not in this PR

The chart can already inject creds into workers via `extraEnv`/`extraEnvFrom`,
but `deployment.yaml` has no such hook, so turning auth on in-cluster needs that
added first. Nothing else blocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6Hcm4s2uXeFt9UerNKcqZ