### PR TITLE
feat(external-models): let a provider expose more than one version of a model

### DIFF
--- a/src/ada/plugins/external_models/__init__.py
+++ b/src/ada/plugins/external_models/__init__.py
@@ -31,6 +31,7 @@ from ada.plugins.external_models.catalog import (
     Collection,
     ExternalModel,
     ExternalModelCatalog,
+    ModelRevision,
     S3ExternalModelCatalog,
     StubExternalModelCatalog,
     demo_catalog_from_env,
@@ -61,6 +62,7 @@ __all__ = [
     "ExternalModelCatalog",
     "Collection",
     "ExternalModel",
+    "ModelRevision",
     # the built-in provider's pieces
     "StubExternalModelCatalog",
     "S3ExternalModelCatalog",

--- a/src/ada/plugins/external_models/adapy_plugin.py
+++ b/src/ada/plugins/external_models/adapy_plugin.py
@@ -34,7 +34,14 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["run_job", "ACTIONS", "DEFAULT_PROVIDER"]
 
-ACTIONS = ("list_providers", "list_collections", "list_models", "model_url", "model_upload_url")
+ACTIONS = (
+    "list_providers",
+    "list_collections",
+    "list_models",
+    "list_model_revisions",
+    "model_url",
+    "model_upload_url",
+)
 
 # Kept so a single-provider deployment need not thread an id through every call.
 # Multi-provider deployments should always pass one explicitly.
@@ -50,6 +57,16 @@ def _can_upload(cat: ExternalModelCatalog) -> bool:
     unlucky provider raise.
     """
     return callable(getattr(cat, "model_upload_url", None))
+
+
+def _has_revisions(cat: ExternalModelCatalog) -> bool:
+    """Does this provider keep more than one version of a model?
+
+    Presence of `list_model_revisions` IS the declaration, exactly as for upload.
+    Reported alongside every listing so a UI knows whether to offer a version
+    picker before it has asked about any particular model.
+    """
+    return callable(getattr(cat, "list_model_revisions", None))
 
 
 def run_job(
@@ -104,6 +121,7 @@ def run_job(
             "action": action,
             "provider": provider,
             "can_upload": _can_upload(cat),
+            "has_revisions": _has_revisions(cat),
             "collections": [asdict(c) for c in collections],
         }
 
@@ -119,12 +137,40 @@ def run_job(
             "provider": provider,
             "collection": collection,
             "can_upload": _can_upload(cat),
+            "has_revisions": _has_revisions(cat),
             "models": [asdict(m) for m in models],
         }
 
     model_id = (options.get("model_id") or "").strip()
     if not model_id:
         raise ValueError(f"action {action!r} requires a 'model_id' option")
+
+    if action == "list_model_revisions":
+        lister = getattr(cat, "list_model_revisions", None)
+        if not callable(lister):
+            # Not a fault in the request: this catalogue keeps one version of a
+            # model. An empty list says "nothing to pick from" in the same shape
+            # a versioned provider uses for an unversioned model, so a caller
+            # needs no branch.
+            _progress(action, 0.9)
+            return {
+                "action": action,
+                "provider": provider,
+                "collection": collection,
+                "model_id": model_id,
+                "has_revisions": False,
+                "revisions": [],
+            }
+        revisions = lister(collection, model_id)
+        _progress(action, 0.9)
+        return {
+            "action": action,
+            "provider": provider,
+            "collection": collection,
+            "model_id": model_id,
+            "has_revisions": True,
+            "revisions": [asdict(r) for r in revisions],
+        }
 
     if action == "model_upload_url":
         signer = getattr(cat, "model_upload_url", None)
@@ -162,7 +208,15 @@ def run_job(
         }
 
     expires = int(options.get("expires_in_seconds") or 900)
-    url = cat.model_download_url(collection, model_id, expires_in_seconds=expires)
+    revision = (options.get("revision") or "").strip()
+    if revision:
+        # Passed ONLY when asked for, so a provider that predates revisions never
+        # sees the keyword. A provider that lists revisions but does not accept
+        # this raises TypeError here rather than silently serving the current
+        # version, which is the failure worth being loud about.
+        url = cat.model_download_url(collection, model_id, expires_in_seconds=expires, revision=revision)
+    else:
+        url = cat.model_download_url(collection, model_id, expires_in_seconds=expires)
 
     # A provider whose URL carries its own signature needs no headers; one whose
     # fetch must be authenticated returns them. getattr rather than a required
@@ -180,6 +234,7 @@ def run_job(
         "provider": provider,
         "collection": collection,
         "model_id": model_id,
+        "revision": revision or None,
         "url": url,
         "headers": headers,
     }

--- a/src/ada/plugins/external_models/catalog.py
+++ b/src/ada/plugins/external_models/catalog.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "Collection",
     "ExternalModel",
+    "ModelRevision",
     "ExternalModelCatalog",
     "StubExternalModelCatalog",
     "S3ExternalModelCatalog",
@@ -78,6 +79,33 @@ class ExternalModel:
     labelled: bool = False
 
 
+@dataclass(frozen=True)
+class ModelRevision:
+    """One stored version of a model, for catalogues that keep more than one.
+
+    A store that rebuilds a model on a schedule and retains the previous
+    output(s) has more than one version of the same `(collection, model)`. Nothing
+    in the three required methods can express that: `list_models` returns one
+    entry per model and `model_download_url` resolves to whatever the provider
+    calls current, so a consumer can only ever reach the newest one.
+
+    `id` is opaque and provider-defined -- a timestamped prefix, an object-version
+    id, a build number. Consumers pass it back verbatim and must not parse it;
+    `name` is what a person picks from.
+    """
+
+    id: str
+    name: str
+    #: ISO-8601 if the provider knows it. A UI orders by this when present, and
+    #: falls back to the order the provider returned otherwise -- so a provider
+    #: that cannot date its revisions should return them newest-first.
+    created_at: str | None = None
+    size: int | None = None
+    #: The one `model_download_url` resolves to when no revision is requested.
+    #: Exactly one revision in a list should carry it.
+    current: bool = False
+
+
 @runtime_checkable
 class ExternalModelCatalog(Protocol):
     """The entire seam. Three methods; anything the viewer needs is composed
@@ -123,6 +151,28 @@ class ExternalModelCatalog(Protocol):
     # reaches the viewer as gzip bytes and fails as a JSON parse error, with
     # nothing anywhere naming compression. One catalogue was found in exactly
     # that state, one object among forty.
+    #
+    # ALSO OPTIONAL, same convention, and these two travel TOGETHER:
+    #
+    #   list_model_revisions(collection, model_id) -> list[ModelRevision]
+    #   model_download_url(..., revision: str | None = None)
+    #
+    # A catalogue that retains more than one version of a model implements the
+    # first to enumerate them, and accepts `revision` on the second to serve one.
+    # A catalogue with a single current version implements neither and the viewer
+    # never offers a version picker for it -- the correct outcome rather than a
+    # control that fails when used.
+    #
+    # WHY `revision` RIDES ON THE EXISTING DOWNLOAD METHOD rather than arriving as
+    # a second one: a consumer then has one way to fetch a model, not two that it
+    # has to choose between. `revision` is passed ONLY when a caller asked for a
+    # specific one, so a provider written before this exists never sees the
+    # keyword and keeps satisfying the Protocol unchanged.
+    #
+    # The pairing is a real obligation, not a suggestion. Implementing
+    # `list_model_revisions` while ignoring `revision` produces a picker whose
+    # every entry silently serves the current version -- which looks like it works
+    # and is wrong in the one way nobody checks.
 
 
 def _model_name(key: str) -> str:
@@ -167,8 +217,39 @@ class StubExternalModelCatalog:
             for k in sorted(keys)
         ]
 
-    def model_download_url(self, collection: str, model_id: str, *, expires_in_seconds: int = 900) -> str:
-        return f"stub://external-models/{collection}/{model_id}"
+    #: Fixture revisions, newest first. Only one collection has them, so the stub
+    #: exercises both halves of the optional contract: a model that is versioned
+    #: and a model that is not.
+    _revisions: dict[str, list[tuple[str, str]]] = field(
+        default_factory=lambda: {
+            "demo/kitchen": [
+                ("2024-01-02", "2024-01-02T00:00:00Z"),
+                ("2024-01-01", "2024-01-01T00:00:00Z"),
+            ]
+        }
+    )
+
+    def list_model_revisions(self, collection: str, model_id: str) -> list[ModelRevision]:
+        entries = self._revisions.get(f"{collection}/{model_id}")
+        if not entries:
+            # An unversioned model in a versioned catalogue. Empty, not an error:
+            # a UI shows no picker for it and everything else still works.
+            return []
+        return [
+            ModelRevision(id=rid, name=f"{rid} (stub)", created_at=created, current=(i == 0))
+            for i, (rid, created) in enumerate(entries)
+        ]
+
+    def model_download_url(
+        self,
+        collection: str,
+        model_id: str,
+        *,
+        expires_in_seconds: int = 900,
+        revision: str | None = None,
+    ) -> str:
+        suffix = f"@{revision}" if revision else ""
+        return f"stub://external-models/{collection}/{model_id}{suffix}"
 
 
 class S3ExternalModelCatalog:

--- a/src/frontend/src/__tests__/services/externalModelClients.test.ts
+++ b/src/frontend/src/__tests__/services/externalModelClients.test.ts
@@ -113,3 +113,47 @@ test("unregistering an id that was never registered is a no-op", () => {
     { id: "vendor", label: "vendor" },
   ]);
 });
