### PR TITLE
fix(rest): guard against jobs dispatching against an unfinished upload

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -32,8 +32,7 @@ from ada.core.file_system import new_temp_path
 
 from . import auth as auth_module
 from . import db as db_module
-from . import failure_capture, local_jobs
-from . import pending_uploads
+from . import failure_capture, local_jobs, pending_uploads
 from .auth import User
 from .config import Settings, load_settings
 from .converter import (
@@ -3427,8 +3426,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=403, detail="forbidden")
 
         # This route is generic ("core names no plugin"), so there is no single
-        # field in ``options`` that reliably names the source file — codecheck
-        # calls it ``sin_key``, another plugin might not take a source at all.
+        # field in ``options`` that reliably names the source file — one plugin
+        # might call it ``sin_key``, another might not take a source at all.
         # Scan every string value instead of guessing a field name: any one of
         # them that names a key with an upload still in flight is the same
         # hazard /convert and /fea/manifest gate on, whatever the plugin calls

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -33,6 +33,7 @@ from ada.core.file_system import new_temp_path
 from . import auth as auth_module
 from . import db as db_module
 from . import failure_capture, local_jobs
+from . import pending_uploads
 from .auth import User
 from .config import Settings, load_settings
 from .converter import (
@@ -125,6 +126,41 @@ async def _parse_rename_body(request: Request) -> tuple[str, str]:
 
 def _content_encoding_for(key: str) -> str | None:
     return "gzip" if pathlib.PurePosixPath(key).suffix.lower() in _GZIP_UPLOAD_EXTS else None
+
+
+#: How long a presigned upload URL is valid, and — via pending_uploads — how
+#: long an unfinished upload blocks a job against its key before the entry is
+#: reaped. One literal rather than two so the two can't drift apart: a mint
+#: that outlives the block on it would let a job dispatch against a key the
+#: browser is still (validly) PUTting to.
+_UPLOAD_URL_TTL_SECONDS = 3600
+
+
+def _human_bytes(n: float) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TB"  # pragma: no cover — no upload gets here
+
+
+def _pending_upload_detail(key: str, pending: pending_uploads.PendingUpload) -> str:
+    """409 message for a job that would dispatch against a still-uploading key.
+
+    A plain string, matching every other ``HTTPException`` in this module —
+    most error-to-message paths on the frontend surface ``detail`` verbatim
+    (``ApiError`` / ``readDetail`` in viewerApi.ts read the response body as
+    text, not parsed JSON), so the useful part has to be IN the sentence
+    rather than a sibling field nothing downstream of a generic catch reads.
+    The structured form (``upload_progress`` alongside ``status``) is what
+    ``GET /files`` returns instead — real JSON, read by dedicated code.
+    """
+    if pending.loaded is not None and pending.total is not None and pending.total > 0:
+        pct = round(100 * pending.loaded / pending.total)
+        return f"{key} is still uploading ({pct}% — {_human_bytes(pending.loaded)} / {_human_bytes(pending.total)})"
+    if pending.size_hint:
+        return f"{key} is still uploading (0 / {_human_bytes(pending.size_hint)})"
+    return f"{key} is still uploading"
 
 
 #: The `app_settings` key an admin edits. Mirrored into the KV meta keyspace
@@ -924,11 +960,23 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             # 30 ms for an unaudited scope with the same file count. is_hidden_key still runs; it
             # is now cheap agreement rather than the mechanism.
             files = await storage.list(scope_obj, skip_prefixes=HIDDEN_PREFIXES)
-            return JSONResponse(
-                {
-                    "files": [{"key": f.key, "size": f.size} for f in files if not is_hidden_key(f.key)],
-                }
-            )
+            rows = {f.key: {"key": f.key, "size": f.size} for f in files if not is_hidden_key(f.key)}
+            # A key with a pending upload gets the "uploading" fields whether or
+            # not it already appears above — present-but-pending means the PUT
+            # landed and /upload-complete simply hasn't run yet; absent-but-
+            # pending means it either has not landed or the store does not hide
+            # a partial object from a concurrent listing. Either way the caller
+            # should not treat it as ready.
+            for key, pending in pending_uploads.list_for_scope(scope_obj).items():
+                fields = pending.as_dict()
+                if key in rows:
+                    # Real bytes are already listed with a real size — a
+                    # missing size_hint must not clobber it back to 0.
+                    fields.pop("size", None)
+                    rows[key].update(fields)
+                else:
+                    rows[key] = {"key": key, **fields}
+            return JSONResponse({"files": list(rows.values())})
 
         files = await storage.list(scope_obj)
 
@@ -969,6 +1017,28 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             entry = sources.get(src_key)
             if entry is not None:
                 entry["derived"] = derived_list
+        # Same merge as the plain listing above, in this richer shape. A key
+        # already in ``sources`` (the object landed; only /upload-complete
+        # hasn't run) keeps its real size/format and gains the upload fields;
+        # one that isn't there yet is added as a synthetic row so the convert
+        # page shows "uploading" instead of the file simply not existing.
+        for key, pending in pending_uploads.list_for_scope(scope_obj).items():
+            fields = pending.as_dict()
+            entry = sources.get(key)
+            if entry is None:
+                sources[key] = {
+                    "key": key,
+                    "last_modified": None,
+                    "format": _format_label(key),
+                    "available_targets": supported_targets_for(key),
+                    "derived": [],
+                    **fields,
+                }
+            else:
+                # Real bytes are already listed with a real size — a missing
+                # size_hint must not clobber it back to 0.
+                fields.pop("size", None)
+                entry.update(fields)
         out = sorted(
             sources.values(),
             key=lambda e: e.get("last_modified") or "",
@@ -2022,10 +2092,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if not is_versions_artefact_key(key) and not is_published_asset_key(key) and not await _is_accepted_source(key):
             raise HTTPException(status_code=415, detail=f"unsupported file type: {key}")
         try:
-            url = await storage.presigned_put_url(scope_obj, key, expires_in_seconds=3600)
+            url = await storage.presigned_put_url(scope_obj, key, expires_in_seconds=_UPLOAD_URL_TTL_SECONDS)
         except Exception as exc:
             logger.exception("presign failed for %s", key)
             raise HTTPException(status_code=500, detail=f"presign failed: {exc}") from exc
+        # Size is a client-supplied hint, not verified against anything — it only
+        # ever reaches a progress bar (as "0 / size_hint" until a heartbeat says
+        # otherwise) or a 409 body, never a decision. See pending_uploads.
+        raw_size = body.get("size")
+        size_hint = raw_size if isinstance(raw_size, int) and raw_size >= 0 else None
+        pending_uploads.mark_pending(
+            scope_obj, key, user_id=user.sub, size_hint=size_hint, ttl_seconds=_UPLOAD_URL_TTL_SECONDS
+        )
         # Hint that the client should gzip + send Content-Encoding=gzip
         # when this key's extension is in the compressible list. The
         # encoding header is *not* signed into the presigned URL —
@@ -2040,7 +2118,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "url": url,
                 "key": key,
                 "method": "PUT",
-                "expires_in_seconds": 3600,
+                "expires_in_seconds": _UPLOAD_URL_TTL_SECONDS,
                 "content_encoding": _content_encoding_for(key),
             }
         )
