### PR TITLE
feat(api): let a plugin job require an admin, from two sources that only tighten

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3001,6 +3001,101 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                             out[slug] = {"slug": slug, "name": slug.replace("_", " ").title()}
         return out
 
+    # Plugin jobs an admin must be to enqueue, named by plugin id. Admin-only to
+    # write like every other non-`public.` setting, and deliberately NOT under
+    # `public.` — who may run a job is not a read window for every user.
+    #
+    # This exists because the plugin's own advertisement cannot be the only
+    # source. A spec is advertised BY THE WORKER (`_live_worker_specs`), so a
+    # worker running an older build that predates the flag advertises no flag,
+    # and a gate that reads only the advertisement would silently disappear —
+    # the deployment would look protected and be open, which is the failure
+    # this whole mechanism exists to prevent. Worker registry rows are also not
+    # currently unforgeable (see the `$KV.ada-viewer-jobs.>` note in adapy's
+    # worker-trust docs), so an advertisement is a statement of intent, not an
+    # authorization decision.
+    #
+    # The two sources are therefore OR-ed, never AND-ed: adding a source can
+    # only ever TIGHTEN. A stale worker cannot open a gate the deployment set,
+    # and a deployment can gate a plugin that never declared anything.
+    PLUGIN_JOB_ADMIN_SETTING = "admin.plugin_jobs.require_admin"
+
+    async def _plugin_ids_gated_by_config(pool) -> set[str] | None:
+        """Plugin ids the DEPLOYMENT says are admin-only.
+
+        Returns ``None`` for "the setting exists but could not be read", which
+        callers must treat as *every* plugin job requiring admin. Failing closed
+        on a malformed value is deliberate: the alternative is a typo quietly
+        removing a gate, and an over-tight gate announces itself immediately
+        while an absent one does not.
+        """
+        if pool is None:
+            return set()
+        try:
+            raw = await db_module.get_setting(pool, PLUGIN_JOB_ADMIN_SETTING)
+        except Exception:
+            # Could not ask. Same answer as a value we could not parse: gate
+            # everything. A gate must never become a 500 — that turns "the
+            # database hiccuped" into "the endpoint is broken" — and it must
+            # never resolve an error to "allowed", which would make an outage
+            # into a silent removal of the restriction.
+            logger.exception(
+                "api: could not read %s; treating every plugin job as admin-only",
+                PLUGIN_JOB_ADMIN_SETTING,
+            )
+            return None
+        if raw is None or not raw.strip():
+            return set()
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            # Not JSON. Accept the shape a person types into a settings box
+            # rather than rejecting it, since rejecting means failing closed.
+            parts = [p.strip() for p in raw.replace(",", " ").split()]
+            return {p for p in parts if p} or None
+        if isinstance(parsed, str):
+            parsed = [parsed]
+        if not isinstance(parsed, list) or any(not isinstance(p, str) for p in parsed):
+            return None
+        return {p.strip() for p in parsed if p and p.strip()}
+
+    def _locally_registered_spec(plugin_id: str) -> dict | None:
+        """The spec this process registered itself, if any.
+
+        Needed because a single-node viewer preloads the plugin INTO THE API and
+        runs its job in-process, so nothing was ever advertised by a worker and
+        ``_live_worker_specs`` is empty. Without this the declaration would be
+        ignored in exactly the deployment where it is the only source there is.
+
+        ``ada.plugins`` is imported defensively, like the discovery path above:
+        the slim API image may not carry ``ada``, and an unavailable registry
+        means "no declaration seen" rather than a refusal — that gap is the
+        reason ``PLUGIN_JOB_ADMIN_SETTING`` exists and does not depend on it.
+        """
+        try:
+            from ada.plugins import plugin_backend_spec
+        except Exception:
+            return None
+        try:
+            return plugin_backend_spec(plugin_id)
+        except Exception:
+            return None
+
+    async def _plugin_job_requires_admin(plugin_id: str, pool, advertised: dict | None) -> bool:
+        """Whether enqueuing ``plugin_id``'s job requires an admin.
+
+        OR across every source — see ``PLUGIN_JOB_ADMIN_SETTING``. Any one of
+        them restricting is enough, so adding a source can only tighten.
+        """
+        if bool((advertised or {}).get("requires_admin")):
+            return True
+        if bool((_locally_registered_spec(plugin_id) or {}).get("requires_admin")):
+            return True
+        gated = await _plugin_ids_gated_by_config(pool)
+        if gated is None:  # unreadable setting -> gate everything
+            return True
+        return plugin_id in gated
+
     @api.post("/plugins/{plugin_id}/jobs")
     async def api_plugin_job(
         plugin_id: str,
@@ -3027,6 +3122,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if not await scope_can_access(user, scope_obj, getattr(request.app.state, "db_pool", None)):
             raise HTTPException(status_code=403, detail="forbidden")
 
+        # Read the advertised spec ONCE: it decides both whether this request
+        # needs an admin and which pool it routes to.
+        plugin_spec: dict | None = None
+        for _spec in (await _live_worker_specs("plugin_specs")).values():
+            if _spec.get("slug") == plugin_id or _spec.get("id") == plugin_id:
+                plugin_spec = _spec
+                break
+
+        # Scope access is not the same question as who may RUN this. A plugin
+        # job can drive a licensed workstation for minutes; some are for admins
+        # even among users who can read the scope it writes into.
+        if await _plugin_job_requires_admin(plugin_id, getattr(request.app.state, "db_pool", None), plugin_spec):
+            if not getattr(user, "is_admin", False):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"plugin job {plugin_id!r} is restricted to administrators",
+                )
+
         # No source file — synthetic source_key over (plugin_id, options hash) so
         # identical requests cache-hit. derived_key holds the JSON summary the
         # plugin returns (the sidecar bundle lives under derived_prefix).