+
+// --- revisions: presence is the declaration ---------------------------------
+
+test("a client without listModelRevisions is a single-version provider", () => {
+  // Absence is the declaration, exactly as with modelUploadUrl. A consumer
+  // checks for the method rather than for a capability flag.
+  const impl = client();
+  registerExternalModelClient("vendor", impl);
+  assert.equal(typeof externalModelClient("vendor")?.listModelRevisions, "undefined");
+});
+
+test("a versioned client exposes its revisions and honours one on modelUrl", async () => {
+  const impl: ExternalModelClient = {
+    listCollections: async () => [],
+    listModels: async () => [],
+    listModelRevisions: async (_collection, modelId) =>
+      modelId === "versioned"
+        ? [
+            { id: "b", name: "b", createdAt: "2024-01-02T00:00:00Z", current: true },
+            { id: "a", name: "a", createdAt: "2024-01-01T00:00:00Z" },
+          ]
+        : [],
+    modelUrl: async (_collection, modelId, opts) => ({
+      url: opts?.revision
+        ? `https://example.invalid/${modelId}@${opts.revision}.glb`
+        : `https://example.invalid/${modelId}.glb`,
+    }),
+  };
+  registerExternalModelClient("vendor", impl);
+  const got = externalModelClient("vendor");
+
+  const revisions = (await got?.listModelRevisions?.("c", "versioned")) ?? [];
+  assert.equal(revisions.length, 2);
+  assert.equal(revisions[0].current, true);
+
+  // An unversioned model in a versioned provider is empty, not an error, so a
+  // caller needs no branch between the two cases.
+  assert.deepEqual(await got?.listModelRevisions?.("c", "plain"), []);
+
+  const pinned = await got?.modelUrl("c", "versioned", { revision: "a" });
+  assert.equal(pinned?.url, "https://example.invalid/versioned@a.glb");
+  const current = await got?.modelUrl("c", "versioned");
+  assert.equal(current?.url, "https://example.invalid/versioned.glb");
+});