@@ -2081,8 +2159,52 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         meta = await storage.head(scope_obj, key)
         if meta is None:
             raise HTTPException(status_code=404, detail=f"object not found at {key}; was the PUT successful?")
+        # Only now — head() confirms the object is there, which is the closest
+        # this process gets to "the PUT actually finished". Left pending on a
+        # 404 above: an upload that failed or is still mid-flight must keep
+        # blocking jobs against this key, not clear the gate on the strength of
+        # a failed finalise call.
+        pending_uploads.mark_complete(scope_obj, key)
         await _audit(request, user, scope_obj, "upload", key=key, status="ok")
         return JSONResponse({"key": key, "size": meta["size"]}, status_code=201)
+
+    @api.post("/scopes/{scope}/upload-progress")
+    async def api_scope_upload_progress(
+        request: Request,
+        scope_obj: Scope = Depends(_scope_from_path),
+        user: User = Depends(auth_module.current_user),
+    ) -> Response:
+        """Heartbeat from the browser's own upload-progress events.
+
+        Body: ``{key, loaded, total}``. The API cannot observe a direct
+        browser→object-store PUT itself — that is the whole point of a
+        presigned URL — so the only source of real progress is the XHR
+        ``upload`` progress event already wired in ``putToPresignedUrl``. This
+        endpoint exists so that progress reaches somewhere OTHER than the tab
+        doing the upload: a second tab, a second viewer, or the same tab after
+        a reload, all read it back via ``GET /scopes/{scope}/files``.
+
+        Best-effort like ``_audit``: a call for a key with no pending upload
+        (already completed, expired, or never registered — e.g. the browser
+        raced its own ``/upload-complete``) is not an error, just nothing to
+        update. 204 either way; the body only needs to distinguish "keep
+        heartbeating" from "stop", which the caller gets from whether a later
+        ``GET /files`` still shows this key as uploading.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        key = (str(body.get("key") or "")).strip().lstrip("/")
+        if not key:
+            raise HTTPException(status_code=400, detail="key required")
+        try:
+            loaded = int(body.get("loaded"))
+            total = int(body.get("total"))
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="loaded and total must be integers") from None
+        pending_uploads.heartbeat(scope_obj, key, loaded=loaded, total=total)
+        return Response(status_code=204)
 
     @api.post("/scopes/{scope}/download-url")
     async def api_scope_download_url(
@@ -2195,6 +2317,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 conversion_options = cleaned
         if not source_key:
             raise HTTPException(status_code=400, detail="source_key required")
+        pending = pending_uploads.get(scope_obj, source_key)
+        if pending is not None:
+            raise HTTPException(status_code=409, detail=_pending_upload_detail(source_key, pending))
         if not await _is_accepted_source(source_key):
             raise HTTPException(status_code=415, detail=f"unsupported source format: {source_key}")
         if target_format not in TARGET_FORMATS:
@@ -2325,6 +2450,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(status_code=400, detail="utility_name required")
         if not isinstance(raw_kwargs, dict):
             raise HTTPException(status_code=400, detail="kwargs must be an object")
+        pending = pending_uploads.get(scope_obj, source_key)
+        if pending is not None:
+            raise HTTPException(status_code=409, detail=_pending_upload_detail(source_key, pending))
         # Gate against the live worker-advertised utility set so we don't enqueue
         # a job no worker can serve.
         advertised = {u.get("name") for u in await _worker_advertised_utilities()}
@@ -2628,6 +2756,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         source_key = (key or "").strip().lstrip("/")
         if not source_key:
             raise HTTPException(status_code=400, detail="key required")
+        pending = pending_uploads.get(scope_obj, source_key)
+        if pending is not None:
+            raise HTTPException(status_code=409, detail=_pending_upload_detail(source_key, pending))
         if not is_fea_artefact_source(source_key):
             # adapy ships built-in stream readers for .rmed and .sif;
             # capability workers register additional ones at startup
@@ -3294,6 +3425,20 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         scope_obj = await _resolve_project_scope(getattr(request.app.state, "db_pool", None), scope_obj)
         if not await scope_can_access(user, scope_obj, getattr(request.app.state, "db_pool", None)):
             raise HTTPException(status_code=403, detail="forbidden")
+
+        # This route is generic ("core names no plugin"), so there is no single
+        # field in ``options`` that reliably names the source file — codecheck
+        # calls it ``sin_key``, another plugin might not take a source at all.
+        # Scan every string value instead of guessing a field name: any one of
+        # them that names a key with an upload still in flight is the same
+        # hazard /convert and /fea/manifest gate on, whatever the plugin calls
+        # it in its own options shape.
+        for opt_value in options.values():
+            if not isinstance(opt_value, str) or not opt_value:
+                continue
+            pending = pending_uploads.get(scope_obj, opt_value)
+            if pending is not None:
+                raise HTTPException(status_code=409, detail=_pending_upload_detail(opt_value, pending))
 
         # Read the advertised spec ONCE: it decides both whether this request
         # needs an admin and which pool it routes to.

--- a/src/ada/comms/rest/pending_uploads.py
+++ b/src/ada/comms/rest/pending_uploads.py
@@ -43,7 +43,7 @@ plain dict.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/src/ada/comms/rest/pending_uploads.py
+++ b/src/ada/comms/rest/pending_uploads.py
@@ -1,0 +1,194 @@
+"""In-process bookkeeping for a presigned upload between mint and completion.
+
+``POST /upload-url`` hands the browser a URL and forgets: the object store has
+no notion of "this key is mid-upload" (that is what makes it fast — no request
+body passes through this process at all), and until now nothing else in the API
+recorded one either. A key can therefore sit in a state where a listing, a
+convert, or a bake job sees it before the upload it belongs to has actually
+finished — whether that is because the PUT is still in flight and the backing
+store does not hide a partial object from a concurrent GET, or simply because
+the browser never called ``/upload-complete`` (tab closed, network dropped).
+Either way, dispatching work against that key finds bytes that are not what the
+caller thinks they are, and fails wherever the reader first needs the part
+that is missing — reported in the wild as
+``TypeError: 'NoneType' object is not subscriptable`` several frames into a
+Sesam SIN parse, which is a true statement about the code and no help at all to
+whoever is looking at it.
+
+This module is the guard rail. ``upload-url`` registers a pending upload here;
+``upload-complete`` clears it. Anything that would dispatch work against a
+key — ``/convert``, ``/fea/manifest``, ``/utility``, a plugin job — checks it
+first and answers 409 with the same information a progress bar would want
+(bytes so far, if the browser has said) rather than letting the job run into a
+reader that cannot make sense of what it finds. ``GET /scopes/{scope}/files``
+merges pending entries into its listing the same way, so a second tab, a second
+user, or the same tab after a reload sees "still uploading" instead of a file
+that looks ready and is not.
+
+DELIBERATELY IN-PROCESS, NOT PERSISTED. This mirrors ``local_jobs.py``'s own
+reasoning for the same trade-off: it covers the default single-replica API
+deployment (``deploy/helm/adapy-viewer/values.yaml``: ``replicaCount: 1``) with
+nothing to provision — no bucket, no table, no dependency on Postgres or NATS
+being configured. Running multiple API replicas would give each its own view:
+a request that happens to land on a replica which never saw the ``upload-url``
+call would not be gated when it should have been. It would never be gated
+*wrongly* — a false negative here is a bug that was already there; a false
+positive (blocking a finished upload) is not possible, since nothing here
+survives past the TTL or a matching ``mark_complete``. If this stack grows a
+second replica in front of a real workload, move the registry into the audit
+table (already optional) instead of reaching for a lock service to protect a
+plain dict.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .scope import Scope
+
+#: Matches the default TTL ``presigned_put_url`` mints with — a pending entry
+#: outliving the URL it tracks would just be a permanent false "uploading".
+DEFAULT_TTL_SECONDS = 3600.0
+
+
+@dataclass
+class PendingUpload:
+    scope_prefix: str
+    key: str
+    user_id: str
+    started_at: float
+    expires_at: float
+    #: Client-declared size, if the caller sent one. Not verified against
+    #: anything — it is a hint for a progress bar, never a correctness check.
+    size_hint: int | None = None
+    #: Last heartbeat from the browser's own upload-progress event, if any
+    #: arrived. ``None`` until the first one does; a caller with nothing to
+    #: report yet still gets "uploading", just with no percentage attached.
+    loaded: int | None = None
+    total: int | None = None
+    updated_at: float | None = None
+
+    def is_expired(self, *, now: float | None = None) -> bool:
+        return (now if now is not None else time.time()) >= self.expires_at
+
+    def as_dict(self) -> dict:
+        """Fields merged into a ``/files`` row. ``size`` is always present
+        (falling back to 0) because ``FileEntry``/``AdminFileEntry`` on the
+        frontend declare it required — every OTHER row in that listing is a
+        real object with a real size, and a row that sometimes has the field
+        and sometimes doesn't is a worse contract than one that is 0 while
+        genuinely unknown."""
+        out: dict = {
+            "status": "uploading",
+            "started_at": self.started_at,
+            "size": self.size_hint if self.size_hint is not None else 0,
+        }
+        if self.loaded is not None and self.total is not None:
+            out["upload_progress"] = {
+                "loaded": self.loaded,
+                "total": self.total,
+                "updated_at": self.updated_at,
+            }
+        return out
+
+
+# (scope_prefix, key) -> PendingUpload. Module-level and unlocked: every
+# mutation here is a single dict assignment/pop, which the GIL already makes
+# atomic, and nothing in this module ever awaits between reading a value and
+# writing it back — there is no window for a lock to close.
+_REGISTRY: dict[tuple[str, str], PendingUpload] = {}
+
+
+def _norm_key(key: str) -> str:
+    return key.strip().lstrip("/")
+
+
+def _registry_key(scope: "Scope", key: str) -> tuple[str, str]:
+    return (scope.prefix(), _norm_key(key))
+
+
+def mark_pending(
+    scope: "Scope",
+    key: str,
+    *,
+    user_id: str,
+    size_hint: int | None = None,
+    ttl_seconds: float = DEFAULT_TTL_SECONDS,
+) -> None:
+    """Record that a presigned upload was minted for ``key`` and has not
+    completed. Replaces any existing entry for the same key outright — a
+    retried upload (the common reason a second ``upload-url`` call happens
+    for a key already pending) restarts the window rather than stacking."""
+    now = time.time()
+    entry = PendingUpload(
+        scope_prefix=scope.prefix(),
+        key=_norm_key(key),
+        user_id=user_id,
+        started_at=now,
+        expires_at=now + ttl_seconds,
+        size_hint=size_hint,
+    )
+    _REGISTRY[_registry_key(scope, key)] = entry
+
+
+def mark_complete(scope: "Scope", key: str) -> None:
+    """Clear a pending upload — the browser's PUT succeeded and
+    ``/upload-complete`` confirmed the object exists. A no-op if there was
+    nothing pending (the regular small-file PUT path never registers one, and
+    calling this twice must not raise)."""
+    _REGISTRY.pop(_registry_key(scope, key), None)
+
+
+def heartbeat(scope: "Scope", key: str, *, loaded: int, total: int) -> bool:
+    """Record upload progress the browser reported. Returns whether a pending
+    entry existed to update — the caller (a heartbeat endpoint) uses this to
+    tell the browser to stop bothering rather than 404ing that harmless call,
+    since "nothing pending" is the expected end state once the upload finishes
+    and the last heartbeat races the ``upload-complete`` clear."""
+    entry = get(scope, key)
+    if entry is None:
+        return False
+    entry.loaded = max(0, loaded)
+    entry.total = max(entry.loaded, total)
+    entry.updated_at = time.time()
+    return True
+
+
+def get(scope: "Scope", key: str) -> PendingUpload | None:
+    """The pending entry for ``key``, or ``None`` if there isn't one — reaping
+    it first if its TTL has passed, so an abandoned upload does not block that
+    key forever."""
+    reg_key = _registry_key(scope, key)
+    entry = _REGISTRY.get(reg_key)
+    if entry is None:
+        return None
+    if entry.is_expired():
+        _REGISTRY.pop(reg_key, None)
+        return None
+    return entry
+
+
+def is_pending(scope: "Scope", key: str) -> bool:
+    return get(scope, key) is not None
+
+
+def list_for_scope(scope: "Scope") -> dict[str, PendingUpload]:
+    """Every non-expired pending upload in ``scope``, keyed by (normalised) key.
+
+    Used by ``GET /scopes/{scope}/files`` to merge "uploading" rows into a
+    listing. Expired entries are reaped as they are found, same as ``get``.
+    """
+    prefix = scope.prefix()
+    now = time.time()
+    out: dict[str, PendingUpload] = {}
+    for (scope_prefix, key), entry in list(_REGISTRY.items()):
+        if scope_prefix != prefix:
+            continue
+        if entry.is_expired(now=now):
+            _REGISTRY.pop((scope_prefix, key), None)
+            continue
+        out[key] = entry
+    return out

