### PR TITLE
feat(rest): preserve a failed job's input in an admin-only failure corpus

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -31,7 +31,7 @@ from ada.core.file_system import new_temp_path
 
 from . import auth as auth_module
 from . import db as db_module
-from . import local_jobs
+from . import failure_capture, local_jobs
 from .auth import User
 from .config import Settings, load_settings
 from .converter import (
@@ -785,6 +785,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             pool = getattr(request.app.state, "db_pool", None)
         if pool is None:
             return
+        # A failed row is only reproducible while its source still exists, and a
+        # user-scope source can be deleted at any time — so preserve it now, not
+        # when someone eventually opens the row. Content-addressed and
+        # deduplicated, so a systematic failure copies each distinct input once;
+        # returns None (and never raises) when disabled or ineligible.
+        failure_key = None
+        if failure_capture.is_failure(status):
+            failure_key = await failure_capture.capture(storage, pool, db_module, scope=scope, key=key, action=action)
         try:
             await db_module.insert_audit(
                 pool,
@@ -799,6 +807,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 duration_ms=duration_ms,
                 job_id=job_id,
                 audit_run_id=audit_run_id,
+                failure_key=failure_key,
             )
         except Exception:
             logger.exception("audit insert failed (action=%s)", action)
@@ -1525,6 +1534,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             except (TypeError, ValueError):
                 return None
 
+        # In-browser conversions patch their row here rather than through _audit
+        # or the worker's _audit_done, so failure capture needs its own call: this
+        # is the whole WASM pipeline, and without it every browser-side failure
+        # would still lose its source the moment the user deletes the file.
+        failure_key = None
+        if failure_capture.is_failure(status):
+            failure_key = await failure_capture.capture_for_job(storage, pool, db_module, job_id)
         try:
             await db_module.update_audit_by_job(
                 pool,
@@ -1536,6 +1552,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 peak_rss_kb=_int_or_none(body.get("peak_rss_kb")),
                 read_bytes=_int_or_none(body.get("read_bytes")),
                 write_bytes=_int_or_none(body.get("write_bytes")),
+                failure_key=failure_key,
             )
         except Exception as exc:
             logger.exception("audit/local update failed for %s", job_id)
@@ -1641,6 +1658,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # 'render' action (the load-time rows use 'view').
         action = "render" if (cm and cm.get("kind") == "render") else "view"
 
+        # A load/render failure is reproducible only from the exact blob that
+        # failed: re-deriving it can yield different bytes, so unlike a
+        # conversion this captures the derived artifact itself.
+        failure_key = None
+        if failure_capture.is_failure(status):
+            failure_key = await failure_capture.capture(
+                storage, pool, db_module, scope=scope_obj, key=key, action=action
+            )
+
         try:
             await db_module.insert_audit(
                 pool,
@@ -1661,6 +1687,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 write_bytes=_int_or_none(body.get("write_bytes")),
                 peak_rss_kb=_int_or_none(body.get("peak_rss_kb")),
                 client_metrics=cm,
+                failure_key=failure_key,
             )
         except Exception:
             logger.exception("audit/view record failed")
@@ -7968,7 +7995,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         try:
             result = await storage.open_stream(scope, key)
         except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
+            # The original is gone — the exact case failure capture exists for.
+            # Serve the preserved copy so a row stays reproducible after the
+            # user deletes (or replaces) the file that broke.
+            failure_key = row.get("failure_key")
+            if not failure_key:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            try:
+                result = await storage.open_stream(failure_capture.failure_scope(), failure_key)
+            except FileNotFoundError:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
         filename = key.rsplit("/", 1)[-1]
         headers = {
             "Content-Disposition": f'attachment; filename="{filename}"',

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -214,6 +214,7 @@ async def insert_audit(
     write_bytes: int | None = None,
     peak_rss_kb: int | None = None,
     client_metrics: dict | None = None,
+    failure_key: str | None = None,
 ) -> None:
     """Insert one audit_log row.
 
@@ -243,9 +244,10 @@ async def insert_audit(
                 (user_sub, scope_kind, scope_id, action, key,
                  target_format, status, error, duration_ms, job_id,
                  traceback, audit_run_id, worker_image_tag,
-                 read_bytes, write_bytes, peak_rss_kb, client_metrics)
+                 read_bytes, write_bytes, peak_rss_kb, client_metrics,
+                 failure_key)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                    $14, $15, $16, $17::jsonb)
+                    $14, $15, $16, $17::jsonb, $18)
             """,
             user_sub,
             scope_kind,
@@ -264,6 +266,7 @@ async def insert_audit(
             write_bytes,
             peak_rss_kb,
             json.dumps(client_metrics) if client_metrics is not None else None,
+            failure_key,
         )
         return
 
@@ -278,9 +281,10 @@ async def insert_audit(
                     (user_sub, scope_kind, scope_id, action, key,
                      target_format, status, error, duration_ms, job_id,
                      traceback, audit_run_id, worker_image_tag,
-                     read_bytes, write_bytes, peak_rss_kb, client_metrics)
+                     read_bytes, write_bytes, peak_rss_kb, client_metrics,
+                     failure_key)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                        $14, $15, $16, $17::jsonb)
+                        $14, $15, $16, $17::jsonb, $18)
                 """,
                 user_sub,
                 scope_kind,
@@ -299,6 +303,7 @@ async def insert_audit(
                 write_bytes,
                 peak_rss_kb,
                 json.dumps(client_metrics) if client_metrics is not None else None,
+                failure_key,
             )
             await _bump_audit_run_counter(conn, audit_run_id, status)
 
@@ -427,6 +432,7 @@ async def update_audit_by_job(
     log_key: str | None = None,
     worker_image_tag: str | None = None,
     convert_meta: dict | None = None,
+    failure_key: str | None = None,
 ) -> None:
     """Patch the audit row tied to a queue job with its final outcome.
 
