### PR TITLE
feat(plugins): let one plugin address several non-interchangeable pools

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -50,7 +50,7 @@ from .converter import (
     supported_targets_for,
 )
 from .handlers import dispatch
-from .queue import JobQueue
+from .queue import JobQueue, capability_token
 from .scope import Scope
 from .scope import can_access as scope_can_access
 from .storage import Storage
@@ -123,6 +123,53 @@ async def _parse_rename_body(request: Request) -> tuple[str, str]:
 
 def _content_encoding_for(key: str) -> str | None:
     return "gzip" if pathlib.PurePosixPath(key).suffix.lower() in _GZIP_UPLOAD_EXTS else None
+
+
+def _merge_spec(base: dict, other: dict) -> None:
+    """Fold a second worker's advertisement of the same slug into ``base``.
+
+    Only the keys named in ``union_fields`` are combined, and only where both
+    sides hold lists; everything else keeps the value the first worker supplied
+    (see :func:`_live_worker_specs` for why "first" is well-defined). Order is
+    preserved and duplicates dropped, so the result reads like one list somebody
+    wrote rather than a concatenation.
+
+    ``union_fields`` is itself unioned. That is what makes a rolling upgrade
+    work: while half the pool runs a build that declares the key and half does
+    not, the half that does still gets its fields merged instead of the
+    behaviour flipping on whichever worker sorted first.
+    """
+
+    def _union(dst: list, src: list) -> list:
+        seen = {json.dumps(v, sort_keys=True) if isinstance(v, (dict, list)) else v for v in dst}
+        for v in src:
+            marker = json.dumps(v, sort_keys=True) if isinstance(v, (dict, list)) else v
+            if marker not in seen:
+                seen.add(marker)
+                dst.append(v)
+        return dst
+
+    fields = base.get("union_fields")
+    fields = list(fields) if isinstance(fields, list) else []
+    incoming = other.get("union_fields")
+    if isinstance(incoming, list):
+        fields = _union(fields, [f for f in incoming if isinstance(f, str)])
+        base["union_fields"] = fields
+
+    for key in fields:
+        if not isinstance(key, str) or key == "union_fields":
+            continue
+        add = other.get(key)
+        if not isinstance(add, list):
+            continue
+        have = base.get(key)
+        if not isinstance(have, list):
+            # The first worker did not carry the key at all (older build, or it
+            # genuinely has nothing to contribute). Start from what this one
+            # has rather than dropping it.
+            base[key] = list(add)
+        else:
+            _union(have, add)
 
 
 _ADAPY_VERSION: str | None = None
@@ -2791,16 +2838,39 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return JSONResponse(row, status_code=201)
 
     async def _live_worker_specs(field: str, fallback_field: str | None = None) -> dict[str, dict]:
-        """Catalog-shaped specs advertised by non-stale workers, keyed by slug
-        (last writer wins). Falls back to a bare slug-list field for older
-        workers that advertise only names, synthesizing a minimal spec."""
+        """Catalog-shaped specs advertised by non-stale workers, keyed by slug.
+        Falls back to a bare slug-list field for older workers that advertise
+        only names, synthesizing a minimal spec.
+
+        WHEN SEVERAL WORKERS ADVERTISE ONE SLUG, two rules apply:
+
+        * **Deterministic, not last-writer-wins.** Workers are visited in
+          worker-id order and the first spec for a slug supplies the scalars.
+          Previously this followed KV listing order, so with two workers on one
+          plugin the advertised version and capability could differ between two
+          consecutive requests for no visible reason.
+        * **Declared list fields are unioned.** A spec may name keys in
+          ``union_fields``; those are combined across every worker advertising
+          the slug instead of one worker's copy winning. That is what lets a
+          sharded pool say what it collectively covers — several workers on the
+          same plugin, each serving a different project, produce one spec
+          listing every project that is online.
+
+        Only the named keys are unioned. A blanket "merge every list" would
+        quietly combine things that are per-worker facts rather than collective
+        ones (a worker's own conversions, its own extension allowlist), and
+        produce a spec describing a worker that does not exist.
+        """
         import time as _time
 
         out: dict[str, dict] = {}
         if not queue.enabled:
             return out
         now = _time.time()
-        for w in await queue.list_workers():
+        # Sorted so the winner is stable across requests. `worker_id` is always
+        # present — list_workers derives it from the KV key.
+        workers = sorted(await queue.list_workers(), key=lambda w: str(w.get("worker_id") or ""))
+        for w in workers:
             hb = w.get("last_heartbeat")
             if not (isinstance(hb, (int, float)) and (now - hb) <= queue.WORKER_STALE_AFTER_S):
                 continue
