### PR TITLE
fix(packaging): ship the REST migrations, and build the conda package in CI so a gap like that is visible

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -201,6 +201,69 @@ jobs:
           if: steps.scope.outputs.run == 'true'
           run: python3 tools/check_bundle_provenance.py -v
 
+    # Build the conda package the way conda-forge does, from THIS checkout.
+    #
+    # Everything else in this workflow runs from a checkout, so nothing else can see what the
+    # PACKAGE contains. Two faults reached a release through that blind spot: `ada-py` shipped 30
+    # migrations as 0, because `[tool.setuptools.package-data]` did not name them, so a
+    # conda-installed API could not create its schema while a checkout worked perfectly; and the
+    # 0.67.0 feedstock build failed on DEXPI tests loading a script the recipe does not ship as a
+    # test file. Both were found after the fact, by the feedstock, not by us.
+    #
+    # This clones the real feedstock, points its recipe at the checkout (rattler-build has no flag
+    # for that -- see tools/localise_feedstock_recipe.py) and builds. Tests run too, so the
+    # feedstock's own definition of what ships and what it runs is checked before a release rather
+    # than after one.
+    conda-package:
+        name: Conda package (feedstock recipe)
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v7
+          with:
+            ref: ${{ github.event.pull_request.head.sha || github.ref }}
+            fetch-depth: 0
+
+        # Only a change that can alter what is packaged, or what the packaged tests assume, can
+        # change the answer. Inline rather than an `on: paths:` filter so the job always reports a
+        # status and can be a required check -- the same shape as the bundle-provenance job above.
+        - name: Could this PR change what the package contains?
+          id: scope
+          env:
+            BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          run: |
+            CHANGED="$(git diff --name-only "$BASE_SHA"...HEAD || true)"
+            if echo "$CHANGED" | grep -qE '^(pyproject\.toml$|src/ada/.*\.(sql|json|xml|zip)$|tests/|files/|scripts/|tools/localise_feedstock_recipe\.py$|\.github/workflows/pr-tests\.yml$)'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "Nothing here changes what is packaged or what the packaged tests assume."
+            fi
+
+        - uses: prefix-dev/setup-pixi@v0.10.2
+          if: steps.scope.outputs.run == 'true'
+          with:
+            pixi-version: v0.68.0
+            environments: tests
+            cache: true
+
+        - name: Clone the feedstock
+          if: steps.scope.outputs.run == 'true'
+          run: git clone --depth 1 https://github.com/conda-forge/ada-py-feedstock.git "$RUNNER_TEMP/feedstock"
+
+        - name: Point its recipe at this checkout
+          if: steps.scope.outputs.run == 'true'
+          run: |
+            pixi run -e tests python tools/localise_feedstock_recipe.py               "$RUNNER_TEMP/feedstock/recipe/recipe.yaml"               --checkout "$GITHUB_WORKSPACE" --pyproject pyproject.toml
+            sed -n '1,25p' "$RUNNER_TEMP/feedstock/recipe/recipe.yaml"
+
+        # The recipe's own variant config and channels; passing -c as well is rejected
+        # ("channel_sources and channels cannot both be set").
+        - name: Build and run the recipe's tests
+          if: steps.scope.outputs.run == 'true'
+          run: |
+            cd "$RUNNER_TEMP/feedstock"
+            pixi exec -s rattler-build rattler-build build               -r recipe/recipe.yaml -m .ci_support/linux_64_.yaml               --output-dir "$RUNNER_TEMP/out"
+
     # Build the viewer image and start the server inside it. Nothing else in this workflow can catch
     # a viewer that won't boot: lint and the test matrix run against the full src/ada tree, but the
     # viewer runtime ships a CURATED subset of it (see the COPY block in deploy/Dockerfile.viewer),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,15 @@ ada = [
     "cadit/dexpi/resources/*.json",
     "fem/results/resources/results.sql",
     "visit/rendering/resources/index.zip",
-    "topo_model/templates_data/*.json"
+    "topo_model/templates_data/*.json",
+    # The REST API's schema migrations, applied at boot under an advisory lock.
+    # WITHOUT THIS LINE THE PACKAGE SHIPS NONE OF THEM: they are data files beside
+    # python modules, so nothing in the build notices they are gone, every test
+    # passes (tests run from a checkout, where the files are simply there), and a
+    # conda- or wheel-installed API cannot migrate a database at all. Confirmed by
+    # building the conda-forge recipe against a checkout: 30 files here, 0 in the
+    # package. See tools/localise_feedstock_recipe.py, which exists because of it.
+    "comms/rest/migrations/*.sql"
 ]
 
 

