### PR TITLE
fix(source-nodes): key rows by the scope prefix, not the dataclass repr

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -1104,7 +1104,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
           The polling shape.
         """
         pool = _source_nodes_pool(request)
-        scope_str = str(scope_obj)
+        # prefix(), not str(). `Scope` is a dataclass, so str() is its REPR --
+        # "Scope(kind='shared', id=None)" -- which is not an identifier: it
+        # changes shape if a field is ever added or reordered, and every row
+        # keyed by the old spelling is orphaned without anything reporting it.
+        # prefix() is the canonical scope key the storage layer already uses.
+        scope_str = scope_obj.prefix()
 
         if not source:
             return JSONResponse(

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -2881,7 +2881,18 @@ class _SyncSourceNodesFacade:
 
     @property
     def scope(self) -> str:
-        return str(self._scope)
+        return self._scope_key
+
+    @property
+    def _scope_key(self) -> str:
+        """The scope's canonical key -- what the reader looks rows up by.
+
+        prefix(), never str(): `Scope` is a dataclass, so str() gives its repr,
+        which is not an identifier. Writer and reader would agree on it today and
+        both be wrong tomorrow, because adding a field to that dataclass silently
+        rewrites the key and orphans every row already stored.
+        """
+        return self._scope.prefix()
 
     def record(self, source: str, nodes: list) -> int:
         """Upsert observed nodes for one source. Returns rows written.
@@ -2894,14 +2905,14 @@ class _SyncSourceNodesFacade:
         """
         from . import db as db_module
 
-        return self._run(db_module.record_source_nodes(self._pool, scope=str(self._scope), source=source, nodes=nodes))
+        return self._run(db_module.record_source_nodes(self._pool, scope=self._scope_key, source=source, nodes=nodes))
 
     def get(self, source: str, node_refs: list) -> list:
         """What is already recorded, so a writer can avoid restating it."""
         from . import db as db_module
 
         return self._run(
-            db_module.get_source_nodes(self._pool, scope=str(self._scope), source=source, node_refs=node_refs)
+            db_module.get_source_nodes(self._pool, scope=self._scope_key, source=source, node_refs=node_refs)
         )
 
 

--- a/tests/comms/rest/test_source_nodes.py
+++ b/tests/comms/rest/test_source_nodes.py
@@ -104,6 +104,30 @@ def test_every_shape_of_the_route_refuses_without_a_database(app_client):
         assert r.status_code == 503, query
 
 
+# --- the scope key ----------------------------------------------------------
+
+
+def test_the_scope_key_is_the_prefix_not_the_dataclass_repr():
+    """Regression: `str(Scope)` is a repr, and a repr is not an identifier.
+
+    Writer and reader would AGREE on the repr, so nothing would look broken --
+    until someone adds a field to `Scope` or reorders it, at which point the key
+    silently changes shape and every row already stored is orphaned with no
+    error anywhere. Found by driving a real export through to a real REST read;
+    neither side's own tests could see it, because each was self-consistent.
+    """
+    from ada.comms.rest.scope import Scope
+
+    shared = Scope.shared()
+    assert shared.prefix() == "shared"
+    assert str(shared) != shared.prefix()
+
+    project = Scope(kind="project", id="abc-123")
+    assert project.prefix() == "projects/abc-123"
+    # The repr embeds field names and quoting; the prefix is a path segment.
+    assert "kind=" not in project.prefix()
+
+
 # --- live Postgres ----------------------------------------------------------
 
 


### PR DESCRIPTION
## The bug

`Scope` is a frozen dataclass, so `str(scope)` is its **repr**:

```python
str(Scope.shared())       # "Scope(kind='shared', id=None)"
Scope.shared().prefix()   # "shared"
```

#328 used the first as the `source_nodes.scope` key — in the route and in the worker facade alike.

**Writer and reader agree on it, so nothing looks wrong.** That is the problem. A repr is not an identifier: add a field to that dataclass, reorder it, or change a default, and the key silently changes shape. Every row already stored is orphaned, no lookup matches, and the answer a consumer gets is `unknown` — indistinguishable from a node nobody has recorded, and for a freshness index, indistinguishable from *safe*.

`prefix()` is the canonical scope key the storage layer already uses, and it is stable by construction: `shared`, `projects/<id>`, `users/<sub>`, `corpus/<slug>`.

## How it was found

By running the whole chain, not by review. A real CAD export recorded 286 nodes and the REST route reported an empty table — because the harness passed a plain string where the route computed a repr.

Neither half's own tests could see it. Each is self-consistent; the disagreement exists only *between* them.

## Scope of the change

No migration. Nothing is deployed on 0.64.0 yet, so there are no rows keyed the old way to carry forward — which is exactly why this is worth landing now rather than after something writes in anger.

Pinned by a test asserting `prefix() != str()` for both scope kinds, so the next person to reach for the convenient one is stopped by a red test rather than by an empty result months later.

## Testing

Verified against a **live Postgres**: 9 tests pass, including the six upsert semantics that had never executed anywhere — `GREATEST` on `last_changed_at`, the non-sticky `observed_at`, and the re-observation-updates-rather-than-accumulates case.

`ADA_TEST_POSTGRES_URL` is no longer hypothetical; a throwaway Postgres from conda-forge works with no container runtime, which may be worth wiring into CI.

`pixi run lint-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnVdor5ZMzD5QYxFQLQioc