### PR TITLE
feat(source-nodes): record when each node of an external source last changed

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import datetime
 import json
 import os
 import pathlib
@@ -1047,6 +1048,118 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "Accept-Ranges": "bytes",
                 "Content-Range": f"bytes {start}-{end}/{size}",
             },
+        )
+
+    # ── Source-node change tracking ──────────────────────────────────
+    #
+    # "Has the external source moved since I exported this?" -- see
+    # migrations/028_source_nodes.sql. Read-only here: rows are written by the
+    # plugin that drives the source, through the worker's source_nodes facade.
+    # A deployment with no Postgres answers 503 rather than an empty list,
+    # because "nothing has changed" and "nobody is recording changes" must not
+    # look the same to a consumer deciding whether to trust an asset.
+
+    def _source_nodes_pool(request: Request):
+        pool = getattr(request.app.state, "db_pool", None)
+        if pool is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "source-node change tracking needs a database; this deployment runs without "
+                    "DATABASE_URL. An asset's freshness cannot be answered here."
+                ),
+            )
+        return pool
+
+    def _source_node_json(n) -> dict:
+        return {
+            "node_ref": n.node_ref,
+            "parent_ref": n.parent_ref,
+            "name": n.name,
+            "last_changed_at": n.last_changed_at.isoformat(),
+            "last_changed_by": n.last_changed_by,
+            "observed_at": n.observed_at.isoformat(),
+        }
+
+    @api.get("/scopes/{scope}/source-nodes")
+    async def api_source_nodes(
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        source: str | None = None,
+        since: str | None = None,
+        refs: str | None = None,
+        limit: int = 1000,
+    ) -> JSONResponse:
+        """Change state for one scope's external-source nodes.
+
+        Three shapes, one route, because they answer one question at different
+        widths:
+
+        * no ``source`` -- which sources are recorded here at all, with counts.
+          What a consumer reads before it knows any refs.
+        * ``refs=a,b,c`` -- those nodes, in one round trip. The freshness check:
+          a caller holding published assets asks about every one at once rather
+          than N times over a slow link.
+        * ``since=<iso8601>`` -- what has moved since a cursor the caller keeps.
+          The polling shape.
+        """
+        pool = _source_nodes_pool(request)
+        scope_str = str(scope_obj)
+
+        if not source:
+            return JSONResponse(
+                {
+                    "scope": scope_str,
+                    "sources": [
+                        {
+                            "source": row["source"],
+                            "nodes": row["nodes"],
+                            "last_changed_at": row["last_changed_at"].isoformat() if row["last_changed_at"] else None,
+                            "observed_at": row["observed_at"].isoformat() if row["observed_at"] else None,
+                        }
+                        for row in await db_module.list_source_node_sources(pool, scope=scope_str)
+                    ],
+                }
+            )
+
+        limit = max(1, min(int(limit or 1000), 10000))
+
+        if refs:
+            wanted = [r.strip() for r in refs.split(",") if r.strip()]
+            if len(wanted) > limit:
+                raise HTTPException(status_code=400, detail=f"at most {limit} refs per request, got {len(wanted)}")
+            found = await db_module.get_source_nodes(pool, scope=scope_str, source=source, node_refs=wanted)
+            by_ref = {n.node_ref: n for n in found}
+            return JSONResponse(
+                {
+                    "scope": scope_str,
+                    "source": source,
+                    "nodes": [_source_node_json(by_ref[r]) for r in wanted if r in by_ref],
+                    # Named rather than merely absent: a ref nobody has recorded
+                    # is not a ref that has not changed, and a caller must be
+                    # able to tell those apart before trusting an asset.
+                    "unknown": [r for r in wanted if r not in by_ref],
+                }
+            )
+
+        parsed_since = None
+        if since:
+            try:
+                parsed_since = datetime.datetime.fromisoformat(since.replace("Z", "+00:00"))
+            except ValueError:
+                raise HTTPException(status_code=400, detail=f"since is not an ISO-8601 timestamp: {since!r}")
+
+        nodes = await db_module.list_source_nodes_changed_since(
+            pool, scope=scope_str, source=source, since=parsed_since, limit=limit
+        )
+        return JSONResponse(
+            {
+                "scope": scope_str,
+                "source": source,
+                "since": parsed_since.isoformat() if parsed_since else None,
+                "nodes": [_source_node_json(n) for n in nodes],
+                "truncated": len(nodes) >= limit,
+            }
         )
 
     @api.get("/scopes/{scope}/blobs/{key:path}")

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -3895,3 +3895,176 @@ async def archive_procedural_engine(pool: asyncpg.Pool, engine_id: str) -> bool:
         engine_id,
     )
     return res.endswith("1")