@@ -461,7 +467,8 @@ async def update_audit_by_job(
                     profile_key = COALESCE($11, profile_key),
                     worker_image_tag = COALESCE($12, worker_image_tag),
                     convert_meta = COALESCE($13, convert_meta),
-                    log_key = COALESCE($14, log_key)
+                    log_key = COALESCE($14, log_key),
+                    failure_key = COALESCE($15, failure_key)
                 WHERE job_id = $1
                 RETURNING audit_run_id
                 """,
@@ -479,6 +486,7 @@ async def update_audit_by_job(
                 worker_image_tag,
                 json.dumps(convert_meta) if convert_meta is not None else None,
                 log_key,
+                failure_key,
             )
             if updated is None or updated["audit_run_id"] is None:
                 return
@@ -1165,6 +1173,33 @@ async def get_worker_packages(pool: asyncpg.Pool, worker_image_tag: str) -> dict
     }
 
 
+async def get_audit_by_job(pool: asyncpg.Pool, job_id: str) -> dict | None:
+    """Scope + source key for a queued job's audit row, newest first.
+
+    The worker patches its audit row by ``job_id`` and its error paths never
+    carry the scope, so failure capture reads it back from here rather than
+    threading a source key through every one of them. Narrow on purpose — this
+    runs on the failure path and only needs enough to address the blob.
+    """
+    row = await pool.fetchrow(
+        """
+        SELECT id, scope_kind, scope_id, key, action, status
+        FROM audit_log WHERE job_id = $1 ORDER BY id DESC LIMIT 1
+        """,
+        job_id,
+    )
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "scope_kind": row["scope_kind"],
+        "scope_id": row["scope_id"],
+        "key": row["key"],
+        "action": row["action"],
+        "status": row["status"],
+    }
+
+
 async def get_audit_by_id(pool: asyncpg.Pool, audit_id: int) -> dict | None:
     """Fetch a single audit row by id. Used by the profile-download
     endpoint to look up the blob key + scope without re-listing, and
@@ -1172,7 +1207,7 @@ async def get_audit_by_id(pool: asyncpg.Pool, audit_id: int) -> dict | None:
     error context for a failed conversion."""
     row = await pool.fetchrow(
         """
-        SELECT id, ts, user_sub, scope_kind, scope_id, profile_key, log_key, key,
+        SELECT id, ts, user_sub, scope_kind, scope_id, profile_key, log_key, failure_key, key,
                action, target_format, status, error, traceback,
                duration_ms, job_id, metrics_samples, audit_run_id,
                issue_bot_status, issue_bot_synced_at, issue_bot_last_error
@@ -1199,6 +1234,7 @@ async def get_audit_by_id(pool: asyncpg.Pool, audit_id: int) -> dict | None:
         "scope_id": row["scope_id"],
         "profile_key": row["profile_key"],
         "log_key": row["log_key"],
+        "failure_key": row["failure_key"],
         "key": row["key"],
         "action": row["action"],
         "target_format": row["target_format"],

--- a/src/ada/comms/rest/failure_capture.py
+++ b/src/ada/comms/rest/failure_capture.py
@@ -1,0 +1,211 @@
+"""Preserve the input of a failed job in an admin-only failure corpus.
+
+A failure is reproducible only while the file it failed on still exists. That
+file belongs to the user, who may delete or replace it at any time, while the
+``audit_log`` row survives — so ``GET /admin/audit/{id}/source`` 404s on exactly
+the rows worth investigating. Copying at failure time closes that race.
+
+The destination is the ``corpus`` scope: already admin-only on every axis and
+already in the admin scope picker, so this adds no authorization surface.
+
+Keys are content-addressed on the source's storage identity, so identical bytes
+are stored once however many rows point at them — ``failure_key`` is a pointer,
+and nothing here may delete a blob another row still references.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+
+from .scope import Scope
+
+logger = logging.getLogger(__name__)
+
+ENABLED_ENV = "ADA_VIEWER_FAILURE_CORPUS"
+SLUG_ENV = "ADA_VIEWER_FAILURE_CORPUS_SLUG"
+TIMEOUT_ENV = "ADA_VIEWER_FAILURE_CORPUS_TIMEOUT_S"
+
+_DEFAULT_SLUG = "failures"
+_DEFAULT_TIMEOUT_S = 30.0
+
+#: Terminal statuses that mean "this job failed on its input".
+FAILED_STATUSES = frozenset({"error", "failed"})
+
+#: Scopes whose files someone can delete. ``corpus`` is absent: those assets are
+#: frozen, so a row naming one stays reproducible without a copy.
+CAPTURED_SCOPE_KINDS = frozenset({"user", "shared", "project"})
+
+#: Actions whose input IS a derived blob. A conversion reads a source and derived
+#: output is rebuildable from it, so capturing that would be redundant — but a
+#: render reads the derived artifact, and re-deriving it can produce different
+#: bytes than the ones that actually failed. For these, the derived blob is the
+#: evidence.
+DERIVED_INPUT_ACTIONS = frozenset({"view", "render"})
+
+_TRUE = {"1", "true", "yes", "on"}
+
+# Slugs whose corpus row this process has ensured. Capture runs on every failure;
+# re-checking a row that cannot vanish mid-process would cost a query each time.
+_ensured_slugs: set[str] = set()
+
+
+def enabled() -> bool:
+    return os.environ.get(ENABLED_ENV, "").strip().lower() in _TRUE
+
+
+def slug() -> str:
+    return os.environ.get(SLUG_ENV, "").strip() or _DEFAULT_SLUG
+
+
+def timeout_s() -> float:
+    try:
+        return float(os.environ.get(TIMEOUT_ENV, "").strip() or _DEFAULT_TIMEOUT_S)
+    except ValueError:
+        return _DEFAULT_TIMEOUT_S
+
+
+def failure_scope() -> Scope:
+    return Scope.corpus(slug())
+
+
+def is_failure(status: str | None) -> bool:
+    return (status or "").strip().lower() in FAILED_STATUSES
+
+
+def _identity(head: dict, scope: Scope, key: str) -> str:
+    """Token naming *these bytes*, from object metadata alone.
+
+    ``e_tag`` is the content discriminator when the backend reports one (S3 and
+    Garage do). It is an MD5 of the content for single-part uploads, so identical
+    files collapse; for multipart it also encodes the part layout, so identical
+    content uploaded with different part sizes stores twice. That costs a
+    duplicate, never a wrong hit. Size is mixed in so a token can only be shared
+    by objects agreeing on both.
+
+    Without an e_tag there is no content signal short of downloading the blob, so
+    the fallback keys on object identity: repeat failures of one object still
+    collapse, two identical files do not.
+    """
+    etag = (head.get("e_tag") or "").strip().strip('"')
+    size = head.get("size")
+    if etag:
+        material = f"etag:{etag}:{size}"
+    else:
+        material = f"obj:{scope.prefix()}/{key}:{size}:{head.get('last_modified')}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:32]
+
+
+def destination_key(head: dict, scope: Scope, key: str) -> str:
+    """``<identity><ext>``.
+
+    The filename is excluded on purpose: including it would store the same bytes
+    twice under two names. Nothing is lost, since the audit row keeps the key the
+    failure happened on. The extension is kept because the repro path dispatches
+    on it, and identical bytes offered as two formats are two reproductions.
+    """
+    basename = key.rsplit("/", 1)[-1]
+    ext = ""
+    if "." in basename:
+        ext = "." + basename.rsplit(".", 1)[-1].lower()
+    return f"{_identity(head, scope, key)}{ext}"
+
+
+def should_capture(scope_kind: str | None, key: str | None, action: str | None = None) -> bool:
+    from .converter import is_derived_key
+
+    if not enabled():
+        return False
+    if scope_kind not in CAPTURED_SCOPE_KINDS or not key:
+        return False
+    if is_derived_key(key) and action not in DERIVED_INPUT_ACTIONS:
+        return False
+    return True
+
+
+async def _ensure_corpus_row(pool, db_module) -> None:
+    """Register the corpus so it appears in the admin scope picker.
+
+    Storage needs no registration, but ``/api/me`` builds the picker from the
+    ``corpora`` table — without a row the captured files are unreachable from
+    the UI.
+    """
+    name = slug()
+    if name in _ensured_slugs or pool is None:
+        return
+    try:
+        if await db_module.get_corpus_by_slug(pool, name) is None:
+            await db_module.create_corpus(
+                pool,
+                slug=name,
+                name="Failure corpus",
+                description="Inputs preserved automatically when a job failed on them.",
+                created_by=None,
+            )
+    except Exception:
+        # Losing the insert race is the expected case (partial-unique on slug),
+        # and an unregistered corpus is no reason to drop the bytes.
+        logger.debug("failure capture: could not ensure corpus row %r", name, exc_info=True)
+    _ensured_slugs.add(name)
+
+
+async def capture(storage, pool, db_module, *, scope: Scope, key: str, action: str | None = None) -> str | None:
+    """Copy ``scope/key`` into the failure corpus; return the destination key.
+
+    ``None`` when disabled, ineligible, already gone, or on any error. Never
+    raises — losing the copy beats losing the audit row it belongs to.
+    """
+    if not should_capture(scope.kind, key, action):
+        return None
+    try:
+        return await asyncio.wait_for(_capture(storage, pool, db_module, scope, key), timeout=timeout_s())
+    except asyncio.TimeoutError:
+        logger.warning("failure capture: timed out copying %s from %s", key, scope.prefix())
+        return None
+    except Exception:
+        logger.exception("failure capture: could not preserve %s from %s", key, scope.prefix())
+        return None
+
+
+async def _capture(storage, pool, db_module, scope: Scope, key: str) -> str | None:
+    head = await storage.head(scope, key)
+    if head is None:
+        logger.info("failure capture: %s in %s is already gone", key, scope.prefix())
+        return None
+
+    dst_scope = failure_scope()
+    dst_key = destination_key(head, scope, key)
+    if await storage.exists(dst_scope, dst_key):
+        return dst_key
+
+    await _ensure_corpus_row(pool, db_module)
+    # overwrite=True because the safe default raises "copy-if-not-exists not
+    # supported" on S3; exists() above is the collision guard, and a lost race
+    # rewrites identical content under a content-addressed key.
+    await storage.copy(scope, key, dst_scope, dst_key, overwrite=True)
+    logger.info("failure capture: preserved %s as %s/%s", key, dst_scope.prefix(), dst_key)
+    return dst_key
+
+
+async def capture_for_job(storage, pool, db_module, job_id: str) -> str | None:
+    """Capture for a queued job, resolving scope/key/action from its audit row.
+
+    The worker's error paths carry only a job id, and there are a dozen of them;
+    reading the row back keeps capture to one call site per funnel.
+    """
+    if not enabled() or pool is None:
+        return None
+    try:
+        row = await db_module.get_audit_by_job(pool, job_id)
+    except Exception:
+        logger.exception("failure capture: could not resolve audit row for job %s", job_id)
+        return None
+    if row is None:
+        return None
+    kind, key, action = row.get("scope_kind"), row.get("key"), row.get("action")
+    if not should_capture(kind, key, action):
+        return None
+    scope = Scope.shared() if kind == "shared" else Scope(kind=kind, id=row.get("scope_id"))
+    return await capture(storage, pool, db_module, scope=scope, key=key, action=action)

--- a/src/ada/comms/rest/migrations/027_audit_log_failure_key.sql
+++ b/src/ada/comms/rest/migrations/027_audit_log_failure_key.sql
@@ -1,0 +1,12 @@
+-- 027_audit_log_failure_key.sql — pointer to the preserved copy of a failed job's source.
+--
+-- A failed conversion is only reproducible while its source blob still exists, and a
+-- user-scope source can be deleted (or expire) at any time — the audit row outlives the
+-- bytes it refers to, so `GET /admin/audit/{id}/source` starts 404ing on exactly the rows
+-- worth investigating. Capture-at-failure copies the source into the admin-only failure
+-- corpus while it is still there; ``failure_key`` is where that copy landed.
+--
+-- Content-addressed on the source's storage identity, so one blob is stored once no matter
+-- how many rows point at it: this column is a many-to-one pointer, not an owner.
+
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS failure_key text;

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -40,7 +40,7 @@ from ada.config import logger
 from ada.core.file_system import new_temp_path
 
 from . import db as db_module
-from . import source_cache
+from . import failure_capture, source_cache
 from .config import load_settings
 from .converter import LEGACY_CONVERT_EXTS, ConverterRegistry, convert
 from .qualification import CAPABILITY_REQUIREMENTS_KEY, evaluate
@@ -365,6 +365,10 @@ _WORKER_IMAGE_TAG: str | None = None
 # worker loop wires it (a handler running in a unit test just sees no stop event
 # and polls to its timeout).
 _WORKER_STOP: "asyncio.Event | None" = None
+# Published for failure capture, which hangs off _audit_done — a dozen error
+# paths reach that with only a job id, and threading a Storage through each of
+# them to preserve a blob would be a lot of plumbing for one best-effort copy.
+_WORKER_STORAGE: "Storage | None" = None
 
 # Chained procedural_detail waits for the upstream structural build (a DIFFERENT
 # pool, no ordering guarantee) to write the neutral artifact before it runs. Poll
@@ -445,6 +449,13 @@ async def _audit_done(
     if db_pool is None:
         return
     metrics = metrics or {}
+    # Preserve the input of a failed job while it still exists: the row outlives
+    # the blob, and a user-scope source can be deleted at any time. Resolved from
+    # the row rather than the call site so every error path is covered by this one
+    # hook. Best-effort and deduplicated; None when disabled or ineligible.
+    failure_key = None
+    if status == "error" and _WORKER_STORAGE is not None:
+        failure_key = await failure_capture.capture_for_job(_WORKER_STORAGE, db_pool, db_module, job_id)
     try:
         await db_module.update_audit_by_job(
             db_pool,
@@ -462,6 +473,7 @@ async def _audit_done(
             log_key=metrics.get("log_key"),
             worker_image_tag=_WORKER_IMAGE_TAG,
             convert_meta=metrics.get("convert_meta"),
+            failure_key=failure_key,
         )
     except Exception:
         logger.exception("worker: audit update failed for job %s", job_id)
@@ -4298,6 +4310,8 @@ async def _run() -> None:
 
     logger.info("worker: booting capabilities=%s", os.environ.get("ADA_WORKER_CAPABILITIES", "base"))
     storage = Storage.from_settings(settings)
+    global _WORKER_STORAGE
+    _WORKER_STORAGE = storage
     queue = JobQueue(settings.queue)
     logger.info("worker: connecting to NATS subject=%s", settings.queue.subject)
     # A worker only ever *uses* the JetStream topology; the API creates

--- a/tests/comms/rest/test_audit_source_fallback.py
+++ b/tests/comms/rest/test_audit_source_fallback.py
@@ -1,0 +1,127 @@
+"""``GET /admin/audit/{id}/source`` falls back to the preserved copy.
+
+Capture exists so a failed row stays reproducible after its source is gone;
+that is only true if the download route actually reaches for the preserved
+copy. Pinning it here keeps every consumer — the CLI's ``audit fetch`` /
+``audit repro`` and the admin panel alike — on one code path, so none of them
+needs to know the failure corpus exists.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as dbm  # noqa: E402
+from ada.comms.rest import failure_capture  # noqa: E402
+from ada.comms.rest import storage as storage_module  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+
+PRESERVED = b"the exact bytes that broke the converter"
+ORIGINAL_KEY = "decks/gone.xml"
+FAILURE_KEY = "0123456789abcdef0123456789abcdef.xml"
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""),
+        database_url="",
+    )
+
+
+def _row(**over):
+    row = {
+        "id": 1,
+        "scope_kind": "user",
+        "scope_id": "sub-abc",
+        "key": ORIGINAL_KEY,
+        "failure_key": None,
+        "status": "error",
+    }
+    row.update(over)
+    return row
+
+
+@pytest.fixture
+def client_with_row(monkeypatch, tmp_path):
+    """App whose audit row is synthetic and whose original source is gone."""
+
+    def _make(row):
+        async def fake_get_audit_by_id(pool, audit_id):
+            return row
+
+        monkeypatch.setattr(dbm, "get_audit_by_id", fake_get_audit_by_id)
+
+        async def fake_open_stream(self, scope, key):
+            # The original is gone; only the preserved copy resolves.
+            if scope.kind == "corpus" and key == FAILURE_KEY:
+
+                async def _stream():
+                    yield PRESERVED
+
+                return storage_module.StreamResult(stream=_stream(), content_encoding=None)
+            raise FileNotFoundError(f"Object at location {scope.prefix()}/{key} not found")
+
+        monkeypatch.setattr(storage_module.Storage, "open_stream", fake_open_stream)
+
+        app = create_app(_settings(tmp_path))
+        client = TestClient(app)
+        client.__enter__()
+        app.state.db_pool = object()
+        return client
+
+    return _make
+
+
+def test_a_row_with_a_preserved_copy_still_downloads(client_with_row):
+    client = client_with_row(_row(failure_key=FAILURE_KEY))
+    r = client.get("/api/admin/audit/1/source")
+    assert r.status_code == 200, r.text
+    assert r.content == PRESERVED
+    # Named for the key the failure happened on, not the content-addressed one —
+    # the operator downloading it is investigating `gone.xml`.
+    assert "gone.xml" in r.headers.get("content-disposition", "")
+
+
+def test_a_row_without_a_preserved_copy_still_404s(client_with_row):
+    """No capture (disabled, ineligible, or source already gone) → unchanged."""
+    client = client_with_row(_row(failure_key=None))
+    assert client.get("/api/admin/audit/1/source").status_code == 404
+
+
+def test_a_preserved_copy_that_is_itself_missing_404s(client_with_row):
+    """A pointer to a blob someone pruned must not 500."""
+    client = client_with_row(_row(failure_key="deadbeef.xml"))
+    assert client.get("/api/admin/audit/1/source").status_code == 404
+
+
+def test_the_fallback_reads_from_the_admin_only_corpus(client_with_row):
+    """The preserved copy lives in a scope only admins can address."""
+    assert failure_capture.failure_scope().kind == "corpus"
+    client = client_with_row(_row(failure_key=FAILURE_KEY))
+    assert client.get("/api/admin/audit/1/source").status_code == 200

