### PR TITLE
fix(worker): a plugin job must not die because `resource` is POSIX-only

### DIFF
--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -2781,6 +2781,35 @@ def _read_self_vmhwm_kb() -> int:
     return 0
 
 
+def _read_self_rusage() -> "tuple[float, float, int] | None":
+    """``(user_seconds, sys_seconds, max_rss_kb)`` for this process and its
+    children, or ``None`` where the counters cannot be read.
+
+    ``resource`` is POSIX-only and does not exist on Windows. That matters
+    because the plugin-job profiling harness runs IN-PROCESS — unlike the
+    convert path, which does its accounting in a forked child that only ever
+    exists on POSIX — so an unguarded ``import resource`` there would fail the
+    JOB, not just the measurement, on any Windows worker with profiling on.
+    Best-effort, like the ``/proc`` readers above: a counter we cannot read is
+    a poorer audit row, never a failed conversion.
+
+    Whole-process by construction: the executor model cannot isolate one
+    thread's counters, so the numbers include any concurrent work on this
+    worker.
+    """
+    try:
+        import resource
+    except ModuleNotFoundError:  # Windows
+        return None
+    me = resource.getrusage(resource.RUSAGE_SELF)
+    kids = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return (
+        me.ru_utime + kids.ru_utime,
+        me.ru_stime + kids.ru_stime,
+        int(max(me.ru_maxrss, kids.ru_maxrss)),
+    )
+
+
 async def _run_plugin_job(
     *,
     job: Job,
@@ -2926,31 +2955,38 @@ async def _run_plugin_job(
             return fn(opts.get("options") or {}, **kwargs)
 
         # Harness: cProfile + rusage/VmHWM/proc-io deltas around the call. All
-        # readings are whole-process (see note above).
+        # readings are whole-process (see note above), and every one of them is
+        # best-effort — cProfile is the only part that works everywhere, and a
+        # counter this platform cannot produce must cost a measurement, not the
+        # job that was being measured.
         import cProfile
-        import resource
 
         prof = cProfile.Profile()
-        ru0_self = resource.getrusage(resource.RUSAGE_SELF)
-        ru0_child = resource.getrusage(resource.RUSAGE_CHILDREN)
+        ru0 = _read_self_rusage()
         rd0, wr0 = _read_self_proc_io()
         prof.enable()
         try:
             result = fn(opts.get("options") or {}, **kwargs)
         finally:
             prof.disable()
-            ru1_self = resource.getrusage(resource.RUSAGE_SELF)
-            ru1_child = resource.getrusage(resource.RUSAGE_CHILDREN)
+            ru1 = _read_self_rusage()
             rd1, wr1 = _read_self_proc_io()
-            cpu_user_ms = int(
-                ((ru1_self.ru_utime - ru0_self.ru_utime) + (ru1_child.ru_utime - ru0_child.ru_utime)) * 1000
-            )
-            cpu_sys_ms = int(
-                ((ru1_self.ru_stime - ru0_self.ru_stime) + (ru1_child.ru_stime - ru0_child.ru_stime)) * 1000
-            )
-            # VmHWM is a monotonic high-water mark; ru_maxrss (kB on Linux) is the
-            # fallback when /proc is unavailable.
-            peak_rss_kb = _read_self_vmhwm_kb() or int(max(ru1_self.ru_maxrss, ru1_child.ru_maxrss))
+            metrics: dict = {
+                "read_bytes": max(0, rd1 - rd0),
+                "write_bytes": max(0, wr1 - wr0),
+            }
+            # VmHWM is a monotonic high-water mark; ru_maxrss (kB on Linux) is
+            # the fallback when /proc is unavailable.
+            peak_rss_kb = _read_self_vmhwm_kb() or (ru1[2] if ru1 else 0)
+            if peak_rss_kb:
+                metrics["peak_rss_kb"] = peak_rss_kb
+            if ru0 is not None and ru1 is not None:
+                # Omitted rather than zeroed where rusage is unavailable. A
+                # zero would be indistinguishable from a job that genuinely
+                # burned no CPU, and the audit panel reads exactly that ratio
+                # to decide a task is "mostly waiting on IO".
+                metrics["cpu_user_ms"] = int((ru1[0] - ru0[0]) * 1000)
+                metrics["cpu_sys_ms"] = int((ru1[1] - ru0[1]) * 1000)
             prof_bytes: bytes | None = None
             try:
                 with tempfile.NamedTemporaryFile(suffix=".prof", delete=False) as tf:
@@ -2960,13 +2996,7 @@ async def _run_plugin_job(
                 os.unlink(_prof_path)
             except Exception:
                 logger.debug("worker: plugin_job profile dump failed for %s", job_id, exc_info=True)
-            prof_holder["metrics"] = {
-                "cpu_user_ms": cpu_user_ms,
-                "cpu_sys_ms": cpu_sys_ms,
-                "peak_rss_kb": peak_rss_kb,
-                "read_bytes": max(0, rd1 - rd0),
-                "write_bytes": max(0, wr1 - wr0),
-            }
+            prof_holder["metrics"] = metrics
             prof_holder["profile_bytes"] = prof_bytes
         return result
 

--- a/tests/comms/rest/test_plugin_job_profiling_portable.py
+++ b/tests/comms/rest/test_plugin_job_profiling_portable.py
@@ -1,0 +1,222 @@
+"""The plugin-job profiling harness must not be POSIX-only.
+
+The convert path does its resource accounting inside a forked child, and that
+child only ever exists on POSIX — so `resource` being unavailable off Linux
+costs nothing there. A plugin job is different: it runs IN-PROCESS in an
+executor thread, so the harness runs wherever the worker runs. An unguarded
+``import resource`` in it fails the JOB, not just the measurement, on a Windows
+worker with ``profile_conversions`` on — which is precisely the configuration an
+off-cluster capability worker runs in: a machine outside the cluster that joins
+a capability pool because it holds something no pod can (a licensed CAD seat, a
+device, a dataset), and which is far more likely to be Windows than any pod is.
+
+So: a counter the platform cannot produce is omitted from the audit row, and the
+job runs.
+"""
+
+import asyncio
+import builtins
+import pathlib
+import re
+import sys
+import types
+
+import pytest
+
+import ada.plugins as plugins_mod
+from ada.comms.rest import worker as worker_mod
+from ada.comms.rest.queue import Job
+
+# --- the reader ------------------------------------------------------------
+
+
+def test_rusage_is_none_when_the_module_does_not_exist(monkeypatch):
+    real_import = builtins.__import__
+
+    def _no_resource(name, *args, **kwargs):
+        if name == "resource":
+            raise ModuleNotFoundError("No module named 'resource'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_resource)
+
+    assert worker_mod._read_self_rusage() is None
+
+
+def test_rusage_reads_real_counters_where_it_can():
+    got = worker_mod._read_self_rusage()
+    if got is None:
+        pytest.skip("no resource module on this platform — the other tests cover that path")
+    user, sys_, rss = got
+    assert user >= 0.0 and sys_ >= 0.0
+    assert rss >= 0
+
+
+def test_resource_is_imported_in_exactly_one_guarded_place():
+    """A regression guard with a specific failure in mind.
+
+    The harness is easy to extend with another counter, and `import resource`
+    at the top of a new block would reintroduce the crash without any test
+    failing — the profiling path only runs when an admin toggles it on. So the
+    invariant is stated directly: worker.py reaches for `resource` once, inside
+    the helper that handles its absence.
+    """
+    src = pathlib.Path(worker_mod.__file__).read_text(encoding="utf-8")
+    assert len(re.findall(r"^\s*import resource\b", src, re.MULTILINE)) == 1
+    guarded = re.search(
+        r"def _read_self_rusage\(.*?\n(.*?)\n\ndef ",
+        src,
+        re.DOTALL,
+    )
+    assert guarded and "import resource" in guarded.group(1)
+
+
+# --- the harness -----------------------------------------------------------
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.updates: list[dict] = []
+
+    async def update(self, job_id, **kw):
+        self.updates.append({"job_id": job_id, **kw})
+
+
+ENTRY_MODULE = "_test_portable_plugin"
+
+
+def _install_plugin(monkeypatch, summary: dict) -> str:
+    """Register a trivial entrypoint and make the worker resolve to it.
+
+    ``plugin_backend_spec`` is imported INSIDE ``_run_plugin_job``, so it is
+    patched on ``ada.plugins`` rather than on the worker module. The entrypoint
+    lives in a synthetic module in ``sys.modules`` so ``import_module`` finds it
+    without depending on how the test tree is laid out on disk.
+    """
+    mod = types.ModuleType(ENTRY_MODULE)
+
+    def run(options, **kwargs):
+        return summary
+
+    mod.run = run
+    monkeypatch.setitem(sys.modules, ENTRY_MODULE, mod)
+    monkeypatch.setattr(
+        plugins_mod,
+        "plugin_backend_spec",
+        lambda pid: {"job_entrypoint": f"{ENTRY_MODULE}:run"},
+    )
+    return f"{ENTRY_MODULE}:run"
+
+
+@pytest.mark.asyncio
+async def test_a_profiled_plugin_job_completes_without_rusage(monkeypatch, tmp_path):
+    """The whole point: profiling on, `resource` absent, job still succeeds."""
+    # Force the no-resource world regardless of the host platform, so this test
+    # asserts the same thing on Linux CI as on a Windows worker.
+    monkeypatch.setattr(worker_mod, "_read_self_rusage", lambda: None)
+
+    audited: dict = {}
+
+    async def _fake_audit_done(db_pool, job_id, status, error, started_at, **kw):
+        audited["status"] = status
+        audited["metrics"] = kw.get("metrics") or {}
+
+    async def _fake_get_setting(pool, key):
+        # profile_conversions on, no per-task filter => the harness runs.
+        return "true" if key == "profile_conversions" else ""
+
+    async def _never_cancelled(pool, job_id):
+        return False
+
+    monkeypatch.setattr(worker_mod, "_audit_done", _fake_audit_done)
+    monkeypatch.setattr(worker_mod.db_module, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(worker_mod.db_module, "audit_is_cancelled", _never_cancelled)
+    _install_plugin(monkeypatch, {"ok": True, "produced": "nothing"})
+
+    stored: dict[str, bytes] = {}
+
+    class _FakeStorage:
+        async def put_bytes(self, scope, key, data, **kw):
+            stored[key] = data
+
+    queue = _FakeQueue()
+    job = Job(
+        job_id="job-1",
+        source_key="synthetic/plugin",
+        derived_key="_derived/summary.json.gz",
+        status="running",
+        target_format="plugin_job",
+        conversion_options={"plugin_id": "demo", "options": {}},
+    )
+
+    await worker_mod._run_plugin_job(
+        job=job,
+        scope=object(),
+        storage=_FakeStorage(),
+        queue=queue,
+        db_pool=object(),  # non-None so the profiling settings are read
+        started_at=0.0,
+    )
+
+    assert audited["status"] == "done"
+    # The summary was written; the job did its work.
+    assert job.derived_key in stored
+
+
+@pytest.mark.asyncio
+async def test_cpu_counters_are_omitted_rather_than_zeroed(monkeypatch):
+    """A zero would be indistinguishable from a job that burned no CPU.
+
+    The audit panel divides summed CPU by summed duration to decide a task is
+    "mostly waiting on IO"; a fabricated zero would make every Windows-worker
+    run vote for that conclusion. An absent column does not vote.
+    """
+    monkeypatch.setattr(worker_mod, "_read_self_rusage", lambda: None)
+
+    captured: dict = {}
+
+    async def _fake_audit_done(db_pool, job_id, status, error, started_at, **kw):
+        captured.update(kw.get("metrics") or {})
+
+    async def _fake_get_setting(pool, key):
+        return "true" if key == "profile_conversions" else ""
+
+    async def _never_cancelled(pool, job_id):
+        return False
+
+    monkeypatch.setattr(worker_mod, "_audit_done", _fake_audit_done)
+    monkeypatch.setattr(worker_mod.db_module, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(worker_mod.db_module, "audit_is_cancelled", _never_cancelled)
+    _install_plugin(monkeypatch, {"ok": True})
+
+    class _FakeStorage:
+        async def put_bytes(self, scope, key, data, **kw):
+            pass
+
+    await worker_mod._run_plugin_job(
+        job=Job(
+            job_id="job-2",
+            source_key="synthetic/plugin",
+            derived_key="_derived/s.json.gz",
+            status="running",
+            target_format="plugin_job",
+            conversion_options={"plugin_id": "demo", "options": {}},
+        ),
+        scope=object(),
+        storage=_FakeStorage(),
+        queue=_FakeQueue(),
+        db_pool=object(),
+        started_at=0.0,
+    )
+
+    assert "cpu_user_ms" not in captured
+    assert "cpu_sys_ms" not in captured
+    # The counters that ARE portable still land.
+    assert "read_bytes" in captured and "write_bytes" in captured
+
+
+def test_the_event_loop_is_not_required_for_the_reader():
+    # Called from an executor thread in production, so it must not assume a
+    # running loop.
+    assert asyncio.get_event_loop_policy() is not None
+    worker_mod._read_self_rusage()


### PR DESCRIPTION
`import resource` inside the plugin-job profiling harness is unguarded.

The convert path gets away with the same import because its accounting happens
in a forked child that only exists on POSIX. A plugin job is different: it runs
**in-process** in an executor thread, so the harness runs wherever the worker
runs. On Windows with `profile_conversions` on, the job fails.

Reproduced against `main` on a Windows host, driving `_run_plugin_job` with a
trivial entrypoint and profiling enabled:

```
outcome: {'status': 'error', 'error': "No module named 'resource'"}
```

Same machine, same scenario, after this change:

```
outcome: {'status': 'done', 'error': None}
```

That configuration is not hypothetical. It is what an off-cluster capability
worker runs in — a machine outside the cluster that joins a capability pool
because it holds something no pod can (a licensed seat, a device, a dataset),
and far more likely to be Windows than any pod is. Profiling is an admin toggle,
so the breakage arrives long after the deploy that introduced it, on the one
worker nobody is watching.

## The fix

The rusage read joins the `/proc` readers as best-effort, behind
`_read_self_rusage()` which returns `None` where the module does not exist.

**CPU counters are omitted rather than zeroed** where they cannot be measured.
The audit panel computes `cpu_fraction` as summed CPU over summed duration to
decide a task is "mostly waiting on IO"; a fabricated zero would make every run
on such a worker vote for that conclusion. An absent column does not vote.
`peak_rss` still comes from VmHWM where `/proc` exists and falls back to
`ru_maxrss` where it does not.

## Testing

Five tests, one skipped on non-POSIX. The one worth calling out asserts that
`resource` is imported in exactly one place and that the place handles its
absence — the harness is easy to extend with another counter, and the profiling
path only runs when an admin turns it on, so nothing else would catch a
reintroduction until it broke a job in production.

The two behavioural tests force the no-`resource` world with a monkeypatch, so
they assert the same thing on Linux CI as on a Windows worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6Hcm4s2uXeFt9UerNKcqZ