+
+
+# ── source nodes — when each node of an external source last changed ─────────
+#
+# See migrations/028_source_nodes.sql for what the table is for. These helpers
+# are the whole query surface: one write, three reads. Everything a consumer
+# needs is composed from them, and nothing here understands a ref.
+
+
+@dataclass(frozen=True)
+class SourceNode:
+    node_ref: str
+    parent_ref: Optional[str]
+    name: Optional[str]
+    last_changed_at: datetime.datetime
+    last_changed_by: Optional[str]
+    observed_at: datetime.datetime
+
+
+def _source_node_row(r) -> SourceNode:
+    return SourceNode(
+        node_ref=r["node_ref"],
+        parent_ref=r["parent_ref"],
+        name=r["name"],
+        last_changed_at=r["last_changed_at"],
+        last_changed_by=r["last_changed_by"],
+        observed_at=r["observed_at"],
+    )
+
+
+async def record_source_nodes(
+    pool: asyncpg.Pool,
+    *,
+    scope: str,
+    source: str,
+    nodes: list,
+) -> int:
+    """Upsert observed nodes. Returns how many rows were written.
+
+    ``nodes`` is a list of dicts with ``node_ref`` and ``last_changed_at``
+    required, and ``parent_ref`` / ``name`` / ``last_changed_by`` optional.
+
+    LAST_CHANGED_AT ONLY EVER MOVES FORWARD. A writer re-observing a node it has
+    seen before may hold an older cursor than the row does -- a backfill, a
+    re-run over a wider window, two writers with different windows -- and letting
+    that overwrite a newer timestamp would mark current assets stale-free when
+    they are not. `observed_at` is always taken from the new write, because "when
+    was this last confirmed" is precisely the thing that must not be sticky.
+
+    Written as one executemany inside a transaction: an hourly sweep stamps a
+    changed leaf and every node above it, so the natural batch is thousands of
+    rows and a round trip each would dominate.
+    """
+    if not nodes:
+        return 0
+    rows = [
+        (
+            scope,
+            source,
+            n["node_ref"],
+            n.get("parent_ref"),
+            n.get("name"),
+            n["last_changed_at"],
+            n.get("last_changed_by"),
+        )
+        for n in nodes
+    ]
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.executemany(
+                """
+                INSERT INTO source_nodes
+                    (scope, source, node_ref, parent_ref, name, last_changed_at, last_changed_by)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT (scope, source, node_ref) DO UPDATE SET
+                    parent_ref      = COALESCE(EXCLUDED.parent_ref, source_nodes.parent_ref),
+                    name            = COALESCE(EXCLUDED.name, source_nodes.name),
+                    last_changed_at = GREATEST(EXCLUDED.last_changed_at, source_nodes.last_changed_at),
+                    last_changed_by = CASE
+                        WHEN EXCLUDED.last_changed_at >= source_nodes.last_changed_at
+                        THEN EXCLUDED.last_changed_by ELSE source_nodes.last_changed_by END,
+                    observed_at     = NOW()
+                """,
+                rows,
+            )
+    return len(rows)
+
+
+async def get_source_node(pool: asyncpg.Pool, *, scope: str, source: str, node_ref: str) -> Optional[SourceNode]:
+    """One node, or None. The staleness check: compare `last_changed_at` against
+    whatever timestamp the caller's copy was made at."""
+    r = await pool.fetchrow(
+        "SELECT node_ref, parent_ref, name, last_changed_at, last_changed_by, observed_at "
+        "FROM source_nodes WHERE scope = $1 AND source = $2 AND node_ref = $3",
+        scope,
+        source,
+        node_ref,
+    )
+    return _source_node_row(r) if r else None
+
+
+async def get_source_nodes(pool: asyncpg.Pool, *, scope: str, source: str, node_refs: list) -> list:
+    """Many nodes in one round trip.
+
+    The batch form exists because the interesting caller holds a whole listing of
+    published assets and wants every answer at once; asking one at a time turns a
+    freshness check into N round trips over a slow link.
+    """
+    if not node_refs:
+        return []
+    rows = await pool.fetch(
+        "SELECT node_ref, parent_ref, name, last_changed_at, last_changed_by, observed_at "
+        "FROM source_nodes WHERE scope = $1 AND source = $2 AND node_ref = ANY($3::text[])",
+        scope,
+        source,
+        list(node_refs),
+    )
+    return [_source_node_row(r) for r in rows]
+
+
+async def list_source_nodes_changed_since(
+    pool: asyncpg.Pool,
+    *,
+    scope: str,
+    source: str,
+    since: Optional[datetime.datetime] = None,
+    limit: int = 1000,
+) -> list:
+    """Nodes whose last change is newer than ``since``, newest first.
+
+    The polling shape: a consumer that keeps its own cursor asks what has moved
+    rather than re-checking everything it holds. ``limit`` is capped by the
+    caller; the index makes the ordering free.
+    """
+    if since is None:
+        rows = await pool.fetch(
+            "SELECT node_ref, parent_ref, name, last_changed_at, last_changed_by, observed_at "
+            "FROM source_nodes WHERE scope = $1 AND source = $2 "
+            "ORDER BY last_changed_at DESC LIMIT $3",
+            scope,
+            source,
+            limit,
+        )
+    else:
+        rows = await pool.fetch(
+            "SELECT node_ref, parent_ref, name, last_changed_at, last_changed_by, observed_at "
+            "FROM source_nodes WHERE scope = $1 AND source = $2 AND last_changed_at > $3 "
+            "ORDER BY last_changed_at DESC LIMIT $4",
+            scope,
+            source,
+            since,
+            limit,
+        )
+    return [_source_node_row(r) for r in rows]
+
+
+async def list_source_node_sources(pool: asyncpg.Pool, *, scope: str) -> list:
+    """Which sources have recorded anything in this scope, with their row counts
+    and freshest observation. What a consumer reads before it knows any refs."""
+    rows = await pool.fetch(
+        "SELECT source, COUNT(*) AS nodes, MAX(last_changed_at) AS last_changed_at, "
+        "MAX(observed_at) AS observed_at FROM source_nodes WHERE scope = $1 GROUP BY source ORDER BY source",
+        scope,
+    )
+    return [
+        {
+            "source": r["source"],
+            "nodes": r["nodes"],
+            "last_changed_at": r["last_changed_at"],
+            "observed_at": r["observed_at"],
+        }
+        for r in rows
+    ]