--- a/tests/comms/rest/test_failure_capture.py
+++ b/tests/comms/rest/test_failure_capture.py
@@ -1,0 +1,248 @@
+"""Capture of a failed job's input into the admin-only failure corpus.
+
+Pins the two properties that make it safe to run on every failure — one object
+per distinct input, and it never raises — plus the eligibility rules.
+
+Storage is faked: what matters is which calls are made, not that an object store
+round-trips them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ada.comms.rest import failure_capture
+from ada.comms.rest.scope import Scope
+
+USER = Scope.user("sub-abc")
+OTHER_USER = Scope.user("sub-xyz")
+DERIVED = "_derived/m.ifc.glb"
+
+
+class FakeStorage:
+    def __init__(self, objects=None):
+        self.objects = objects or {}  # (scope_prefix, key) -> head dict
+        self.copies: list[tuple[str, str, str, str]] = []
+        self.copy_error: Exception | None = None
+        self.copy_delay = 0.0
+
+    async def head(self, scope, key):
+        return self.objects.get((scope.prefix(), key))
+
+    async def exists(self, scope, key):
+        return (scope.prefix(), key) in self.objects
+
+    async def copy(self, src_scope, src_key, dst_scope, dst_key, *, overwrite=False):
+        if self.copy_delay:
+            await asyncio.sleep(self.copy_delay)
+        if self.copy_error is not None:
+            raise self.copy_error
+        self.copies.append((src_scope.prefix(), src_key, dst_scope.prefix(), dst_key))
+        self.objects[(dst_scope.prefix(), dst_key)] = {"e_tag": "copied", "size": 1}
+
+
+class FakeDb:
+    def __init__(self, corpus=None):
+        self.corpus = corpus
+        self.created: list[str] = []
+        self.rows: dict[str, dict] = {}
+
+    async def get_corpus_by_slug(self, pool, slug):
+        return self.corpus
+
+    async def create_corpus(self, pool, *, slug, name, description=None, created_by=None):
+        self.created.append(slug)
+        self.corpus = {"slug": slug}
+        return self.corpus
+
+    async def get_audit_by_job(self, pool, job_id):
+        return self.rows.get(job_id)
+
+
+def _head(etag="etag-1", size=1234, last_modified="2026-01-01T00:00:00+00:00"):
+    return {"e_tag": etag, "size": size, "last_modified": last_modified}
+
+
+def _run(storage, db=None, **kw):
+    return asyncio.run(failure_capture.capture(storage, object(), db or FakeDb(), **kw))
+
+
+@pytest.fixture
+def on(monkeypatch):
+    monkeypatch.setenv(failure_capture.ENABLED_ENV, "true")
+    failure_capture._ensured_slugs.clear()
+
+
+# ── the governance flag ───────────────────────────────────────────────────
+
+
+def test_capture_is_off_unless_explicitly_enabled(monkeypatch):
+    monkeypatch.delenv(failure_capture.ENABLED_ENV, raising=False)
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): _head()})
+    assert _run(storage, scope=USER, key="m.ifc") is None
+    assert storage.copies == [], "must not duplicate user data until an operator opts in"
+
+
+# ── eligibility ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "scope", [Scope.user("sub-abc"), Scope.shared(), Scope.project("proj-1")], ids=["user", "shared", "project"]
+)
+def test_live_scopes_are_captured(on, scope):
+    storage = FakeStorage({(scope.prefix(), "m.ifc"): _head()})
+    assert _run(storage, scope=scope, key="m.ifc") is not None
+    assert len(storage.copies) == 1
+
+
+def test_corpus_sources_are_not_captured(on):
+    """Corpus assets are frozen, so a row naming one stays reproducible."""
+    corpus = Scope.corpus("cad-baseline")
+    storage = FakeStorage({(corpus.prefix(), "m.ifc"): _head()})
+    assert _run(storage, scope=corpus, key="m.ifc") is None
+    assert storage.copies == []
+
+
+@pytest.mark.parametrize("action", [None, "convert"])
+def test_derived_output_of_a_conversion_is_not_captured(on, action):
+    """Rebuildable from the source the same row already points at."""
+    storage = FakeStorage({(USER.prefix(), DERIVED): _head()})
+    assert _run(storage, scope=USER, key=DERIVED, action=action) is None
+    assert storage.copies == []
+
+
+@pytest.mark.parametrize("action", ["view", "render"])
+def test_a_failed_render_captures_the_derived_blob_it_read(on, action):
+    """A render's input IS the derived artifact: re-deriving may not reproduce
+    the bytes that actually failed, so the blob itself is the evidence."""
+    storage = FakeStorage({(USER.prefix(), DERIVED): _head()})
+    got = _run(storage, scope=USER, key=DERIVED, action=action)
+    assert got is not None and got.endswith(".glb")
+    assert len(storage.copies) == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [("error", True), ("failed", True), ("ok", False), ("done", False), ("cancelled", False), (None, False)],
+)
+def test_only_failing_statuses_count(status, expected):
+    assert failure_capture.is_failure(status) is expected
+
+
+# ── stored once ───────────────────────────────────────────────────────────
+
+
+def test_identical_content_from_different_users_shares_one_object(on):
+    same = _head(etag="shared-etag", size=999)
+    storage = FakeStorage({(USER.prefix(), "a.ifc"): same, (OTHER_USER.prefix(), "b.ifc"): dict(same)})
+    db = FakeDb()
+    first = _run(storage, db, scope=USER, key="a.ifc")
+    second = _run(storage, db, scope=OTHER_USER, key="b.ifc")
+    assert first == second and first is not None
+    assert len(storage.copies) == 1, "the second capture must not re-copy identical bytes"
+
+
+def test_repeat_failure_on_one_object_copies_once(on):
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): _head()})
+    db = FakeDb()
+    keys = [_run(storage, db, scope=USER, key="m.ifc") for _ in range(5)]
+    assert len(set(keys)) == 1
+    assert len(storage.copies) == 1
+
+
+def test_different_content_gets_different_objects(on):
+    storage = FakeStorage(
+        {(USER.prefix(), "a.ifc"): _head(etag="etag-a", size=1), (USER.prefix(), "b.ifc"): _head(etag="etag-b", size=2)}
+    )
+    db = FakeDb()
+    assert _run(storage, db, scope=USER, key="a.ifc") != _run(storage, db, scope=USER, key="b.ifc")
+    assert len(storage.copies) == 2
+
+
+def test_same_bytes_under_different_names_share_one_object(on):
+    """Dedup survives a rename — the filename is not part of the identity."""
+    same = _head(etag="one-etag", size=42)
+    storage = FakeStorage({(USER.prefix(), "a.ifc"): same, (USER.prefix(), "renamed.ifc"): dict(same)})
+    db = FakeDb()
+    assert _run(storage, db, scope=USER, key="a.ifc") == _run(storage, db, scope=USER, key="renamed.ifc")
+    assert len(storage.copies) == 1
+
+
+def test_same_bytes_offered_as_two_formats_stay_separate(on):
+    same = _head(etag="one-etag", size=42)
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): same, (USER.prefix(), "m.step"): dict(same)})
+    db = FakeDb()
+    a, b = _run(storage, db, scope=USER, key="m.ifc"), _run(storage, db, scope=USER, key="m.step")
+    assert a != b and a.endswith(".ifc") and b.endswith(".step")
+
+
+def test_destination_keeps_the_extension_but_not_the_name(on):
+    storage = FakeStorage({(USER.prefix(), "decks/big model.ifc"): _head()})
+    got = _run(storage, scope=USER, key="decks/big model.ifc")
+    assert got.endswith(".ifc") and "big model" not in got
+
+
+def test_without_an_etag_dedup_falls_back_to_object_identity(on):
+    """No content signal short of downloading, so repeat failures of one object
+    still collapse but two identical files do not."""
+    no_etag = {"e_tag": None, "size": 5, "last_modified": "2026-01-01T00:00:00+00:00"}
+    storage = FakeStorage({(USER.prefix(), "a.ifc"): no_etag, (OTHER_USER.prefix(), "b.ifc"): dict(no_etag)})
+    db = FakeDb()
+    a = _run(storage, db, scope=USER, key="a.ifc")
+    assert a == _run(storage, db, scope=USER, key="a.ifc")
+    assert a != _run(storage, db, scope=OTHER_USER, key="b.ifc")
+
+
+# ── never raises ──────────────────────────────────────────────────────────
+
+
+def test_an_input_that_is_already_gone_is_not_an_error(on):
+    storage = FakeStorage({})
+    assert _run(storage, scope=USER, key="gone.ifc") is None
+    assert storage.copies == []
+
+
+def test_a_failed_copy_never_propagates(on):
+    """Recording the failure matters more than preserving its input."""
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): _head()})
+    storage.copy_error = RuntimeError("object store unavailable")
+    assert _run(storage, scope=USER, key="m.ifc") is None
+
+
+def test_a_slow_copy_is_bounded(on, monkeypatch):
+    monkeypatch.setenv(failure_capture.TIMEOUT_ENV, "0.05")
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): _head()})
+    storage.copy_delay = 5.0
+    assert _run(storage, scope=USER, key="m.ifc") is None
+
+
+def test_corpus_row_is_created_so_the_scope_is_reachable_in_the_ui(on):
+    storage = FakeStorage({(USER.prefix(), "m.ifc"): _head()})
+    db = FakeDb(corpus=None)
+    _run(storage, db, scope=USER, key="m.ifc")
+    assert db.created == [failure_capture.slug()]
+
+
+# ── job-id resolution (the worker's single hook) ──────────────────────────
+
+
+def test_capture_for_job_resolves_scope_and_action_from_the_row(on):
+    storage = FakeStorage({(USER.prefix(), DERIVED): _head()})
+    db = FakeDb()
+    db.rows["job-1"] = {"scope_kind": "user", "scope_id": "sub-abc", "key": DERIVED, "action": "render"}
+    assert asyncio.run(failure_capture.capture_for_job(storage, object(), db, "job-1")) is not None
+    assert storage.copies[0][:2] == (USER.prefix(), DERIVED)
+
+
+def test_capture_for_job_ignores_a_corpus_row(on):
+    storage = FakeStorage({(Scope.corpus("base").prefix(), "m.ifc"): _head()})
+    db = FakeDb()
+    db.rows["job-2"] = {"scope_kind": "corpus", "scope_id": "base", "key": "m.ifc", "action": "convert"}
+    assert asyncio.run(failure_capture.capture_for_job(storage, object(), db, "job-2")) is None
+    assert storage.copies == []
+
+
+def test_capture_for_job_tolerates_a_missing_row(on):
+    assert asyncio.run(failure_capture.capture_for_job(FakeStorage({}), object(), FakeDb(), "nope")) is None

--- a/tests/comms/rest/test_failure_capture_hooks.py
+++ b/tests/comms/rest/test_failure_capture_hooks.py
@@ -1,0 +1,141 @@
+"""Every path that records a terminal failure must capture its input.
+
+Four write rows, and they are genuinely separate: ``_audit`` inserts for
+in-process work, the worker patches by job id, in-browser conversions patch
+through ``audit/local``, and browser load/render failures insert through
+``audit/view``. The last two call the db layer directly rather than going
+through either of the first two, so a hook that covers only those would
+silently exempt the whole browser side.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-storage-"))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as dbm  # noqa: E402
+from ada.comms.rest import failure_capture  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+
+JOB_ID = "wasm-abc123"
+DERIVED = "_derived/m.ifc.glb"
+PRESERVED = "cafebabe.glb"
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(enabled=False, issuer="", client_id="", audience="", admin_group="", cli_token_secret=""),
+        database_url="",
+    )
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path):
+    """Client with the db layer stubbed and capture spied."""
+    captured: list[dict] = []
+    written: list[dict] = []
+
+    async def fake_owner(pool, job_id):
+        from ada.comms.rest.auth import User
+
+        return {"user_sub": User.local_dev().sub}
+
+    async def fake_update(pool, **kw):
+        written.append(kw)
+
+    async def fake_insert(pool, **kw):
+        written.append(kw)
+
+    async def fake_capture(storage, pool, db_module, *, scope, key, action=None):
+        captured.append({"key": key, "action": action})
+        return PRESERVED
+
+    async def fake_capture_for_job(storage, pool, db_module, job_id):
+        captured.append({"job_id": job_id})
+        return PRESERVED
+
+    monkeypatch.setattr(dbm, "get_audit_owner_by_job", fake_owner)
+    monkeypatch.setattr(dbm, "update_audit_by_job", fake_update)
+    monkeypatch.setattr(dbm, "insert_audit", fake_insert)
+    monkeypatch.setattr(failure_capture, "capture", fake_capture)
+    monkeypatch.setattr(failure_capture, "capture_for_job", fake_capture_for_job)
+
+    app = create_app(_settings(tmp_path))
+    client = TestClient(app)
+    client.__enter__()
+    app.state.db_pool = object()
+    return client, captured, written
+
+
+# ── in-browser conversions (audit/local) ──────────────────────────────────
+
+
+def test_a_browser_conversion_failure_captures(harness):
+    client, captured, written = harness
+    r = client.post(f"/api/scopes/user:me/audit/local/{JOB_ID}", json={"status": "error"})
+    assert r.status_code == 200, r.text
+    assert captured == [{"job_id": JOB_ID}], "the WASM pipeline must not be exempt"
+    assert written[0]["failure_key"] == PRESERVED
+
+
+@pytest.mark.parametrize("status", ["done", "ok", "skipped", "cancelled"])
+def test_a_browser_conversion_success_captures_nothing(harness, status):
+    client, captured, written = harness
+    assert client.post(f"/api/scopes/user:me/audit/local/{JOB_ID}", json={"status": status}).status_code == 200
+    assert captured == []
+    assert written[0]["failure_key"] is None
+
+
+# ── browser load / render (audit/view) ────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", ["error", "failed"])
+def test_a_failed_model_load_captures_the_blob_it_read(harness, status):
+    client, captured, written = harness
+    r = client.post("/api/scopes/user:me/audit/view", json={"key": DERIVED, "status": status})
+    assert r.status_code == 201, r.text
+    # Derived, and captured anyway: for a render the artifact IS the input.
+    assert captured == [{"key": DERIVED, "action": "view"}]
+    assert written[0]["failure_key"] == PRESERVED
+
+
+def test_a_failed_render_window_is_captured_under_the_render_action(harness):
+    client, captured, written = harness
+    r = client.post(
+        "/api/scopes/user:me/audit/view",
+        json={"key": DERIVED, "status": "error", "client_metrics": {"kind": "render"}},
+    )
+    assert r.status_code == 201, r.text
+    assert captured == [{"key": DERIVED, "action": "render"}]
+
+
+def test_a_successful_view_captures_nothing(harness):
+    client, captured, written = harness
+    assert client.post("/api/scopes/user:me/audit/view", json={"key": DERIVED, "status": "ok"}).status_code == 201
+    assert captured == []
+    assert written[0]["failure_key"] is None