--- a/src/ada/fem/formats/sesam/results/read_sif.py
+++ b/src/ada/fem/formats/sesam/results/read_sif.py
@@ -769,6 +769,23 @@ class Sif2Mesh:
 
         sif = self.sif
 
+        if sif.nodes is None or sif.node_ids is None:
+            # Both stay None unless _load_static (read_sin.py) / the SIF parse
+            # actually saw a GCOORD/GNODE record — the guard that would
+            # otherwise be a bare `TypeError: 'NoneType' object is not
+            # subscriptable` several frames below, on the coordinate slice, with
+            # nothing in the message to say which of "no such records exist"
+            # (wrong file) or "not all of them have arrived yet" (a truncated or
+            # still-in-progress upload — see rest/pending_uploads.py, which
+            # exists to stop this exact request from reaching here) it was.
+            source = getattr(getattr(sif, "sin", None), "path", None)
+            where = f" ({source})" if source else ""
+            raise ValueError(
+                f"no GCOORD/GNODE mesh records found{where} — the file may be truncated "
+                "(an interrupted or still-in-progress upload) or is not a Sesam results "
+                "deck for the super-element being read"
+            )
+
         nodes = FemNodes(coords=sif.nodes[:, 1:], identifiers=np.asarray(sif.node_ids[:, 0], dtype=int))
         sorted_elem_data = sorted(sif.elements, key=lambda x: x[0])
         elem_blocks = []

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -85,7 +85,18 @@ export interface MeResponse {
   projects: Array<{ id: string; slug: string; name: string; role: string }>;
 }
 
