### PR TITLE
fix(rest): list the plugins this process registered when there is no queue

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3671,6 +3671,25 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return None
         return {p.strip() for p in parsed if p and p.strip()}
 
+    def _locally_registered_specs() -> list[dict]:
+        """Every spec this process registered itself.
+
+        The listing's counterpart of ``_locally_registered_spec``: a viewer with
+        no queue preloads its plugins INTO THE API and runs their jobs here, so
+        no worker ever advertises them. Without this the listing is empty in
+        exactly the deployment whose jobs run in this process, and a plugin's
+        own advertised options (what its run form offers) never reach the page.
+        Defensive for the same reason: the slim API image may not carry ``ada``.
+        """
+        try:
+            from ada.plugins import plugin_backend_specs
+        except Exception:
+            return []
+        try:
+            return plugin_backend_specs()
+        except Exception:
+            return []
+
     def _locally_registered_spec(plugin_id: str) -> dict | None:
         """The spec this process registered itself, if any.
 
@@ -3951,6 +3970,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "origin": "code" if slug in builtin_slugs else "db",
                 "online": True,
             }
+        # With no queue, plugin jobs run in THIS process (see `local_jobs`), so
+        # what it registered is online by definition — and the only source there
+        # is. Only then: behind a queue a job goes to a worker, and a spec this
+        # API happens to have imported says nothing about whether one is up.
+        if not queue.enabled:
+            for spec in _locally_registered_specs():
+                slug = spec.get("slug") or spec.get("id")
+                if slug and slug not in by_slug:
+                    by_slug[slug] = {**spec, "slug": slug, "origin": "code", "online": True}
 
         # `requires_admin` is reported as the EFFECTIVE gate, not merely what a
         # worker declared: a deployment can gate a plugin that declared nothing

--- a/tests/comms/rest/test_plugin_job_admin_gate.py
+++ b/tests/comms/rest/test_plugin_job_admin_gate.py
@@ -273,3 +273,22 @@ def test_the_listing_reports_the_effective_gate_not_just_the_declaration(tmp_pat
 
     spec = next(p for p in body["plugins"] if p["slug"] == "adapy-test-open")
     assert spec["requires_admin"] is True
+
+
+def test_the_listing_carries_what_this_process_registered_when_there_is_no_queue(tmp_path):
+    """A queue-less viewer runs plugin jobs in-process, so no worker advertises
+    them. The listing must still say the plugin is there, with the extra keys it
+    registered — that is how its run form learns what it may offer."""
+    register_plugin_backend(
+        "adapy-test-local",
+        job_entrypoint=f"{__name__}:_entrypoint",
+        run_options={"standards": [{"id": "std-a"}]},
+    )
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        body = client.get("/api/plugins").json()
+
+    spec = next(p for p in body["plugins"] if p["slug"] == "adapy-test-local")
+    assert spec["online"] is True
+    assert spec["run_options"] == {"standards": [{"id": "std-a"}]}


### PR DESCRIPTION
## Problem

A queue-less viewer (single node, `queue.enabled` false) preloads its plugins into the API process and runs their jobs there through `local_jobs`. No worker ever advertises them, so `GET /api/plugins`, which reads only live worker specs, returned an empty list. The plugin was registered and its jobs ran, but nothing it advertised with `register_plugin_backend(**extra)` reached the frontend. A plugin's run form that reads its own advertised options found nothing.

## Change

When there is no queue, `api_plugins` also lists the specs this process registered (`plugin_backend_specs()`), marked `origin: code`, `online: true`. This mirrors `_locally_registered_spec`, which the admin gate already uses for the same reason.

- Only without a queue. Behind a queue a job goes to a worker, and a spec the API happens to have imported says nothing about whether a worker is up.
- A live worker's spec for the same slug still wins.
- `ada.plugins` is imported defensively, as in the neighbouring helper, because the slim API image may not carry `ada`.

## Tests

`tests/comms/rest/test_plugin_job_admin_gate.py::test_the_listing_carries_what_this_process_registered_when_there_is_no_queue`. Locally, `pixi run -e viewer-api-tests pytest tests/comms/rest/test_plugin_job_admin_gate.py tests/comms/rest/test_capability_sharding_route.py tests/comms/rest/test_qualification_surfacing.py tests/core/test_plugins.py` gives 52 passed. black and isort are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSV6keH8cZzSY2y1qvjZzj
