### PR TITLE
fix: a lost connection must not leave a process permanently broken

### DIFF
--- a/deploy/Dockerfile.viewer
+++ b/deploy/Dockerfile.viewer
@@ -154,6 +154,21 @@ COPY src/ada/cad/ /app/src/ada/cad/
 # rather than stubbed the way ada.sections has to be.
 COPY src/ada/core/__init__.py /app/src/ada/core/__init__.py
 COPY src/ada/core/file_system.py /app/src/ada/core/file_system.py
+# ada.plugins — the backend-plugin registry. Unlike the two above its absence does not crashloop
+# anything: the API imports it defensively and logs "ada.plugins discovery failed (non-fatal)". But
+# it logged that with a traceback on EVERY boot, for a module that was never shipped rather than one
+# that broke — so the loudest recurring line in the API's log described a deliberate omission.
+#
+# It also left a real gap. _locally_registered_spec (see app.py) resolves the plugin-job admin
+# declaration for a single-node viewer that preloads a plugin INTO the API, where no worker
+# advertises it and the registry is the only source there is. Without this module that source can
+# never answer, so the gate silently ran on fewer inputs than it was written for.
+#
+# Safe to ship, on the same test ada/cad passes above: ada/plugins/__init__.py and the whole
+# external_models subtree are stdlib-only (logging, typing, dataclasses, os, datetime,
+# importlib.metadata) — nothing numpy- or OCC-bound. With no plugin distribution installed in the
+# slim env, discovery correctly finds no entry points and registers nothing.
+COPY src/ada/plugins/ /app/src/ada/plugins/
 # pyproject.toml is the single source of truth for the version. The viewer copies adapy source
 # (no installed-dist metadata) and a stripped ada/__init__ (no __version__), so config.js reads
 # the version from here for window.ADAPY_VERSION (see _resolve_adapy_version).

--- a/src/ada/comms/rest/nats_ws.py
+++ b/src/ada/comms/rest/nats_ws.py
@@ -1,0 +1,151 @@
+"""Make a server-closed WebSocket look like what nats-py already handles: EOF.
+
+THE BUG THIS EXISTS FOR. ``nats-py``'s ``WebSocketTransport.readline`` special-
+cases exactly one aiohttp message type::
+
+    async def readline(self):
+        data = await self._ws.receive()
+        if data.type == aiohttp.WSMsgType.CLOSED:
+            return b""
+        return data.data
+
+``CLOSED`` is the type aiohttp reports for a socket that is *already* closed. It
+is not the type it reports when the peer closes one. A peer-initiated close
+arrives as ``WSMsgType.CLOSE``, and aiohttp returns that message to the caller
+with ``.data`` set to the **close code — an int**. So ``readline`` hands an int
+to the protocol parser, which does ``bytearray.extend(data)``, and the read loop
+dies on::
+
+    TypeError: can't extend bytearray with int
+
+``CLOSING`` (``.data is None``) and ``ERROR`` (``.data`` is an exception) fail
+the same way for the same reason.
+
+WHY THAT IS WORSE THAN A CRASH. ``Client._read_loop`` handles every *expected*
+failure by calling ``_process_op_err``, which is what schedules a reconnect. Its
+final catch-all does not::
+
+    except Exception as ex:
+        _logger.error("nats: encountered error", exc_info=ex)
+        break
+
+So the TypeError above breaks out of the read loop without ever entering the
+reconnect path. The client is left with no reader, ``is_connected`` still true,
+and no exception raised to anyone: it neither recovers nor fails. Every
+subsequent request times out, and a long-lived process can sit like that
+indefinitely while continuing to look healthy in its own logs.
+
+WHAT THIS CHANGES, AND WHY IT IS ENOUGH. Reporting a close as ``b""`` is not a
+workaround — it is the same signal the TCP transport gives, and the path
+nats-py is already written for. An empty read leaves the parser buffer
+untouched; the next loop iteration sees ``at_eof()`` (aiohttp has marked the
+socket closed by then, as the CLOSE branch calls ``close()`` before returning),
+raises ``UnexpectedEOF``, and goes through ``_process_op_err`` into a normal
+reconnect. Nothing else about the transport changes.
+
+WHO IS AFFECTED. Only clients using the WebSocket transport, which is what a
+``ws://`` or ``wss://`` URL selects — the shape used when the bus is reached
+through an HTTP ingress rather than a raw TCP port. A TCP client gets a clean
+EOF from the OS and reconnects correctly today, which is why this can go
+unnoticed for a long time: the same server restart that recovers everywhere else
+permanently strands the WebSocket clients.
+
+WHY A SUBCLASS AND NOT A PATCHED METHOD. Rebinding the name the client module
+looks up leaves ``nats.aio.transport.WebSocketTransport`` itself untouched, so
+anything else in the process that imports it directly is unaffected. If a later
+``nats-py`` fixes this upstream the subclass becomes a redundant no-op rather
+than a conflict, because it does the same thing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Marks our subclass so :func:`install_websocket_close_fix` is idempotent.
+#: Reconnects build a fresh transport from whatever the client module names, so
+#: installing once per process is all that is needed — but ``connect`` may be
+#: called many times in one process and must not stack patches.
+_INSTALLED_FLAG = "_ada_close_is_eof"
+
+
+def _build_transport_class():
+    """Subclass the WebSocket transport, overriding only ``readline``.
+
+    Imported lazily: ``aiohttp`` is an optional dependency that only a
+    WebSocket URL requires, and this module must be importable without it.
+    """
+    import aiohttp
+    from nats.aio.transport import WebSocketTransport
+
+    # Every aiohttp message type that means "there is nothing more to read".
+    # CLOSE is the one that matters in practice (a server shutting down or
+    # rolling); CLOSING and ERROR are included because they carry a non-bytes
+    # payload for the same reason and would fail in the same place.
+    over = (
+        aiohttp.WSMsgType.CLOSE,
+        aiohttp.WSMsgType.CLOSING,
+        aiohttp.WSMsgType.CLOSED,
+        aiohttp.WSMsgType.ERROR,
+    )
+
+    class ClosingAwareWebSocketTransport(WebSocketTransport):
+        """A WebSocket transport that reports every kind of close as EOF."""
+
+        async def readline(self):
+            msg = await self._ws.receive()
+            if msg.type in over:
+                # The one line that matters. Anything else here would be a
+                # close code, ``None`` or an exception — never bytes.
+                return b""
+            # Deliberately unchanged for every other type, including TEXT:
+            # narrowing what the transport accepts is a separate decision from
+            # fixing how it reports a close, and not one this needs to make.
+            return msg.data
+
+    setattr(ClosingAwareWebSocketTransport, _INSTALLED_FLAG, True)
+    return ClosingAwareWebSocketTransport
+
+
+def install_websocket_close_fix() -> bool:
+    """Install the transport above, returning whether it is in place.
+
+    Idempotent and non-fatal. A ``False`` return means this environment cannot
+    take the fix — no ``aiohttp``, or a ``nats-py`` whose internals have moved —
+    and is logged rather than raised: the connection that follows may well work,
+    and refusing to open it would turn a degraded reconnect into no service at
+    all.
+    """
+    try:
+        import nats.aio.client as nats_client
+    except Exception:  # pragma: no cover - nats-py is a hard dependency here
+        logger.debug("nats-ws: nats.aio.client unavailable; close-as-EOF fix not installed")
+        return False
+
+    existing = getattr(nats_client, "WebSocketTransport", None)
+    if existing is None:
+        # The client no longer resolves the transport through this name, so
+        # rebinding it would silently do nothing. Say so rather than report
+        # a fix that is not installed.
+        logger.warning(
+            "nats-ws: this nats-py does not expose WebSocketTransport on its client module; "
+            "a server-closed WebSocket may not trigger a reconnect"
+        )
+        return False
+
+    if getattr(existing, _INSTALLED_FLAG, False):
+        return True
+
+    try:
+        nats_client.WebSocketTransport = _build_transport_class()
+    except Exception:
+        logger.warning(
+            "nats-ws: could not install the close-as-EOF WebSocket transport; "
+            "a server-closed WebSocket may not trigger a reconnect",
+            exc_info=True,
+        )
+        return False
+
+    logger.debug("nats-ws: WebSocket close now reported as EOF")
+    return True

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -288,6 +288,57 @@ class JobQueue:
         """
         return url.startswith("ws://") or url.startswith("wss://")
 