--- a/tests/core/cadit/dexpi/test_fixtures_current.py
+++ b/tests/core/cadit/dexpi/test_fixtures_current.py
@@ -13,8 +13,35 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 
+import pytest
+
 _REPO = pathlib.Path(__file__).resolve().parents[4]
 _GENERATOR = _REPO / "scripts" / "gen_dexpi_examples.py"
+
+# A REPO LINT, NOT A PACKAGE TEST, so it is skipped where there is no repo.
+#
+# The conda package ships `tests` and `files` as test files and does NOT ship
+# `scripts`, so in that environment the generator this compares against simply is
+# not there and both tests die on FileNotFoundError -- which is how the ada-py
+# feedstock's build for 0.67.0 failed, with 2 failed against 2982 passed.
+#
+# Skipping is right rather than merely convenient: the guard asserts that files
+# checked into the repository match a generator checked into the same repository.
+# In a package build both are frozen copies from one tarball, so the comparison can
+# only ever restate what git already guaranteed -- it cannot fail there for a real
+# reason, and it cannot catch drift that has not happened yet.
+#
+# Keyed on the repository root looking like a checkout rather than on the generator
+# being absent: if `scripts/gen_dexpi_examples.py` goes missing from a real
+# checkout, that IS drift, and this must fail loudly rather than quietly skip.
+#
+# The feedstock already carries the same judgement for another test, as a
+# `--deselect` in its recipe. Making the decision here means the next such test
+# needs no feedstock change.
+pytestmark = pytest.mark.skipif(
+    not (_REPO / "pyproject.toml").is_file(),
+    reason="anti-drift guard over repository contents; no checkout here (a packaged test run ships no scripts/)",
+)
 
 
 def _load_generator():

