### PR TITLE
fix: Explain the issue-target token per forge

### DIFF
--- a/src/frontend/src/components/admin/IssueTargetTab.tsx
+++ b/src/frontend/src/components/admin/IssueTargetTab.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useState} from "react";
 import {IssueTargetConfig, viewerApi} from "@/services/viewerApi";
+import InfoIcon from "@/components/icons/InfoIcon";
 
 // Admin tab — configure where the audit-bot publishes failure
 // issues (the admin audit-panel design notes).
@@ -17,12 +18,96 @@ const KIND_HINTS: Record<IssueTargetConfig["kind"], string> = {
     forgejo: "Forgejo / Gitea. base_url is required, e.g. https://git.example.com/api/v1",
 };
 
+// Per-forge setup guide, shown behind the ⓘ toggle. The bot only ever
+// reads, creates and comments on issues, so the token it needs is
+// narrow — spelling that out here saves a round-trip to the docs and
+// discourages pasting an over-scoped credential into the secret store.
+const KIND_INFO: Partial<Record<IssueTargetConfig["kind"], React.ReactNode>> = {
+    github: (
+        <>
+            <p>
+                Use a <strong>fine-grained personal access token</strong>:{" "}
+                <em>Settings → Developer settings → Personal access tokens → Fine-grained tokens</em>.
+            </p>
+            <ul className="list-disc pl-4 space-y-1">
+                <li>
+                    <strong>Repository access</strong> — <em>Only select repositories</em>, and pick the
+                    repository entered above.
+                </li>
+                <li>
+                    <strong>Permissions</strong> — <code>Issues: Read and write</code>, and nothing else.
+                    <code>Metadata: Read-only</code> is added automatically.
+                </li>
+                <li>
+                    The token's account needs at least <strong>Triage</strong> on the repository. Below
+                    that, GitHub silently drops the labels on a new issue — and the bot finds its own
+                    issues by label, so every run would open a duplicate instead of commenting.
+                </li>
+                <li>
+                    Organisation-owned repositories may need fine-grained tokens enabled for the
+                    organisation, and the token approved by an owner, before it works.
+                </li>
+                <li>
+                    A classic token with the <code>repo</code> scope also works, but grants full code
+                    access. GitHub App installation tokens do not work: they expire hourly, and this
+                    reads one static value from the environment.
+                </li>
+                <li>
+                    <strong>Base URL</strong> — blank for github.com, <code>https://your-host/api/v3</code>{" "}
+                    for Enterprise Server.
+                </li>
+            </ul>
+        </>
+    ),
+    forgejo: (
+        <>
+            <p>
+                Use a <strong>user access token</strong>:{" "}
+                <em>User settings → Applications → Access tokens</em>.
+            </p>
+            <ul className="list-disc pl-4 space-y-1">
+                <li>
+                    <strong>Scope</strong> — <code>write:issue</code>, which implies read. Older versions
+                    without per-resource scopes need the coarse <code>repo</code> scope instead.
+                </li>
+                <li>
+                    The token owner must have <strong>write</strong> access to the repository, and the
+                    repository must have its issue tracker enabled.
+                </li>
+                <li>
+                    Scopes cannot be edited after creation — a token with the wrong scope has to be
+                    deleted and re-issued.
+                </li>
+                <li>
+                    <strong>Base URL is required</strong>, and must include the API root:{" "}
+                    <code>https://your-host/api/v1</code>, not just the host.
+                </li>
+            </ul>
+        </>
+    ),
+};
+
+// What the bot actually does with the token — the short version of
+// "why these permissions and no more". Same for either forge.
+const API_CALLS_NOTE = (
+    <>
+        <p className="font-semibold text-gray-200">What the token is used for</p>
+        <ul className="list-disc pl-4 space-y-1">
+            <li>List open issues carrying the audit label, to find an existing report.</li>
+            <li>Create an issue for a failure fingerprint that has no report yet.</li>
+            <li>Comment on an issue when a known failure recurs.</li>
+            <li>Edit the dashboard issue body so it stays a single up-to-date summary.</li>
+        </ul>
+    </>
+);
+
 const IssueTargetTab: React.FC = () => {
     const [cfg, setCfg] = useState<IssueTargetConfig | null>(null);
     const [loadErr, setLoadErr] = useState<string | null>(null);
     const [saveErr, setSaveErr] = useState<string | null>(null);
     const [busy, setBusy] = useState(false);
     const [savedAt, setSavedAt] = useState<number | null>(null);
+    const [showInfo, setShowInfo] = useState(false);
 
     // Local editable copy. We don't bind directly to ``cfg`` so the
     // save button has a clear "discard changes" flow.
@@ -75,6 +160,7 @@ const IssueTargetTab: React.FC = () => {
 
     const dirty = JSON.stringify(draft) !== JSON.stringify(cfg);
     const isDisabled = draft.kind === "disabled";
+    const info = KIND_INFO[draft.kind];
 
     return (
         <div className="flex flex-col h-full overflow-auto">
@@ -108,6 +194,31 @@ const IssueTargetTab: React.FC = () => {
                     <div className="text-[11px] text-gray-500">{KIND_HINTS[draft.kind]}</div>
                 </label>
 
+                {info && (
+                    <div className="border border-gray-700 rounded-sm">
+                        <button
+                            type="button"
+                            onClick={() => setShowInfo((v) => !v)}
+                            aria-expanded={showInfo}
+                            className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-gray-300 hover:text-white hover:bg-gray-800"
+                        >
+                            <InfoIcon className="w-4 h-4 shrink-0"/>
+                            <span className="flex-1">
+                                Which token does {draft.kind === "github" ? "GitHub" : "Forgejo / Gitea"} need,
+                                and with what permissions?
+                            </span>
+                            <span className="text-gray-500">{showInfo ? "▾" : "▸"}</span>
+                        </button>
+                        {showInfo && (
+                            <div
+                                className="px-3 pb-3 pt-2 text-[11px] leading-relaxed text-gray-400 space-y-2 border-t border-gray-700 [&_code]:bg-gray-900 [&_code]:px-1 [&_code]:rounded-sm [&_code]:text-gray-200">
+                                {info}
+                                {API_CALLS_NOTE}
+                            </div>
+                        )}
+                    </div>
+                )}
+
                 <label className="block text-xs text-gray-300 space-y-1">
                     <span className="block">Repository <span className="text-gray-500">(owner/name)</span></span>
                     <input
@@ -120,14 +231,23 @@ const IssueTargetTab: React.FC = () => {
                     />
                 </label>
 
-                {draft.kind === "forgejo" && (
+                {!isDisabled && (
                     <label className="block text-xs text-gray-300 space-y-1">
-                        <span className="block">Base URL <span className="text-gray-500">(forge API root)</span></span>
+                        <span className="block">
+                            Base URL{" "}
+                            <span className="text-gray-500">
+                                {draft.kind === "github"
+                                    ? "(optional — blank means github.com)"
+                                    : "(forge API root)"}
+                            </span>
+                        </span>
                         <input
                             type="text"
                             value={draft.base_url}
                             onChange={(e) => setDraft({...draft, base_url: e.target.value})}
-                            placeholder="https://git.example.com/api/v1"
+                            placeholder={draft.kind === "github"
+                                ? "https://api.github.com"
+                                : "https://git.example.com/api/v1"}
                             className="bg-gray-900 border border-gray-600 rounded-sm px-2 py-1 text-sm text-gray-100 font-mono w-full max-w-md"
                         />
                     </label>


### PR DESCRIPTION
The issue-target tab asks for a token but never says what kind, or with which permissions. The first attempt is therefore a guess, and an over-scoped token — a classic `repo`-scope PAT, say — is the guess that looks safest while granting the most.

This adds an info toggle to the tab whose contents follow the selected forge:

- **GitHub** — a fine-grained token with `Issues: Read and write`, scoped to the one repository.
- **Forgejo / Gitea** — a user access token with `write:issue`.

Both panels list the four API calls the bot actually makes (list by label, create, comment, edit body), so the narrow permission set reads as a consequence rather than an assertion.

Two failure modes that are hard to diagnose from the outside are called out on the forge they apply to:

- On GitHub, a token whose account has less than **Triage** has its labels **silently dropped** at issue creation — no error, `201 Created`. Since the bot recognises its own issues by label, it quietly stops deduplicating and opens a fresh issue on every run.
- On Forgejo, `base_url` must include the `/api/v1` root, not just the host.

### Also: Base URL was unreachable for GitHub

`KIND_HINTS.github` has always promised *"base_url defaults to api.github.com if blank"*, but the input rendered only when `kind === "forgejo"`. Both `build_client` and the `PUT /admin/audit/issue-target` handler accept a base URL for GitHub, so GitHub Enterprise was configurable through the API and not through the UI. The field now shows for either forge, marked optional for GitHub.

### Notes

- Frontend only; no API or schema change. The token-store model is untouched — the database still holds only the env var's name.
- Verified against a live GitHub target: issues open and comment as expected.
- `tsc --noEmit` clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aPKGQsH2DT2CEtehR4tzz