+    @staticmethod
+    def _connection_policy_options() -> dict:
+        """How the client behaves when the connection drops. Not credentials.
+
+        Kept apart from :meth:`_connect_options` on purpose: that one answers
+        "what did the operator configure", and its tests assert the mapping is
+        exact. This one is policy that always applies, whatever the credentials.
+
+        RECONNECT FOR AS LONG AS THE PROCESS LIVES. nats-py gives up after
+        ``max_reconnect_attempts`` (60) tries at ``reconnect_time_wait`` (2s) —
+        about two minutes — and giving up is not a pause. It raises
+        ``NoServersError``, calls ``close()``, and from then on EVERY operation
+        raises ``ConnectionClosedError: nats: connection closed`` for the life of
+        the process. There is no path back: nothing retries a closed client, and
+        a closed client is what the process is left holding.
+
+        Two minutes is shorter than an ordinary restart of the bus, so the
+        default turns a routine restart into a permanent outage for whichever
+        long-lived processes were not restarted alongside it. An API in that
+        state still serves HTTP — so it stays healthy to a liveness probe while
+        failing every request that touches the queue, and nothing restarts it
+        either.
+
+        A negative value is nats-py's "never stop reconnecting". There is no
+        scenario in which one of these processes wants to stop trying to reach
+        the bus and carry on running: without the bus there is nothing it can do.
+        """
+
+        async def _disconnected() -> None:
+            logger.warning("queue: disconnected from NATS; reconnecting until it comes back")
+
+        async def _reconnected() -> None:
+            logger.info("queue: reconnected to NATS")
+
+        async def _closed() -> None:
+            # With unlimited retries this should only ever follow a deliberate
+            # close. If it appears without one, the policy above is not in force
+            # and every later operation on this client will fail.
+            logger.warning("queue: NATS connection closed")
+
+        return {
+            "max_reconnect_attempts": -1,
+            # Say it out loud when the connection comes and goes. Otherwise the
+            # only account of a disconnect is whatever the library's own logger
+            # emits, and the transition that matters most — reconnected, so the
+            # backlog is draining — is invisible.
+            "disconnected_cb": _disconnected,
+            "reconnected_cb": _reconnected,
+            "closed_cb": _closed,
+        }
+
     def _connect_options(self, name: str | None) -> dict:
         """Build the ``nats.connect()`` kwargs for the configured credentials.
 
@@ -366,7 +417,7 @@ class JobQueue:
         """
         if not self.enabled:
             raise QueueDisabled("ADA_VIEWER_NATS_URL not set")