### PR DESCRIPTION
A failure is reproducible only while the file it failed on still exists. That file belongs to the user, who can delete or replace it at any time, while the audit row survives — so `GET /admin/audit/{id}/source` 404s on exactly the rows worth investigating. This copies the input at failure time to close that race.

### Where it goes

The `corpus` scope. It is already admin-only on every axis (`can_access` returns `is_admin` for it regardless of slug) and already appears in the admin scope picker, so this adds no authorization surface. A new bucket or scope kind would mean a second ACL to keep in step with that one.

### Stored once

Keys are content-addressed on the source's storage identity via `Storage.head` — object metadata, no download. The same bytes failing repeatedly (a retried job, a sweep re-running one input, two users holding the same file) occupy one object, and capture skips the copy when the key already exists.

The filename is deliberately **not** part of the key: including it would store identical content twice under two names. Nothing is lost — the audit row keeps the key the failure happened on, and that is the index into the corpus. The extension is kept, because the repro path dispatches on it.

`failure_key` is a many-to-one pointer, so nothing here may delete a blob another row still references.

Identity comes from the ETag plus size. For single-part uploads that is an MD5 of the content, so identical files collapse; for multipart it also encodes the part layout, so the same content uploaded with different part sizes stores twice — a wasted copy, never a wrong hit. With no ETag the fallback keys on object identity: repeat failures of one object still collapse, two identical files do not.