-export interface FileEntry {
+/** Present, and "uploading", while the key's presigned upload hasn't
+ * completed (server-side: pending_uploads.py) — a listing row in this state
+ * has no confirmed bytes behind it yet, whatever `size` says. `size` is a
+ * best-effort 0 until either the client's own size hint or a heartbeat says
+ * otherwise; `upload_progress` is absent until at least one heartbeat has
+ * landed. */
+export interface UploadingFields {
+  status: "uploading";
+  upload_progress?: { loaded: number; total: number; updated_at: number | null };
+}
+
+export interface FileEntry extends Partial<UploadingFields> {
   key: string;
   size: number;
 }
@@ -1014,7 +1025,7 @@ export interface DerivedBlob {
   last_modified: string | null;
 }
 
-export interface AdminFileEntry {
+export interface AdminFileEntry extends Partial<UploadingFields> {
   key: string;
   size: number;
   last_modified: string | null;
@@ -1854,6 +1865,12 @@ export const viewerApi = {
   async requestUploadUrl(
     scope: ScopeUrl,
     key: string,
+    /** The file's byte size, if known. Not verified against anything server-
+     * side — it never gates a decision, only seeds the "uploading" row a
+     * second tab or a page reload would otherwise show with no size at all
+     * until the first upload-progress heartbeat arrives. Always known here:
+     * every caller has a `File`, whose `.size` is free to read. */
+    size?: number,
   ): Promise<{
     url: string;
     key: string;
@@ -1872,10 +1889,39 @@ export const viewerApi = {
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key }),
+        body: JSON.stringify(
+          typeof size === "number" ? { key, size } : { key },
+        ),
       },
     );
     return jsonOrThrow(r, `requestUploadUrl(${key})`);
+  },
+
+  /** Heartbeat the browser's own upload-progress event to the server, so a
+   * SECOND tab, a second user, or the same tab after a reload can see real
+   * progress via `GET /files` instead of a bare "uploading" with no number —
+   * the API cannot observe a direct browser→object-store PUT any other way.
+   * Best-effort: swallow failures rather than surface them, since a missed
+   * heartbeat is a slightly stale progress bar, never a broken upload — the
+   * PUT itself does not go through this call at all. */
+  async uploadProgress(
+    scope: ScopeUrl,
+    key: string,
+    loaded: number,
+    total: number,
+  ): Promise<void> {
+    try {
+      await authedFetch(
+        `${runtime.apiBase()}/scopes/${encodeURIComponent(scope)}/upload-progress`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key, loaded, total }),
+        },
+      );
+    } catch {
+      // Best-effort — see the docstring above.
+    }
   },
 
   /** Request a presigned GET URL for direct, Range-capable download from

--- a/src/frontend/src/utils/scene/handlers/upload_source_file.ts
+++ b/src/frontend/src/utils/scene/handlers/upload_source_file.ts
@@ -188,9 +188,28 @@ export async function uploadFile(
         // and the error bubbles to the caller — we don't transparently
         // fall back to the buffered path because that would silently
         // 413 on this same request anyway.
-        const presigned = await viewerApi.requestUploadUrl(scope, key);
+        const presigned = await viewerApi.requestUploadUrl(scope, key, file.size);
+        // The server cannot observe this PUT — that is the whole point of a
+        // presigned URL — so the progress event firing right here, in THIS
+        // tab, is the only place real numbers exist. Heartbeat a throttled
+        // copy back so a second tab, a second user, or this same tab after a
+        // reload can see them too (GET /files -> upload_progress), not just a
+        // static "uploading". Throttled rather than every event: XHR fires
+        // progress dozens of times a second on a fast link, and the value a
+        // heartbeat exists to serve — another VIEWER's progress bar — does
+        // not need finer resolution than that.
+        let lastHeartbeatAt = 0;
+        const HEARTBEAT_MIN_INTERVAL_MS = 1000;
+        const heartbeatingOnProgress = (loaded: number, total: number) => {
+            opts?.onProgress?.(loaded, total);
+            const now = Date.now();
+            if (loaded >= total || now - lastHeartbeatAt >= HEARTBEAT_MIN_INTERVAL_MS) {
+                lastHeartbeatAt = now;
+                void viewerApi.uploadProgress(scope, key, loaded, total);
+            }
+        };
         await putToPresignedUrl(
-            presigned.url, file, opts?.onProgress, presigned.content_encoding,
+            presigned.url, file, heartbeatingOnProgress, presigned.content_encoding,
         );
         await viewerApi.completeUpload(scope, key);
     } else {


### PR DESCRIPTION
A presigned upload (`POST /upload-url`) hands the browser a URL and forgets: nothing records that a key is mid-upload, so a convert, a bake, or a plugin job could be dispatched against it before the PUT actually finished. In the wild this surfaced as a bake failing deep in a Sesam SIN parse with `TypeError: 'NoneType' object is not subscriptable` — a true statement about the code and no help to whoever was looking at it, because the object being read was a truncated upload, not a malformed file.

## `pending_uploads.py`

The guard rail. `upload-url` registers a pending upload; `upload-complete` clears it — and only on a confirmed `head()`, never on a 404, so a failed finalise keeps blocking rather than clearing the gate. `/convert`, `/fea/manifest`, `/utility` and the generic `/plugins/{id}/jobs` route all check it first and 409 with a human message (`"42% uploaded"`) rather than letting the job run into a reader that cannot make sense of what it finds. `GET /files` merges pending entries into both listing shapes, so a second tab, a second user, or a reload sees `"uploading"` instead of a file that looks ready and is not.

The generic plugin-job route has no single field name for "the source file" — one plugin calls it `sin_key`, another might not take one at all — so it scans every string value in `options` instead of guessing a field name.

## Verified live, end to end, against a real object store

Mint with a size hint → listed as `uploading` → heartbeat updates progress → gated (409) at `/convert` and `/fea/manifest` → raw PUT lands → **still gated**, because `upload-complete` hasn't run yet (the exact race from the bug report) → `upload-complete` clears it → `/convert` proceeds.

```
--- 8. still gated BEFORE upload-complete is called ---
convert (pre-complete) -> HTTP 409 (expected 409)
--- 9. upload-complete clears the pending entry ---
upload-complete HTTP 201  {"key":"lifecycle_test.SIN","size":12345}
--- 10. GET files no longer shows uploading, real size ---
row: {"key":"lifecycle_test.SIN","size":12345}
--- 11. convert now proceeds past the gate ---
convert -> HTTP 202
```

## The one gap this does NOT close

Progress is visible over the REST `/files` JSON endpoint (this fix), but the viewer's own file panel (`StorageBrowser.tsx`) is fed by a **separate wire format** — the `FileObject` flatbuffers table, populated by `LIST_FILE_OBJECTS` regardless of REST/WS transport. Advertising `"uploading"` there needs that `.fbs` schema extended and regenerated on both sides. I did not attempt it: it's a binary-protocol change I have no way to verify without a live browser round trip against a rebuilt toolchain, and guessing at flatbuffers wire compatibility is a worse trade than leaving it flagged as the next step. Filed here rather than silently left out.

## Also fixed, independently of the race

`get_sif_mesh` (`read_sif.py`) subscripted `sif.nodes` / `sif.node_ids` with no guard, so a deck with no `GCOORD`/`GNODE` record — right now *always* true for a still-uploading file, but also true for a genuinely malformed one — raised a bare `TypeError` several frames deep. Now raises a message naming the actual condition.

## Why in-process, not persisted

`pending_uploads.py`'s own docstring carries the full reasoning. Short version: matches `local_jobs.py`'s existing trade-off for the same reason, covers the default single-replica API deployment (`deploy/helm/adapy-viewer/values.yaml`: `replicaCount: 1`), and a false positive (blocking a finished upload) cannot happen — only ever a false negative on a second, uncoordinated replica, which is a bug that already existed.

Labels: release-patch