--- a/tests/core/tools/test_localise_feedstock_recipe.py
+++ b/tests/core/tools/test_localise_feedstock_recipe.py
@@ -1,0 +1,139 @@
+"""The feedstock recipe, pointed at a checkout.
+
+Everything adapy's suite runs, it runs from a checkout — so nothing we test can see
+what the PACKAGE contains. Two real failures came out of that blind spot: `ada-py`
+shipping with zero migration `.sql` files, and the 0.67.0 feedstock build failing on
+DEXPI tests that load a script the recipe does not ship. Both were found after the
+fact, by something other than us.
+
+The rewrite these tests cover is what lets CI build the feedstock's own recipe
+against this checkout, so a packaging fault shows up before a release rather than
+after one. It is textual on purpose — a YAML round-trip drops the recipe's comments,
+and one of those records why a test is deselected — which is exactly why the shape
+of what it edits is worth pinning.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "tools"))
+
+from localise_feedstock_recipe import (  # noqa: E402
+    RecipeRewriteError,
+    localise,
+    project_version,
+)
+
+RECIPE = """schema_version: 1
+
+context:
+  name: ada-py
+  version: "0.64.1"
+  python_min: "3.11"
+
+recipe:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Krande/adapy/archive/v${{ version }}.tar.gz
+  sha256: 1088444dcb0c07895bf821c8c128c0f3f94bf60f587ec5f42121a1be3544c17c
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: ${{ name }}-core
+    tests:
+      - files:
+          source:
+            - tests
+            - files
+        script:
+          # it is a repo lint, not a package test.
+          - pytest tests --deselect tests/core/cad/test_tess_env_defaults.py::test_x
+"""
+
+
+def test_the_tarball_is_replaced_by_the_checkout():
+    out = localise(RECIPE, "/work/adapy")
+    assert "path: /work/adapy" in out
+    # Neither half of the fetch may survive: a leftover `url` would be built INSTEAD
+    # of the checkout on some rattler versions, which is the one failure mode that
+    # would make this whole check silently test the released package again.
+    source_block = out.split("build:", 1)[0]
+    assert "url:" not in source_block
+    assert "sha256:" not in source_block
+
+
+def test_the_comments_survive():
+    # The rewrite is textual precisely to keep these. The deselect comment is the
+    # only record of WHY that test is excluded from the package build; a YAML
+    # round-trip would drop it and the next person would delete the deselect.
+    out = localise(RECIPE, "/work/adapy")
+    assert "it is a repo lint, not a package test." in out
+
+
+def test_the_version_can_be_overridden_and_only_the_context_one_moves():
+    # Building a checkout ahead of the released version while still claiming the old
+    # number is the confusion this tool exists to remove.
+    out = localise(RECIPE, "/work/adapy", version="0.67.0")
+    assert 'version: "0.67.0"' in out
+    assert 'version: "0.64.1"' not in out
+    # The outputs refer to it indirectly and must keep doing so, or the built
+    # package's name stops tracking the context.
+    assert "version: ${{ version }}" in out
+
+
+def test_the_version_is_left_alone_when_not_asked_for():
+    out = localise(RECIPE, "/work/adapy")
+    assert 'version: "0.64.1"' in out
+
+
+def test_the_rest_of_the_recipe_is_untouched():
+    out = localise(RECIPE, "/work/adapy", version="0.67.0")
+    for fragment in ("schema_version: 1", "name: ada-py", "python_min:", "- tests", "- files", "number: 0"):
+        assert fragment in out, fragment
+
+
+def test_a_recipe_with_no_source_is_refused_rather_than_silently_built():
+    # Building the wrong thing is worse than not building: a recipe this cannot
+    # localise would fetch the released tarball and report a pass that says nothing
+    # about the checkout.
+    with pytest.raises(RecipeRewriteError, match="no `source:` block"):
+        localise("schema_version: 1\ncontext:\n  name: x\n", "/work/adapy")
+
+
+def test_the_version_override_refuses_when_there_is_nothing_to_override():
+    with pytest.raises(RecipeRewriteError, match="context.version"):
+        localise("source:\n  url: x\n\nbuild:\n  number: 0\n", "/work/adapy", version="1.0.0")
+
+
+def test_the_project_version_is_read_from_pyproject(tmp_path):
+    p = tmp_path / "pyproject.toml"
+    p.write_text('[project]\nname = "ada-py"\nversion = "1.2.3"\n', encoding="utf-8")
+    assert project_version(p) == "1.2.3"
+
+
+def test_a_pyproject_without_a_version_is_an_error(tmp_path):
+    p = tmp_path / "pyproject.toml"
+    p.write_text('[project]\nname = "ada-py"\n', encoding="utf-8")
+    with pytest.raises(RecipeRewriteError):
+        project_version(p)
+
+
+def test_it_localises_the_real_feedstock_recipe_shape(tmp_path):
+    """A guard against the recipe drifting away from what this can rewrite.
+
+    The upstream recipe is not vendored here, so this uses the shape above — but the
+    assertion that matters is that a rewrite leaves NO fetch behind, which is the
+    thing that would make the check pass while testing the released package.
+    """
+    out = localise(RECIPE, str(tmp_path), version="9.9.9")
+    assert out.count("path:") == 1
+    assert "https://github.com/" not in out

--- a/tests/core/tools/test_localise_feedstock_recipe.py
+++ b/tests/core/tools/test_localise_feedstock_recipe.py
@@ -20,7 +20,24 @@ import sys
 
 import pytest
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "tools"))
+_TOOLS = pathlib.Path(__file__).resolve().parents[3] / "tools"
+
+# SKIPPED AT MODULE LEVEL, before the import below, because the thing it imports is
+# not in the package. The recipe ships `tests` and `files`; `tools/` is not among
+# them, so in a packaged test run this module raises ModuleNotFoundError during
+# COLLECTION -- and a `pytestmark` skip cannot help, because collection has already
+# failed by the time marks are read.
+#
+# Found by the conda-package job on its first run, against this very commit. That is
+# the same fault class the job exists to catch, and this module happened to be an
+# instance of it: a test about the repository, unable to run anywhere else.
+if not (_TOOLS / "localise_feedstock_recipe.py").is_file():
+    pytest.skip(
+        "tests the repository's tools/, which a packaged test run does not ship",
+        allow_module_level=True,
+    )
+
+sys.path.insert(0, str(_TOOLS))
 
 from localise_feedstock_recipe import (  # noqa: E402
     RecipeRewriteError,

--- a/tests/core/tools/test_package_data_is_complete.py
+++ b/tests/core/tools/test_package_data_is_complete.py
@@ -1,0 +1,99 @@
+"""Data files that live beside python modules must be named in `package-data`.
+
+THE FAILURE THIS PREVENTS IS SILENT AT EVERY STAGE. A data file omitted from
+`[tool.setuptools.package-data]` is still on disk in a checkout, so every test
+passes; the build emits no warning, because nothing distinguishes a file you forgot
+from a file you meant to leave out; and the fault appears only when something reads
+it from an installed package.
+
+It happened: `ada/comms/rest/migrations/*.sql` was not listed, so the built package
+carried 30 migrations in the repository and 0 in the wheel. The REST API applies
+those at boot, so a conda- or wheel-installed deployment could not create its own
+schema — while a deployment running from a checkout worked perfectly.
+
+This is the cheap half of the guard, and it runs everywhere. The expensive half is
+building the conda recipe against the checkout and looking inside the artifact
+(see tools/localise_feedstock_recipe.py); that catches the same class and more, but
+needs a build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+_REPO = pathlib.Path(__file__).resolve().parents[3]
+_PKG = _REPO / "src" / "ada"
+
+pytestmark = pytest.mark.skipif(
+    not (_REPO / "pyproject.toml").is_file(),
+    reason="reads the repository's pyproject.toml; a packaged test run has no checkout",
+)
+
+
+def _declared_patterns() -> list[str]:
+    text = (_REPO / "pyproject.toml").read_text(encoding="utf-8")
+    block = re.search(r"\[tool\.setuptools\.package-data\]\s*\nada\s*=\s*\[(.*?)\]", text, re.S)
+    assert block, "could not find [tool.setuptools.package-data] ada = [...]"
+    return re.findall(r'"([^"]+)"', block.group(1))
+
+
+def _is_declared(relative: pathlib.PurePosixPath, patterns: list[str]) -> bool:
+    return any(relative.match(pattern) for pattern in patterns)
+
+
+#: Suffixes that are data rather than code. Deliberately a short list of the kinds
+#: this package actually ships: broadening it to "anything not .py" would sweep in
+#: caches and editor droppings and make the test a nuisance rather than a guard.
+_DATA_SUFFIXES = {".sql", ".json", ".xml", ".zip"}
+
+#: Directories whose contents are inputs to the build rather than package data.
+_NOT_PACKAGE_DATA = {"__pycache__"}
+
+
+def test_every_data_file_under_src_ada_is_declared():
+    """Nothing shipped-looking is left out of `package-data`.
+
+    Failing here means the file is on disk for you and absent for everyone who
+    installs the package.
+    """
+    missing: list[str] = []
+    patterns = _declared_patterns()
+    for path in _PKG.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in _DATA_SUFFIXES:
+            continue
+        if any(part in _NOT_PACKAGE_DATA for part in path.parts):
+            continue
+        relative = pathlib.PurePosixPath(path.relative_to(_PKG).as_posix())
+        if not _is_declared(relative, patterns):
+            missing.append(str(relative))
+
+    assert not missing, (
+        "these data files are not covered by [tool.setuptools.package-data] in pyproject.toml, "
+        "so they exist in a checkout and are absent from an installed package:\n  " + "\n  ".join(sorted(missing))
+    )
+
+
+def test_the_rest_migrations_are_declared_by_name():
+    """Named on its own because it is the one that already went wrong, and because
+    the consequence is severe and remote: the API applies these at boot, so a
+    package missing them cannot create its schema, and the error surfaces on a
+    deployment rather than in a build."""
+    patterns = _declared_patterns()
+    migrations = sorted((_PKG / "comms" / "rest" / "migrations").glob("*.sql"))
+    assert migrations, "no migrations found; has the directory moved?"
+    for path in migrations:
+        relative = pathlib.PurePosixPath(path.relative_to(_PKG).as_posix())
+        assert _is_declared(relative, patterns), f"{relative} would not ship"
+
+
+def test_a_declared_pattern_that_matches_nothing_is_reported():
+    """A pattern for a file that no longer exists is dead weight that reads as
+    coverage. Not fatal — a glob may legitimately be empty in a partial checkout —
+    so it is a warning rather than a failure."""
+    patterns = _declared_patterns()
+    unmatched = [p for p in patterns if not list(_PKG.glob(p))]
+    if unmatched:
+        pytest.skip(f"package-data patterns matching nothing right now: {unmatched}")