--- a/src/frontend/src/services/externalModelClients.ts
+++ b/src/frontend/src/services/externalModelClients.ts
@@ -15,7 +15,11 @@
 // everything here — there is one place to look, and the dispatch lives beside
 // the names it dispatches on.
 
-import type { ExternalCollection, ExternalModel } from "./externalModelTypes";
+import type {
+  ExternalCollection,
+  ExternalModel,
+  ExternalModelRevision,
+} from "./externalModelTypes";
 
 export class ExternalModelsError extends Error {
   constructor(message: string) {
@@ -60,8 +64,29 @@ export interface ExternalModelClient {
   modelUrl(
     collection: string,
     modelId: string,
-    opts?: ExternalModelClientOpts & { expiresInSeconds?: number },
+    opts?: ExternalModelClientOpts & {
+      expiresInSeconds?: number;
+      /** Fetch a specific stored version. Only ever set by a caller that got the
+       *  id from `listModelRevisions`, so a provider without revisions never
+       *  sees it. */
+      revision?: string;
+    },
   ): Promise<{ url: string; headers?: Record<string, string> }>;
+  /** OPTIONAL, and presence IS the declaration — as with upload, and as on the
+   *  worker side. A provider that keeps more than one version of a model
+   *  implements this to enumerate them, and honours `revision` on `modelUrl` to
+   *  serve one. The two travel together: listing revisions while ignoring
+   *  `revision` gives a picker whose every entry silently serves the current
+   *  version.
+   *
+   *  Returns an empty array for a model this provider does not version, so a
+   *  caller needs no branch between "unversioned provider" and "unversioned
+   *  model". */
+  listModelRevisions?(
+    collection: string,
+    modelId: string,
+    opts?: ExternalModelClientOpts,
+  ): Promise<ExternalModelRevision[]>;
   /** OPTIONAL, and presence IS the declaration — exactly as on the worker side.
    *  A read-only catalogue implements nothing and the viewer never offers
    *  upload for it, rather than offering a control that fails when pressed. */

--- a/src/frontend/src/services/externalModelTypes.ts
+++ b/src/frontend/src/services/externalModelTypes.ts
@@ -25,6 +25,21 @@ export interface ExternalModel {
   size?: number | null;
 }
 
+/** One stored version of a model, for providers that keep more than one.
+ *
+ *  `id` is opaque and provider-defined; consumers pass it back verbatim and must
+ *  not parse it. `name` is what a person picks from. A provider that cannot date
+ *  its revisions should return them newest-first, because that is the order a UI
+ *  falls back to when `createdAt` is absent. */
+export interface ExternalModelRevision {
+  id: string;
+  name: string;
+  createdAt?: string | null;
+  size?: number | null;
+  /** The one a fetch without a revision resolves to. Exactly one per list. */
+  current?: boolean;
+}
+
 export interface ExternalModelProvider {
   id: string;
   label: string;

--- a/src/frontend/src/services/externalModels.ts
+++ b/src/frontend/src/services/externalModels.ts
@@ -55,6 +55,7 @@ import type {
   ExternalCollection,
   ExternalModel,
   ExternalModelProvider,
+  ExternalModelRevision,
 } from "./externalModelTypes";
 
 export {
@@ -71,6 +72,7 @@ export type {
   ExternalCollection,
   ExternalModel,
   ExternalModelProvider,
+  ExternalModelRevision,
 } from "./externalModelTypes";
 export {
   ExternalModelsError,
@@ -310,12 +312,13 @@ export async function modelUrl(
   collection: string,
   modelId: string,
   scope: ScopeUrl,
-  opts?: { expiresInSeconds?: number; signal?: AbortSignal },
+  opts?: { expiresInSeconds?: number; revision?: string; signal?: AbortSignal },
 ): Promise<{ url: string; headers: Record<string, string> }> {
   const impl = externalModelClient(provider);
   if (impl) {
     const got = await impl.modelUrl(collection, modelId, {
       expiresInSeconds: opts?.expiresInSeconds,
+      revision: opts?.revision,
       signal: opts?.signal,
     });
     if (!got?.url) throw new ExternalModelsError("provider returned no url");
@@ -329,6 +332,7 @@ export async function modelUrl(
       collection,
       model_id: modelId,
       expires_in_seconds: opts?.expiresInSeconds,
+      revision: opts?.revision,
       // ALWAYS bust the cache. The result is a short-lived signed URL, so a
       // cache hit returns one minted for an earlier request — which the store
       // then rejects as expired. Unlike the listing actions this is never
@@ -343,6 +347,40 @@ export async function modelUrl(
   // populated for one whose fetch must be authenticated. Returning them beside
   // the URL is what lets a single call site serve both without knowing which.
   return { url: out.url, headers: out.headers ?? {} };
+}
+
+/** The stored versions of one model, newest first, or `[]`.
+ *
+ *  Empty covers both "this provider keeps one version" and "this model is not
+ *  versioned", deliberately: a caller renders a picker when the list has more
+ *  than one entry and needs no branch between the two cases. */
+export async function listModelRevisions(
+  provider: string,
+  collection: string,
+  modelId: string,
+  scope: ScopeUrl,
+  opts?: { refresh?: string; signal?: AbortSignal },
+): Promise<ExternalModelRevision[]> {
+  const impl = externalModelClient(provider);
+  if (impl) {
+    // Optional on the client interface too, so an implementation without it is
+    // a provider with one version rather than an error.
+    if (!impl.listModelRevisions) return [];
+    return (await impl.listModelRevisions(collection, modelId, opts)) ?? [];
+  }
+
+  const out = await runAction<{ revisions?: ExternalModelRevision[] }>(
+    {
+      action: "list_model_revisions",
+      provider,
+      collection,
+      model_id: modelId,
+      refresh: opts?.refresh,
+    },
+    scope,
+    opts?.signal,
+  );
+  return out.revisions ?? [];
 }
 
 // --- upload -----------------------------------------------------------------

--- a/tests/plugins/test_external_models.py
+++ b/tests/plugins/test_external_models.py
@@ -22,6 +22,7 @@ from ada.plugins.external_models.catalog import (
     Collection,
     ExternalModel,
     ExternalModelCatalog,
+    ModelRevision,
     S3ExternalModelCatalog,
     StubExternalModelCatalog,
     demo_catalog_from_env,
@@ -403,3 +404,114 @@ def test_the_store_asks_for_gzip_and_a_type_together():
     assert glb["Content-Encoding"] == "gzip"
     assert glb["Content-Type"] == "model/gltf-binary"
     assert cat.model_upload_headers("plant-a", "scene.gltf")["Content-Type"] == "model/gltf+json"
+
+
+# --- revisions: a provider opts in by implementing it -----------------------
+
+
+def test_a_single_version_provider_declares_no_revisions():
+    """Nothing to configure and nothing to raise.
+
+    A catalogue that keeps one version of a model implements neither method, so
+    `has_revisions` is False and the action still answers — with an empty list,
+    which is the same shape a versioned provider returns for an unversioned
+    model. A caller therefore needs no branch between the two cases.
+    """
+    cat = _FakeS3(["demo/a.glb"])
+    out = run_job({"action": "list_collections"}, catalog=cat)
+    assert out["has_revisions"] is False
+
+    out = run_job(
+        {"action": "list_model_revisions", "collection": "demo", "model_id": "a"},
+        catalog=cat,
+    )
+    assert out["has_revisions"] is False
+    assert out["revisions"] == []
+
+
+def test_a_versioned_provider_lists_its_revisions_newest_first():
+    cat = StubExternalModelCatalog()
+    out = run_job({"action": "list_models", "collection": "demo"}, catalog=cat)
+    assert out["has_revisions"] is True
+
+    out = run_job(
+        {"action": "list_model_revisions", "collection": "demo", "model_id": "kitchen"},
+        catalog=cat,
+    )
+    assert [r["id"] for r in out["revisions"]] == ["2024-01-02", "2024-01-01"]
+    # Exactly one is current, and it is the one a plain fetch resolves to.
+    assert [r["current"] for r in out["revisions"]] == [True, False]
+
+
+def test_an_unversioned_model_in_a_versioned_provider_is_empty_not_an_error():
+    cat = StubExternalModelCatalog()
+    out = run_job(
+        {"action": "list_model_revisions", "collection": "demo", "model_id": "pipe-rack"},
+        catalog=cat,
+    )
+    assert out["has_revisions"] is True
+    assert out["revisions"] == []
+
+
+def test_a_revision_is_only_passed_when_one_was_asked_for():
+    """The kwarg must not reach a provider that predates revisions.
+
+    This is what lets the feature be additive: `model_download_url` keeps its
+    original signature for every existing provider, and only a caller holding a
+    revision id causes the keyword to be sent at all.
+    """
+
+    class _Old:
+        def list_collections(self):
+            return [Collection(id="c", name="c")]
+
+        def list_models(self, collection):
+            return [ExternalModel(id="m", name="m", collection=collection, key="c/m.glb")]
+
+        def model_download_url(self, collection, model_id, *, expires_in_seconds=900):
+            # No `revision` parameter at all. Passing one would raise TypeError,
+            # so this test failing is exactly the regression to catch.
+            return "old://c/m"
+
+    out = run_job({"action": "model_url", "collection": "c", "model_id": "m"}, catalog=_Old())
+    assert out["url"] == "old://c/m"
+    assert out["revision"] is None
+
+
+def test_a_requested_revision_reaches_the_provider():
+    cat = StubExternalModelCatalog()
+    out = run_job(
+        {
+            "action": "model_url",
+            "collection": "demo",
+            "model_id": "kitchen",
+            "revision": "2024-01-01",
+        },
+        catalog=cat,
+    )
+    assert out["revision"] == "2024-01-01"
+    assert out["url"].endswith("@2024-01-01")
+    # And without one, the same call resolves to whatever the provider calls
+    # current -- the pre-existing behaviour, unchanged.
+    plain = run_job({"action": "model_url", "collection": "demo", "model_id": "kitchen"}, catalog=cat)
+    assert plain["url"] == "stub://external-models/demo/kitchen"
+
+
+def test_revision_payload_is_json_serialisable():
+    import json
+
+    cat = StubExternalModelCatalog()
+    out = run_job(
+        {"action": "list_model_revisions", "collection": "demo", "model_id": "kitchen"},
+        catalog=cat,
+    )
+    json.dumps(out)
+    assert set(out["revisions"][0]) == {"id", "name", "created_at", "size", "current"}
+
+
+def test_model_revision_is_exported_from_the_package():
+    # A provider implementing the optional half imports this from the package
+    # root, like Collection and ExternalModel.
+    import ada.plugins.external_models as pkg
+
+    assert pkg.ModelRevision is ModelRevision


### PR DESCRIPTION
## The problem

A catalogue that rebuilds a model on a schedule and retains the previous output has more than one version of the same `(collection, model)`. The seam cannot express that:

- `list_models` returns one entry per model
- `model_download_url` resolves to whatever the provider considers current

So a consumer can only ever reach the newest version, even when the store still holds the others and a person wants to compare two.

## The change

The vocabulary, plus two optional methods, following the convention this package already uses for uploads and download headers — **presence is the declaration**:

```python
ModelRevision(id, name, created_at, size, current)

list_model_revisions(collection, model_id) -> list[ModelRevision]   # optional
model_download_url(..., revision: str | None = None)                # optional
```

A catalogue with a single version implements neither, satisfies the Protocol unchanged, and the viewer offers no picker for it — rather than offering a control that fails when used.

**Why `revision` rides on the existing download method** rather than arriving as a second one: a consumer then has one way to fetch a model, not two it has to choose between. The keyword is passed *only* when a caller holds a revision id, so a provider written before this never sees it. That is what makes the change additive rather than a signature break, and there is a test pinning it — a provider whose `model_download_url` has no `revision` parameter still serves `model_url`.

**The two methods are a pair, and the docstring states it as an obligation.** Implementing `list_model_revisions` while ignoring `revision` produces a picker whose every entry silently serves the current version. It looks like it works and is wrong in the one way nobody checks.

Both transports, because core owns both halves of this seam:

| | |
| --- | --- |
| worker | `list_model_revisions` action; `revision` option on `model_url` |
| browser | optional `listModelRevisions` on `ExternalModelClient`; `revision` on `modelUrl` |

Listings carry `has_revisions` beside `can_upload`, so a UI can decide whether to offer a picker before asking about any particular model.

An empty list means "no versions to choose from", and covers two cases deliberately — a provider that keeps one version, and an unversioned model inside a versioned provider — so a caller needs no branch between them.

`StubExternalModelCatalog` gains fixture revisions on one of its two demo models, so the contract is exercisable with no network and both halves are covered. `S3ExternalModelCatalog` implements neither: it is the worked example of a provider opting out.

**No UI is included.** This is the API a picker would be built on.

## Testing

- 43 plugin tests pass, including 7 new ones covering both halves of the optional contract.
- 2553 passed across `tests/plugins` + `tests/core`. 5 pre-existing failures in `tests/core/fem/results/test_fea_docs.py`, all `Freetype library not found` in this environment and unrelated to this change.
- `pixi run lint-check` clean.
- **The frontend vitest suite could not be run here** — no node toolchain on the machine this was written on — so the two TypeScript tests added are unverified locally and rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnVdor5ZMzD5QYxFQLQioc