@@ -2808,7 +2878,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             if isinstance(specs, list):
                 for s in specs:
                     if isinstance(s, dict) and isinstance(s.get("slug"), str) and s["slug"]:
-                        out[s["slug"]] = s
+                        slug = s["slug"]
+                        if slug not in out:
+                            out[slug] = dict(s)
+                        else:
+                            _merge_spec(out[slug], s)
             elif fallback_field:
                 bare = w.get(fallback_field)
                 if isinstance(bare, list):
@@ -2859,14 +2933,41 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # (e.g. a capacity worker) picks the job up.
         target_capability = body.get("capability")
         if isinstance(target_capability, str) and target_capability.strip():
-            target_capability = target_capability.strip().lower()
+            target_capability = capability_token(target_capability)
         else:
             target_capability = None
             for spec in (await _live_worker_specs("plugin_specs")).values():
                 if spec.get("slug") == plugin_id or spec.get("id") == plugin_id:
                     cap = spec.get("worker_capability")
                     if isinstance(cap, str) and cap.strip():
-                        target_capability = cap.strip().lower()
+                        target_capability = capability_token(cap)
+                    # SHARDED POOLS. A plugin may advertise `capability_option`
+                    # naming one of its own options; when the request supplies
+                    # that option the job routes to `<capability>-<value>`
+                    # instead of `<capability>`.
+                    #
+                    # This exists because a pool is one durable consumer: every
+                    # worker in it competes for the same messages, so workers
+                    # that are NOT interchangeable — each holding a different
+                    # licence, dataset or device — cannot share one. Routing
+                    # them apart by NAKing the wrong ones is the design this
+                    # replaced; it burned the delivery budget and dead-lettered
+                    # valid jobs (see the note on `pull_subscribe`).
+                    #
+                    # Subject routing does it instead, and the worker needs no
+                    # new code: it just lists the sharded token in
+                    # ADA_WORKER_CAPABILITIES. Core still names no plugin and
+                    # knows nothing about what the option MEANS.
+                    #
+                    # An absent or unusable option falls back to the bare
+                    # capability rather than erroring, so a worker that
+                    # subscribes to both serves unqualified requests too, and a
+                    # single-worker deployment never has to qualify anything.
+                    opt_name = spec.get("capability_option")
+                    if target_capability and isinstance(opt_name, str) and opt_name:
+                        shard = capability_token(options.get(opt_name))
+                        if shard:
+                            target_capability = f"{target_capability}-{shard}"
                     break
 
         # No queue: run it here, in a thread, and hand back a job id the status

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -109,6 +109,42 @@ class QueueDisabled(RuntimeError):
     """Raised when queue operations are attempted but no NATS URL is configured."""
 
 
+#: Longest a single capability token may be. Generous for a project code or a
+#: device name, short enough that a pasted paragraph cannot become a subject.
+MAX_CAPABILITY_TOKEN_LEN = 48
+
+
+def capability_token(value: object) -> str:
+    """Normalise ``value`` into one NATS subject token, or ``""``.
+
+    A capability becomes a subject segment (``ada.viewer.jobs.convert.<cap>``)
+    and a durable-consumer name suffix, so it may not contain ``.``, ``*``,
+    ``>`` or whitespace — a project code with a dot in it would silently create
+    a *deeper* subject that no consumer filters on, and the job would sit in the
+    stream forever looking merely slow.
+
+    THIS FUNCTION IS THE CONTRACT between the API and the worker. The API
+    derives the subject it publishes on and the worker derives the subject it
+    subscribes to; if the two normalised differently — one lower-casing, the
+    other not — every sharded job would be published to a subject nobody is
+    listening on. Both call this.
+
+    Returns ``""`` when nothing usable survives, which callers must read as "no
+    shard", never as a token.
+    """
+    text = str(value or "").strip().lower()
+    out: list[str] = []
+    for ch in text:
+        if ch.isascii() and (ch.isalnum() or ch == "-"):
+            out.append(ch)
+        elif out and out[-1] != "-":
+            # Collapse any run of separators (dots, spaces, slashes) into one
+            # dash rather than dropping them: `site-a/2` and `site-a 2` should
+            # not both become `site-a2`, which would merge two distinct pools.
+            out.append("-")
+    return "".join(out).strip("-")[:MAX_CAPABILITY_TOKEN_LEN].strip("-")
+
+
 def _worker_advertises_engine(w: dict, ext: str, engine: str) -> bool:
     """True if worker registry entry ``w`` lists ``engine`` in its step_glb_pipeline enum for the
     ``ext`` → glb conversion — i.e. that pool can actually run the requested STEP→GLB engine."""