--- a/tools/localise_feedstock_recipe.py
+++ b/tools/localise_feedstock_recipe.py
@@ -1,0 +1,113 @@
+"""Point a conda-forge feedstock recipe at a local checkout instead of a release tarball.
+
+WHY THIS EXISTS. Everything adapy's own suite runs, it runs from a checkout — so no
+test of ours can see what the *package* contains. Two real failures came from
+exactly that blind spot:
+
+  * `ada-py` shipped with zero migration `.sql` files, because
+    `[tool.setuptools.package-data]` did not name them. Every test passed; the
+    deployed package could not migrate a database.
+  * the 0.67.0 feedstock build failed on two DEXPI tests that load
+    `scripts/gen_dexpi_examples.py`, which the recipe does not ship as a test file.
+    Found after the release was cut, by the feedstock, not by us.
+
+Both are packaging faults, and the only thing that can catch a packaging fault is
+building the package. This rewrites the feedstock's recipe so `rattler-build` builds
+THIS checkout rather than a published tarball, which makes the feedstock's own
+definition — what is installed, which test files ship, which tests it runs — a thing
+CI can check before a release rather than after.
+
+The rewrite is deliberately textual and minimal. A YAML round-trip would drop the
+recipe's comments, and those comments are load-bearing: one of them records why a
+particular test is deselected. Only two things change, and both are named in the
+result so a reader of the modified file can see what was done to it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+#: Matches the whole `source:` block of a v1 recipe that fetches a tarball. Anchored
+#: on the key at column 0 and terminated by the next top-level key, so an indented
+#: `url:` elsewhere in the file cannot be mistaken for it.
+_SOURCE_BLOCK = re.compile(
+    r"^source:\n(?:[ \t]+.*\n|\n)*?(?=^[A-Za-z_]|\Z)",
+    re.MULTILINE,
+)
+
+_VERSION_LINE = re.compile(r'^(?P<indent>\s*)version:\s*"[^"]*"\s*$', re.MULTILINE)
+
+
+class RecipeRewriteError(RuntimeError):
+    """The recipe did not look the way this tool needs it to."""
+
+
+def localise(recipe_text: str, checkout: str, version: str | None = None) -> str:
+    """Return `recipe_text` with its source replaced by `checkout`.
+
+    ``version`` overrides ``context.version`` when given. That matters because the
+    original value is the released version, and building a checkout that is ahead of
+    it would produce a package claiming to be the older one — which is exactly the
+    confusion this whole tool exists to remove.
+    """
+    if "source:" not in recipe_text:
+        raise RecipeRewriteError("no `source:` block found; is this a v1 recipe?")
+
+    replacement = (
+        "source:\n"
+        "  # Rewritten by tools/localise_feedstock_recipe.py: build THIS checkout\n"
+        "  # rather than a published tarball, so packaging faults are visible before\n"
+        "  # a release rather than after one.\n"
+        f"  path: {checkout}\n"
+        # The blank line the original block ended with, so the file reads the same
+        # way after rewriting as it did before.
+        + "\n"
+    )
+    # A FUNCTION, not the string: `re.sub` reads backslashes in a replacement as
+    # escapes, so a Windows checkout path (`C:\work\adapy`) either corrupts the
+    # output or raises `bad escape \w`. Returning it from a lambda takes it
+    # literally, which is the only correct reading of a filesystem path.
+    new_text, count = _SOURCE_BLOCK.subn(lambda _: replacement, recipe_text, count=1)
+    if count != 1:
+        raise RecipeRewriteError("could not isolate the `source:` block")
+    if "url:" in new_text.split("outputs:", 1)[0] and "path:" not in new_text.split("outputs:", 1)[0]:
+        raise RecipeRewriteError("the source block still fetches a url after rewriting")
+
+    if version is not None:
+        # Only the FIRST version line, which is `context.version`. The outputs refer
+        # to it through `${{ version }}` and must keep doing so.
+        new_text, n = _VERSION_LINE.subn(lambda m: f'{m.group("indent")}version: "{version}"', new_text, count=1)
+        if n != 1:
+            raise RecipeRewriteError("could not find `context.version` to override")
+    return new_text
+
+
+def project_version(pyproject: pathlib.Path) -> str:
+    """The version this checkout declares, so the built package is named honestly."""
+    text = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RecipeRewriteError(f'no `version = "..."` in {pyproject}')
+    return match.group(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("recipe", type=pathlib.Path, help="the feedstock's recipe/recipe.yaml")
+    parser.add_argument("--checkout", required=True, help="path the recipe should build from")
+    parser.add_argument("--pyproject", type=pathlib.Path, default=None, help="take the version from here")
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=None, help="write here (default: in place)")
+    args = parser.parse_args(argv)
+
+    version = project_version(args.pyproject) if args.pyproject else None
+    rewritten = localise(args.recipe.read_text(encoding="utf-8"), args.checkout, version)
+    (args.output or args.recipe).write_text(rewritten, encoding="utf-8")
+    print(f"recipe now builds {args.checkout}" + (f" as version {version}" if version else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three changes, one theme: **the package is not the checkout, and nothing here could see the difference.**

## 1. The REST migrations were never shipped

Found on the first run of the new check:

```
migrations in the checkout : 30
migrations in the package  :  0
```

`[tool.setuptools.package-data]` did not name `comms/rest/migrations/*.sql`, so the REST API's schema migrations — applied at boot under an advisory lock — were absent from every wheel and conda package ever built. A deployment running from a checkout worked perfectly; a conda-installed one could not create its own schema. `029_plugin_job_schedules.sql` is in that set.

Adding the line takes it to 30 of 30, verified by rebuilding and reading the artifact.

This had been reported before and not fixed, because nothing could demonstrate it. That is what the rest of this PR is for.

## 2. The 0.67.0 feedstock failure

[conda-forge/ada-py-feedstock#196](https://github.com/conda-forge/ada-py-feedstock/pull/196) fails on two DEXPI tests that load `scripts/gen_dexpi_examples.py`, which the recipe does not ship as a test file:

```
2 failed, 2982 passed
FileNotFoundError: .../test-files/ada-py/1/scripts/gen_dexpi_examples.py
```

Those are an anti-drift guard over *repository contents*: they assert that checked-in fixtures match a checked-in generator. In a package build both are frozen copies from one tarball, so the comparison can only restate what git already guaranteed — it cannot fail there for a real reason. They now skip when there is no checkout, keyed on the repo root rather than on the generator being absent, so a generator that vanishes from a real checkout still fails loudly.

The feedstock already carries the same judgement for another test, as a `--deselect` commented *"it is a repo lint, not a package test"*. Deciding it here means the next such test needs no feedstock change.

**This does not rescue 0.67.0** — that tarball is cut. Either the feedstock PR deselects the two, or the release moves to a version carrying this commit.

## 3. Building the package in CI

Why nothing caught either: everything in this suite runs from a checkout, where the files are simply there. A missing `package-data` entry produces no warning, because the build cannot tell a file you forgot from one you meant to leave out.

**rattler-build has no flag for building a recipe from a local path** — `rattler-build build --help` contains zero matches for `--source`, and the documented mechanism is the recipe's own `source: path:`. So `tools/localise_feedstock_recipe.py` rewrites the feedstock's recipe to point at the checkout. Textually, to keep the recipe's comments — one of which is the only record of why that test is deselected — and refusing rather than proceeding if it cannot isolate the `source:` block, since building the released tarball would report a pass that says nothing about the checkout.

Two guards, deliberately unequal in cost:

| guard | cost | catches |
|---|---|---|
| `test_package_data_is_complete.py` | milliseconds, runs everywhere | a data file not named in `package-data`, by name |
| `conda-package` PR job | a build | what the recipe ships as test files, and what the tests it runs assume |

The job clones the real feedstock, points its recipe here, and builds with tests. Scoped inline to changes that can alter what is packaged, so it always reports a status and can be a required check — the same shape as the existing bundle-provenance job.

## Verification

- Locally on Windows with `--test skip` (the recipe's test env needs Linux-only packages, so the test leg belongs on the ubuntu runner): the localised recipe builds `ada-py-0.67.0` and `ada-py-core-0.67.0` from this checkout using the feedstock's own variant config.
- Reverting the `pyproject.toml` line makes the static guard fail, naming `comms/rest/migrations/001_initial.sql` — so it bites.
- 13 new tests.

One wrinkle worth recording: `-c conda-forge` cannot be passed alongside the variant config — rattler-build rejects *"channel_sources and channels cannot both be set"* — so the job uses the recipe's own channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnVdor5ZMzD5QYxFQLQioc