@@ -3046,39 +3159,37 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             target_capability = capability_token(target_capability)
         else:
             target_capability = None
-            for spec in (await _live_worker_specs("plugin_specs")).values():
-                if spec.get("slug") == plugin_id or spec.get("id") == plugin_id:
-                    cap = spec.get("worker_capability")
-                    if isinstance(cap, str) and cap.strip():
-                        target_capability = capability_token(cap)
-                    # SHARDED POOLS. A plugin may advertise `capability_option`
-                    # naming one of its own options; when the request supplies
-                    # that option the job routes to `<capability>-<value>`
-                    # instead of `<capability>`.
-                    #
-                    # This exists because a pool is one durable consumer: every
-                    # worker in it competes for the same messages, so workers
-                    # that are NOT interchangeable — each holding a different
-                    # licence, dataset or device — cannot share one. Routing
-                    # them apart by NAKing the wrong ones is the design this
-                    # replaced; it burned the delivery budget and dead-lettered
-                    # valid jobs (see the note on `pull_subscribe`).
-                    #
-                    # Subject routing does it instead, and the worker needs no
-                    # new code: it just lists the sharded token in
-                    # ADA_WORKER_CAPABILITIES. Core still names no plugin and
-                    # knows nothing about what the option MEANS.
-                    #
-                    # An absent or unusable option falls back to the bare
-                    # capability rather than erroring, so a worker that
-                    # subscribes to both serves unqualified requests too, and a
-                    # single-worker deployment never has to qualify anything.
-                    opt_name = spec.get("capability_option")
-                    if target_capability and isinstance(opt_name, str) and opt_name:
-                        shard = capability_token(options.get(opt_name))
-                        if shard:
-                            target_capability = f"{target_capability}-{shard}"
-                    break
+            if plugin_spec is not None:
+                cap = plugin_spec.get("worker_capability")
+                if isinstance(cap, str) and cap.strip():
+                    target_capability = capability_token(cap)
+                # SHARDED POOLS. A plugin may advertise `capability_option`
+                # naming one of its own options; when the request supplies
+                # that option the job routes to `<capability>-<value>`
+                # instead of `<capability>`.
+                #
+                # This exists because a pool is one durable consumer: every
+                # worker in it competes for the same messages, so workers
+                # that are NOT interchangeable — each holding a different
+                # licence, dataset or device — cannot share one. Routing
+                # them apart by NAKing the wrong ones is the design this
+                # replaced; it burned the delivery budget and dead-lettered
+                # valid jobs (see the note on `pull_subscribe`).
+                #
+                # Subject routing does it instead, and the worker needs no
+                # new code: it just lists the sharded token in
+                # ADA_WORKER_CAPABILITIES. Core still names no plugin and
+                # knows nothing about what the option MEANS.
+                #
+                # An absent or unusable option falls back to the bare
+                # capability rather than erroring, so a worker that
+                # subscribes to both serves unqualified requests too, and a
+                # single-worker deployment never has to qualify anything.
+                opt_name = plugin_spec.get("capability_option")
+                if target_capability and isinstance(opt_name, str) and opt_name:
+                    shard = capability_token(options.get(opt_name))
+                    if shard:
+                        target_capability = f"{target_capability}-{shard}"
 
         # No queue: run it here, in a thread, and hand back a job id the status
         # endpoint below can serve. A single-node viewer (the examples, a laptop)