--- a/src/ada/comms/rest/migrations/028_source_nodes.sql
+++ b/src/ada/comms/rest/migrations/028_source_nodes.sql
@@ -1,0 +1,69 @@
+-- 028_source_nodes.sql — when each node of an external source last changed.
+--
+-- THE PROBLEM. A model kept in an external CAD system is exported into this
+-- viewer as assets, and an asset is a snapshot: correct when it was made and
+-- silently wrong afterwards. Nothing here can say whether the source has moved
+-- since, so every consumer either re-exports on a schedule it guesses at, or
+-- serves stale geometry without knowing. Both are bad, and neither is visible.
+--
+-- WHAT THIS TABLE IS. One row per node of a source hierarchy, carrying the last
+-- time that node — or anything beneath it — changed. That is the whole answer to
+-- "is what I hold still current", and it is a single indexed lookup rather than
+-- a walk.
+--
+-- THE ANCESTOR ROLL-UP IS THE WRITER'S JOB, not this schema's. A writer that
+-- observes a leaf change stamps the leaf AND every node above it, so a consumer
+-- asking about a branch reads one row instead of a recursive query over a
+-- hierarchy this database deliberately does not model. `parent_ref` is recorded
+-- so a reader can reconstruct shape if it wants to, and is never required to.
+--
+-- OPAQUE IDENTIFIERS, ON PURPOSE. `node_ref` is whatever the source calls a
+-- node, stored verbatim and never parsed here. Different sources have entirely
+-- different grammars, and a schema that understood one of them would have to
+-- grow a branch for the next. `source` names which vocabulary a ref belongs to
+-- so two sources can share a scope without colliding.
+--
+-- SCOPE-KEYED, like every other per-project table: a source hierarchy belongs to
+-- the project it was exported from, and a caller who cannot read the scope must
+-- not be able to read its change history either.
+
+CREATE TABLE IF NOT EXISTS source_nodes (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The scope string as the API resolves it, stored rather than FK'd: scopes
+    -- include kinds that are not rows in any table (the shared bucket, corpora),
+    -- and this table must be usable from all of them.
+    scope           TEXT NOT NULL,
+    -- Which external source this ref belongs to. Free text, matching the
+    -- provider id a plugin registers under.
+    source          TEXT NOT NULL,
+    node_ref        TEXT NOT NULL,
+    parent_ref      TEXT,
+    -- Display name, when the writer knows one. Not an identifier: two nodes may
+    -- share a name, and a rename must not orphan history.
+    name            TEXT,
+    -- When this node or anything under it last changed IN THE SOURCE. This is
+    -- the column the whole table exists for.
+    last_changed_at TIMESTAMPTZ NOT NULL,
+    -- Who made that change, when the source records it. Optional because not
+    -- every source attributes edits.
+    last_changed_by TEXT,
+    -- When a writer last confirmed the two columns above. Distinct from
+    -- last_changed_at and NOT redundant: "checked ten minutes ago, unchanged
+    -- since Tuesday" and "last heard from on Tuesday" are different states, and
+    -- only the second is a reason to distrust the answer.
+    observed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per node per source per scope. This is the upsert target: a writer
+-- re-stamping a node it has seen before must update rather than accumulate, or
+-- an hourly job turns into an append-only log of the same tree.
+CREATE UNIQUE INDEX IF NOT EXISTS source_nodes_identity
+    ON source_nodes (scope, source, node_ref);
+
+-- "What changed since T", the sweep query a consumer polls with.
+CREATE INDEX IF NOT EXISTS source_nodes_changed_at
+    ON source_nodes (scope, source, last_changed_at DESC);
+
+-- Children of a node, for a reader that does want to walk.
+CREATE INDEX IF NOT EXISTS source_nodes_parent
+    ON source_nodes (scope, source, parent_ref);

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -2859,6 +2859,52 @@ async def _run_component_build(
     await _audit_done(db_pool, job_id, "done", None, started_at)
 
 
+class _SyncSourceNodesFacade:
+    """Synchronous view of the source-node change table, scoped to one job.
+
+    A plugin that drives an external CAD system knows when each node of it last
+    changed, and this is how it says so. Bridged onto the worker's event loop the
+    same way :class:`_SyncStorageFacade` is, because a plugin entrypoint runs in
+    an executor thread.
+
+    Constructed only when the worker HAS a pool. A worker without ``DATABASE_URL``
+    is a supported deployment, so the facade is simply not passed and a plugin
+    sees the parameter absent -- which it must handle, exactly as it handles a
+    storage backend that refuses a write.
+    """
+
+    def __init__(self, pool, scope, loop):
+        self._pool, self._scope, self._loop = pool, scope, loop
+
+    def _run(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    @property
+    def scope(self) -> str:
+        return str(self._scope)
+
+    def record(self, source: str, nodes: list) -> int:
+        """Upsert observed nodes for one source. Returns rows written.
+
+        Each node is a dict: ``node_ref`` and ``last_changed_at`` required,
+        ``parent_ref`` / ``name`` / ``last_changed_by`` optional. A writer that
+        observes a leaf change is expected to stamp every node ABOVE it too --
+        the roll-up is the writer's job, so that a consumer asking about a branch
+        reads one row rather than walking a hierarchy this table does not model.
+        """
+        from . import db as db_module
+
+        return self._run(db_module.record_source_nodes(self._pool, scope=str(self._scope), source=source, nodes=nodes))
+
+    def get(self, source: str, node_refs: list) -> list:
+        """What is already recorded, so a writer can avoid restating it."""
+        from . import db as db_module
+
+        return self._run(
+            db_module.get_source_nodes(self._pool, scope=str(self._scope), source=source, node_refs=node_refs)
+        )
+
+
 class _SyncStorageFacade:
     """Synchronous view of the async :class:`Storage`, scoped to one job.
 
@@ -3135,11 +3181,15 @@ async def _run_plugin_job(
 
     try:
         _sig = inspect.signature(fn)
-        _accepts_cancel = "cancel_event" in _sig.parameters or any(
-            p.kind is inspect.Parameter.VAR_KEYWORD for p in _sig.parameters.values()
-        )
+        _has_varkw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in _sig.parameters.values())
+        _accepts_cancel = "cancel_event" in _sig.parameters or _has_varkw
+        # Same negotiation, same reason: an entrypoint written before this kwarg
+        # existed keeps working untouched rather than dying on an unexpected
+        # keyword.
+        _accepts_source_nodes = "source_nodes" in _sig.parameters or _has_varkw
     except (TypeError, ValueError):
         _accepts_cancel = False
+        _accepts_source_nodes = False
 
     # --- In-process profiling harness (toggle + per-task filter gated) ------
     # Read the same admin toggle the convert path reads (`profile_conversions`)
@@ -3172,6 +3222,11 @@ async def _run_plugin_job(
         )
         if _accepts_cancel:
             kwargs["cancel_event"] = cancel_event
+        # Only when this worker actually has a pool. Passing a facade that cannot
+        # reach a database would turn a supported deployment into a plugin that
+        # fails at its first write instead of one that knows it cannot record.
+        if _accepts_source_nodes and db_pool is not None:
+            kwargs["source_nodes"] = _SyncSourceNodesFacade(db_pool, scope, loop)
         if not profile_enabled:
             return fn(opts.get("options") or {}, **kwargs)
 

--- a/tests/comms/rest/test_source_nodes.py
+++ b/tests/comms/rest/test_source_nodes.py
@@ -1,0 +1,265 @@
+"""Source-node change tracking — the route and the repository helpers.
+
+Two paths, the split ``test_db.py`` already uses:
+
+* **Always run** — the no-database behaviour, through the in-process API. This
+  is the part worth pinning hardest: a deployment without Postgres must REFUSE
+  the question rather than answer it emptily.
+* **Live Postgres** (skipped unless ``ADA_TEST_POSTGRES_URL`` is set) — the
+  upsert semantics, which are where the subtle bugs are.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-source-nodes-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as dbm  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+
+POSTGRES_URL = os.environ.get("ADA_TEST_POSTGRES_URL", "").strip()
+needs_postgres = pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="ADA_TEST_POSTGRES_URL not set; skipping live Postgres tests",
+)
+
+SOURCE = "demo-cad"
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url="",
+    )
+
+
+@pytest.fixture
+def app_client(tmp_path: pathlib.Path):
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        yield client
+
+
+# --- no database: refuse, do not answer emptily -----------------------------
+
+
+def test_without_a_database_the_route_refuses_rather_than_returning_nothing(app_client):
+    """The single most important behaviour here.
+
+    An empty list and "nobody is recording changes" are indistinguishable to a
+    consumer deciding whether its exported asset is still current — and reading
+    the second as the first means serving stale geometry with confidence. So a
+    deployment with no Postgres answers 503.
+    """
+    r = app_client.get("/api/scopes/shared/source-nodes")
+    assert r.status_code == 503
+    # The message has to name the cause, because the fix is a deployment change
+    # and nothing in the response body would otherwise point at it.
+    assert "DATABASE_URL" in r.json()["detail"]
+
+
+def test_every_shape_of_the_route_refuses_without_a_database(app_client):
+    for query in (
+        "",
+        f"?source={SOURCE}",
+        f"?source={SOURCE}&refs=a,b",
+        f"?source={SOURCE}&since=2024-01-01T00:00:00Z",
+    ):
+        r = app_client.get(f"/api/scopes/shared/source-nodes{query}")
+        assert r.status_code == 503, query
+
+
+# --- live Postgres ----------------------------------------------------------
+
+
+async def _fresh_pool():
+    pool = await dbm.init_pool(POSTGRES_URL)
+    await pool.execute("DELETE FROM source_nodes WHERE scope = 'test-scope'")
+    return pool
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_migration_creates_the_table_and_its_identity_index():
+    pool = await dbm.init_pool(POSTGRES_URL)
+    try:
+        cols = {
+            r["column_name"]
+            for r in await pool.fetch(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = 'source_nodes'"
+            )
+        }
+        assert {"scope", "source", "node_ref", "parent_ref", "last_changed_at", "observed_at"} <= cols
+        idx = {
+            r["indexname"] for r in await pool.fetch("SELECT indexname FROM pg_indexes WHERE tablename='source_nodes'")
+        }
+        assert "source_nodes_identity" in idx
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_record_then_read_back():
+    pool = await _fresh_pool()
+    try:
+        t = datetime.datetime(2024, 5, 1, 12, 0, tzinfo=datetime.timezone.utc)
+        written = await dbm.record_source_nodes(
+            pool,
+            scope="test-scope",
+            source=SOURCE,
+            nodes=[
+                {"node_ref": "a", "parent_ref": None, "name": "root", "last_changed_at": t},
+                {
+                    "node_ref": "b",
+                    "parent_ref": "a",
+                    "name": "child",
+                    "last_changed_at": t,
+                    "last_changed_by": "someone",
+                },
+            ],
+        )
+        assert written == 2
+
+        one = await dbm.get_source_node(pool, scope="test-scope", source=SOURCE, node_ref="b")
+        assert one.parent_ref == "a"
+        assert one.last_changed_by == "someone"
+
+        many = await dbm.get_source_nodes(pool, scope="test-scope", source=SOURCE, node_refs=["a", "b", "nope"])
+        assert {n.node_ref for n in many} == {"a", "b"}
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_last_changed_at_only_moves_forward():
+    """The subtle one, and the reason the upsert uses GREATEST.
+
+    A writer re-observing a node may hold an OLDER cursor than the row does — a
+    backfill, a re-run over a wider window, two writers with different windows.
+    Letting that overwrite a newer timestamp would report a stale asset as
+    current, which is the exact failure this table exists to prevent.
+    """
+    pool = await _fresh_pool()
+    try:
+        new = datetime.datetime(2024, 5, 2, tzinfo=datetime.timezone.utc)
+        old = datetime.datetime(2024, 5, 1, tzinfo=datetime.timezone.utc)
+
+        await dbm.record_source_nodes(
+            pool,
+            scope="test-scope",
+            source=SOURCE,
+            nodes=[{"node_ref": "a", "last_changed_at": new, "last_changed_by": "newer"}],
+        )
+        await dbm.record_source_nodes(
+            pool,
+            scope="test-scope",
+            source=SOURCE,
+            nodes=[{"node_ref": "a", "last_changed_at": old, "last_changed_by": "older"}],
+        )
+
+        row = await dbm.get_source_node(pool, scope="test-scope", source=SOURCE, node_ref="a")
+        assert row.last_changed_at == new
+        # The author travels with the timestamp: keeping "older" beside a
+        # timestamp it did not produce would be a row that contradicts itself.
+        assert row.last_changed_by == "newer"
+        # observed_at is NOT sticky -- it records the latest confirmation, which
+        # is what separates "checked recently, unchanged" from "not heard from".
+        assert row.observed_at > new
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_re_observation_updates_rather_than_accumulates():
+    pool = await _fresh_pool()
+    try:
+        t = datetime.datetime(2024, 5, 1, tzinfo=datetime.timezone.utc)
+        for _ in range(3):
+            await dbm.record_source_nodes(
+                pool, scope="test-scope", source=SOURCE, nodes=[{"node_ref": "a", "last_changed_at": t}]
+            )
+        n = await pool.fetchval("SELECT COUNT(*) FROM source_nodes WHERE scope='test-scope' AND node_ref='a'")
+        # An hourly job must not turn into an append-only log of the same tree.
+        assert n == 1
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_changed_since_is_newest_first_and_bounded():
+    pool = await _fresh_pool()
+    try:
+        base = datetime.datetime(2024, 5, 1, tzinfo=datetime.timezone.utc)
+        await dbm.record_source_nodes(
+            pool,
+            scope="test-scope",
+            source=SOURCE,
+            nodes=[{"node_ref": f"n{i}", "last_changed_at": base + datetime.timedelta(days=i)} for i in range(5)],
+        )
+        got = await dbm.list_source_nodes_changed_since(
+            pool, scope="test-scope", source=SOURCE, since=base + datetime.timedelta(days=1)
+        )
+        assert [n.node_ref for n in got] == ["n4", "n3", "n2"]
+
+        assert len(await dbm.list_source_nodes_changed_since(pool, scope="test-scope", source=SOURCE, limit=2)) == 2
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_sources_summary_is_per_scope():
+    pool = await _fresh_pool()
+    try:
+        t = datetime.datetime(2024, 5, 1, tzinfo=datetime.timezone.utc)
+        await dbm.record_source_nodes(
+            pool, scope="test-scope", source=SOURCE, nodes=[{"node_ref": "a", "last_changed_at": t}]
+        )
+        await dbm.record_source_nodes(
+            pool, scope="test-scope", source="other", nodes=[{"node_ref": "a", "last_changed_at": t}]
+        )
+        summary = {row["source"]: row["nodes"] for row in await dbm.list_source_node_sources(pool, scope="test-scope")}
+        # Same ref in two sources is two rows, not a collision -- which is what
+        # the `source` column in the identity index is for.
+        assert summary == {SOURCE: 1, "other": 1}
+    finally:
+        await dbm.close_pool(pool)


### PR DESCRIPTION
## The problem

A model kept in an external CAD system is exported into the viewer as assets, and an asset is a snapshot: correct when it was made, and silently wrong afterwards. Nothing here can say whether the source has moved since.

So a consumer either re-exports on a schedule it guesses at, or serves stale geometry without knowing. Both are bad, and neither is visible.

## The change

One table, four repository helpers, one read route.

```
source_nodes    (scope, source, node_ref) -> last_changed_at
GET /api/scopes/{scope}/source-nodes
```

Three shapes on one route, because they are one question at different widths:

| query | answers |
| --- | --- |
| *(none)* | which sources are recorded here, with counts |
| `?source=X&refs=a,b,c` | those nodes, in one round trip — the freshness check a caller holding a listing of assets makes |
| `?source=X&since=<iso>` | what has moved since a cursor the caller keeps |

**The ancestor roll-up is the writer's job.** A writer that observes a leaf change stamps the leaf *and every node above it*, so a consumer asking about a branch reads one row rather than issuing a recursive query. That is what lets this schema not model a hierarchy at all — `parent_ref` is recorded so a reader *can* reconstruct shape, and is never required to.

**Identifiers stay opaque.** `node_ref` is whatever the source calls a node, stored verbatim and never parsed here. Sources have entirely different grammars, and a schema that understood one would grow a branch for the next. `source` namespaces them so two can share a scope without colliding.

## Two decisions worth review

**No database means 503, not an empty list.** Postgres stays optional. But "nothing has changed" and "nobody is recording changes" are indistinguishable to a consumer deciding whether to trust an asset — and reading the second as the first means serving stale geometry confidently. The route refuses, and the message names `DATABASE_URL`, because the fix is a deployment change nothing else in the response would point at.

**`last_changed_at` only ever moves forward.** A writer re-observing a node may hold an *older* cursor than the row does — a backfill, a re-run over a wider window, two writers with different windows. Letting that overwrite a newer timestamp would report a stale asset as current, which is the exact failure this table exists to prevent. Hence `GREATEST` in the upsert, with the author travelling alongside the timestamp so a row cannot contradict itself.

`observed_at` is deliberately *not* sticky: "checked ten minutes ago, unchanged since Tuesday" and "last heard from on Tuesday" are different states, and only the second is a reason to distrust the answer.

## The write path

Extends the plugin contract additively, exactly as `cancel_event` already does: `source_nodes` is passed only to an entrypoint whose signature accepts it, and only when the worker actually has a pool. An older plugin is untouched, and a worker without `DATABASE_URL` simply does not receive the facade rather than being handed one that fails at first use.

## Testing

- The no-database behaviour runs everywhere and is pinned in both shapes.
- The upsert semantics are live-Postgres tests in the style `test_db.py` already uses, skipped unless `ADA_TEST_POSTGRES_URL` is set. **This machine has no container runtime, so those are unverified locally and rely on CI.**
- 26 passed across the REST tests that do not need the CAD native libraries. The rest of that suite crashes this Windows environment with a native `0xc06d007f`, which **reproduces on an unmodified tree** and is unrelated to this change.
- `pixi run lint-check` clean.

No UI, and no writer in this repo — this is the API a writer and its consumers are built on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnVdor5ZMzD5QYxFQLQioc