-        options = self._connect_options(name)
+        options = {**self._connect_options(name), **self._connection_policy_options()}
         if self._is_websocket_url((self._cfg.url or "").strip().lower()):
             # Teach nats-py to treat a server-closed WebSocket as EOF, so it
             # reconnects instead of dying silently inside its read loop. See

--- a/src/ada/comms/rest/queue.py
+++ b/src/ada/comms/rest/queue.py
@@ -38,6 +38,7 @@ from ada.config import logger
 
 from .config import QueueConfig
 from .converter import derived_key_for
+from .nats_ws import install_websocket_close_fix
 
 JOB_STATUS_QUEUED = "queued"
 JOB_STATUS_RUNNING = "running"
@@ -278,6 +279,15 @@ class JobQueue:
     _BIND_WAIT_SECONDS = 60.0
     _BIND_POLL_SECONDS = 2.0
 
+    @staticmethod
+    def _is_websocket_url(url: str) -> bool:
+        """Whether this URL selects nats-py's WebSocket transport.
+
+        Off the URL rather than off a credential, because the URL is what
+        actually chooses the transport.
+        """
+        return url.startswith("ws://") or url.startswith("wss://")
+
     def _connect_options(self, name: str | None) -> dict:
         """Build the ``nats.connect()`` kwargs for the configured credentials.
 
@@ -295,7 +305,7 @@ class JobQueue:
         # WebSocket URL is the shape an off-cluster worker uses when the bus is
         # reached through an HTTPS ingress rather than a raw TCP port.
         url = (self._cfg.url or "").strip().lower()
-        if url.startswith("ws://") or url.startswith("wss://"):
+        if self._is_websocket_url(url):
             _require("aiohttp", "the WebSocket transport", "ADA_VIEWER_NATS_URL")
 
         opts: dict = {}
@@ -356,7 +366,15 @@ class JobQueue:
         """
         if not self.enabled:
             raise QueueDisabled("ADA_VIEWER_NATS_URL not set")