@@ -3192,6 +3303,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "origin": "code" if slug in builtin_slugs else "db",
                 "online": True,
             }
+
+        # `requires_admin` is reported as the EFFECTIVE gate, not merely what a
+        # worker declared: a deployment can gate a plugin that declared nothing
+        # (see PLUGIN_JOB_ADMIN_SETTING). A UI that hid its button on the
+        # declaration alone would offer an action the API then refuses, which
+        # reads as a broken button rather than as a permission.
+        #
+        # This is an affordance, never the gate. The gate is in the POST.
+        pool = getattr(request.app.state, "db_pool", None)
+        gated = await _plugin_ids_gated_by_config(pool)
+        for slug, spec in by_slug.items():
+            spec["requires_admin"] = bool(spec.get("requires_admin")) or gated is None or slug in gated
         return JSONResponse({"plugins": list(by_slug.values())})
 
     @api.get("/scopes/{scope}/procedural-models/equipment-types")

--- a/src/ada/plugins/__init__.py
+++ b/src/ada/plugins/__init__.py
@@ -84,7 +84,7 @@ def register_plugin_backend(
     the spec verbatim so a plugin can advertise its own flags without a core
     change (mirrors the engine catalogs).
 
-    Two ``extra`` keys core *does* act on, both opt-in and both absent by
+    Three ``extra`` keys core *does* act on, all opt-in and all absent by
     default:
 
     ``capability_option: str``
@@ -104,6 +104,22 @@ def register_plugin_backend(
         workers advertising one slug means one worker's copy wins and the others
         are invisible — so a sharded pool cannot say what it collectively
         covers. Only list-valued keys are merged, and only the named ones.
+
+    ``requires_admin: bool``
+        Declares that enqueuing this plugin's job needs an admin, not merely a
+        user who can reach the scope. Use it for a job that costs something a
+        normal user should not be able to spend — one that drives a licensed
+        workstation, a device, or a pool of one.
+
+        **This declaration is a floor, not the whole gate.** A spec is
+        advertised BY A WORKER, so a worker on an older build advertises no flag
+        at all, and a gate that trusted only this would silently vanish exactly
+        when the deployment is least uniform. Core therefore OR-s it with an
+        admin-only setting (``admin.plugin_jobs.require_admin``, a list of
+        plugin ids) that no worker can influence. Either source restricts; a
+        source can only ever tighten. Declare it here so the intent travels with
+        the plugin, and set the setting so the deployment does not depend on
+        every worker being current.
     """
     if not plugin_id or not isinstance(plugin_id, str):
         raise ValueError("plugin_id must be a non-empty string")

--- a/tests/comms/rest/test_plugin_job_admin_gate.py
+++ b/tests/comms/rest/test_plugin_job_admin_gate.py
@@ -1,0 +1,277 @@
+"""Who may ENQUEUE a plugin job, as opposed to who may reach the scope it writes.
+
+Scope access answers a different question. A plugin job can drive a licensed
+workstation, a device, or a pool of one for minutes at a time, and some of those
+are for admins even among users who can legitimately read the scope the result
+lands in. Before this, ``POST /api/plugins/{id}/jobs`` asked only
+``scope_can_access``, so an admin-only button was an affordance and not a
+permission — anyone authenticated could send the same body from a console.
+
+The gate is OR-ed across three sources, and the OR is the point: a source can
+only ever TIGHTEN. The reason is that the obvious single source fails OPEN. A
+plugin spec is advertised BY A WORKER, so a worker on an older build advertises
+no flag, and a gate reading only that would disappear precisely when a
+deployment is least uniform — looking protected while being open. The
+deployment-side setting cannot be influenced by any worker, so it holds when the
+advertisement does not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+
+# Importing ada.comms.rest.app evaluates a module-level `create_app()` which
+# materializes a local Storage. Point it at a temp dir so the import succeeds in
+# environments without `./viewer-data`.
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import ada.comms.rest.auth as _auth
+import ada.comms.rest.db as _db
+from ada.comms.rest.app import create_app
+from ada.comms.rest.config import AuthConfig, LocalConfig, QueueConfig, Settings
+from ada.plugins import register_plugin_backend, reset_registry
+
+GATE_SETTING = "admin.plugin_jobs.require_admin"
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def as_user(monkeypatch):
+    """Run the next client as a NON-admin.
+
+    With auth disabled every request is ``User.local_dev()``, which is an admin —
+    convenient for local work and useless for testing a gate, so this swaps it.
+    """
+
+    monkeypatch.setattr(
+        _auth.User,
+        "local_dev",
+        classmethod(
+            lambda cls: cls(sub="viewer", email="v@x", display_name="V", groups=frozenset(), is_admin=False)
+        ),
+    )
+
+
+def _entrypoint(options, *, storage, scope, on_progress, derived_prefix, **_kw):
+    return {"ok": True}
+
+
+@contextlib.contextmanager
+def _client(tmp_path, *, setting: str | None = None):
+    """A test client, optionally with the deployment gate setting present.
+
+    ``database_url`` is empty, so ``app.state.db_pool`` is None and the settings
+    lookup is skipped entirely. Handing it a sentinel pool plus a stubbed
+    ``get_setting`` is what exercises the configured path without a database.
+
+    The pool is installed AFTER the client context is entered, because that is
+    what runs the lifespan — which sets ``db_pool`` itself and would otherwise
+    overwrite the sentinel between assignment and first request.
+    """
+    app = create_app(_settings(tmp_path))
+    with TestClient(app, raise_server_exceptions=False) as client:
+        if setting is not None:
+            app.state.db_pool = object()
+
+            async def _get_setting(_pool, key):
+                return setting if key == GATE_SETTING else None
+
+            _db.get_setting = _get_setting
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def _restore_get_setting():
+    original = _db.get_setting
+    yield
+    _db.get_setting = original
+
+
+# --- the declaration -------------------------------------------------------
+
+
+def test_a_plugin_that_declares_requires_admin_refuses_a_normal_user(tmp_path, as_user):
+    register_plugin_backend("adapy-test-gated", job_entrypoint=f"{__name__}:_entrypoint", requires_admin=True)
+
+    with _client(tmp_path) as client:
+        r = client.post("/api/plugins/adapy-test-gated/jobs", json={"options": {}})
+
+    assert r.status_code == 403, r.text
+    # Named, because "forbidden" alone sends the reader to look at scope access.
+    assert "adapy-test-gated" in r.json()["detail"]
+    assert "administrators" in r.json()["detail"]
+
+
+def test_the_same_plugin_runs_for_an_admin(tmp_path):
+    register_plugin_backend("adapy-test-gated", job_entrypoint=f"{__name__}:_entrypoint", requires_admin=True)
+
+    with _client(tmp_path) as client:
+        r = client.post("/api/plugins/adapy-test-gated/jobs", json={"options": {}})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["job_id"]
+
+
+def test_a_plugin_that_declares_nothing_is_unchanged_for_a_normal_user(tmp_path, as_user):
+    """The gate is opt-in. Every existing plugin job must behave as before."""
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path) as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 200, r.text
+
+
+# --- the deployment setting, which is the half a worker cannot influence ----
+
+
+def test_the_setting_gates_a_plugin_that_declared_nothing(tmp_path, as_user):
+    """THE REGRESSION THIS EXISTS FOR.
+
+    A worker on a build predating ``requires_admin`` advertises no flag. If the
+    advertisement were the only source, this request would be allowed and the
+    deployment would look protected while being open.
+    """
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path, setting='["adapy-test-open"]') as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 403, r.text
+
+
+def test_the_setting_leaves_plugins_it_does_not_name_alone(tmp_path, as_user):
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path, setting='["some-other-plugin"]') as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 200, r.text
+
+
+def test_a_hand_typed_comma_list_is_honoured(tmp_path, as_user):
+    """Someone will type this into a settings box. Rejecting it would mean
+    failing closed on a value whose intent is unambiguous."""
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path, setting="adapy-test-open, another-one") as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 403, r.text
+
+
+def test_an_unreadable_setting_gates_everything_rather_than_nothing(tmp_path, as_user):
+    """Fails CLOSED. A malformed value must not quietly remove the gate: an
+    over-tight gate announces itself the moment someone tries to use it, and an
+    absent one announces nothing at all."""
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path, setting='{"not": "a list"}') as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 403, r.text
+
+
+def test_an_empty_setting_gates_nothing(tmp_path, as_user):
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    with _client(tmp_path, setting="   ") as client:
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 200, r.text
+
+
+def test_a_settings_read_that_raises_gates_rather_than_500s(tmp_path, as_user):
+    """Two failures in one: a gate must not become a server fault, and an error
+    must not resolve to "allowed". A pool that cannot serve the lookup is an
+    outage, and an outage silently removing a restriction is the worse outcome.
+    """
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app, raise_server_exceptions=False) as client:
+
+        class _BrokenPool:
+            pass  # no fetchrow -- exactly the shape that used to raise
+
+        app.state.db_pool = _BrokenPool()
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 403, r.text
+
+
+def test_an_admin_still_gets_through_a_broken_settings_read(tmp_path):
+    """Failing closed must not mean failing shut. The gate is admin-only, not
+    nobody-at-all, or a database blip would take the capability away entirely."""
+    register_plugin_backend("adapy-test-open", job_entrypoint=f"{__name__}:_entrypoint")
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app, raise_server_exceptions=False) as client:
+
+        class _BrokenPool:
+            pass
+
+        app.state.db_pool = _BrokenPool()
+        r = client.post("/api/plugins/adapy-test-open/jobs", json={"options": {}})
+
+    assert r.status_code == 200, r.text
+
+
+# --- what the UI is told ---------------------------------------------------
+
+
+def test_the_listing_reports_the_effective_gate_not_just_the_declaration(tmp_path, monkeypatch):
+    """A UI hiding its button on the declaration alone would offer an action the
+    API then refuses, which reads as a broken button rather than a permission."""
+    from ada.comms.rest import catalog
+
+    monkeypatch.setattr(
+        catalog,
+        "builtin_plugin_specs",
+        lambda: [{"slug": "adapy-test-open", "id": "adapy-test-open", "name": "Open"}],
+    )
+
+    with _client(tmp_path, setting='["adapy-test-open"]') as client:
+        body = client.get("/api/plugins").json()
+
+    spec = next(p for p in body["plugins"] if p["slug"] == "adapy-test-open")
+    assert spec["requires_admin"] is True

