### PR TITLE
feat(queue): let the worker registry live in its own KV bucket

### DIFF
--- a/deploy/worker-trust.md
+++ b/deploy/worker-trust.md
@@ -87,10 +87,14 @@ worker-internal
 worker-ext-01                                               # one per external host
                sub      ada.viewer.jobs.convert.cad         # its pool, nothing else
                JS API   $JS.API.CONSUMER.*.ADA_VIEWER_JOBS.ada-viewer-worker-cad
-               KV       write $KV.ada-viewer-jobs.__meta_worker__ext-01
+               KV       write $KV.ada-viewer-workers.__meta_worker__ext-01
                         write $KV.ada-viewer-jobs.*          # job status — see residual risks
                         read  $KV.ada-viewer-jobs.>
 ```
+
+Note the two different buckets on the `KV` lines. That is
+`ADA_VIEWER_NATS_REGISTRY_KV_BUCKET`, and without it the first line cannot be
+written at all — see below.
 
 The subject layout makes this practical without inventing anything: pools are
 already `<subject>.<capability>` and durables are already
@@ -106,11 +110,50 @@ publish permission (`__meta_worker__ext-01` above) and the id becomes
 under a name it was not issued. This is worth doing even before admission
 (§3), because it is what makes an admission list keyed by worker id meaningful.
 
+**This did not work as first written, and the fix is a deployment setting.**
+The pin was proposed against `$KV.ada-viewer-jobs.__meta_worker__ext-01` — the
+registry row in the *jobs* bucket. But a worker must write arbitrary job ids to
+report progress, so the same credential needs `$KV.ada-viewer-jobs.*`. NATS
+subject wildcards match a WHOLE token and `__meta_worker__<id>` **is** one
+token, so that `*` already covers every worker's registry row: the pin sitting
+next to it granted nothing the credential did not already have. The complement
+cannot be expressed either — a `deny` on `$KV.ada-viewer-jobs.__meta_worker__*`
+matches nothing, for the same reason. So every credential that could report job
+progress could overwrite any worker's registry row, including one claiming a
+`plugin_id` it does not own, which is exactly the impersonation in §2.
+
+`ADA_VIEWER_NATS_REGISTRY_KV_BUCKET` moves the registry into a bucket of its
+own. Job progress then needs `$KV.ada-viewer-jobs.*` and nothing in the registry
+bucket, and the per-worker pin becomes a real restriction:
+
+```
+write $KV.ada-viewer-workers.__meta_worker__ext-01     # only its own row
+write $KV.ada-viewer-jobs.*                            # any job's status
+```
+
+It is **opt-in**: unset (the default) keeps the registry in the jobs bucket,
+exactly as before. Turning it on while workers are running would otherwise empty
+the admin panel — and with it `/api/plugins` and extension-based routing — for
+every worker that has not restarted onto the new bucket, so `list_workers()`
+reads both while the split is on and prefers the dedicated bucket's row. Enable
+it on the API first (it creates the bucket), then roll the workers; a worker
+whose API has not created the bucket yet logs that it will not appear in the
+registry and goes on serving jobs.
+
+What this does **not** close: reading. A credential that can read the registry
+bucket can read every row in it, because KV reads go through
+`$JS.API.DIRECT.GET` rather than the `$KV.` subject. Registry rows are not
+secret — the threat in §2 is a forged *write*.
+
 ### Code changes
 
 * ✅ `QueueConfig` gains `creds_file`, `user`, `password`, `token`,
   `nkey_seed_file`, `tls_ca` (+ `ADA_VIEWER_NATS_*` env), and `connect()` passes
   them through to `nats.connect()`. `nats-py` supports all of these directly.
+* ✅ **`ADA_VIEWER_NATS_REGISTRY_KV_BUCKET`** — the worker registry in a KV
+  bucket of its own, so a credential can be pinned to one worker's own row.
+  Opt-in; `list_workers()` reads the old bucket too while the split is on, so
+  enabling it does not blank the registry mid-rollout.
 * ✅ **`connect(manage=False)` for workers.** Stream and consumer
   *administration* moves behind a flag the API sets and the worker does not, so
   worker credentials need no stream-admin rights. Without this, least privilege
@@ -394,6 +437,15 @@ Two details worth knowing before step 3:
 
 ## 6. Residual risks
 
+* **The registry pin only exists if the deployment splits the bucket.**
+  `ADA_VIEWER_NATS_REGISTRY_KV_BUCKET` is unset by default, and while it is
+  unset the registry shares the jobs bucket — where the `$KV.<jobs>.*` that job
+  progress requires covers every worker's row, and the per-worker pin above is
+  decoration. There is no way to detect from inside adapy that an operator
+  intended the pin and did not get it, because a permission that grants too much
+  produces no error anywhere. Verify it the way any too-wide permission is
+  verified: connect with a worker's own credential and try to write another
+  worker's registry row.
 * **Job-status KV cannot be scoped per worker.** Job ids are random, so a
   credential able to update the job it is processing can update any job's status
   (not read its blobs). Accepted for now. The clean fix is to move status

--- a/src/ada/comms/rest/config.py
+++ b/src/ada/comms/rest/config.py
@@ -41,6 +41,30 @@ class QueueConfig:
     subject: str
     kv_bucket: str
     durable: str
+    # Separate KV bucket for the worker registry. Empty (the default) keeps the
+    # registry in ``kv_bucket`` alongside job rows, which is what every
+    # deployment does today.
+    #
+    # WHY IT IS WORTH SEPARATING. A worker must write arbitrary job ids to
+    # report progress, so its credential needs ``$KV.<kv_bucket>.>``. Registry
+    # rows live in that same bucket under ``__meta_worker__<id>``, and a NATS
+    # subject wildcard matches a WHOLE token -- ``__meta_worker__<id>`` is one
+    # token, so the ``>`` that job progress requires already covers every
+    # worker's registry row, and no ``deny`` can carve them back out
+    # (``__meta_worker__*`` is not a prefix pattern). Any credential that can
+    # report job progress can therefore overwrite any worker's registry row,
+    # including one claiming a ``plugin_id`` it does not own -- and the API
+    # believes what a registry row claims.
+    #
+    # Moving the registry into its own bucket puts those rows on
+    # ``$KV.<registry_kv_bucket>.<worker_id>``, where the id IS the whole token,
+    # so a credential can finally be pinned to one worker's own row. That is
+    # what ``deploy/worker-trust.md`` proposed and could not express.
+    #
+    # Opt-in rather than default because switching buckets while workers are
+    # running would empty the admin panel for a heartbeat window. See
+    # ``JobQueue.list_workers``, which reads both during the changeover.
+    registry_kv_bucket: str = ""
     # --- credentials -------------------------------------------------
     # All empty (the default) is an unauthenticated connection, which is
     # what every deployment does today and what a `nats -js` server with
@@ -160,6 +184,7 @@ def load_settings() -> Settings:
         stream=os.environ.get("ADA_VIEWER_NATS_STREAM", "ADA_VIEWER_JOBS"),
         subject=os.environ.get("ADA_VIEWER_NATS_SUBJECT", "ada.viewer.jobs.convert"),
         kv_bucket=os.environ.get("ADA_VIEWER_NATS_KV_BUCKET", "ada-viewer-jobs"),
+        registry_kv_bucket=os.environ.get("ADA_VIEWER_NATS_REGISTRY_KV_BUCKET", "").strip(),
         durable=os.environ.get("ADA_VIEWER_NATS_DURABLE", "ada-viewer-worker"),
         creds_file=os.environ.get("ADA_VIEWER_NATS_CREDS", "").strip(),
         user=os.environ.get("ADA_VIEWER_NATS_USER", "").strip(),

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -215,8 +215,39 @@ class JobQueue:
         self._nc = None
         self._js = None
         self._kv = None
+        # The bucket holding worker registry rows. Aliases ``_kv`` unless
+        # ``registry_kv_bucket`` names a different one, so every registry method
+        # below has exactly one code path whichever mode the deployment is in.
+        self._registry_kv = None
 
     # --- lifecycle ---------------------------------------------------
+
+    @property
+    def registry_bucket(self) -> str:
+        """Bucket the worker registry lives in — the jobs bucket unless split out."""
+        return self._cfg.registry_kv_bucket or self._cfg.kv_bucket
+
+    @property
+    def registry_is_separate(self) -> bool:
+        """True when the registry has a bucket of its own.
+
+        The only thing this changes is whether a NATS credential *can* be
+        scoped to one worker's own row; nothing about the data differs.
+        """
+        return bool(self._cfg.registry_kv_bucket) and self._cfg.registry_kv_bucket != self._cfg.kv_bucket
+
+    @property
+    def _registry_bucket_handle(self):
+        """The KV handle registry rows are written to.
+
+        Derived rather than assigned in the un-split mode: that mode IS the jobs
+        bucket, and a second attribute that has to be kept pointing at ``_kv``
+        is a second thing that can be forgotten to be set (by a new connect
+        path, or by a test that builds a queue by hand).
+        """
+        if self.registry_is_separate:
+            return self._registry_kv
+        return self._kv
 
     @property
     def enabled(self) -> bool:
@@ -385,6 +416,17 @@ class JobQueue:
         except BadRequestError:
             self._kv = await self._js.key_value(self._cfg.kv_bucket)
 
+        # Registry bucket — also idempotent, and created LAST for the same
+        # reason the jobs bucket is: ``_bind_existing`` waits on it, so a bucket
+        # that exists has to imply everything created before it exists too.
+        if self.registry_is_separate:
+            try:
+                self._registry_kv = await self._js.create_key_value(
+                    bucket=self._cfg.registry_kv_bucket, history=1
+                )
+            except BadRequestError:
+                self._registry_kv = await self._js.key_value(self._cfg.registry_kv_bucket)
+
     async def _bind_existing(self) -> None:
         """Bind to the API-created KV bucket without creating anything.
 
@@ -399,7 +441,7 @@ class JobQueue:
         while True:
             try:
                 self._kv = await self._js.key_value(self._cfg.kv_bucket)
-                return
+                break
             # BucketNotFoundError subclasses NotFoundError; the plain
             # form also covers "the backing KV_<bucket> stream is absent".
             except NotFoundError:
@@ -416,12 +458,46 @@ class JobQueue:
                 )
                 await asyncio.sleep(self._BIND_POLL_SECONDS)
 
+        if not self.registry_is_separate:
+            return
+
+        # The registry bucket, on the same terms. Deliberately NOT fatal when it
+        # is missing: registration is best-effort everywhere else in this class
+        # (``register_worker`` returns quietly when there is no bucket, the
+        # admin panel just shows one fewer row), and an API that has not yet
+        # been upgraded to create this bucket must not stop a worker from
+        # pulling jobs it is otherwise able to serve. A worker that cannot
+        # register is a worker missing from a listing; a worker that will not
+        # start is an outage.
+        deadline = time.monotonic() + self._BIND_WAIT_SECONDS
+        while True:
+            try:
+                self._registry_kv = await self._js.key_value(self._cfg.registry_kv_bucket)
+                return
+            except NotFoundError:
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "queue: registry KV bucket %r does not exist after %.0fs — this worker "
+                        "will run but will not appear in the worker registry. It is created by "
+                        "the API on startup; either the API has not been upgraded to a version "
+                        "that creates it, or this client's credentials cannot see it.",
+                        self._cfg.registry_kv_bucket,
+                        self._BIND_WAIT_SECONDS,
+                    )
+                    return
+                logger.info(
+                    "queue: waiting for registry KV bucket %s to be created by the API",
+                    self._cfg.registry_kv_bucket,
+                )
+                await asyncio.sleep(self._BIND_POLL_SECONDS)
+
     async def close(self) -> None:
         if self._nc is not None:
             await self._nc.drain()
             self._nc = None
             self._js = None
             self._kv = None
+            self._registry_kv = None
 
     async def purge_jobs(self, job_ids) -> int:
         """Delete still-queued work-queue messages whose body (a job_id) is in
@@ -801,23 +877,42 @@ class JobQueue:
 
     async def register_worker(self, worker_id: str, info: dict) -> None:
         """Write/refresh the worker entry. Idempotent — workers call
-        this on startup and again on each heartbeat tick."""
-        if self._kv is None:
+        this on startup and again on each heartbeat tick.
+
+        Writes to the registry bucket, which is the jobs bucket unless
+        ``registry_kv_bucket`` split it out. The key keeps its
+        ``__meta_worker__`` prefix in both modes: it costs nothing, it keeps one
+        code path, and it means a deployment can copy rows between buckets
+        during a changeover without rewriting keys.
+        """
+        bucket = self._registry_bucket_handle
+        if bucket is None:
             return
         key = f"{self._WORKER_KEY_PREFIX}{worker_id}"
-        await self._kv.put(key, json.dumps(info).encode("utf-8"))
+        await bucket.put(key, json.dumps(info).encode("utf-8"))
 
     async def unregister_worker(self, worker_id: str) -> None:
         """Drop the worker entry. Best-effort — called from the worker's
         shutdown path. If it fails the entry will go stale within one
         heartbeat-staleness window, which the admin panel filters out."""
-        if self._kv is None:
-            return
         key = f"{self._WORKER_KEY_PREFIX}{worker_id}"
-        try:
-            await self._kv.delete(key)
-        except KeyNotFoundError:
-            pass
+        bucket = self._registry_bucket_handle
+        if bucket is not None:
+            try:
+                await bucket.delete(key)
+            except KeyNotFoundError:
+                pass
+        # A row this worker wrote before the registry moved buckets. Deleting it
+        # is what stops a shut-down worker lingering in the listing for the full
+        # prune horizon, and it is why ``list_workers`` can stop reading the old
+        # bucket once no such rows come back. Broad except: a narrowed
+        # credential may no longer be allowed to touch the jobs bucket's
+        # registry rows at all, and that is not a shutdown failure.
+        if self.registry_is_separate and self._kv is not None:
+            try:
+                await self._kv.delete(key)
+            except Exception:
+                pass
 
     async def list_workers(self) -> list[dict]:
         """Return every worker entry. Each row carries whatever the
@@ -826,19 +921,39 @@ class JobQueue:
 
         Staleness filtering is the caller's concern: this method just
         snapshots the bucket.
+
+        Reads the OLD bucket too while the registry is split out, so that
+        turning ``registry_kv_bucket`` on does not empty the admin panel — and
+        with it ``/api/plugins`` and extension-based routing — for every worker
+        that has not restarted onto the new bucket yet. A row in the dedicated
+        bucket wins over a same-id row in the jobs bucket: that is the worker
+        that has already moved, so its entry is the fresher one.
         """
-        if self._kv is None:
-            return []
+        rows: dict[str, dict] = {}
+        # Old bucket first, so the dedicated bucket's rows overwrite it.
+        buckets = []
+        if self.registry_is_separate and self._kv is not None:
+            buckets.append(self._kv)
+        handle = self._registry_bucket_handle
+        if handle is not None:
+            buckets.append(handle)
+        for bucket in buckets:
+            for worker_id, info in await self._read_worker_rows(bucket):
+                rows[worker_id] = info
+        return list(rows.values())
+
+    async def _read_worker_rows(self, bucket) -> list[tuple[str, dict]]:
+        """``(worker_id, entry)`` for every registry row in one KV bucket."""
         try:
-            keys = await self._kv.keys()
+            keys = await bucket.keys()
         except (BucketNotFoundError, Exception):
             return []
-        workers: list[dict] = []
+        out: list[tuple[str, dict]] = []
         for key in keys:
             if not key.startswith(self._WORKER_KEY_PREFIX):
                 continue
             try:
-                entry = await self._kv.get(key)
+                entry = await bucket.get(key)
             except KeyNotFoundError:
                 continue
             if entry.value is None:
@@ -849,9 +964,10 @@ class JobQueue:
                 continue
             if not isinstance(info, dict):
                 continue
-            info["worker_id"] = key[len(self._WORKER_KEY_PREFIX) :]
-            workers.append(info)
-        return workers
+            worker_id = key[len(self._WORKER_KEY_PREFIX) :]
+            info["worker_id"] = worker_id
+            out.append((worker_id, info))
+        return out
 
     # Hard-prune horizon for dead worker entries — much longer than the ``WORKER_STALE_AFTER_S``
     # online window used for routing/UI. A pod that crashes or scales down can leave its registry

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -421,9 +421,7 @@ class JobQueue:
         # that exists has to imply everything created before it exists too.
         if self.registry_is_separate:
             try:
-                self._registry_kv = await self._js.create_key_value(
-                    bucket=self._cfg.registry_kv_bucket, history=1
-                )
+                self._registry_kv = await self._js.create_key_value(bucket=self._cfg.registry_kv_bucket, history=1)
             except BadRequestError:
                 self._registry_kv = await self._js.key_value(self._cfg.registry_kv_bucket)
 

--- a/tests/comms/rest/test_worker_registry_bucket.py
+++ b/tests/comms/rest/test_worker_registry_bucket.py
@@ -1,0 +1,225 @@
+"""The worker registry can live in a KV bucket of its own.
+
+WHY IT MATTERS. A worker must write arbitrary job ids to report progress, so
+its NATS credential needs ``$KV.<jobs-bucket>.>``. Registry rows sit in that
+same bucket under ``__meta_worker__<id>``, and a NATS subject wildcard matches a
+WHOLE token — ``__meta_worker__<id>`` is one token, so the ``>`` that job
+progress requires already covers every worker's registry row. No ``deny`` takes
+it back either: ``__meta_worker__*`` is not a prefix pattern. So any credential
+that can report job progress can overwrite any worker's registry row, including
+one claiming a ``plugin_id`` it does not own — and the API believes what a
+registry row claims.
+
+Splitting the registry into its own bucket is what makes a per-worker
+permission expressible at all. These tests cover the behaviour that split has
+to preserve, and the changeover that would otherwise empty the admin panel.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from nats.js.errors import KeyNotFoundError
+
+from ada.comms.rest.config import QueueConfig
+from ada.comms.rest.queue import JobQueue
+
+
+class FakeEntry:
+    def __init__(self, value: bytes | None):
+        self.value = value
+
+
+class FakeKV:
+    """Enough of ``nats.js.kv.KeyValue`` for the registry methods."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.store: dict[str, bytes] = {}
+
+    async def put(self, key: str, value: bytes) -> None:
+        self.store[key] = value
+
+    async def get(self, key: str) -> FakeEntry:
+        if key not in self.store:
+            raise KeyNotFoundError()
+        return FakeEntry(self.store[key])
+
+    async def delete(self, key: str) -> None:
+        if key not in self.store:
+            raise KeyNotFoundError()
+        del self.store[key]
+
+    async def keys(self) -> list[str]:
+        return list(self.store)
+
+
+def _queue(registry_bucket: str = "") -> tuple[JobQueue, FakeKV, FakeKV]:
+    q = JobQueue(
+        QueueConfig(
+            url=None,
+            stream="s",
+            subject="subj",
+            kv_bucket="jobs",
+            durable="d",
+            registry_kv_bucket=registry_bucket,
+        )
+    )
+    jobs, registry = FakeKV("jobs"), FakeKV("registry")
+    # What connect()/_bind_existing() would have left behind.
+    q._kv = jobs
+    if q.registry_is_separate:
+        q._registry_kv = registry
+    return q, jobs, registry
+
+
+def _row(kv: FakeKV, worker_id: str) -> dict:
+    return json.loads(kv.store[f"__meta_worker__{worker_id}"].decode())
+
+
+# --- the default: nothing changes -----------------------------------------
+
+
+def test_unset_keeps_the_registry_in_the_jobs_bucket():
+    q, _, _ = _queue()
+    assert q.registry_is_separate is False
+    assert q.registry_bucket == "jobs"
+
+
+@pytest.mark.asyncio
+async def test_unset_reads_and_writes_the_jobs_bucket():
+    q, jobs, registry = _queue()
+    await q.register_worker("w1", {"capabilities": ["base"]})
+    assert _row(jobs, "w1")["capabilities"] == ["base"]
+    assert registry.store == {}
+
+    assert [w["worker_id"] for w in await q.list_workers()] == ["w1"]
+
+    await q.unregister_worker("w1")
+    assert jobs.store == {}
+
+
+@pytest.mark.asyncio
+async def test_unset_follows_kv_even_when_never_connected():
+    """The un-split mode resolves through ``_kv`` rather than a second attribute
+    somebody has to remember to point at it — a connect path or a test that sets
+    only ``_kv`` must still register."""
+    q = JobQueue(QueueConfig(url=None, stream="s", subject="subj", kv_bucket="jobs", durable="d"))
+    q._kv = FakeKV("jobs")
+    assert q._registry_kv is None
+    await q.register_worker("w1", {"capabilities": []})
+    assert "__meta_worker__w1" in q._kv.store
+
+
+# --- split out -------------------------------------------------------------
+
+
+def test_registry_bucket_is_reported_when_set():
+    q, _, _ = _queue("workers")
+    assert q.registry_is_separate is True
+    assert q.registry_bucket == "workers"
+
+
+def test_naming_the_same_bucket_is_not_a_split():
+    """Pointing the registry at the jobs bucket by name must behave exactly like
+    leaving it unset — otherwise the merge path below would scan one bucket
+    twice and report every worker as its own duplicate."""
+    q = JobQueue(
+        QueueConfig(
+            url=None, stream="s", subject="subj", kv_bucket="jobs", durable="d", registry_kv_bucket="jobs"
+        )
+    )
+    assert q.registry_is_separate is False
+
+
+@pytest.mark.asyncio
+async def test_split_writes_registry_rows_away_from_job_rows():
+    """The whole point: no registry row lands in the bucket whose ``>`` every
+    worker credential holds."""
+    q, jobs, registry = _queue("workers")
+    await q.register_worker("w1", {"capabilities": ["cad"]})
+    assert _row(registry, "w1")["capabilities"] == ["cad"]
+    assert jobs.store == {}
+
+
+@pytest.mark.asyncio
+async def test_registry_key_stays_one_subject_token():
+    """``$KV.<bucket>.<key>`` is the subject a permission names. The key must
+    stay a single token, or an exact per-worker publish permission stops being
+    expressible and this whole change buys nothing."""
+    q, _, registry = _queue("workers")
+    await q.register_worker("ext-01", {})
+    (key,) = registry.store
+    assert "." not in key
+    assert ">" not in key and "*" not in key
+
+
+# --- the changeover --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_split_still_lists_workers_that_have_not_moved_yet():
+    """Turning the split on must not empty the admin panel — and with it
+    /api/plugins and extension routing — for workers still writing to the old
+    bucket because they have not restarted."""
+    q, jobs, registry = _queue("workers")
+    jobs.store["__meta_worker__old"] = json.dumps({"capabilities": ["base"]}).encode()
+    await q.register_worker("new", {"capabilities": ["cad"]})
+
+    assert sorted(w["worker_id"] for w in await q.list_workers()) == ["new", "old"]
+
+
+@pytest.mark.asyncio
+async def test_the_moved_row_wins_over_the_stale_one():
+    """Same worker, both buckets: the dedicated bucket's row is the one written
+    by the worker that has already restarted, so it is the fresher of the two."""
+    q, jobs, registry = _queue("workers")
+    jobs.store["__meta_worker__w1"] = json.dumps({"capabilities": ["base"], "where": "old"}).encode()
+    await q.register_worker("w1", {"capabilities": ["cad"], "where": "new"})
+
+    workers = await q.list_workers()
+    assert len(workers) == 1
+    assert workers[0]["where"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_unregister_clears_both_buckets():
+    """Otherwise a worker that shuts down during the changeover lingers in the
+    listing for the full prune horizon, from the row nobody deletes."""
+    q, jobs, registry = _queue("workers")
+    jobs.store["__meta_worker__w1"] = json.dumps({"capabilities": ["base"]}).encode()
+    await q.register_worker("w1", {"capabilities": ["cad"]})
+
+    await q.unregister_worker("w1")
+    assert jobs.store == {}
+    assert registry.store == {}
+
+
+@pytest.mark.asyncio
+async def test_unregister_survives_a_credential_that_cannot_touch_the_old_bucket():
+    """A narrowed worker credential may no longer write the jobs bucket's
+    registry rows at all. That is the intended end state, not a shutdown
+    failure."""
+
+    class Forbidden(FakeKV):
+        async def delete(self, key):
+            raise PermissionError("permissions violation")
+
+    q, _, registry = _queue("workers")
+    q._kv = Forbidden("jobs")
+    await q.register_worker("w1", {})
+
+    await q.unregister_worker("w1")  # must not raise
+    assert registry.store == {}
+
+
+@pytest.mark.asyncio
+async def test_a_missing_registry_bucket_is_empty_not_an_error():
+    """A worker whose API has not been upgraded to create the bucket binds
+    nothing. It must still run — a worker missing from a listing beats a worker
+    that will not start."""
+    q, _, _ = _queue("workers")
+    q._registry_kv = None
+    await q.register_worker("w1", {})  # quietly does nothing
+    assert await q.list_workers() == []

--- a/tests/comms/rest/test_worker_registry_bucket.py
+++ b/tests/comms/rest/test_worker_registry_bucket.py
@@ -126,9 +126,7 @@ def test_naming_the_same_bucket_is_not_a_split():
     leaving it unset — otherwise the merge path below would scan one bucket
     twice and report every worker as its own duplicate."""
     q = JobQueue(
-        QueueConfig(
-            url=None, stream="s", subject="subj", kv_bucket="jobs", durable="d", registry_kv_bucket="jobs"
-        )
+        QueueConfig(url=None, stream="s", subject="subj", kv_bucket="jobs", durable="d", registry_kv_bucket="jobs")
     )
     assert q.registry_is_separate is False
 


### PR DESCRIPTION
`deploy/worker-trust.md` proposes pinning a worker's registry key in its NATS
credential, so the worker id becomes authenticated by NATS with no adapy code at
all:

```
write $KV.ada-viewer-jobs.__meta_worker__ext-01
```

**That does not work as written**, and the reason is subject syntax rather than
anything about the design.

## Why the pin grants nothing today

A worker must write arbitrary job ids to report progress, so the same credential
needs `$KV.ada-viewer-jobs.*`. Registry rows live in that same bucket, and
`__meta_worker__<id>` **is a single subject token** — NATS wildcards match a
whole token, there is no partial-token form. So the `*` that job progress
requires already covers every worker's registry row, and the pin sitting beside
it grants nothing the credential did not already have.

The complement cannot be expressed either: a `deny` on
`$KV.ada-viewer-jobs.__meta_worker__*` matches nothing, for the same reason.

| what | KV key | subject |
| --- | --- | --- |
| job status | `<job_id>` | `$KV.ada-viewer-jobs.<job_id>` |
| worker registry | `__meta_worker__<id>` | `$KV.ada-viewer-jobs.__meta_worker__<id>` |

So **any credential that can report job progress can overwrite any worker's
registry row** — including one claiming a `plugin_id` it does not own, which the
API then believes. That is the impersonation path in §2 of `worker-trust.md`,
and neither transport auth nor per-capability subject scoping closes it. It is
pre-existing and it is not urgent in a single-namespace deployment where network
position is the boundary; it matters as soon as a holder of such a credential
sits outside the cluster.

## What this changes

`ADA_VIEWER_NATS_REGISTRY_KV_BUCKET` moves the registry into a bucket of its
own. Rows then sit on `$KV.<registry>.__meta_worker__<id>`, job progress needs
nothing in that bucket, and the per-worker pin becomes a real restriction:

```
write $KV.ada-viewer-workers.__meta_worker__ext-01   # only its own row
write $KV.ada-viewer-jobs.*                          # any job's status
```

**Opt-in, and that is the deliberate part.** Unset — the default — keeps the
registry in the jobs bucket, byte for byte as before. Switching buckets while
workers are running would otherwise empty the admin panel, and with it
`/api/plugins` and extension-based routing, for every worker that had not yet
restarted onto the new bucket. That is the failure mode worth designing around,
because it looks like a fleet that quietly went offline rather than like an
error. So while the split is on:

* `list_workers()` reads **both** buckets, and a row in the dedicated bucket
  wins for a given id — that is the worker which has already moved, so it is the
  fresher entry.
* `unregister_worker()` clears both, so a worker that shuts down mid-changeover
  does not linger in the listing until the prune horizon.
* A worker whose API has not yet created the bucket logs that it will not appear
  in the registry, and goes on serving jobs. A worker missing from a listing
  beats a worker that will not start.

Rollout is therefore: set it on the API first (it creates the bucket), then roll
the workers.

The un-split mode resolves through `_kv` rather than through a second attribute
that has to be kept pointing at it, so no connect path — or hand-built test
queue — can forget to alias it.

The key keeps its `__meta_worker__` prefix in both modes. It costs nothing, it
keeps one code path, and it means rows can be copied between buckets during a
changeover without rewriting keys.

## What this does not close

**Reading.** KV reads go through `$JS.API.DIRECT.GET`, not the `$KV.` subject,
so a credential that can read the bucket can read every row in it. Registry rows
are not secret — the threat in §2 is a forged *write*. Said out loud in the doc
rather than left to be discovered.

**And the pin only exists if a deployment actually splits the bucket.** While
`ADA_VIEWER_NATS_REGISTRY_KV_BUCKET` is unset the hole above is exactly as it
was, and nothing inside adapy can detect that an operator intended the pin and
did not get it, because a permission that grants too much produces no error
anywhere. That is now a named residual risk in `worker-trust.md`, with the way
to verify it: connect with a worker's own credential and try to write another
worker's registry row.

## Tests

`tests/comms/rest/test_worker_registry_bucket.py`, 12 cases:

* the default is unchanged — same bucket, same keys, and it resolves through
  `_kv` even on a queue that was never connected;
* naming the *same* bucket is not a split (otherwise the merge path would scan
  one bucket twice and report every worker as its own duplicate);
* when split, rows land away from job rows;
* the key stays a single subject token — without which the pin stops being
  expressible and the whole change buys nothing;
* the changeover: both buckets are listed, the moved row wins, unregister clears
  both;
* the two degraded cases — a credential no longer permitted to touch the old
  bucket, and a registry bucket that does not exist yet.

Verified by running `tests/comms/rest` on this commit's parent and on this
commit: the same 40 pre-existing failures either way (missing optional
dependencies in the ad-hoc environment used to run them, unrelated to this
change), 530 → 542 passed, the 12 new tests being the entire delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaaF2gNpgsMpVMGv3rseZK