@@ -802,6 +838,8 @@ __all__ = [
     "Job",
     "JobQueue",
     "QueueDisabled",
+    "capability_token",
+    "MAX_CAPABILITY_TOKEN_LEN",
     "JOB_STATUS_QUEUED",
     "JOB_STATUS_RUNNING",
     "JOB_STATUS_DONE",

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -129,13 +129,22 @@ def capability_token(value: object) -> str:
     other not — every sharded job would be published to a subject nobody is
     listening on. Both call this.
 
+    Underscore is kept, not rewritten to a dash. It is a legal subject
+    character and existing pools are named with it (``fem_solver``), so
+    rewriting it would move those workers to a new subject while some job
+    producers still published to the old one — a silent delivery failure caused
+    by a normaliser meant to prevent exactly that.
+
+    Idempotent: ``capability_token(capability_token(x)) == capability_token(x)``,
+    which is what makes it safe to apply at more than one point on the path.
+
     Returns ``""`` when nothing usable survives, which callers must read as "no
     shard", never as a token.
     """
     text = str(value or "").strip().lower()
     out: list[str] = []
     for ch in text:
-        if ch.isascii() and (ch.isalnum() or ch == "-"):
+        if ch.isascii() and (ch.isalnum() or ch in "-_"):
             out.append(ch)
         elif out and out[-1] != "-":
             # Collapse any run of separators (dots, spaces, slashes) into one
@@ -473,7 +482,15 @@ class JobQueue:
         forever: no message left in the work queue, and the KV entry gone once
         the terminal-status cleanup sweep runs.
         """
-        cap = (job.target_capability or self.DEFAULT_CAPABILITY).strip().lower()
+        # Normalised HERE rather than at each producer. `target_capability` is
+        # set from a dozen places — the plugin route, the audit dispatcher, a
+        # detailing spec, a procedural engine lookup, a manifest — and several
+        # of them pass a value straight through from a worker's advertisement.
+        # The worker derives its subscription subject through the same function,
+        # so converging here is what guarantees the two agree no matter which
+        # producer built the job. Doing it per-producer would mean the next one
+        # added is a silent delivery failure nobody notices.
+        cap = capability_token(job.target_capability) or self.DEFAULT_CAPABILITY
         subject = f"{self._cfg.subject}.{cap}"
         await self._js.publish(subject, job.job_id.encode("utf-8"))
 

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -43,7 +43,14 @@ from . import db as db_module
 from . import source_cache
 from .config import load_settings
 from .converter import LEGACY_CONVERT_EXTS, ConverterRegistry, convert
-from .queue import JOB_STATUS_DONE, JOB_STATUS_ERROR, JOB_STATUS_RUNNING, Job, JobQueue
+from .queue import (
+    JOB_STATUS_DONE,
+    JOB_STATUS_ERROR,
+    JOB_STATUS_RUNNING,
+    Job,
+    JobQueue,
+    capability_token,
+)
 from .scope import Scope
 from .storage import Storage
 from .subprocess_convert import (
@@ -143,12 +150,17 @@ def _worker_id() -> str:
 def _pool_capabilities(capabilities: list[str]) -> list[str]:
     """Capability pools this worker should subscribe to.
 
-    Lower-cased and de-duplicated while preserving order, so a repeated or
-    differently-cased entry in ``ADA_WORKER_CAPABILITIES`` cannot open two
-    consumers on the same subject. Falls back to ``["base"]`` so a worker is
-    never left subscribed to nothing.
+    Normalised through :func:`capability_token` and de-duplicated while
+    preserving order, so a repeated or differently-cased entry in
+    ``ADA_WORKER_CAPABILITIES`` cannot open two consumers on the same subject.
+    Falls back to ``["base"]`` so a worker is never left subscribed to nothing.
+
+    Deliberately the same normaliser the API uses to build the subject it
+    PUBLISHES on. A sharded capability like ``cad-Site A`` has to reduce to an
+    identical token on both sides, or the job is published to a subject nothing
+    is subscribed to and sits in the stream looking merely slow.
     """
-    pools = [c.strip().lower() for c in capabilities if c and c.strip()]
+    pools = [t for t in (capability_token(c) for c in capabilities) if t]
     return list(dict.fromkeys(pools)) or ["base"]
 
 

--- a/src/ada/plugins/__init__.py
+++ b/src/ada/plugins/__init__.py
@@ -82,7 +82,29 @@ def register_plugin_backend(
     the globally-unique kebab-case id that namespaces everything (routes, sidecar
     prefix, manifest map). Idempotent by ``plugin_id``. ``**extra`` is folded into
     the spec verbatim so a plugin can advertise its own flags without a core
-    change (mirrors the engine catalogs)."""
+    change (mirrors the engine catalogs).
+
+    Two ``extra`` keys core *does* act on, both opt-in and both absent by
+    default:
+
+    ``capability_option: str``
+        Names one of the plugin's own options. When a job request supplies it,
+        ``POST /api/plugins/{id}/jobs`` routes to ``<worker_capability>-<value>``
+        instead of ``<worker_capability>``, letting one plugin address several
+        pools whose workers are *not* interchangeable — each holding a different
+        licence, dataset or device. Core never learns what the option means; it
+        only normalises the value into a subject token. Workers opt in by
+        listing the sharded token in ``ADA_WORKER_CAPABILITIES``, and a worker
+        listing both the bare and the sharded form serves unqualified requests
+        too. An absent or unusable value falls back to the bare capability.
+
+    ``union_fields: list[str]``
+        Names spec keys that should be COMBINED across every worker advertising
+        this plugin rather than taken from one of them. Without it, several
+        workers advertising one slug means one worker's copy wins and the others
+        are invisible — so a sharded pool cannot say what it collectively
+        covers. Only list-valued keys are merged, and only the named ones.
+    """
     if not plugin_id or not isinstance(plugin_id, str):
         raise ValueError("plugin_id must be a non-empty string")
     spec: dict = {

--- a/tests/comms/rest/test_capability_sharding.py
+++ b/tests/comms/rest/test_capability_sharding.py
@@ -1,0 +1,198 @@
+"""Sharded capability pools, and the spec union that makes them visible.
+
+A capability pool is ONE durable consumer: every worker in it competes for the
+same messages. That is right when the workers are interchangeable and wrong when
+they are not — several workers each holding a different licence, dataset or
+device cannot share a pool, because the job goes to whichever pulls first.
+
+Routing them apart by making the wrong worker NAK is the design this replaces;
+`pull_subscribe`'s own docstring records that it burned the per-message delivery
+budget and dead-lettered valid jobs. Subject routing does it instead:
+`capability_option` on the plugin spec turns one option's value into a subject
+suffix, and the worker subscribes to that suffix.
+
+Two properties carry the whole thing:
+
+* the API and the worker must normalise a capability IDENTICALLY, or jobs are
+  published where nothing listens;
+* several workers advertising one plugin must not erase each other, or the UI
+  cannot say which shards are online.
+"""
+
+import os
+import tempfile
+
+# Importing ada.comms.rest.app evaluates a module-level `create_app()`
+# which materializes a local Storage. Point it at a temp dir so the
+# import succeeds in environments without `./viewer-data`.
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest  # noqa: E402
+
+from ada.comms.rest.app import _merge_spec  # noqa: E402
+from ada.comms.rest.queue import (  # noqa: E402
+    MAX_CAPABILITY_TOKEN_LEN,
+    capability_token,
+)
+from ada.comms.rest.worker import _pool_capabilities  # noqa: E402
+
+# --- the token -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("alpha", "alpha"),
+        ("  alpha  ", "alpha"),
+        ("SITE-A", "site-a"),
+        ("mesh-tools", "mesh-tools"),
+    ],
+)
+def test_ordinary_values_survive_intact(raw, expected):
+    assert capability_token(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["a.b", "a b", "a/b", "a\tb", "a*b", "a>b"])
+def test_subject_breaking_characters_become_one_dash(raw):
+    # A dot would create a DEEPER subject that no consumer filters on, so the
+    # job would sit in the stream looking merely slow rather than failing.
+    assert capability_token(raw) == "a-b"
+
+
+def test_separator_runs_collapse_but_do_not_vanish():
+    # `SITE-A/2` and `SITE-A 511` must not both become `site-a511`: dropping
+    # separators can merge two pools that were meant to be distinct.
+    assert capability_token("SITE-A/2") == "site-a-2"
+    assert capability_token("SITE-A   2") == "site-a-2"
+    assert capability_token("SITE-A//2") == "site-a-2"
+
+
+@pytest.mark.parametrize("raw", ["", "   ", None, ".", "...", "***", 0])
+def test_nothing_usable_yields_the_empty_token(raw):
+    # Callers read "" as "no shard". It must never become a token, or every
+    # unqualified request would land on a subject named after punctuation.
+    assert capability_token(raw) == ""
+
+
+def test_a_long_value_is_bounded_and_still_well_formed():
+    token = capability_token("x" * 500)
+    assert len(token) == MAX_CAPABILITY_TOKEN_LEN
+    assert not token.startswith("-") and not token.endswith("-")
+
+
+def test_truncation_never_leaves_a_trailing_dash():
+    # Cutting mid-separator would otherwise give `...-`, and `cap-shard-` is a
+    # different subject from `cap-shard`.
+    raw = "a" * (MAX_CAPABILITY_TOKEN_LEN - 1) + " " + "b" * 20
+    assert not capability_token(raw).endswith("-")
+
+
+# --- publisher and subscriber must agree -----------------------------------
+
+
+@pytest.mark.parametrize("raw", ["alpha", "SITE A", "site.a", "  BETA  ", "SITE-A/2"])
+def test_the_worker_subscribes_to_exactly_what_the_api_publishes(raw):
+    """The one property that makes sharding work at all.
+
+    The API builds the subject from the request; the worker builds it from
+    ADA_WORKER_CAPABILITIES. If the two normalised differently the job would be
+    published to a subject nothing is subscribed to.
+    """
+    api_side = f"cad-{capability_token(raw)}"
+    worker_side = _pool_capabilities([f"cad-{raw}"])[0]
+    assert api_side == worker_side
+
+
+def test_pool_capabilities_still_dedupes_across_normalisation():
+    # Two spellings of one pool must not open two consumers on one subject.
+    assert _pool_capabilities(["CAD", "cad", " cad "]) == ["cad"]
+
+
+def test_a_worker_with_nothing_usable_still_serves_base():
+    assert _pool_capabilities(["", "  ", "..."]) == ["base"]
+
+
+def test_a_worker_can_hold_both_the_bare_and_the_sharded_pool():
+    # This is what lets one worker answer unqualified requests as well as its
+    # own shard, so a single-worker deployment never has to qualify anything.
+    assert _pool_capabilities(["cad", "cad-alpha"]) == ["cad", "cad-alpha"]
+
+
+# --- the spec union --------------------------------------------------------
+
+
+def _spec(**over):
+    base = {"slug": "cad-export", "version": "1.0.0", "union_fields": ["projects"], "projects": []}
+    base.update(over)
+    return base
+
+
+def test_declared_list_fields_are_combined_across_workers():
+    a = _spec(projects=["alpha"])
+    _merge_spec(a, _spec(projects=["beta"]))
+    assert a["projects"] == ["alpha", "beta"]
+
+
+def test_the_union_preserves_order_and_drops_duplicates():
+    a = _spec(projects=["alpha", "beta"])
+    _merge_spec(a, _spec(projects=["beta", "gamma"]))
+    assert a["projects"] == ["alpha", "beta", "gamma"]
+
+
+def test_undeclared_fields_are_not_merged():
+    # A blanket "merge every list" would combine per-worker facts into a spec
+    # describing a worker that does not exist.
+    a = _spec(projects=["alpha"], source_exts=[".a"])
+    _merge_spec(a, _spec(projects=["beta"], source_exts=[".b"]))
+    assert a["source_exts"] == [".a"]
+
+
+def test_scalars_keep_the_first_workers_value():
+    a = _spec(version="1.0.0")
+    _merge_spec(a, _spec(version="9.9.9"))
+    assert a["version"] == "1.0.0"
+
+
+def test_union_fields_is_itself_unioned_for_rolling_upgrades():
+    # Half the pool on a build that declares the key, half not: the half that
+    # does must still get merged rather than the behaviour depending on which
+    # worker sorted first.
+    a = {"slug": "cad-export", "projects": ["alpha"]}  # older build, no union_fields
+    _merge_spec(a, _spec(projects=["beta"]))
+    assert a["projects"] == ["alpha", "beta"]
+    assert a["union_fields"] == ["projects"]
+
+
+def test_a_field_absent_from_the_first_worker_is_adopted():
+    a = {"slug": "cad-export", "union_fields": ["projects"]}
+    _merge_spec(a, _spec(projects=["beta"]))
+    assert a["projects"] == ["beta"]
+
+
+def test_a_non_list_value_on_the_incoming_spec_is_ignored():
+    a = _spec(projects=["alpha"])
+    _merge_spec(a, _spec(projects="beta"))
+    assert a["projects"] == ["alpha"]
+
+
+def test_dict_entries_dedupe_by_value_not_identity():
+    a = _spec(union_fields=["items"], items=[{"k": 1}])
+    _merge_spec(a, _spec(union_fields=["items"], items=[{"k": 1}, {"k": 2}]))
+    assert a["items"] == [{"k": 1}, {"k": 2}]
+
+
+def test_union_fields_cannot_name_itself_into_a_loop():
+    a = _spec(union_fields=["union_fields", "projects"], projects=["alpha"])
+    _merge_spec(a, _spec(union_fields=["union_fields", "projects"], projects=["beta"]))
+    assert a["projects"] == ["alpha", "beta"]
+    assert a["union_fields"] == ["union_fields", "projects"]
+
+
+def test_merging_does_not_mutate_the_incoming_spec():
+    # `out[slug]` is a copy; the caller's list must not be aliased into it, or
+    # one worker's registry row would grow another worker's entries.
+    a = _spec(projects=["alpha"])
+    b = _spec(projects=["beta"])
+    _merge_spec(a, b)
+    assert b["projects"] == ["beta"]

--- a/tests/comms/rest/test_capability_sharding.py
+++ b/tests/comms/rest/test_capability_sharding.py
@@ -196,3 +196,28 @@ def test_merging_does_not_mutate_the_incoming_spec():
     b = _spec(projects=["beta"])
     _merge_spec(a, b)
     assert b["projects"] == ["beta"]
+
+
+# --- existing pools must not move -------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["base", "weld_gen", "fem_solver", "abaqus", "cad-export", "a1"])
+def test_capability_names_already_in_use_are_unchanged(name):
+    """The compatibility guard.
+
+    `_pool_capabilities` now normalises, so any name this function REWRITES
+    moves a live worker to a different subject. Underscore is the realistic
+    case: it is legal in a NATS subject and pools are named with it. If this
+    test ever has to change, a deployment somewhere silently stops receiving
+    jobs.
+    """
+    assert capability_token(name) == name
+    assert _pool_capabilities([name]) == [name]
+
+
+def test_the_token_is_idempotent():
+    # Applied at both the publish and the subscribe end, so a value that has
+    # already been through it must survive a second pass unchanged.
+    for raw in ["ALPHA", "site a/2", "weld_gen", "  x  ", "a.b.c", ""]:
+        once = capability_token(raw)
+        assert capability_token(once) == once

--- a/tests/comms/rest/test_capability_sharding_route.py
+++ b/tests/comms/rest/test_capability_sharding_route.py
@@ -1,0 +1,221 @@
+"""``POST /api/plugins/{id}/jobs`` routes a sharded plugin to the right pool.
+
+The unit tests beside this one pin the token and the union. This one drives the
+actual route, because the thing that breaks in production is not the normaliser
+— it is the wiring: which capability ends up on the enqueued job, given a live
+worker's advertisement and a request body.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-shard-storage-"))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+from ada.comms.rest.queue import Job, JobQueue  # noqa: E402
+
+PLUGIN = "cad-export"
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        # Non-empty so `queue.enabled` is True and the endpoint takes the NATS
+        # path rather than the in-process one, which ignores capability.
+        queue=QueueConfig(
+            url="nats://test-not-dialled",
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="kv",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""),
+        database_url="",
+    )
+
+
+def _worker(worker_id: str, spec: dict) -> dict:
+    return {
+        "worker_id": worker_id,
+        "last_heartbeat": time.time(),
+        "capabilities": ["cad"],
+        "plugin_specs": [spec],
+    }
+
+
+def _spec(**over) -> dict:
+    base = {
+        "slug": PLUGIN,
+        "id": PLUGIN,
+        "name": "CAD export",
+        "worker_capability": "cad",
+        "job_entrypoint": "example:run",
+    }
+    base.update(over)
+    return base
+
+
+def _build(monkeypatch, tmp_path, workers: list[dict]):
+    """An app whose queue is faked: no NATS, but a real route."""
+    enqueued: list[Job] = []
+
+    async def fake_connect(self, **kwargs):
+        return None
+
+    async def fake_list_workers(self):
+        return workers
+
+    async def fake_enqueue(self, source_key, **kw):
+        job = Job(
+            job_id="job-1",
+            source_key=source_key,
+            derived_key=kw.get("derived_key") or "",
+            status="queued",
+            target_format=kw.get("target_format") or "glb",
+            target_capability=kw.get("target_capability"),
+        )
+        enqueued.append(job)
+        return job
+
+    async def fake_publish(self, job):
+        # The route enqueues with `publish=False` and publishes after the audit
+        # row lands (the fix for the stranded-"queued" race), so the fake has to
+        # cover both halves or the real publish reaches a NATS that is not there.
+        return None
+
+    monkeypatch.setattr(JobQueue, "publish", fake_publish)
+    monkeypatch.setattr(JobQueue, "connect", fake_connect)
+    monkeypatch.setattr(JobQueue, "list_workers", fake_list_workers)
+    monkeypatch.setattr(JobQueue, "enqueue", fake_enqueue)
+    return create_app(_settings(tmp_path)), enqueued
+
+
+def _post(app, options: dict, **body):
+    with TestClient(app) as client:
+        return client.post(f"/api/plugins/{PLUGIN}/jobs", json={"options": options, **body})
+
+
+# --- routing ---------------------------------------------------------------
+
+
+def test_without_capability_option_the_bare_pool_is_used(monkeypatch, tmp_path):
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec())])
+
+    assert _post(app, {"project": "alpha"}).status_code == 200
+
+    # The plugin never declared a sharding option, so `project` is just an
+    # opaque option — core must not invent routing from it.
+    assert enqueued[0].target_capability == "cad"
+
+
+def test_a_declared_option_shards_the_pool(monkeypatch, tmp_path):
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec(capability_option="project"))])
+
+    assert _post(app, {"project": "alpha"}).status_code == 200
+
+    assert enqueued[0].target_capability == "cad-alpha"
+
+
+def test_the_shard_value_is_normalised_into_a_subject_token(monkeypatch, tmp_path):
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec(capability_option="project"))])
+
+    assert _post(app, {"project": "SITE A/2"}).status_code == 200
+
+    # A dot or space would make a subject nothing filters on; the job would sit
+    # in the stream looking merely slow.
+    cap = enqueued[0].target_capability
+    assert cap == "cad-site-a-2"
+    assert "." not in cap and " " not in cap
+
+
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_an_empty_shard_value_falls_back_to_the_bare_pool(monkeypatch, tmp_path, value):
+    # Falling back rather than erroring is what lets one worker subscribe to
+    # both `cad` and `cad-alpha` and serve unqualified requests too.
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec(capability_option="project"))])
+
+    assert _post(app, {"project": value}).status_code == 200
+
+    assert enqueued[0].target_capability == "cad"
+
+
+def test_a_missing_option_falls_back_to_the_bare_pool(monkeypatch, tmp_path):
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec(capability_option="project"))])
+
+    assert _post(app, {}).status_code == 200
+
+    assert enqueued[0].target_capability == "cad"
+
+
+def test_an_explicit_capability_in_the_body_still_wins(monkeypatch, tmp_path):
+    app, enqueued = _build(monkeypatch, tmp_path, [_worker("w1", _spec(capability_option="project"))])
+
+    assert _post(app, {"project": "alpha"}, capability="Other Pool").status_code == 200
+
+    # And it is normalised the same way, so an override cannot name a subject
+    # the worker side could never produce.
+    assert enqueued[0].target_capability == "other-pool"
+
+
+# --- the union, through the route -----------------------------------------
+
+
+def test_two_workers_on_one_plugin_no_longer_erase_each_other(monkeypatch, tmp_path):
+    """The reason the union exists.
+
+    Two workers, one plugin, different shards. Before the union, whichever
+    worker's row came back last supplied the whole spec, so the viewer could
+    only ever see one project as available.
+    """
+    spec_a = _spec(capability_option="project", union_fields=["projects"], projects=["alpha"])
+    spec_b = _spec(capability_option="project", union_fields=["projects"], projects=["beta"])
+    app, _ = _build(monkeypatch, tmp_path, [_worker("w1", spec_a), _worker("w2", spec_b)])
+
+    with TestClient(app) as client:
+        plugins = client.get("/api/plugins").json()["plugins"]
+
+    entry = next(p for p in plugins if p["slug"] == PLUGIN)
+    assert sorted(entry["projects"]) == ["alpha", "beta"]
+
+
+def test_the_advertised_spec_is_stable_across_requests(monkeypatch, tmp_path):
+    """Deterministic, not last-writer-wins.
+
+    Two workers disagreeing on a scalar previously resolved by KV listing
+    order, so the advertised version could differ between two consecutive
+    requests for no visible reason.
+    """
+    workers = [
+        _worker("w2", _spec(version="2.0.0")),
+        _worker("w1", _spec(version="1.0.0")),
+    ]
+    app, _ = _build(monkeypatch, tmp_path, workers)
+
+    with TestClient(app) as client:
+        first = client.get("/api/plugins").json()["plugins"]
+        # Same rows, opposite order: the answer must not move.
+        workers.reverse()
+        second = client.get("/api/plugins").json()["plugins"]
+
+    def version_of(payload):
+        return next(p for p in payload if p["slug"] == PLUGIN)["version"]
+
+    assert version_of(first) == version_of(second) == "1.0.0"  # worker id w1 sorts first

--- a/tests/comms/rest/test_capability_sharding_route.py
+++ b/tests/comms/rest/test_capability_sharding_route.py
@@ -219,3 +219,39 @@ def test_the_advertised_spec_is_stable_across_requests(monkeypatch, tmp_path):
         return next(p for p in payload if p["slug"] == PLUGIN)["version"]
 
     assert version_of(first) == version_of(second) == "1.0.0"  # worker id w1 sorts first
+
+
+# --- every producer converges on one subject --------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("weld_gen", "ada.viewer.jobs.convert.weld_gen"),
+        ("Fem Solver", "ada.viewer.jobs.convert.fem-solver"),
+        ("abaqus", "ada.viewer.jobs.convert.abaqus"),
+        (None, "ada.viewer.jobs.convert.base"),
+    ],
+)
+def test_publish_normalises_whatever_producer_set_the_capability(raw, expected):
+    """`target_capability` is set from a dozen call sites and only one of them
+    goes through the plugin route. The worker derives its subscription with
+    `capability_token`, so `publish` has to as well or a job from any other
+    producer lands on a subject nothing is listening to — silently."""
+    import asyncio
+
+    published: list[str] = []
+
+    class _JS:
+        async def publish(self, subject, payload):
+            published.append(subject)
+
+    q = JobQueue(
+        QueueConfig(url="nats://x", stream="ada", subject="ada.viewer.jobs.convert", kv_bucket="kv", durable="d")
+    )
+    q._js = _JS()
+    job = Job(job_id="j", source_key="s", derived_key="d", status="queued", target_capability=raw)
+
+    asyncio.run(q.publish(job))
+
+    assert published == [expected]


### PR DESCRIPTION
A capability pool is **one durable consumer**, so every worker in it competes
for the same messages. That is correct when the workers are interchangeable and
wrong when they are not: several workers each holding a different licence,
dataset or device cannot share a pool, because a job goes to whichever one pulls
first.

Routing them apart by making the wrong worker NAK is the design `pull_subscribe`
already replaced — its own docstring records that the NAK loop burned the
per-message delivery budget and dead-lettered valid jobs.

## `capability_option`

A plugin may advertise `capability_option` naming one of its own options. When a
request supplies it, `POST /api/plugins/{id}/jobs` routes to
`<worker_capability>-<value>` instead of `<worker_capability>`.

Core still names no plugin and never learns what the option *means* — it only
normalises the value into a subject token. **The worker needs no new code at
all**: it lists the sharded token in `ADA_WORKER_CAPABILITIES`, and a worker
listing both the bare and the sharded form serves unqualified requests too, so a
single-worker deployment never has to qualify anything.

An absent or unusable value falls back to the bare capability rather than
erroring, which is what keeps that fallback working.

### One normaliser, both sides

`capability_token()` is shared by the API and the worker on purpose. A
capability becomes a subject segment, so a value with a dot in it would create a
*deeper* subject that nothing filters on — and the job would sit in the stream
looking merely slow rather than failing. Having the publisher and the subscriber
derive their subject through one function is what stops those drifting; there is
a test asserting the round trip for each awkward input.

Separator runs collapse to a single dash rather than being dropped, so
`site-a/2` and `site-a 2` do not both become `site-a2` and silently merge two
pools that were meant to be distinct.

## The spec union

`_live_worker_specs` was **last writer wins by slug**. Several workers
advertising one plugin meant one worker's spec survived and the rest were
invisible — so a sharded pool had no way to say what it collectively covers.
Two changes:

- **Deterministic.** Workers are visited in worker-id order. Previously this
  followed KV listing order, so with two workers on one plugin the advertised
  version could differ between two consecutive requests for no visible reason.
- **`union_fields`.** Keys a spec names there are combined across every worker
  advertising the slug. Only the named ones — a blanket "merge every list" would
  fold per-worker facts (a worker's own conversions, its own extension
  allowlist) into a spec describing a worker that does not exist.

`union_fields` is itself unioned, so a rolling upgrade where half the pool
declares it still merges rather than flipping behaviour on whichever worker
sorted first.

## Compatibility

Both keys are opt-in and absent by default; nothing changes for a plugin that
declares neither.

## Testing

48 new tests. Blast radius verified rather than assumed — running the new route
tests against `main` fails exactly the five sharding/union/determinism cases and
passes the five fallback cases, which is the intended surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6Hcm4s2uXeFt9UerNKcqZ