--- a/tests/comms/rest/test_plugin_job_admin_gate.py
+++ b/tests/comms/rest/test_plugin_job_admin_gate.py
@@ -85,9 +85,7 @@ def as_user(monkeypatch):
     monkeypatch.setattr(
         _auth.User,
         "local_dev",
-        classmethod(
-            lambda cls: cls(sub="viewer", email="v@x", display_name="V", groups=frozenset(), is_admin=False)
-        ),
+        classmethod(lambda cls: cls(sub="viewer", email="v@x", display_name="V", groups=frozenset(), is_admin=False)),
     )
 
 


### PR DESCRIPTION
`POST /api/plugins/{id}/jobs` authorised on `scope_can_access` alone. That is a
different question from who may **run** the job: a plugin job can drive a
licensed workstation, a device, or a pool of one for minutes at a time. The
plugin cannot decide either — its entrypoint receives
`options, storage, scope, on_progress, derived_prefix, cancel_event` and **no
user**. So an admin-only button in a plugin UI was an affordance, not a
permission: anyone authenticated with access to the scope could send the same
body from a console.

This adds the gate, generically. Core still names no plugin.

## Why two sources, and not just a flag

The obvious design is a `requires_admin` flag on the plugin's advertised spec.
On its own it **fails open**.

A spec is advertised *by a worker* (`_live_worker_specs`). A worker running a
build that predates the flag advertises nothing, so a gate reading only the
advertisement disappears precisely when a deployment is least uniform — leaving
it protected-looking and open. That is the same failure shape as an old client
ignoring an unknown environment variable: nothing errors, and the protection is
simply absent. Worker registry rows are also not unforgeable today, so an
advertisement is a statement of intent rather than an authorization decision.