-        self._nc = await nats.connect(self._cfg.url, **self._connect_options(name))
+        options = self._connect_options(name)
+        if self._is_websocket_url((self._cfg.url or "").strip().lower()):
+            # Teach nats-py to treat a server-closed WebSocket as EOF, so it
+            # reconnects instead of dying silently inside its read loop. See
+            # ada.comms.rest.nats_ws for what breaks without this. Installed
+            # here rather than at import so it only touches processes that
+            # actually use the transport.
+            install_websocket_close_fix()
+        self._nc = await nats.connect(self._cfg.url, **options)
         self._js = self._nc.jetstream()
 
         if not manage:

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -146,6 +146,35 @@ POOL_STREAK_LIMIT = max(1, int(os.environ.get("ADA_WORKER_POOL_STREAK_LIMIT", "8
 # stays free to fire these.
 IN_PROGRESS_REFRESH_SECONDS = 30
 
+# How often the worker re-publishes its registration. Also, incidentally, the
+# only round-trip to the bus an IDLE worker makes: a pull fetch that times out
+# with no messages is indistinguishable from a healthy quiet queue, so the
+# heartbeat is the one thing whose failure means something.
+BUS_HEARTBEAT_SECONDS = 15.0
+
+# Consecutive heartbeat failures after which the worker exits non-zero instead
+# of continuing to look alive.
+#
+# WHY THIS EXISTS. A worker whose connection is gone should either recover or
+# stop; the state worth designing against is the third one, where it does
+# neither. The client library is not guaranteed to fail loudly — a read loop can
+# stop without raising, leaving ``is_connected`` true and every subsequent
+# request timing out — and nothing else here would notice. The liveness file is
+# touched by the poll loop, which keeps iterating happily against a dead
+# connection, so it goes on reporting health. The registry row goes stale and
+# the worker vanishes from the admin view, but the process does not care.
+#
+# So jobs route to a pool that no longer consumes, and sit. That is the failure
+# this bounds: not the disconnect, which is ordinary, but the silence after it.
+#
+# The number is a compromise between the two ways of being wrong. Too low and a
+# transient blip restarts a worker mid-job, losing work that would have
+# recovered on its own. Too high and jobs queue against a dead pool for as long
+# as it takes. At the cadence above this is a full minute of consecutive
+# failures — far longer than a reconnect after a routine bus restart, short
+# enough that nothing waits on it for long.
+BUS_HEARTBEAT_FAILURE_LIMIT = 4
+
 
 def _bool_env(name: str, *, default: bool) -> bool:
     raw = os.environ.get(name)
@@ -4280,6 +4309,56 @@ def _warm_convert_imports() -> None:
         logger.info("worker: warm-imported %s (%s) in %.2fs", mod, why, time.perf_counter() - t0)
 
 
+async def _heartbeat_until_stopped(
+    *,
+    publish: Callable[[], Awaitable[bool]],
+    stop: asyncio.Event,
+    bus_lost: asyncio.Event,
+    interval: float = BUS_HEARTBEAT_SECONDS,
+    failure_limit: int = BUS_HEARTBEAT_FAILURE_LIMIT,
+) -> None:
+    """Re-publish the registration on ``interval``, and watch the bus while doing it.
+
+    Two jobs, because one round-trip answers both. The registration keeps the
+    worker visible to the admin view; whether it *arrives* is the only routine
+    evidence an idle worker has that the bus is still there. An idle pull fetch
+    times out whether the queue is quiet or the connection is dead, so it can
+    never be that evidence.
+
+    Returns when ``stop`` is set — either by the caller (a shutdown signal) or
+    by this loop after ``failure_limit`` consecutive failures, in which case it
+    sets ``bus_lost`` first. The caller is what decides the exit code; see
+    BUS_HEARTBEAT_FAILURE_LIMIT for why there is one to decide.
+
+    Consecutive is the point. The counter resets on every success, so a worker
+    that heartbeats fine for hours with the occasional blip never trips it; only
+    a run of failures with no success between them does.
+    """
+    failures = 0
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            if await publish():
+                failures = 0
+                continue
+            failures += 1
+            if failures < failure_limit:
+                continue
+            logger.error(
+                "worker: %d consecutive heartbeats failed (~%.0fs); the bus is unreachable "
+                "and this worker is not serving the pools it advertises. Exiting so it is "
+                "restarted rather than left silently idle.",
+                failures,
+                failures * interval,
+            )
+            bus_lost.set()
+            stop.set()
+            return
+        else:
+            return  # stop set — exit cleanly
+
+
 async def _run() -> None:
     # Make the worker's own lifecycle logs visible. The "ada" logger otherwise
     # inherits root's WARNING level, which silently drops every worker: INFO
@@ -4617,7 +4696,14 @@ async def _run() -> None:
     }
     reported_packages = [p for p in worker_packages if str(p.get("name") or "").lower() in _named]
 
-    async def _publish_registration() -> None:
+    async def _publish_registration() -> bool:
+        """Publish the registration; return whether it reached the bus.
+
+        Still non-fatal on its own — one failed heartbeat is a blip, and the
+        registry row it writes is decorative. The return value is what lets the
+        caller tell a blip from a connection that is never coming back; see
+        BUS_HEARTBEAT_FAILURE_LIMIT.
+        """
         try:
             await queue.register_worker(
                 worker_id,
@@ -4651,6 +4737,8 @@ async def _run() -> None:
             )
         except Exception:
             logger.exception("worker: register_worker failed (non-fatal)")
+            return False
+        return True
 
     await _publish_registration()
     logger.info(
@@ -4782,19 +4870,15 @@ async def _run() -> None:
             # Windows: skip graceful signal wiring.
             pass
 
-    # Heartbeat loop — re-publish the registration every 15 s so the
-    # admin panel can filter stale workers (a pod that crashed without
-    # graceful shutdown will fall off the list within HEARTBEAT_STALE_S).
-    async def _heartbeat_loop() -> None:
-        while not stop.is_set():
-            try:
-                await asyncio.wait_for(stop.wait(), timeout=15.0)
-            except asyncio.TimeoutError:
-                await _publish_registration()
-            else:
-                return  # stop set — exit cleanly
+    # Set when the heartbeat has failed BUS_HEARTBEAT_FAILURE_LIMIT times running.
+    # Distinguishes "we were asked to stop" from "we lost the bus and stopped
+    # ourselves", which have to exit with different codes: a supervisor should
+    # restart the second and not the first.
+    bus_lost = asyncio.Event()
 
-    heartbeat_task = asyncio.create_task(_heartbeat_loop())
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_until_stopped(publish=_publish_registration, stop=stop, bus_lost=bus_lost)
+    )
 
     # The previous threadpool ran convert() in-process; that's been
     # replaced by a per-job forked subprocess (see subprocess_convert).
@@ -4982,6 +5066,14 @@ async def _run() -> None:
             except Exception:
                 logger.exception("worker: db pool close failed")
         logger.info("worker: stopped")
+
+    if bus_lost.is_set():
+        # Non-zero so a supervisor restarts us. Deliberately raised out here,
+        # after the cleanup above: unregistering and closing are best-effort and
+        # each already tolerate a dead connection, and skipping them would leave
+        # a stale registry row behind on the one exit path that most needs the
+        # row gone.
+        raise SystemExit("worker: exiting after losing the connection to the bus")
 
 
 def run() -> None:

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ada-py-viewer",
-  "version": "0.45.0",
+  "version": "0.61.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ada-py-viewer",
-      "version": "0.45.0",
+      "version": "0.61.5",
       "workspaces": [
         "packages/plugins/*"
       ],
@@ -2203,9 +2203,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2325,9 +2325,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2345,11 +2345,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -3014,9 +3014,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.375",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4547,9 +4547,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5931,9 +5931,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/tests/comms/rest/test_nats_ws_close.py
+++ b/tests/comms/rest/test_nats_ws_close.py
@@ -1,0 +1,135 @@
+"""A server-closed WebSocket has to look like EOF, or the client never reconnects.
+
+``nats-py``'s WebSocket transport recognises one aiohttp close type, ``CLOSED``,
+which is what aiohttp reports for a socket that is *already* closed. A peer
+closing one is reported as ``CLOSE``, and the message aiohttp hands back carries
+the close **code** in ``.data`` — an int. ``CLOSING`` carries ``None`` and
+``ERROR`` carries an exception.
+
+Passing any of those through reaches ``bytearray.extend(...)`` in the protocol
+parser and raises ``TypeError``, which the read loop catches in a final
+catch-all that logs and breaks WITHOUT going through the reconnect path every
+other branch uses. The connection is then neither live nor failed: no reader,
+``is_connected`` still true, every later request timing out, and nothing raised
+to anyone.
+
+So these tests are about one property — a close, of any flavour, produces
+``b""`` — and one consequence, which is that the alternative is not "slightly
+wrong" but fatal.
+"""
+
+import asyncio
+
+import pytest
+
+aiohttp = pytest.importorskip("aiohttp", reason="the WebSocket transport is an aiohttp extra")
+
+from ada.comms.rest.nats_ws import (  # noqa: E402
+    _build_transport_class,
+    install_websocket_close_fix,
+)
+
+
+class _FakeWebSocket:
+    """The one method the transport calls, handing back a scripted message."""
+
+    def __init__(self, message):
+        self._message = message
+
+    async def receive(self):
+        return self._message
+
+
+def _readline(message):
+    """Run the patched ``readline`` against a single scripted ws message.
+
+    Built with ``__new__`` deliberately: the real ``__init__`` opens an
+    ``aiohttp.ClientSession``, and nothing here is testing construction.
+    """
+    cls = _build_transport_class()
+    transport = cls.__new__(cls)
+    transport._ws = _FakeWebSocket(message)
+    return asyncio.run(transport.readline())
+
+
+def test_a_peer_close_reads_as_eof_not_as_its_close_code():
+    # The case that breaks in the wild: a server restarting or being rolled.
+    # aiohttp sets .data to the close code, so the unguarded path returns 1001.
+    msg = aiohttp.WSMessage(aiohttp.WSMsgType.CLOSE, 1001, "going away")
+    assert _readline(msg) == b""
+
+
+def test_the_close_code_would_be_fatal_if_passed_through():
+    # Why the test above matters, without reaching into the library: this is
+    # exactly what the protocol parser does with whatever readline returns.
+    buf = bytearray()
+    with pytest.raises(TypeError):
+        buf.extend(1001)
+
+
+@pytest.mark.parametrize(
+    "msg_type, data",
+    [
+        (aiohttp.WSMsgType.CLOSING, None),
+        (aiohttp.WSMsgType.CLOSED, None),
+        (aiohttp.WSMsgType.ERROR, RuntimeError("boom")),
+    ],
+    ids=["closing", "closed", "error"],
+)
+def test_every_other_end_of_stream_reads_as_eof_too(msg_type, data):
+    # None and an exception are no more extendable into a bytearray than an int
+    # is. CLOSED already worked; it is here so a future edit cannot lose it.
+    assert _readline(aiohttp.WSMessage(msg_type, data, None)) == b""
+
+
+def test_a_real_frame_is_still_passed_through_untouched():
+    # The fix must not become a filter. Narrowing what the transport accepts is
+    # a different decision from fixing how it reports a close.
+    payload = b"PING\r\n"
+    assert _readline(aiohttp.WSMessage(aiohttp.WSMsgType.BINARY, payload, None)) == payload
+
+
+def test_installing_rebinds_the_name_the_client_resolves():
+    import nats.aio.client as nats_client
+    import nats.aio.transport as nats_transport
+
+    original = nats_client.WebSocketTransport
+    try:
+        assert install_websocket_close_fix() is True
+        patched = nats_client.WebSocketTransport
+        # The client builds a fresh transport on every reconnect, so patching
+        # the name it looks up is what makes the fix survive one.
+        assert patched is not nats_transport.WebSocketTransport
+        assert issubclass(patched, nats_transport.WebSocketTransport)
+
+        # Idempotent: connect() may be called many times in one process, and
+        # each call must not wrap the previous subclass in another.
+        assert install_websocket_close_fix() is True
+        assert nats_client.WebSocketTransport is patched
+    finally:
+        nats_client.WebSocketTransport = original
+
+
+def test_the_library_module_itself_is_left_alone():
+    # Anything else in the process that imports the transport directly keeps
+    # the stock class. The patch is scoped to how the client resolves it.
+    import nats.aio.client as nats_client
+    import nats.aio.transport as nats_transport
+
+    original = nats_client.WebSocketTransport
+    stock = nats_transport.WebSocketTransport
+    try:
+        install_websocket_close_fix()
+        assert nats_transport.WebSocketTransport is stock
+    finally:
+        nats_client.WebSocketTransport = original
+
+
+def test_an_environment_that_cannot_take_the_fix_says_so_instead_of_raising(monkeypatch):
+    # A nats-py that no longer resolves the transport through this name would
+    # make the rebind silently do nothing. Better to report it un-installed and
+    # still open the connection: a degraded reconnect beats no service.
+    import nats.aio.client as nats_client
+
+    monkeypatch.delattr(nats_client, "WebSocketTransport", raising=True)
+    assert install_websocket_close_fix() is False

--- a/tests/comms/rest/test_queue_credentials.py
+++ b/tests/comms/rest/test_queue_credentials.py
@@ -186,7 +186,17 @@ async def test_credentials_reach_nats_connect(monkeypatch):
 
     await q.connect(manage=False, name="adapy-worker-ext-01")
 
-    assert seen["opts"] == {"name": "adapy-worker-ext-01", "user_credentials": "/secrets/ext-01.creds"}
+    # Asserted key by key rather than as a whole-dict equality: connect() also
+    # merges the always-on connection policy (see _connection_policy_options).
+    # Pinning the exact settings-to-credential-option mapping stays the job of
+    # test_queue_transport_deps, which still asserts it on _connect_options.
+    assert seen["opts"]["name"] == "adapy-worker-ext-01"
+    assert seen["opts"]["user_credentials"] == "/secrets/ext-01.creds"
+    # Nothing else authenticating snuck in.
+    assert not {"user", "password", "token", "nkeys_seed", "nkeys_seed_str"} & seen["opts"].keys()
+    # And the policy did reach the real connect call — the thing that keeps this
+    # client reconnecting instead of closing permanently after ~2 minutes.
+    assert seen["opts"]["max_reconnect_attempts"] < 0
 
 
 # --- settings --------------------------------------------------------

--- a/tests/comms/rest/test_queue_reconnect.py
+++ b/tests/comms/rest/test_queue_reconnect.py
@@ -1,0 +1,66 @@
+"""Giving up on the bus is not an option any of these processes has.
+
+``nats-py`` stops reconnecting after ``max_reconnect_attempts`` (60) tries at
+``reconnect_time_wait`` (2s) — roughly two minutes. Giving up is not a pause: it
+raises ``NoServersError``, calls ``close()``, and every later operation raises
+``ConnectionClosedError: nats: connection closed`` for the life of the process.
+Nothing retries a closed client, and a closed client is what the process is left
+holding.
+
+Two minutes is shorter than an ordinary restart of the bus, so the default turns
+a routine restart into a permanent outage for any long-lived process that was
+not restarted alongside it. An API in that state still serves HTTP — so it looks
+healthy to a liveness probe while failing every request that touches the queue,
+and nothing restarts it either.
+
+These tests pin the policy, because it is invisible at the call site: nothing
+about ``connect()`` reveals which of the two behaviours it got.
+"""
+
+import inspect
+
+from ada.comms.rest.config import QueueConfig
+from ada.comms.rest.queue import JobQueue
+
+
+def _queue(**over) -> JobQueue:
+    base = dict(url="nats://localhost:4222", stream="S", subject="subj", kv_bucket="kv", durable="d")
+    base.update(over)
+    return JobQueue(QueueConfig(**base))
+
+
+def test_the_client_never_stops_trying_to_reach_the_bus():
+    # Negative is nats-py's "never stop reconnecting". Zero and the default 60
+    # both eventually close the client permanently, which is the failure.
+    assert JobQueue._connection_policy_options()["max_reconnect_attempts"] < 0
+
+
+def test_coming_and_going_is_reported():
+    # A disconnect that heals should still leave a trace: "how long was it
+    # down" is not answerable afterwards if nothing said so at the time.
+    policy = JobQueue._connection_policy_options()
+    for cb in ("disconnected_cb", "reconnected_cb", "closed_cb"):
+        assert inspect.iscoroutinefunction(policy[cb]), cb
+
+
+def test_policy_is_kept_out_of_the_credential_mapping():
+    # The two are separate on purpose. _connect_options answers "what did the
+    # operator configure" and its tests assert that mapping is exact; folding
+    # always-on policy into it would break them for no reason and blur what
+    # each is for.
+    assert _queue()._connect_options("client") == {"name": "client"}
+
+
+def test_policy_applies_whatever_the_credentials_are():
+    # Merged at connect time, so no auth branch can drop it — the kind of
+    # setting that otherwise gets lost when a new branch is added above it.
+    for over in (
+        {},
+        {"url": "ws://localhost:8080"},
+        {"url": "wss://example.invalid"},
+        {"user": "u", "password": "p"},
+        {"token": "t"},
+    ):
+        q = _queue(**over)
+        merged = {**q._connect_options("client"), **q._connection_policy_options()}
+        assert merged["max_reconnect_attempts"] < 0, over

--- a/tests/comms/rest/test_worker_bus_watchdog.py
+++ b/tests/comms/rest/test_worker_bus_watchdog.py
@@ -1,0 +1,115 @@
+"""A worker that has lost the bus must stop, not go quiet.
+
+The failure this guards against is not a disconnect — those are ordinary and
+usually heal — but the state after one where the worker neither recovers nor
+fails. A client library can stop reading without raising, leaving the connection
+object claiming to be connected while every request times out. Nothing else in
+the worker notices: the liveness file is touched by the poll loop, which keeps
+iterating happily against a dead connection, and the registry row simply goes
+stale. Meanwhile jobs route to pools this worker advertises and no longer
+consumes, and they sit there.
+
+The heartbeat is the only round-trip an idle worker makes whose failure means
+anything (an idle pull fetch times out whether the queue is quiet or the socket
+is dead), so it is what watches. These tests pin the three things that has to
+get right: it gives up after a *run* of failures, a success anywhere in that run
+clears it, and being asked to stop is not the same as losing the bus.
+"""
+
+import asyncio
+
+import pytest
+
+from ada.comms.rest.worker import BUS_HEARTBEAT_FAILURE_LIMIT, _heartbeat_until_stopped
+
+# Far below the production cadence so these run instantly. The behaviour under
+# test is the counting, not the waiting.
+TICK = 0.001
+
+
+async def _run_with(results, *, failure_limit=3, stop=None):
+    """Drive the loop with a scripted sequence of publish outcomes.
+
+    The loop is left to run until it returns on its own, or until the script is
+    exhausted and the test stops it — whichever happens first.
+    """
+    stop = stop or asyncio.Event()
+    bus_lost = asyncio.Event()
+    calls = []
+    pending = list(results)
+
+    async def publish() -> bool:
+        if not pending:
+            # Script exhausted without the loop giving up: end the test rather
+            # than spin. A test that hangs here is a test that found a bug.
+            stop.set()
+            return True
+        outcome = pending.pop(0)
+        calls.append(outcome)
+        return outcome
+
+    await asyncio.wait_for(
+        _heartbeat_until_stopped(
+            publish=publish,
+            stop=stop,
+            bus_lost=bus_lost,
+            interval=TICK,
+            failure_limit=failure_limit,
+        ),
+        timeout=5.0,
+    )
+    return bus_lost, calls
+
+
+@pytest.mark.asyncio
+async def test_a_run_of_failures_gives_up_and_says_which_kind_of_stop_it_was():
+    bus_lost, calls = await _run_with([False, False, False], failure_limit=3)
+    assert bus_lost.is_set()
+    # Exactly at the limit — not one heartbeat later, not one earlier.
+    assert calls == [False, False, False]
+
+
+@pytest.mark.asyncio
+async def test_one_success_anywhere_in_the_run_clears_the_count():
+    # THE POINT OF "CONSECUTIVE". A worker that heartbeats fine for hours with
+    # the occasional blip must never trip this; only an unbroken run does. With
+    # a limit of 3, this script never has three failures in a row.
+    bus_lost, calls = await _run_with([False, False, True, False, False], failure_limit=3)
+    assert not bus_lost.is_set()
+    assert calls == [False, False, True, False, False]
+
+
+@pytest.mark.asyncio
+async def test_being_asked_to_stop_is_not_losing_the_bus():
+    # The two exits take different codes: a supervisor should restart one and
+    # leave the other alone. A shutdown that reported bus_lost would put every
+    # deliberate stop into a restart loop.
+    stop = asyncio.Event()
+    bus_lost = asyncio.Event()
+
+    async def publish() -> bool:
+        raise AssertionError("must not heartbeat after stop is set")
+
+    stop.set()
+    await asyncio.wait_for(
+        _heartbeat_until_stopped(publish=publish, stop=stop, bus_lost=bus_lost, interval=TICK, failure_limit=3),
+        timeout=5.0,
+    )
+    assert not bus_lost.is_set()
+
+
+@pytest.mark.asyncio
+async def test_giving_up_also_stops_the_rest_of_the_worker():
+    # The poll loop watches `stop`; without setting it the heartbeat would exit
+    # alone and leave the worker consuming from a connection it just declared
+    # dead — the exact silent state this whole mechanism exists to end.
+    stop = asyncio.Event()
+    bus_lost, _ = await _run_with([False] * 3, failure_limit=3, stop=stop)
+    assert bus_lost.is_set()
+    assert stop.is_set()
+
+
+def test_the_shipped_limit_is_a_meaningful_stretch_of_time():
+    # Guards the constant itself. Dropping it to 1 would restart a worker on a
+    # single blip and lose in-flight work that would have recovered.
+    assert BUS_HEARTBEAT_FAILURE_LIMIT >= 3


### PR DESCRIPTION
A process that loses its connection to the bus should either reconnect or stop.
This fixes the third case, where it does neither — and where, from the outside
and from its own logs, it is indistinguishable from a healthy process with
nothing to do.

Observed twice: jobs sitting `queued` against a pool whose worker was still
printing `worker: ready, polling …`, and an API answering every queue-backed
request with `nats: connection closed` for ten hours while its liveness probe
stayed green.

Two smaller fixes ride along at the end — a missing module in the slim image and
a dependabot bump — rather than each taking its own CI run.

## What breaks

Three independent causes. Any one produces the same silence.

### 1. A server-closed WebSocket kills the read loop instead of reconnecting

The WebSocket transport in `nats-py` recognises exactly one aiohttp close type:

```python
async def readline(self):
    data = await self._ws.receive()
    if data.type == aiohttp.WSMsgType.CLOSED:
        return b""
    return data.data
```

`CLOSED` is what aiohttp reports for a socket that is *already* closed. It is
not what it reports when the peer closes one. A peer-initiated close arrives as
`CLOSE`, and aiohttp returns that message to the caller with `.data` set to the
close **code — an int**. So `readline` hands an int to the protocol parser,
which does `bytearray.extend(data)`:

```
TypeError: can't extend bytearray with int
```

`CLOSING` (`.data is None`) and `ERROR` (`.data` is an exception) fail the same
way for the same reason.

**Why that is worse than a crash.** `Client._read_loop` handles every expected
failure by calling `_process_op_err`, which is what schedules a reconnect. Its
final catch-all does not:

```python
except Exception as ex:
    _logger.error("nats: encountered error", exc_info=ex)
    break
```

So the TypeError breaks out of the read loop without ever entering the reconnect
path. No reader, `is_connected` still true, nothing raised to anyone.

**Who is affected.** Only clients using the WebSocket transport — what a `ws://`
or `wss://` URL selects, the shape used when the bus is reached through an HTTP
ingress rather than a raw TCP port. A TCP client gets a clean EOF from the OS
and reconnects correctly, which is why this can go unnoticed: the same server
restart that every TCP client rides out permanently strands the WebSocket ones.

### 2. Giving up on reconnect is permanent, and two minutes is not long

The client stops after `max_reconnect_attempts` (60) tries at
`reconnect_time_wait` (2s). Giving up is not a pause — it raises
`NoServersError`, calls `close()`, and from then on **every** operation raises
`ConnectionClosedError: nats: connection closed` for the life of the process.
Nothing retries a closed client, and a closed client is what the process holds.

Two minutes is shorter than an ordinary restart of the bus. So the default turns
a routine restart into a permanent outage for whichever long-lived processes
were not restarted alongside it — and an API in that state still serves HTTP, so
it stays healthy to a liveness probe while failing every request that touches
the queue. Nothing restarts it either.

This one needs no library bug to trigger. It is the default behaviour meeting a
slow rollout.

### 3. Nothing was watching

Even with both fixed, a read loop that stops without raising for any other
reason leaves the same silence, and nothing in the worker would notice:

- the liveness file is touched by the poll loop, which keeps iterating happily
  against a dead connection, so it goes on reporting health;
- the registry row goes stale and the worker drops out of the admin view, but
  the process does not care;
- an idle pull fetch times out whether the queue is quiet or the socket is dead,
  so it can never be the signal.

## What this changes

**`ada.comms.rest.nats_ws`** subclasses the transport so every flavour of close
reports `b""`. Not a workaround — it is the same signal the TCP transport gives
and the path the library is already written for: an empty read leaves the parser
buffer untouched, the next iteration sees `at_eof()` (aiohttp has marked the
socket closed by then, since its `CLOSE` branch calls `close()` before
returning), and `UnexpectedEOF` goes through `_process_op_err` into a normal
reconnect.

Installed only when the URL selects that transport, and only on the name
`nats.aio.client` resolves — `nats.aio.transport.WebSocketTransport` is left
untouched. Idempotent, and a no-op if a later release fixes this upstream. If
the environment cannot take it, it logs and returns `False` rather than raising:
a degraded reconnect beats refusing to connect at all.

**`_connection_policy_options`** sets unlimited reconnects and connection-state
callbacks. There is no scenario in which one of these processes wants to stop
trying to reach the bus and carry on running: without it there is nothing it can
do. Kept separate from `_connect_options` and merged at connect time — that one
answers "what did the operator configure" and its tests assert the mapping is
exact, so always-on policy does not belong in it.

**The registration heartbeat now doubles as a connection watchdog.** It is the
one round-trip an idle worker makes whose failure means something. After
`BUS_HEARTBEAT_FAILURE_LIMIT` consecutive failures the worker exits non-zero so
a supervisor restarts it.

*Consecutive* is the point — any success resets the count, so a worker that
heartbeats fine for hours with the occasional blip never trips it. A deliberate
shutdown sets `stop` without `bus_lost` and still exits zero, so it is not
restarted. Cleanup runs on both paths, so the stale registry row goes away on
the one exit that most needs it gone.

The heartbeat loop moved out of a closure into `_heartbeat_until_stopped` so the
counting can be tested directly.

## Also in here

**`ada.plugins` now ships into the slim viewer image.** The slim runtime is
assembled from a hand-picked list of `ada` subtrees and this one was never added
when the plugin system landed, so every viewer image has logged an ERROR with a
traceback on every boot for a module that was never shipped rather than one that
broke.

It also left a real gap: `_locally_registered_spec` resolves the plugin-job
admin declaration for a single-node viewer that preloads a plugin *into* the
API, where no worker advertises it and the in-process registry is the only
source there is. Without the module that source can never answer.

Safe on the same test `ada/cad` passes — `ada/plugins` and the whole
`external_models` subtree are stdlib-only, nothing numpy- or OCC-bound. Verified
by importing it from a tree containing only the stripped `ada/__init__.py`,
`config.py` and `plugins/`: `discover_plugins()` returns `[]` and
`external_models` imports without pulling anything native in. With no plugin
distribution installed in the slim env, discovery finds no entry points and
registers nothing — this makes the image match what the code already assumes
rather than changing what it does.

**browserslist 4.28.2 → 4.28.8**, closing dependabot alert 120
(GHSA-73wf-gq98-2v4g / CVE-2026-73088, high).

Exposure is low and worth stating rather than implying: browserslist is
dev-scope only, reachable solely as `@vitejs/plugin-react` → `@babel/core` →
`helper-compilation-targets`, so nothing of it reaches the shipped bundle. The
vulnerable path also needs a hostile `browserslist-stats.json` in the build
tree, and there is none — no such file in the repo, and `package.json` declares
no browserslist config at all. Patched anyway: a known high-severity advisory in
the build toolchain is worth one lockfile line, and an alert nobody acts on
trains people to ignore the next one.

Lockfile only — both requiring ranges already admitted the patched version, so
`package.json` is untouched. Nothing added, nothing removed; browserslist plus
its own data-package closure, all dev. `npm ci --dry-run` resolves all 464
packages. The root `version` field also moves 0.45.0 → 0.61.5, which is
pre-existing drift npm corrected in passing — `package.json` already said
0.61.5.

## Tests

18 new, across `test_nats_ws_close.py`, `test_worker_bus_watchdog.py` and
`test_queue_reconnect.py`.

The first two fixes were checked against a reverted implementation to confirm
the tests are not vacuous: passing the close payload through fails 4 of them,
and dropping the success-reset fails the consecutive-count test.

The close-code test does not assert on library internals — it pins our
behaviour, and separately shows that `bytearray.extend(1001)` raises, which is
what makes passing it through fatal rather than merely wrong. That keeps the
suite from breaking when the dependency moves.

One existing assertion changed: `test_credentials_reach_nats_connect` compared
the whole options dict, which now also carries the connection policy. It is now
asserted key by key, plus that nothing else authenticating snuck in — the exact
settings-to-credential-option mapping is still pinned whole in
`test_queue_transport_deps`, against `_connect_options`.

`194 passed, 1 skipped` across the queue / worker / capability / plugin REST
tests, re-run after rebasing onto 0.61.5; `black`, `ruff` and `isort` clean.

**Not covered:** no test drives a real reconnect against a live server closing a
real socket. The close handling, the reconnect precondition, the retry policy
and the watchdog counting are each covered, and the aiohttp and client paths
between them were read rather than assumed — but the end-to-end has been
reasoned through, not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L13WqtijrPrLyPXUuTBQuq
