### PR TITLE
fix(cadit): unblock wasm ifc/mesh conversions and unnamed SAT faces

### DIFF
--- a/src/ada/cadit/sat/read/faces.py
+++ b/src/ada/cadit/sat/read/faces.py
@@ -31,6 +31,13 @@ class PlateFactory:
         chunks = acis_record.chunks
 
         name = self.sat_store.get_name(chunks[self.name_idx])
+        if not name:
+            # No name resolves for this face (no attribute, or an attribute
+            # chain ending before a string attrib). Plates are matched to their
+            # XML element by name, so an unnamed face can never become one:
+            # skip it like any other unusable face rather than failing below.
+            logger.warning(f"face record {acis_record.index} carries no name attribute. Skipping...")
+            return None
         if not name.startswith("FACE"):
             raise NotImplementedError(f"Only face_refs starting with 'FACE' is supported. Found {name}")
 

--- a/src/frontend/src/utils/pyodide/pyodide_worker.js
+++ b/src/frontend/src/utils/pyodide/pyodide_worker.js
@@ -209,6 +209,18 @@ async function ensureAdapyWheel() {
     return adapyWheelPromise;
 }
 
+// Every cell dispatches through `import ada.cadit.wasm_convert`, so the adapy
+// wheel is a precondition of all of them, not just the CAD formats. ada's
+// __init__ is eager, hence trimesh + pyquaternion first (numpy comes from
+// bootstrap). Kept outside the per-format stacks on purpose: formats that need
+// no CAD kernel install only their own packages, and previously reached the
+// dispatch import with no `ada` on sys.path.
+async function ensureAdapyRuntime() {
+    await ensureTrimesh();
+    await ensurePyquaternion();
+    await ensureAdapyWheel();
+}
+
 // Lazy STEP stack — adacpp kernel + adapy.cad, both from wheels.
 async function ensureStepStack() {
     if (!stepStackPromise) {
@@ -359,11 +371,13 @@ _pc.compile_doc(_pc_doc, engine=_pc_engine)
 // then calls wasm_convert.run.
 
 async function ensureStacks(format, target) {
+    // Invariant: adapy first, for every format. See ensureAdapyRuntime.
+    await ensureAdapyRuntime();
     const tgt = (target || "glb").toLowerCase();
     if (format === "fea") return ensureFemStack();
     if (format === "fea_glb") return ensureFemStack(); // SIF/SIN result → single GLB
     if (format === "mesh") return ensureMeshStack();
-    if (format === "ifc" && tgt === "glb") return ensureIfcStack(); // raw ifcopenshell fast path
+    if (format === "ifc" && tgt === "glb") return ensureIfcStack(); // ifcopenshell geometry fast path
     if (format === "step" && tgt === "glb") return ensureStepStack(); // adacpp fast path
     if (format === "fem") {
         await ensureFemStack();

--- a/tests/core/cadit/sat/test_unnamed_face_skipped.py
+++ b/tests/core/cadit/sat/test_unnamed_face_skipped.py
@@ -1,0 +1,54 @@
+"""Regression: a SAT face with no name attribute must be skipped, not fatal.
+
+``iter_flat_plates`` walks every ``face`` record and resolves its name through
+the attribute pointer. A face carrying no attribute, or one whose attribute
+chain ends before a string attrib, resolves to an empty name — which used to
+fall into the prefix guard and abort the whole model import. Plates are matched
+to their XML element by name, so such a face can never become a plate and
+skipping it is lossless; a face that *is* named but uses an unexpected scheme
+still raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ada.cadit.sat.read.faces import PlateFactory
+from ada.cadit.sat.store import SatStore
+
+# Minimal synthetic ACIS records. Chunk 2 of a ``face`` is its attribute
+# pointer; chunk 4 of an attribute is the next-attribute pointer.
+FACE_NO_ATTRIBUTE = "-3 face $-1 -1 -1 $-1 $-1 $5 $2 $-1 $6 forward double out F F #"
+FACE_COLOUR_ONLY = "-13 face $14 -1 -1 $-1 $-1 $5 $2 $-1 $6 forward double out F F #"
+COLOUR_ATTRIBUTE = "-14 rgb_color-st-attrib $-1 -1 $-1 $-1 $13 1 0 0 #"
+FACE_FOREIGN_NAME = "-23 face $24 -1 -1 $-1 $-1 $5 $2 $-1 $6 forward double out F F #"
+FOREIGN_NAME_ATTRIBUTE = "-24 string_attrib-name_attrib-gen-attrib $-1 -1 $-1 $-1 $23 @15 SOME_OTHER_ID @2 35 #"
+
+
+def _factory(*records: str) -> PlateFactory:
+    store = SatStore()
+    for record in records:
+        store.add(record)
+    return PlateFactory(store)
+
+
+@pytest.mark.parametrize(
+    "records, face_index",
+    [
+        pytest.param((FACE_NO_ATTRIBUTE,), 3, id="no-attribute"),
+        pytest.param((FACE_COLOUR_ONLY, COLOUR_ATTRIBUTE), 13, id="colour-attribute-only"),
+    ],
+)
+def test_face_without_a_name_is_skipped(records, face_index):
+    factory = _factory(*records)
+    face = factory.sat_store.get(face_index)
+    assert factory.sat_store.get_name(face.chunks[PlateFactory.name_idx]) == ""
+    # Skipped like any other unusable face — no exception, no plate.
+    assert factory.get_face_name_and_points(face) is None
+
+
+def test_face_with_an_unexpected_name_still_raises():
+    factory = _factory(FACE_FOREIGN_NAME, FOREIGN_NAME_ATTRIBUTE)
+    face = factory.sat_store.get(23)
+    with pytest.raises(NotImplementedError, match="35"):
+        factory.get_face_name_and_points(face)

--- a/tests/core/cadit/test_wasm_host_stack_invariant.py
+++ b/tests/core/cadit/test_wasm_host_stack_invariant.py
@@ -1,0 +1,65 @@
+"""Every WASM host must install adapy before dispatching a conversion.
+
+Both pyodide hosts dispatch every cell through ``ada.cadit.wasm_convert``, so
+the adapy wheel is a precondition of all of them. Formats needing no CAD kernel
+previously installed only their own packages and died at that import. The hosts
+are JavaScript and no JS suite runs in CI, so the invariant is pinned here.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+HOSTS = (
+    "src/frontend/src/utils/pyodide/pyodide_worker.js",
+    "tools/pyodide-test/wasm_sweep_driver.js",
+)
+
+RUNTIME_HELPER = "ensureAdapyRuntime"
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the body of ``async function <name>(...) { ... }`` by brace matching."""
+    m = re.search(r"async function " + re.escape(name) + r"\s*\([^)]*\)\s*\{", source)
+    assert m is not None, f"{name} not found"
+    depth, start = 0, m.end() - 1
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start + 1 : i]
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+def _code_body(root_dir, host: str, name: str) -> str:
+    """The function's body, comments stripped.
+
+    Stripping matters: the comment above the call names the helper, and would
+    otherwise satisfy every check below even with the call itself deleted.
+    """
+    source = (root_dir / host).read_text(encoding="utf-8")
+    body = _function_body(source, name)
+    return re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", body, flags=re.S))
+
+
+@pytest.mark.parametrize("host", HOSTS)
+def test_adapy_runtime_helper_installs_the_wheel(root_dir, host):
+    body = _code_body(root_dir, host, RUNTIME_HELPER)
+    # ada/__init__.py is eager: trimesh + pyquaternion must precede the import.
+    for required in ("ensureTrimesh", "ensurePyquaternion", "ensureAdapyWheel"):
+        assert required in body, f"{host}: {RUNTIME_HELPER} does not await {required}"
+
+
+@pytest.mark.parametrize("host", HOSTS)
+def test_ensure_stacks_installs_adapy_before_any_format_branch(root_dir, host):
+    body = _code_body(root_dir, host, "ensureStacks")
+    assert RUNTIME_HELPER in body, f"{host}: ensureStacks never awaits {RUNTIME_HELPER}"
+    # Nothing may branch or return ahead of the install, or a format whose stack
+    # skips the CAD kernel reaches the dispatch import without `ada` again.
+    head = body[: body.index(RUNTIME_HELPER)]
+    for token in (r"\bif\b", r"\breturn\b", r"\?"):
+        assert not re.search(token, head), f"{host}: ensureStacks branches before awaiting {RUNTIME_HELPER}"

--- a/tools/pyodide-test/wasm_sweep_driver.js
+++ b/tools/pyodide-test/wasm_sweep_driver.js
@@ -120,6 +120,18 @@ async function ensureAdapyWheel() {
     return adapyP;
 }
 
+// Every cell dispatches through `import ada.cadit.wasm_convert`, so the adapy
+// wheel is a precondition of all of them, not just the CAD formats. ada's
+// __init__ is eager, hence trimesh + pyquaternion first (numpy comes from
+// bootstrap). Kept outside the per-format stacks on purpose: formats that need
+// no CAD kernel install only their own packages, and previously reached the
+// dispatch import with no `ada` on sys.path.
+async function ensureAdapyRuntime() {
+    await ensureTrimesh();
+    await ensurePyquaternion();
+    await ensureAdapyWheel();
+}
+
 async function ensureIfcStack() {
     if (!ifcP)
         ifcP = (async () => {
@@ -201,11 +213,13 @@ async function ensureFemStack() {
 // here. We only install the right packages/wheels for a cell, then call run().
 
 async function ensureStacks(format, target) {
+    // Invariant: adapy first, for every format. See ensureAdapyRuntime.
+    await ensureAdapyRuntime();
     const tgt = (target || "glb").toLowerCase();
     if (format === "fea") return ensureFemStack();
     if (format === "fea_glb") return ensureFemStack(); // SIF/SIN result → single GLB
     if (format === "mesh") return ensureMeshStack();
-    if (format === "ifc" && tgt === "glb") return ensureIfcStack(); // raw ifcopenshell fast path
+    if (format === "ifc" && tgt === "glb") return ensureIfcStack(); // ifcopenshell geometry fast path
     if (format === "step" && tgt === "glb") return ensureStepStack(); // adacpp fast path
     if (format === "fem") await ensureFemStack();
     else await ensureSatStack();


### PR DESCRIPTION
Two independent conversion failures, folded into one PR to keep CI and release noise down.

### 1. `ModuleNotFoundError: No module named 'ada'` on every wasm ifc→glb and mesh cell

Both pyodide hosts dispatch every conversion through `ada.cadit.wasm_convert`, so the adapy wheel is a precondition of *every* cell. `ensureStacks` installed it per format, and the `ifc`/`mesh` paths need no CAD kernel — so their stacks installed only ifcopenshell/trimesh:

```js
if (format === "mesh") return ensureMeshStack();          // no adapy
if (format === "ifc" && tgt === "glb") return ensureIfcStack();  // no adapy
```

Once the conversion logic moved out of the hosts and into this package, those cells died at the dispatch import — before any conversion logic ran, so an ifc→glb the engine handles perfectly well never got the chance. `step` and the CAD formats were unaffected because their stacks already installed adapy.

Fixed by hoisting the requirement into `ensureAdapyRuntime` and awaiting it unconditionally at the top of `ensureStacks`. The fast paths still skip the CAD kernel; they just gain the module they dispatch through.

### 2. A SAT face with no name aborts the whole model import

A face carrying no attribute (`$-1`), and a face whose attribute chain ends before a string attrib, both resolve to an empty name — which fell into the prefix guard:

```
NotImplementedError: Only face_refs starting with 'FACE' is supported. Found
```

Note the empty name: the guard was rejecting an *unnamed* face, not one with an unexpected prefix. One such face aborted the entire import, while every other unusable-face case in the same function warns and skips. Plates are matched to their XML element by name, so an unnamed face can never become a plate and skipping it is lossless. A face that *is* named but uses an unexpected scheme still raises.

Pure-python parsing, no backend dependency — this one reproduces off wasm entirely.

### Tests

The hosts are JavaScript and no JS suite runs in CI, which is why the first bug survived — so both tests live in the Python suite CI does run. Each was verified to fail when its fix is reverted, and the invariant test was additionally checked against three mutations (install moved behind a format branch, install deleted, helper dropping the wheel), each failing exactly the expected assertion.

Fixtures are synthetic; no sample data added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Bb3ugvU6FEj4bukxTfP73
