### PR TITLE
feat: an API-side env hook, so a deployment can authenticate its own API

### DIFF
--- a/deploy/helm/adapy-viewer/templates/deployment.yaml
+++ b/deploy/helm/adapy-viewer/templates/deployment.yaml
@@ -87,6 +87,21 @@ spec:
             {{- end }}
             {{- include "adapy-viewer.authEnv" . | nindent 12 }}
             {{- include "adapy-viewer.databaseEnv" . | nindent 12 }}
+            {{- /* Last, deliberately: a duplicate env name resolves to the final
+                 occurrence, so extraEnv can override anything the chart derived
+                 above without needing a chart release to do it. */}}
+            {{- range $name, $value := .Values.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- /* Whole-secret env for the API, for values that must not appear in a
+               values file — a NATS credential, above all. Keys are used verbatim,
+               so the secret must already name them as the variables the code
+               reads (e.g. ADA_VIEWER_NATS_NKEY_SEED_VALUE). */}}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if eq .Values.storage.kind "local" }}
           volumeMounts:
             - name: data

--- a/deploy/helm/adapy-viewer/values.yaml
+++ b/deploy/helm/adapy-viewer/values.yaml
@@ -43,6 +43,21 @@ strategy:
     maxSurge: 1
     maxUnavailable: 0
 
+## Free-form env for the API container (name -> value, rendered verbatim).
+## The worker pools have had this for a while; the API had no hook at all,
+## which is why a deployment could authenticate its workers to NATS but not
+## its API — see deploy/worker-trust.md §5.
+extraEnv: {}
+
+## envFrom sources for the API container (e.g. [{secretRef: {name: my-secret}}]).
+## For values that must not appear in a values file. Keys are consumed
+## verbatim, so the secret must name them as the variables the code reads —
+## e.g. a NATS credential:
+##   extraEnvFrom:
+##     - secretRef:
+##         name: adapy-viewer-nats-creds   # key: ADA_VIEWER_NATS_NKEY_SEED_VALUE
+extraEnvFrom: []
+
 ## Conversion worker. Pulls source files from storage, converts to GLB,
 ## writes back under _derived/. Required for IFC/STEP/FEM viewing —
 ## without it only existing GLB files can be displayed.


### PR DESCRIPTION
## Why

The worker pools already render `extraEnv` / `extraEnvFrom` (`_helpers.tpl`), so a Secret reaches them with no chart change. The **API** deployment had neither, and its env block is entirely chart-derived — so there was no way to hand the API a NATS credential.

That asymmetry is exactly what blocks turning queue authentication on: you can authenticate every worker and not the one process that *owns* the JetStream topology (`connect(manage=True)` — it creates the stream and the KV bucket). The result would be a bus that rejects the API. `deploy/worker-trust.md` §5 records it as the remaining gap:

> The chart can already inject creds into workers but not into the API. […] `deployment.yaml` has no such hook, so step 3 has to add one (or an explicit `nats.auth` block) before the API can authenticate. Nothing else blocks turning auth on.

This adds the general hook rather than a NATS-specific block, so it also covers `ADA_VIEWER_NATS_REGISTRY_KV_BUCKET` (0.58.0) and anything else a deployment needs to set without a chart release.

## What

- `values.yaml`: `extraEnv: {}` and `extraEnvFrom: []` at the API level, documented with the NATS credential as the motivating example.
- `templates/deployment.yaml`: renders both. `extraEnv` goes **last** in the env list deliberately — a duplicate env name resolves to the final occurrence, so this doubles as an override for anything the chart derived above.

## Compatibility

Both default empty. With `extraEnvFrom` unset the API container renders **no** `envFrom` key at all, so existing deployments are byte-identical.

Verified with `helm template` against a real deployment's values, both with and without the new keys, plus `helm lint` (clean).