The flag is therefore OR-ed with an admin-only setting,
**`admin.plugin_jobs.require_admin`** — a list of plugin ids that no worker can
influence. A third source is the in-process registry, needed because a
single-node viewer preloads the plugin *into the API* and advertises nothing at
all; without it the declaration would be ignored in the one deployment where it
is the only source there is.

**OR, never AND.** Adding a source can only ever tighten. A stale worker cannot
open a gate the deployment set, and a deployment can gate a plugin that declared
nothing.

## Failing closed, in both directions

A **malformed** setting gates everything rather than nothing. An over-tight gate
announces itself the moment somebody tries to use it; an absent one announces
nothing at all, which is the whole failure being designed against.

A settings read that **raises** does the same, rather than 500-ing. A gate must
not turn a database hiccup into a broken endpoint, and it must never resolve an
error to *allowed*. Found by a test: a pool that could not serve the lookup made
the endpoint fault, which is now covered.

Both cases assert that **an admin still gets through** — failing closed must not
mean failing shut, or a blip would take the capability away entirely.

## For the UI

`GET /api/plugins` reports the **effective** gate, not just the declaration, so
a UI hiding its button on the declaration alone cannot offer an action the API
then refuses. It is an affordance; the gate is the POST.

## Incidental

The capability lookup now folds into the same single read of the advertised spec
that the gate needed anyway — one `_live_worker_specs` call instead of two.
Routing behaviour is unchanged; the sharded-pool comment moves with it.

## Verification

11 new tests. Plugin-job, admin and auth suites: **45 passed, 9 skipped**.

The full `tests/comms/rest` run **could not complete on the machine this was
written on**: several FEM/CAD tests take a native LAPACK fault
(`numpy.linalg.svd`, Windows exception `0xc06d007f`). That reproduces on
unmodified `main` and is unrelated to this change, but it does mean the whole
suite has not been seen green locally — CI is the check that matters here.

One regression was caught and fixed during this: `test_plugin_job_audit_race`
began failing because the new settings read blew up on its `FakePool`. That is
what prompted the fail-closed-on-exception path rather than being papered over
in the test.