### Four write paths, none sharing a funnel

`_audit`, the worker's `_audit_done`, and the two browser endpoints (`audit/local`, `audit/view`) which call the db layer directly. All four capture. The worker and `audit/local` resolve scope/key/action from the row rather than threading a source key through a dozen error paths.

### What gets captured depends on what the job read

- **Conversion** reads a source; its derived output is rebuildable from that source, so derived keys are skipped.
- **Load / render** reads the derived artifact, and re-deriving it can produce different bytes than the ones that failed — so there the artifact itself is the evidence and is preserved.
- **Corpus** sources are frozen and cannot vanish under a row, so they are never copied.

### Repro keeps working

`GET /admin/audit/{id}/source` falls back to the preserved copy when the original is gone, so `audit fetch` / `audit repro` and the admin panel need no changes and no knowledge of the corpus.

### Safety

Off by default (`ADA_VIEWER_FAILURE_CORPUS`): it duplicates user data into a location every admin can read, which is a deployment decision rather than a default. Capture never raises and is bounded by a timeout — losing the copy beats losing the row it belongs to.

### Tests

42 new tests; full REST suite 664 passed / 91 skipped. Each hook was verified to fail its test when reverted, including the two browser paths.

Two known gaps, neither a regression: `.rmed` sidecars are not co-captured (`audit fetch` never downloaded them either), and there is no backfill — existing rows whose sources are already gone stay unreproducible. No retention policy yet; dedup covers the growth mode, and a TTL is better set against real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Bb3ugvU6FEj4bukxTfP73
