### PR TITLE
feat(plugin-jobs): cron for plugin jobs, configurable from the admin panel

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -309,6 +309,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 _scheduler_loop(app.state.db_pool),
                 name="audit-scheduler",
             )
+        # Plugin-job scheduler. Same conditions as the audit scheduler above and
+        # for the same reason: without a pool there are no schedules to read, and
+        # without a queue there is nothing to enqueue onto.
+        app.state.plugin_scheduler_task = None
+        if app.state.db_pool is not None and queue.enabled:
+            app.state.plugin_scheduler_task = asyncio.create_task(
+                _plugin_schedule_loop(app.state.db_pool),
+                name="plugin-job-scheduler",
+            )
         # Issue-bot poller (M5). Only needs the DB pool — the bot
         # talks to an HTTP forge, not NATS, so a queue-less deploy
         # can still publish failure issues. Skipped without a pool.
@@ -366,6 +375,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # down.
         for attr in (
             "scheduler_task",
+            "plugin_scheduler_task",
             "issue_bot_task",
             "profile_parser_task",
             "worker_prune_task",
@@ -3405,6 +3415,115 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return True
         return plugin_id in gated
 
+    async def _enqueue_plugin_job(
+        *,
+        plugin_id: str,
+        options: dict,
+        scope_obj: Scope,
+        capability: str | None = None,
+        user,
+        pool=None,
+        request: Request | None = None,
+        derived_prefix: str | None = None,
+        derived_key: str | None = None,
+        plugin_spec: dict | None = None,
+    ) -> str:
+        """Enqueue one plugin job and return its job id.
+
+        ONE ENQUEUE PATH, two callers: ``POST /plugins/{id}/jobs`` and the
+        plugin-job scheduler's tick. That is not tidiness -- it is the property
+        that makes a scheduled firing indistinguishable from a user-initiated one
+        to the worker, so capability routing, audit rows, cancellation and the
+        cached-blob short circuit cannot drift between them. A second enqueue for
+        the scheduler would be a second set of those behaviours to keep in step.
+
+        AUTHORISATION IS THE CALLER'S. This helper does not check scope access or
+        the plugin's admin gate: the route does both before calling, and the tick
+        runs as the system identity by construction. Putting the checks here would
+        read as safer and would in fact be looser, because the tick would then be
+        passing a synthetic admin through a gate built for real users.
+        """
+        import hashlib as _hashlib
+
+        # Synthetic source_key over (plugin_id, options hash) so identical
+        # requests cache-hit. A SCHEDULE therefore has to vary its options, which
+        # is what SCHEDULE_FIRE_TOKEN is for -- see the note on it.
+        opts_hash = _hashlib.sha256(json.dumps(options, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+        source_key = f"_synthetic/plugin_job/{plugin_id}/{opts_hash}"
+        if not isinstance(derived_key, str) or not derived_key.strip():
+            derived_key = f"_derived/plugin_jobs/{plugin_id}/{opts_hash}.json"
+
+        if plugin_spec is None:
+            for _spec in (await _live_worker_specs("plugin_specs")).values():
+                if _spec.get("slug") == plugin_id or _spec.get("id") == plugin_id:
+                    plugin_spec = _spec
+                    break
+
+        # Route to the pool advertising this plugin's worker_capability. An
+        # explicit override wins; otherwise read it off the live spec.
+        target_capability = None
+        if isinstance(capability, str) and capability.strip():
+            target_capability = capability_token(capability)
+        elif plugin_spec is not None:
+            cap = plugin_spec.get("worker_capability")
+            if isinstance(cap, str) and cap.strip():
+                target_capability = capability_token(cap)
+            # SHARDED POOLS: a plugin may advertise `capability_option` naming one
+            # of its own options; supplying it routes to `<capability>-<value>`.
+            # See the long note on the route for why subject routing rather than
+            # NAKing is how non-interchangeable workers are kept apart.
+            opt_name = plugin_spec.get("capability_option")
+            if target_capability and isinstance(opt_name, str) and opt_name:
+                shard = capability_token(options.get(opt_name))
+                if shard:
+                    target_capability = f"{target_capability}-{shard}"
+
+        # No queue: run it here, in a thread. A single-node viewer otherwise has
+        # no way to run a plugin job at all.
+        if not queue.enabled:
+            try:
+                local = local_jobs.start_plugin_job(
+                    plugin_id=plugin_id,
+                    options=options,
+                    derived_prefix=derived_prefix,
+                    derived_key=derived_key,
+                    storage=storage,
+                    scope=scope_obj,
+                )
+            except LookupError as exc:
+                raise HTTPException(status_code=501, detail=str(exc)) from exc
+            return local.job_id
+
+        job = await queue.enqueue(
+            source_key,
+            target_format="plugin_job",
+            scope_kind=scope_obj.kind,
+            scope_id=scope_obj.id,
+            conversion_options={
+                "plugin_id": plugin_id,
+                "options": options,
+                "derived_prefix": derived_prefix,
+            },
+            derived_key=derived_key,
+            target_capability=target_capability,
+            # Hold the publish until the audit row exists -- publishing first is
+            # what strands a row at "queued" with no message left to recover it.
+            publish=False,
+        )
+        await _audit(
+            request,
+            user,
+            scope_obj,
+            "plugin_job",
+            key=source_key,
+            target_format="plugin_job",
+            status="queued",
+            job_id=job.job_id,
+            pool=pool,
+        )
+        await queue.publish(job)
+        return job.job_id
+
     @api.post("/plugins/{plugin_id}/jobs")
     async def api_plugin_job(
         plugin_id: str,
@@ -3449,114 +3568,27 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     detail=f"plugin job {plugin_id!r} is restricted to administrators",
                 )
 
-        # No source file — synthetic source_key over (plugin_id, options hash) so
-        # identical requests cache-hit. derived_key holds the JSON summary the
-        # plugin returns (the sidecar bundle lives under derived_prefix).
+        # Everything from here is shared with the plugin-job scheduler -- see
+        # _enqueue_plugin_job. The checks above (scope access, the admin gate) are
+        # this route's alone, which is why they are not in the helper.
         import hashlib as _hashlib
 
         opts_hash = _hashlib.sha256(json.dumps(options, sort_keys=True).encode("utf-8")).hexdigest()[:16]
-        source_key = f"_synthetic/plugin_job/{plugin_id}/{opts_hash}"
         derived_key = body.get("derived_key")
         if not isinstance(derived_key, str) or not derived_key.strip():
             derived_key = f"_derived/plugin_jobs/{plugin_id}/{opts_hash}.json"
-
-        # Route to the pool advertising this plugin's worker_capability. Caller may
-        # override; otherwise read it off the live plugin spec so the right pool
-        # (e.g. a capacity worker) picks the job up.
-        target_capability = body.get("capability")
-        if isinstance(target_capability, str) and target_capability.strip():
-            target_capability = capability_token(target_capability)
-        else:
-            target_capability = None
-            if plugin_spec is not None:
-                cap = plugin_spec.get("worker_capability")
-                if isinstance(cap, str) and cap.strip():
-                    target_capability = capability_token(cap)
-                # SHARDED POOLS. A plugin may advertise `capability_option`
-                # naming one of its own options; when the request supplies
-                # that option the job routes to `<capability>-<value>`
-                # instead of `<capability>`.
-                #
-                # This exists because a pool is one durable consumer: every
-                # worker in it competes for the same messages, so workers
-                # that are NOT interchangeable — each holding a different
-                # licence, dataset or device — cannot share one. Routing
-                # them apart by NAKing the wrong ones is the design this
-                # replaced; it burned the delivery budget and dead-lettered
-                # valid jobs (see the note on `pull_subscribe`).
-                #
-                # Subject routing does it instead, and the worker needs no
-                # new code: it just lists the sharded token in
-                # ADA_WORKER_CAPABILITIES. Core still names no plugin and
-                # knows nothing about what the option MEANS.
-                #
-                # An absent or unusable option falls back to the bare
-                # capability rather than erroring, so a worker that
-                # subscribes to both serves unqualified requests too, and a
-                # single-worker deployment never has to qualify anything.
-                opt_name = plugin_spec.get("capability_option")
-                if target_capability and isinstance(opt_name, str) and opt_name:
-                    shard = capability_token(options.get(opt_name))
-                    if shard:
-                        target_capability = f"{target_capability}-{shard}"
-
-        # No queue: run it here, in a thread, and hand back a job id the status
-        # endpoint below can serve. A single-node viewer (the examples, a laptop)
-        # otherwise has no way to run a plugin job at all — the button was dead in
-        # exactly the setup that puts the model in front of you. The plugin sees an
-        # identical contract either way, so nothing about it knows which path ran.
-        if not queue.enabled:
-            try:
-                local = local_jobs.start_plugin_job(
-                    plugin_id=plugin_id,
-                    options=options,
-                    derived_prefix=body.get("derived_prefix"),
-                    derived_key=derived_key,
-                    storage=storage,
-                    scope=scope_obj,
-                )
-            except LookupError as exc:
-                # The plugin's backend is not importable in THIS process. With a
-                # worker that is the pool's problem; here it is the answer.
-                raise HTTPException(status_code=501, detail=str(exc)) from exc
-            return JSONResponse({"job_id": local.job_id, "derived_key": derived_key})
-
-        job = await queue.enqueue(
-            source_key,
-            target_format="plugin_job",
-            scope_kind=scope_obj.kind,
-            scope_id=scope_obj.id,
-            conversion_options={
-                "plugin_id": plugin_id,
-                "options": options,
-                "derived_prefix": body.get("derived_prefix"),
-            },
+        job_id = await _enqueue_plugin_job(
+            plugin_id=plugin_id,
+            options=options,
+            scope_obj=scope_obj,
+            capability=body.get("capability"),
+            user=user,
+            request=request,
+            derived_prefix=body.get("derived_prefix"),
             derived_key=derived_key,
-            target_capability=target_capability,
-            # Hold the publish until the audit row exists. A plugin_job is short
-            # (tens of ms — often just the cached-blob short circuit), which is
-            # well inside the time this handler takes to get its INSERT in, and
-            # the worker's terminal write is UPDATE ... WHERE job_id with no
-            # upsert. Publishing first is what strands a row at "queued" with no
-            # message and no KV entry left to recover it from.
-            publish=False,
+            plugin_spec=plugin_spec,
         )
-        # Register as a first-class audit task (row keyed by job_id). Without this
-        # the worker's mark_audit_running/_audit_done no-op, /my-jobs shows nothing,
-        # and cancel/metrics/profiling can't attach. action + target_format are
-        # free-text; "plugin_job" keeps it filterable from conversions.
-        await _audit(
-            request,
-            user,
-            scope_obj,
-            "plugin_job",
-            key=source_key,
-            target_format="plugin_job",
-            status="queued",
-            job_id=job.job_id,
-        )
-        await queue.publish(job)
-        return JSONResponse({"job_id": job.job_id, "derived_key": derived_key})
+        return JSONResponse({"job_id": job_id, "derived_key": derived_key})
 
     # Settings whose key begins with this prefix are readable by ANY
     # authenticated user; every other key in app_settings stays admin-only.
@@ -6233,6 +6265,327 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             _audit_dispatch(run["id"], s, worker_pool, "system", pool),
             name=f"audit-dispatch-{run['id']}",
         )
+
+    # ── Plugin-job schedules (cron for plugin jobs) ───────────────
+
+    #: Options key the tick stamps with each firing's timestamp.
+    #:
+    #: ALWAYS, AND THERE IS NO WAY TO TURN IT OFF. Core hashes a plugin job's
+    #: options into its source key so identical requests cache-hit, which is
+    #: right for a user pressing a button twice and catastrophic for a schedule:
+    #: byte-identical options every hour means the second firing and every one
+    #: after returns the FIRST run's summary. Hourly green ticks, the worker never
+    #: touched, and a caller trusting data that stopped moving.
+    #:
+    #: Read by nobody. It exists to change the hash, exactly as `refresh` does on
+    #: the plugin-job read path -- and it is stamped by the TICK rather than
+    #: offered as a schedule field, because a scheduled run that legitimately
+    #: answers "same as last time" cannot be told apart from one that never
+    #: happened.
+    SCHEDULE_FIRE_TOKEN = "scheduled_at"
+
+    def _plugin_schedule_options(schedule_row: dict, fired_at) -> dict:
+        """The options to dispatch: the schedule's own, plus the fire token."""
+        options = dict(schedule_row.get("options") or {})
+        options[SCHEDULE_FIRE_TOKEN] = fired_at.isoformat()
+        return options
+
+    @admin.get("/plugin-jobs/schedules")
+    async def admin_plugin_job_schedules_list(request: Request) -> JSONResponse:
+        pool = _require_pool(request)
+        include_archived = request.query_params.get("include_archived") in ("1", "true", "yes")
+        rows = await db_module.list_plugin_job_schedules(pool, include_archived=include_archived)
+        return JSONResponse({"schedules": rows})
+
+    @admin.post("/plugin-jobs/schedules")
+    async def admin_plugin_job_schedules_create(
+        request: Request,
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Create a schedule.
+
+        Body: ``{"name", "cron_expr", "scope", "plugin_id", "options",
+        "capability", "enabled"}``.
+
+        ``plugin_id`` is NOT checked against the live plugin registry. A schedule
+        may legitimately be created before the worker that serves it exists, or
+        survive a pool being down for a day; refusing here would make the admin
+        panel depend on a worker being up to configure anything. An id nothing
+        serves shows up as a queued job that nobody picks up, which is already
+        visible in /my-jobs.
+        """
+        pool = _require_pool(request)
+        body = await request.json() if await request.body() else {}
+        name = (body.get("name") or "").strip()
+        cron_expr = _validate_cron(body.get("cron_expr") or "")
+        scope_str = (body.get("scope") or "").strip()
+        plugin_id = (body.get("plugin_id") or "").strip()
+        options = body.get("options") or {}
+        capability = (body.get("capability") or "").strip() or None
+        enabled = bool(body.get("enabled", True))
+
+        if not name:
+            raise HTTPException(status_code=400, detail="name required")
+        if not scope_str:
+            raise HTTPException(status_code=400, detail="scope required")
+        if not plugin_id:
+            raise HTTPException(status_code=400, detail="plugin_id required")
+        if not isinstance(options, dict):
+            raise HTTPException(status_code=400, detail="options must be an object")
+        if SCHEDULE_FIRE_TOKEN in options:
+            # Refused rather than silently overwritten: a caller who set it
+            # believes it means something, and the tick is about to replace it.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"options.{SCHEDULE_FIRE_TOKEN} is reserved — the scheduler stamps it on every "
+                    "firing so that two firings never share an options hash and cache-hit"
+                ),
+            )
+        # Parses only. Slug-to-id resolution happens at fire time so renaming a
+        # project does not strand a schedule.
+        _ = _parse_scope(scope_str, user)
+
+        try:
+            row = await db_module.create_plugin_job_schedule(
+                pool,
+                name=name,
+                cron_expr=cron_expr,
+                scope=scope_str,
+                plugin_id=plugin_id,
+                options=options,
+                capability=capability,
+                enabled=enabled,
+                next_fire_at=_next_fire(cron_expr),
+                created_by=user.sub,
+            )
+        except Exception as exc:
+            if exc.__class__.__name__ == "UniqueViolationError":
+                raise HTTPException(status_code=409, detail=f"schedule name {name!r} already in use") from exc
+            raise
+        return JSONResponse(row, status_code=201)
+
+    @admin.patch("/plugin-jobs/schedules/{schedule_id}")
+    async def admin_plugin_job_schedules_update(
+        schedule_id: str,
+        request: Request,
+        user: User = Depends(auth_module.current_user),
+    ) -> JSONResponse:
+        """Partial update. Only the fields present in the body move."""
+        pool = _require_pool(request)
+        body = await request.json() if await request.body() else {}
+        fields: dict = {}
+
+        if "name" in body:
+            name = (body.get("name") or "").strip()
+            if not name:
+                raise HTTPException(status_code=400, detail="name cannot be empty")
+            fields["name"] = name
+        if "cron_expr" in body:
+            fields["cron_expr"] = _validate_cron(body.get("cron_expr") or "")
+            # A changed expression makes the stored next_fire_at meaningless, so
+            # it is recomputed here rather than left to drift until the next fire.
+            fields["next_fire_at"] = _next_fire(fields["cron_expr"])
+        if "scope" in body:
+            scope_str = (body.get("scope") or "").strip()
+            if not scope_str:
+                raise HTTPException(status_code=400, detail="scope cannot be empty")
+            _ = _parse_scope(scope_str, user)
+            fields["scope"] = scope_str
+        if "plugin_id" in body:
+            plugin_id = (body.get("plugin_id") or "").strip()
+            if not plugin_id:
+                raise HTTPException(status_code=400, detail="plugin_id cannot be empty")
+            fields["plugin_id"] = plugin_id
+        if "options" in body:
+            options = body.get("options") or {}
+            if not isinstance(options, dict):
+                raise HTTPException(status_code=400, detail="options must be an object")
+            if SCHEDULE_FIRE_TOKEN in options:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"options.{SCHEDULE_FIRE_TOKEN} is reserved — the scheduler stamps it",
+                )
+            fields["options"] = options
+        if "capability" in body:
+            fields["capability"] = (body.get("capability") or "").strip() or None
+        if "enabled" in body:
+            fields["enabled"] = bool(body.get("enabled"))
+            # Re-enabling a schedule whose next_fire_at is long past would fire
+            # immediately and then again on its real slot. Recomputed from now.
+            if fields["enabled"]:
+                current = await db_module.get_plugin_job_schedule(pool, schedule_id)
+                if current is None:
+                    raise HTTPException(status_code=404, detail="schedule not found")
+                fields.setdefault("next_fire_at", _next_fire(current["cron_expr"]))
+
+        row = await db_module.update_plugin_job_schedule(pool, schedule_id, **fields)
+        if row is None:
+            raise HTTPException(status_code=404, detail="schedule not found")
+        return JSONResponse(row)
+
+    @admin.delete("/plugin-jobs/schedules/{schedule_id}")
+    async def admin_plugin_job_schedules_archive(schedule_id: str, request: Request) -> JSONResponse:
+        pool = _require_pool(request)
+        if not await db_module.archive_plugin_job_schedule(pool, schedule_id):
+            raise HTTPException(status_code=404, detail="schedule not found, or already archived")
+        return JSONResponse({"archived": schedule_id})
+
+    @admin.post("/plugin-jobs/schedules/{schedule_id}/run")
+    async def admin_plugin_job_schedules_run_now(schedule_id: str, request: Request) -> JSONResponse:
+        """Fire a schedule immediately, without waiting for its slot.
+
+        The reason this exists is that a schedule is otherwise unverifiable: an
+        admin who has just created one has no way to learn whether its options,
+        scope and plugin actually produce a job short of waiting for the cron to
+        come round. It does not disturb the timetable -- ``next_fire_at`` is left
+        alone, so the scheduled slot still happens.
+        """
+        pool = _require_pool(request)
+        row = await db_module.get_plugin_job_schedule(pool, schedule_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="schedule not found")
+        from datetime import datetime, timezone
+
+        outcome = await _plugin_schedule_fire(pool, row, fired_at=datetime.now(timezone.utc))
+        if outcome.get("skipped"):
+            # 409: the request was valid, the state said no. The reason is the
+            # useful half.
+            raise HTTPException(status_code=409, detail=outcome["skipped"])
+        return JSONResponse(outcome)
+
+    async def _plugin_schedule_loop(pool) -> None:
+        """Tick every 30 s, claim due schedules, enqueue them as plugin jobs.
+
+        A deliberate mirror of ``_scheduler_loop`` above: same interval, same
+        drain-the-backlog inner loop, same "one tick's exception must not kill the
+        loop" posture. The two are separate because their payloads are, not
+        because they disagree about how ticking works.
+        """
+        from datetime import datetime, timezone
+
+        TICK_INTERVAL_S = 30.0
+        logger.info("plugin-job scheduler: starting (tick every %ss)", TICK_INTERVAL_S)
+        try:
+            while True:
+                try:
+                    now = datetime.now(timezone.utc)
+                    while True:
+                        try:
+                            # Claimed with a placeholder next_fire_at and
+                            # corrected below, once this row's cron_expr is known.
+                            row = await db_module.claim_due_plugin_job_schedule(pool, now=now, next_fire_at=now)
+                        except Exception:
+                            logger.exception("plugin-job scheduler: claim failed")
+                            break
+                        if row is None:
+                            break
+                        try:
+                            await db_module.update_plugin_job_schedule(
+                                pool,
+                                row["id"],
+                                next_fire_at=_next_fire(row["cron_expr"], after=now),
+                            )
+                        except Exception as exc:
+                            # next_fire_at is now `now`, so this row would be
+                            # claimed again on the next tick and spin. Disable it
+                            # and say why rather than let it hammer the queue.
+                            logger.exception("plugin-job scheduler: could not advance %s", row["id"])
+                            await db_module.update_plugin_job_schedule(pool, row["id"], enabled=False)
+                            await db_module.set_plugin_job_schedule_skip_reason(
+                                pool,
+                                row["id"],
+                                f"disabled: could not compute the next firing from {row['cron_expr']!r}: {exc}",
+                            )
+                            continue
+
+                        await _plugin_schedule_fire(pool, row, fired_at=now)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("plugin-job scheduler: tick failed")
+                await asyncio.sleep(TICK_INTERVAL_S)
+        except asyncio.CancelledError:
+            logger.info("plugin-job scheduler: stopped")
+            raise
+
+    async def _plugin_schedule_fire(pool, schedule_row: dict, *, fired_at) -> dict:
+        """Enqueue one schedule's job. Returns what happened.
+
+        ``{"job_id": ..., "schedule": ...}`` on a firing, or
+        ``{"skipped": "<reason>"}`` when state said no. Every skip is also written
+        to the row, because a schedule that silently does nothing is the failure
+        this whole feature exists to remove.
+        """
+        sched_id = schedule_row["id"]
+        plugin_id = schedule_row["plugin_id"]
+
+        try:
+            scope_obj = _parse_scope(schedule_row["scope"], _SystemUser())
+            scope_obj = await _resolve_project_scope(pool, scope_obj)
+        except HTTPException as exc:
+            reason = f"scope {schedule_row['scope']!r} did not resolve ({exc.status_code}): {exc.detail}"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+        except Exception as exc:
+            logger.exception("plugin-job scheduler: scope resolution crashed for %s", sched_id)
+            reason = f"scope resolution crashed: {exc}"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+
+        # Concurrent-fire guard. A plugin job can hold a single licensed
+        # workstation for minutes, so an overlapping firing does not just double
+        # the load -- the two contend for one resource and the loser fails in a
+        # way that reads as the plugin's fault. The missed slot is NOT backfired:
+        # the next slot is the next chance, which is the same choice the audit
+        # scheduler makes and for the same reason.
+        try:
+            in_flight = await db_module.plugin_job_in_flight(
+                pool,
+                scope_kind=scope_obj.kind,
+                scope_id=scope_obj.id,
+                plugin_id=plugin_id,
+            )
+        except Exception:
+            logger.exception("plugin-job scheduler: concurrent-fire check failed for %s", sched_id)
+            # Not firing is the safe half of an unknown: a duplicate run on a
+            # single-seat resource is worse than a missed slot.
+            reason = "could not check whether a previous job is still running; slot skipped"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+        if in_flight:
+            reason = f"previous {plugin_id} job still queued or running"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+
+        options = _plugin_schedule_options(schedule_row, fired_at)
+        try:
+            job_id = await _enqueue_plugin_job(
+                plugin_id=plugin_id,
+                options=options,
+                scope_obj=scope_obj,
+                capability=schedule_row.get("capability"),
+                user=_SystemUser(),
+                pool=pool,
+            )
+        except HTTPException as exc:
+            reason = f"enqueue refused ({exc.status_code}): {exc.detail}"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+        except Exception as exc:
+            logger.exception("plugin-job scheduler: enqueue crashed for %s", sched_id)
+            reason = f"enqueue crashed: {exc}"
+            await db_module.set_plugin_job_schedule_skip_reason(pool, sched_id, reason)
+            return {"skipped": reason}
+
+        await db_module.update_plugin_job_schedule(pool, sched_id, last_job_id=job_id)
+        logger.info(
+            "plugin-job scheduler: fired %s (%s) -> job %s",
+            schedule_row["name"],
+            plugin_id,
+            job_id,
+        )
+        return {"job_id": job_id, "schedule": schedule_row["name"], "plugin_id": plugin_id}
 
     # ── Issue-bot configuration + poller (M5) ─────────────────────
 

--- a/src/ada/comms/rest/db.py
+++ b/src/ada/comms/rest/db.py
@@ -4100,3 +4100,229 @@ async def list_source_node_sources(pool: asyncpg.Pool, *, scope: str) -> list:
         }
         for r in rows
     ]
+
+
+# ── Plugin-job schedules (cron for plugin jobs) ─────────────────────
+#
+# Deliberately shaped like the audit_schedules helpers above so the two read the
+# same way side by side -- same claim strategy, same skip-reason convention. See
+# migrations/029_plugin_job_schedules.sql for why they are separate tables.
+
+
+def _plugin_job_schedule_row(r) -> dict:
+    """Project a plugin_job_schedules row to its JSON-ready dict shape."""
+    return {
+        "id": str(r["id"]),
+        "name": r["name"],
+        "cron_expr": r["cron_expr"],
+        "scope": r["scope"],
+        "plugin_id": r["plugin_id"],
+        # asyncpg hands JSONB back as a string unless a codec is registered, and
+        # this module registers none. Decoded here so every caller sees a dict
+        # rather than half of them re-parsing it.
+        "options": (json.loads(r["options"]) if isinstance(r["options"], str) else (r["options"] or {})),
+        "capability": r["capability"],
+        "enabled": r["enabled"],
+        "last_fired_at": (r["last_fired_at"].isoformat() if r["last_fired_at"] else None),
+        "next_fire_at": (r["next_fire_at"].isoformat() if r["next_fire_at"] else None),
+        "last_skipped_reason": r["last_skipped_reason"],
+        "last_job_id": r["last_job_id"],
+        "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+        "created_by": r["created_by"],
+        "archived_at": (r["archived_at"].isoformat() if r["archived_at"] else None),
+    }
+
+
+_PLUGIN_JOB_SCHEDULE_COLS = (
+    "id, name, cron_expr, scope, plugin_id, options, capability, enabled, "
+    "last_fired_at, next_fire_at, last_skipped_reason, last_job_id, "
+    "created_at, created_by, archived_at"
+)
+
+
+async def list_plugin_job_schedules(pool: asyncpg.Pool, *, include_archived: bool = False) -> list:
+    where = "" if include_archived else " WHERE archived_at IS NULL"
+    rows = await pool.fetch(
+        f"SELECT {_PLUGIN_JOB_SCHEDULE_COLS} FROM plugin_job_schedules{where} ORDER BY created_at DESC"
+    )
+    return [_plugin_job_schedule_row(r) for r in rows]
+
+
+async def get_plugin_job_schedule(pool: asyncpg.Pool, schedule_id: str) -> Optional[dict]:
+    row = await pool.fetchrow(
+        f"SELECT {_PLUGIN_JOB_SCHEDULE_COLS} FROM plugin_job_schedules WHERE id = $1",
+        schedule_id,
+    )
+    return _plugin_job_schedule_row(row) if row else None
+
+
+async def create_plugin_job_schedule(
+    pool: asyncpg.Pool,
+    *,
+    name: str,
+    cron_expr: str,
+    scope: str,
+    plugin_id: str,
+    options: dict,
+    capability: Optional[str] = None,
+    enabled: bool = True,
+    next_fire_at=None,
+    created_by: Optional[str] = None,
+) -> dict:
+    """Insert one schedule. ``next_fire_at`` is pre-computed by the caller from
+    ``cron_expr``, which is also where the expression is validated."""
+    row = await pool.fetchrow(
+        f"""
+        INSERT INTO plugin_job_schedules
+            (name, cron_expr, scope, plugin_id, options, capability, enabled, next_fire_at, created_by)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
+        RETURNING {_PLUGIN_JOB_SCHEDULE_COLS}
+        """,
+        name,
+        cron_expr,
+        scope,
+        plugin_id,
+        json.dumps(options or {}),
+        capability,
+        enabled,
+        next_fire_at,
+        created_by,
+    )
+    return _plugin_job_schedule_row(row)
+
+
+async def update_plugin_job_schedule(pool: asyncpg.Pool, schedule_id: str, **fields) -> Optional[dict]:
+    """Partial update. Only the named columns move.
+
+    Built as a dynamic SET list rather than one statement per field, but the
+    column names come from a FIXED allow-list -- a caller cannot name a column
+    that is not here, so the interpolation below never carries a caller's string
+    into the SQL.
+    """
+    allowed = (
+        "name",
+        "cron_expr",
+        "scope",
+        "plugin_id",
+        "options",
+        "capability",
+        "enabled",
+        "next_fire_at",
+        "last_fired_at",
+        "last_skipped_reason",
+        "last_job_id",
+    )
+    sets, values = [], []
+    for column in allowed:
+        if column not in fields:
+            continue
+        value = fields[column]
+        if column == "options":
+            sets.append(f"{column} = ${len(values) + 1}::jsonb")
+            values.append(json.dumps(value or {}))
+        else:
+            sets.append(f"{column} = ${len(values) + 1}")
+            values.append(value)
+    if not sets:
+        return await get_plugin_job_schedule(pool, schedule_id)
+    values.append(schedule_id)
+    row = await pool.fetchrow(
+        f"UPDATE plugin_job_schedules SET {', '.join(sets)} "
+        f"WHERE id = ${len(values)} RETURNING {_PLUGIN_JOB_SCHEDULE_COLS}",
+        *values,
+    )
+    return _plugin_job_schedule_row(row) if row else None
+
+
+async def archive_plugin_job_schedule(pool: asyncpg.Pool, schedule_id: str) -> bool:
+    """Soft delete. The audit rows a schedule produced outlive it, and archiving
+    frees the name for re-use."""
+    result = await pool.execute(
+        "UPDATE plugin_job_schedules SET archived_at = NOW(), enabled = FALSE " "WHERE id = $1 AND archived_at IS NULL",
+        schedule_id,
+    )
+    return result.endswith(" 1")
+
+
+async def claim_due_plugin_job_schedule(pool: asyncpg.Pool, *, now, next_fire_at) -> Optional[dict]:
+    """Atomically claim ONE due schedule, or None.
+
+    ``FOR UPDATE SKIP LOCKED`` so several API replicas can tick concurrently and
+    still fire a given row at most once -- the losers' UPDATE matches nothing and
+    they move on. ``last_skipped_reason`` is cleared on claim; the caller re-sets
+    it if the dispatch then decides not to fire.
+
+    ``next_fire_at`` is a provisional value the caller corrects immediately after,
+    once the row's own ``cron_expr`` is known. Claiming first and computing second
+    is what keeps the claim a single statement.
+    """
+    row = await pool.fetchrow(
+        f"""
+        UPDATE plugin_job_schedules
+        SET last_fired_at = $1,
+            next_fire_at = $2,
+            last_skipped_reason = NULL
+        WHERE id = (
+            SELECT id FROM plugin_job_schedules
+            WHERE enabled
+              AND archived_at IS NULL
+              AND next_fire_at IS NOT NULL
+              AND next_fire_at <= $1
+            ORDER BY next_fire_at ASC
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING {_PLUGIN_JOB_SCHEDULE_COLS}
+        """,
+        now,
+        next_fire_at,
+    )
+    return _plugin_job_schedule_row(row) if row else None
+
+
+async def set_plugin_job_schedule_skip_reason(pool: asyncpg.Pool, schedule_id: str, reason: str) -> None:
+    """Record why a due slot produced no job.
+
+    Best-effort: a schedule that fires matters more than the note explaining one
+    that did not, so this never raises into the tick.
+    """
+    try:
+        await pool.execute(
+            "UPDATE plugin_job_schedules SET last_skipped_reason = $2 WHERE id = $1",
+            schedule_id,
+            reason,
+        )
+    except Exception:
+        logger.exception("plugin-job scheduler: could not record skip reason for %s", schedule_id)
+
+
+async def plugin_job_in_flight(pool: asyncpg.Pool, *, scope_kind: str, scope_id, plugin_id: str) -> bool:
+    """Is a job for this plugin and scope still queued or running?
+
+    The concurrent-fire guard, and it matters more for a plugin than for an audit
+    sweep: a plugin job can hold a single licensed workstation for minutes, so two
+    overlapping firings do not merely double the load -- they contend for one
+    resource, and the loser tends to fail in a way that reads as the plugin's
+    fault rather than as a scheduling one.
+
+    Matched on the synthetic source key's prefix, which is where the plugin id
+    lives; audit_log carries no plugin column. ``starts_with`` rather than
+    ``LIKE``: that key begins with an underscore, which LIKE reads as a
+    single-character wildcard.
+    """
+    prefix = f"_synthetic/plugin_job/{plugin_id}/"
+    row = await pool.fetchrow(
+        """
+        SELECT 1 FROM audit_log
+        WHERE target_format = 'plugin_job'
+          AND status IN ('queued', 'running')
+          AND scope_kind = $1
+          AND scope_id IS NOT DISTINCT FROM $2
+          AND starts_with(key, $3)
+        LIMIT 1
+        """,
+        scope_kind,
+        scope_id,
+        prefix,
+    )
+    return row is not None

--- a/src/ada/comms/rest/migrations/029_plugin_job_schedules.sql
+++ b/src/ada/comms/rest/migrations/029_plugin_job_schedules.sql
@@ -1,0 +1,84 @@
+-- 029_plugin_job_schedules.sql — cron for plugin jobs.
+--
+-- WHAT THIS IS FOR. A plugin job that should run on a schedule had nowhere to be
+-- scheduled from. The alternative was a cron on the machine the worker runs on,
+-- POSTing to this API — which means that machine holds a credential able to
+-- enqueue, the schedule is invisible to the admin panel, and changing when it
+-- runs means logging into the box. For a plugin driving a licensed workstation
+-- that is the wrong place for all three.
+--
+-- A row here defines a recurring plugin job: every tick the scheduler claims the
+-- due row and enqueues it through exactly the path ``POST /plugins/{id}/jobs``
+-- uses. The worker cannot tell a scheduled firing from a user-initiated one, and
+-- that is the point — capability routing, audit rows, cancellation and the
+-- cached-blob short circuit all behave identically because none of them are
+-- re-implemented here.
+--
+-- SEPARATE FROM ``audit_schedules`` RATHER THAN GENERALISING IT. The two tables
+-- carry different payloads: an audit run names a worker pool and a sweep, a
+-- plugin job names a plugin and an arbitrary options document. Folding them
+-- together would mean a nullable column per difference and a `kind` discriminator
+-- on a table that is already firing in production — a data migration on live
+-- scheduling, to save a table. The tick logic IS shared in spirit and deliberately
+-- mirrored in shape, so the two read the same way side by side.
+--
+-- WHY THERE IS NO ``allow_cache``. Core hashes a plugin job's options into its
+-- source key so identical requests cache-hit. A schedule sends byte-identical
+-- options on every firing, so without intervention the second run and every one
+-- after it would return the FIRST run's summary: hourly green ticks, the worker
+-- never touched, and a caller believing it has fresh data. The tick therefore
+-- always varies the options it dispatches (see ``_plugin_schedule_fire``), and
+-- the absence of a knob here is the decision — a scheduled run that legitimately
+-- answers "same as last time" is indistinguishable from one that did not happen.
+
+CREATE TABLE IF NOT EXISTS plugin_job_schedules (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Human label shown in the admin UI, and echoed into the audit row so a
+    -- firing can be traced back to the schedule that caused it.
+    name          TEXT NOT NULL,
+    -- Standard 5-field cron expression. Validated with croniter before
+    -- insert/update, so a malformed value is a 400 from the REST layer rather
+    -- than a schedule that silently never fires.
+    cron_expr     TEXT NOT NULL,
+    -- Wire-format scope string ("shared", "project:<slug-or-uuid>"), resolved at
+    -- fire time rather than stored resolved: a project renamed between creation
+    -- and firing should still work, and the resolution is the same code the
+    -- route uses.
+    scope         TEXT NOT NULL,
+    -- Which plugin's job to run. Not an FK: plugins are advertised by live
+    -- workers, so the set of valid values is not a table and a schedule may
+    -- legitimately outlive the worker that served it.
+    plugin_id     TEXT NOT NULL,
+    -- The options document handed to the plugin, verbatim. The plugin owns its
+    -- shape; core neither validates nor interprets it beyond hashing it.
+    options       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Optional capability override. NULL routes to whatever the plugin's live
+    -- spec advertises, which is what a single-pool deployment wants.
+    capability    TEXT,
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    last_fired_at TIMESTAMPTZ,
+    next_fire_at  TIMESTAMPTZ,
+    -- Why the last due slot did NOT produce a job. Set when the tick skips --
+    -- an unresolvable scope, a previous run still in flight -- and cleared on a
+    -- successful claim. Without it a skipped schedule is indistinguishable from
+    -- one that fired and whose job failed somewhere else entirely.
+    last_skipped_reason TEXT,
+    -- The job id of the most recent firing, so the admin panel can link a
+    -- schedule straight to what it produced.
+    last_job_id   TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    TEXT,
+    -- Soft delete, matching audit_schedules: the audit rows a schedule produced
+    -- outlive it, and the name becomes re-usable once archived.
+    archived_at   TIMESTAMPTZ
+);
+
+-- Name uniqueness only among live rows, so an archived schedule's name can be
+-- re-claimed for a new one with the same purpose.
+CREATE UNIQUE INDEX IF NOT EXISTS plugin_job_schedules_live_name
+    ON plugin_job_schedules (name) WHERE archived_at IS NULL;
+
+-- The tick's claim query: the next enabled, unarchived row that is due.
+CREATE INDEX IF NOT EXISTS plugin_job_schedules_due
+    ON plugin_job_schedules (next_fire_at)
+    WHERE enabled AND archived_at IS NULL;

--- a/tests/comms/rest/test_plugin_job_schedules.py
+++ b/tests/comms/rest/test_plugin_job_schedules.py
@@ -1,0 +1,338 @@
+"""Cron for plugin jobs — the table, the claim, and the cache-bust.
+
+Two paths, the split ``test_db.py`` established:
+
+* **Always run** — the no-database behaviour and the pure option-shaping.
+* **Live Postgres** (skipped unless ``ADA_TEST_POSTGRES_URL`` is set) — the claim
+  semantics, which is where a scheduler goes wrong quietly: double-firing across
+  replicas, or never advancing and hammering the queue.
+
+The test that matters most is ``test_two_firings_never_share_an_options_hash``.
+Core hashes a plugin job's options into its source key so identical requests
+cache-hit; a schedule sends byte-identical options every slot, so without the
+fire token the second firing and every one after returns the FIRST run's summary.
+Hourly green ticks, the worker never touched, and a caller trusting data that
+stopped moving. That failure reports success at every layer, which is what makes
+it worth a test rather than a comment.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+os.environ.setdefault("ADA_VIEWER_STORAGE_KIND", "local")
+os.environ.setdefault("ADA_VIEWER_LOCAL_PATH", tempfile.mkdtemp(prefix="ada-test-plugin-sched-"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from ada.comms.rest import db as dbm  # noqa: E402
+from ada.comms.rest.app import create_app  # noqa: E402
+from ada.comms.rest.config import (  # noqa: E402
+    AuthConfig,
+    LocalConfig,
+    QueueConfig,
+    Settings,
+)
+
+POSTGRES_URL = os.environ.get("ADA_TEST_POSTGRES_URL", "").strip()
+needs_postgres = pytest.mark.skipif(
+    not POSTGRES_URL,
+    reason="ADA_TEST_POSTGRES_URL not set; skipping live Postgres tests",
+)
+
+PLUGIN = "demo-plugin"
+
+
+def _settings(tmp_path: pathlib.Path, database_url: str = "") -> Settings:
+    return Settings(
+        storage_kind="local",
+        s3=None,
+        local=LocalConfig(path=str(tmp_path), prefix=""),
+        host="127.0.0.1",
+        port=0,
+        static_path="",
+        queue=QueueConfig(
+            url=None,
+            stream="ada",
+            subject="ada.viewer.jobs.convert",
+            kv_bucket="ada-viewer-jobs",
+            durable="ada-viewer-worker",
+        ),
+        auth=AuthConfig(
+            enabled=False,
+            issuer="",
+            client_id="",
+            audience="",
+            admin_group="",
+            cli_token_secret="",
+        ),
+        database_url=database_url,
+    )
+
+
+@pytest.fixture
+def app_client(tmp_path: pathlib.Path):
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        yield client
+
+
+# --- the cache-bust ----------------------------------------------------------
+
+
+def _source_key(plugin_id: str, options: dict) -> str:
+    """The same synthetic key core computes. Duplicated deliberately: if core's
+    formula changes, this test should fail rather than silently stop covering
+    the thing it exists for."""
+    digest = hashlib.sha256(json.dumps(options, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+    return f"_synthetic/plugin_job/{plugin_id}/{digest}"
+
+
+def test_two_firings_never_share_an_options_hash():
+    """The whole reason the fire token exists.
+
+    Without it, a schedule's options are byte-identical on every slot, the source
+    key is identical, and core's cache short-circuits every run after the first.
+    """
+    base = {"action": "changes-since", "since_days": 1}
+
+    first = dict(base, scheduled_at="2026-09-09T10:00:00+00:00")
+    second = dict(base, scheduled_at="2026-09-09T11:00:00+00:00")
+
+    assert _source_key(PLUGIN, first) != _source_key(PLUGIN, second)
+    # And the thing being guarded against: the bare options DO collide.
+    assert _source_key(PLUGIN, base) == _source_key(PLUGIN, dict(base))
+
+
+def test_the_fire_token_is_reserved_on_create(app_client):
+    """A caller who sets it believes it means something, and the tick is about to
+    overwrite it. Refused rather than silently replaced."""
+    r = app_client.post(
+        "/api/admin/plugin-jobs/schedules",
+        json={
+            "name": "x",
+            "cron_expr": "0 * * * *",
+            "scope": "shared",
+            "plugin_id": PLUGIN,
+            "options": {"scheduled_at": "whenever"},
+        },
+    )
+    # 400 for the reserved key, or 503 without a database — both are refusals,
+    # and which one depends on deployment rather than on this rule.
+    assert r.status_code in (400, 503)
+    if r.status_code == 400:
+        assert "reserved" in r.json()["detail"]
+
+
+# --- no database -------------------------------------------------------------
+
+
+def test_without_a_database_the_admin_routes_refuse(app_client):
+    """Schedules live in Postgres, so a deployment without one cannot have any.
+
+    Refusing beats an empty list: "no schedules configured" and "scheduling is
+    not available here" lead an operator to different next steps.
+    """
+    r = app_client.get("/api/admin/plugin-jobs/schedules")
+    assert r.status_code in (503, 404), r.text
+
+
+# --- live Postgres -----------------------------------------------------------
+
+
+async def _fresh_pool():
+    pool = await dbm.init_pool(POSTGRES_URL)
+    await pool.execute("DELETE FROM plugin_job_schedules")
+    return pool
+
+
+def _schedule_kwargs(**over):
+    base = dict(
+        name="nightly",
+        cron_expr="0 2 * * *",
+        scope="shared",
+        plugin_id=PLUGIN,
+        options={"action": "changes-since", "since_days": 1},
+        capability=None,
+        created_by="tester",
+    )
+    base.update(over)
+    return base
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_migration_creates_the_table():
+    pool = await dbm.init_pool(POSTGRES_URL)
+    try:
+        cols = {
+            r["column_name"]
+            for r in await pool.fetch(
+                "SELECT column_name FROM information_schema.columns WHERE table_name='plugin_job_schedules'"
+            )
+        }
+        assert {"name", "cron_expr", "scope", "plugin_id", "options", "next_fire_at", "last_skipped_reason"} <= cols
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_options_round_trip_as_a_dict():
+    """asyncpg hands JSONB back as a string unless a codec is registered, and this
+    module registers none — so a caller would otherwise get a str where the tick
+    expects a mapping, and `dict(options)` would silently produce nonsense."""
+    pool = await _fresh_pool()
+    try:
+        row = await dbm.create_plugin_job_schedule(
+            pool, next_fire_at=datetime.datetime.now(datetime.timezone.utc), **_schedule_kwargs()
+        )
+        assert isinstance(row["options"], dict)
+        assert row["options"]["since_days"] == 1
+        assert isinstance((await dbm.get_plugin_job_schedule(pool, row["id"]))["options"], dict)
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_due_schedule_is_claimed_exactly_once():
+    """Cross-replica safety. Two ticks racing the same row must produce one fire.
+
+    The second claim returns None because the first advanced `next_fire_at` out of
+    the due window inside the same statement — which is why the claim is one
+    UPDATE and not a SELECT followed by an UPDATE.
+    """
+    pool = await _fresh_pool()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        await dbm.create_plugin_job_schedule(
+            pool, next_fire_at=now - datetime.timedelta(minutes=1), **_schedule_kwargs()
+        )
+
+        first = await dbm.claim_due_plugin_job_schedule(pool, now=now, next_fire_at=now + datetime.timedelta(hours=1))
+        second = await dbm.claim_due_plugin_job_schedule(pool, now=now, next_fire_at=now + datetime.timedelta(hours=1))
+
+        assert first is not None
+        assert second is None
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_disabled_or_archived_schedule_is_never_claimed():
+    pool = await _fresh_pool()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        due = now - datetime.timedelta(minutes=1)
+        await dbm.create_plugin_job_schedule(pool, next_fire_at=due, enabled=False, **_schedule_kwargs(name="off"))
+        archived = await dbm.create_plugin_job_schedule(pool, next_fire_at=due, **_schedule_kwargs(name="archived"))
+        assert await dbm.archive_plugin_job_schedule(pool, archived["id"])
+
+        assert await dbm.claim_due_plugin_job_schedule(pool, now=now, next_fire_at=now) is None
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_claim_clears_the_skip_reason_and_a_skip_sets_it():
+    """A stale reason is worse than none: it describes a slot that has since
+    fired, and an operator reading it concludes the schedule is still broken."""
+    pool = await _fresh_pool()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        row = await dbm.create_plugin_job_schedule(
+            pool, next_fire_at=now - datetime.timedelta(minutes=1), **_schedule_kwargs()
+        )
+        await dbm.set_plugin_job_schedule_skip_reason(pool, row["id"], "previous job still running")
+        assert (await dbm.get_plugin_job_schedule(pool, row["id"]))["last_skipped_reason"]
+
+        claimed = await dbm.claim_due_plugin_job_schedule(pool, now=now, next_fire_at=now + datetime.timedelta(hours=1))
+        assert claimed["last_skipped_reason"] is None
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_an_archived_name_can_be_reclaimed():
+    pool = await _fresh_pool()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        first = await dbm.create_plugin_job_schedule(pool, next_fire_at=now, **_schedule_kwargs(name="same"))
+        await dbm.archive_plugin_job_schedule(pool, first["id"])
+        # The unique index is partial on archived_at IS NULL precisely so this
+        # works -- an operator should be able to replace a schedule's purpose
+        # without inventing a new name for it.
+        again = await dbm.create_plugin_job_schedule(pool, next_fire_at=now, **_schedule_kwargs(name="same"))
+        assert again["id"] != first["id"]
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_live_name_collides():
+    pool = await _fresh_pool()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        await dbm.create_plugin_job_schedule(pool, next_fire_at=now, **_schedule_kwargs(name="dup"))
+        with pytest.raises(Exception) as caught:
+            await dbm.create_plugin_job_schedule(pool, next_fire_at=now, **_schedule_kwargs(name="dup"))
+        assert "UniqueViolation" in caught.value.__class__.__name__
+    finally:
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_the_in_flight_guard_keys_on_plugin_and_scope():
+    """The concurrent-fire guard. A plugin job can hold one licensed workstation
+    for minutes, so two overlapping firings contend for a single resource.
+
+    Keyed on the synthetic source-key prefix because audit_log has no plugin
+    column, and matched with ``starts_with`` rather than LIKE -- that key begins
+    with an underscore, which LIKE reads as a wildcard.
+    """
+    pool = await _fresh_pool()
+    try:
+        await pool.execute("DELETE FROM audit_log WHERE scope_kind = 'shared'")
+        assert not await dbm.plugin_job_in_flight(pool, scope_kind="shared", scope_id=None, plugin_id=PLUGIN)
+
+        await pool.execute(
+            "INSERT INTO audit_log (user_sub, scope_kind, scope_id, action, key, target_format, status) "
+            "VALUES ('system', 'shared', NULL, 'plugin_job', $1, 'plugin_job', 'running')",
+            _source_key(PLUGIN, {"a": 1}),
+        )
+        assert await dbm.plugin_job_in_flight(pool, scope_kind="shared", scope_id=None, plugin_id=PLUGIN)
+        # A different plugin is not blocked by this one's run.
+        assert not await dbm.plugin_job_in_flight(pool, scope_kind="shared", scope_id=None, plugin_id="other")
+    finally:
+        await pool.execute("DELETE FROM audit_log WHERE scope_kind = 'shared'")
+        await dbm.close_pool(pool)
+
+
+@needs_postgres
+@pytest.mark.asyncio
+async def test_a_terminal_job_does_not_block_the_next_firing():
+    pool = await _fresh_pool()
+    try:
+        await pool.execute("DELETE FROM audit_log WHERE scope_kind = 'shared'")
+        await pool.execute(
+            "INSERT INTO audit_log (user_sub, scope_kind, scope_id, action, key, target_format, status) "
+            "VALUES ('system', 'shared', NULL, 'plugin_job', $1, 'plugin_job', 'ok')",
+            _source_key(PLUGIN, {"a": 1}),
+        )
+        assert not await dbm.plugin_job_in_flight(pool, scope_kind="shared", scope_id=None, plugin_id=PLUGIN)
+    finally:
+        await pool.execute("DELETE FROM audit_log WHERE scope_kind = 'shared'")
+        await dbm.close_pool(pool)


### PR DESCRIPTION
## The problem

A plugin job that should run on a schedule had nowhere to be scheduled from. The alternative was a cron on the machine the worker runs on, POSTing to this API — which means **that machine holds a credential able to enqueue**, the schedule is invisible to the admin panel, and changing when it runs means logging into the box.

For a plugin driving a licensed workstation, that is the wrong place for all three.

## The change

A `plugin_job_schedules` row defines a recurring job, and the tick enqueues it through **exactly** the path `POST /plugins/{id}/jobs` uses. The worker cannot tell a scheduled firing from a user-initiated one, so capability routing, sharded pools, audit rows, cancellation and the cached-blob short circuit all behave identically — because none of them are re-implemented. `_enqueue_plugin_job` is factored out for that reason and shared by both callers; a second enqueue would be a second set of those behaviours to keep in step.

It also **removes** a credential rather than adding one: the tick dispatches as the existing `_SystemUser`, so a schedule satisfies a plugin's `requires_admin` gate without any admin token existing outside the API.

| route | |
| --- | --- |
| `GET /admin/plugin-jobs/schedules` | list |
| `POST /admin/plugin-jobs/schedules` | create |
| `PATCH /admin/plugin-jobs/schedules/{id}` | partial update |
| `DELETE /admin/plugin-jobs/schedules/{id}` | archive (soft) |
| `POST /admin/plugin-jobs/schedules/{id}/run` | fire now, without disturbing the timetable |

## The cache would have made this silently useless

Core hashes a job's options into its source key so identical requests cache-hit — right for a user pressing a button twice, catastrophic for a schedule. Byte-identical options every slot means the second firing **and every one after** returns the *first* run's summary: hourly green ticks, the worker never touched, and a caller trusting data that stopped moving.

So the tick stamps a fire timestamp into every dispatch, and there is deliberately **no flag to disable it** — a scheduled run that legitimately answers "same as last time" cannot be told apart from one that never happened. Setting that key on a schedule is a `400` rather than being silently overwritten.

## Why a separate table from `audit_schedules`

The payloads differ — a worker pool and a sweep, versus a plugin and an arbitrary options document. Folding them would mean a nullable column per difference and a `kind` discriminator on a table **already firing in production**: a data migration on live scheduling, to save a table. The tick is deliberately mirrored in shape so the two read the same way side by side.

## The concurrent-fire guard matters more here

A plugin job can hold one licensed workstation for minutes, so overlapping firings don't merely double the load — they contend for a single resource and the loser fails in a way that reads as the plugin's fault.

- A missed slot is **not** backfired; the next slot is the next chance.
- An *unknown* — the guard query itself failing — resolves to **not firing**, because a duplicate run on a single-seat resource is worse than a gap.
- Every refusal is written to `last_skipped_reason`, because a schedule that silently does nothing is the failure this exists to remove. A claim **clears** it: a stale reason describes a slot that has since fired, and leads an operator to think the schedule is still broken.

## Testing

12 new tests against a **live Postgres**:

- claim-exactly-once across racing ticks (the claim is one `UPDATE`, not a `SELECT` then an `UPDATE`)
- the JSONB → dict round-trip, since asyncpg returns a string without a codec and this module registers none
- the in-flight guard's `starts_with` — `LIKE` would read the key's leading underscore as a wildcard
- the options-hash divergence that is the whole point

68 passed across the neighbouring REST suites. `pixi run lint-check` clean.

**Based on `feat/source-nodes-write-route`** rather than `main`, since that is what the worker currently overlays — retarget to `main` if you'd rather it land independently.

No admin UI yet; this is the API a panel tab is built on, mirroring the audit-schedules one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnVdor5ZMzD5QYxFQLQioc