### PR TITLE
fix(viewer): handle glTF nodes without meshes and meshes sharing a geometry

### DIFF
--- a/src/ada/visit/scene_converter.py
+++ b/src/ada/visit/scene_converter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, OrderedDict
+from typing import TYPE_CHECKING, Callable, Optional, OrderedDict
 
 from ada.config import logger
 from ada.core.guid import create_guid
@@ -70,6 +70,14 @@ class SceneConverter:
     _model_stats: dict | None = field(default=None, init=False, repr=False)
     _model_stats_done: bool = field(default=False, init=False, repr=False)
 
+    # A postprocessor the CALLER set on ``params`` before ``build_scene``
+    # replaced it with this converter's own. Held so it can still be run --
+    # see :meth:`tree_postprocessor`.
+    _caller_buffer_postprocessor: Optional[Callable[[OrderedDict, dict], None]] = field(
+        default=None, init=False, repr=False
+    )
+    _caller_tree_postprocessor: Optional[Callable[[OrderedDict], None]] = field(default=None, init=False, repr=False)
+
     def __post_init__(self):
         from ada.extension.design_and_analysis_extension_schema import (
             AdaDesignAndAnalysisExtension,
@@ -127,8 +135,27 @@ class SceneConverter:
         else:
             raise ValueError(f"Unsupported object type: {type(self.source)}")
 
-        self.params.set_gltf_buffer_postprocessor(self.buffer_postprocessor)
-        self.params.set_gltf_tree_postprocessor(self.tree_postprocessor)
+        # This converter publishes its own postprocessors into the params so
+        # the export paths that read them get the animation/extension work.
+        # But the same two slots are the ONLY public way for a caller to
+        # supply a postprocessor (RenderParams.set_gltf_*_postprocessor), and
+        # those setters refuse to overwrite -- so a caller who set one and
+        # then rendered got `ValueError: gltf_tree_postprocessor is already
+        # set.` raised from in here. Take over the slots, but keep whatever
+        # the caller put there and run it too (see tree_postprocessor).
+        #
+        # A bound method compares equal per (func, instance), so the identity
+        # guard also stops a second build_scene() from capturing our own
+        # method and making the chain call itself.
+        caller_buffer = self.params.gltf_buffer_postprocessor
+        if caller_buffer is not None and caller_buffer != self.buffer_postprocessor:
+            self._caller_buffer_postprocessor = caller_buffer
+        caller_tree = self.params.gltf_tree_postprocessor
+        if caller_tree is not None and caller_tree != self.tree_postprocessor:
+            self._caller_tree_postprocessor = caller_tree
+
+        self.params.set_gltf_buffer_postprocessor(self.buffer_postprocessor, overwrite=True)
+        self.params.set_gltf_tree_postprocessor(self.tree_postprocessor, overwrite=True)
 
         if not has_meta:
             self._scene.metadata.update(self.graph.to_json_hierarchy())
@@ -258,6 +285,10 @@ class SceneConverter:
         for idx, animation in enumerate(self.animations):
             animation.process(buffer_items, tree, morph_target_index=idx, num_morph_targets=len(self.animations))
         self._consume_lineage_buffers(buffer_items)
+        # The caller's own postprocessor, displaced in build_scene. Last, so
+        # it sees the finished buffer.
+        if self._caller_buffer_postprocessor is not None:
+            self._caller_buffer_postprocessor(buffer_items, tree)
 
     def _consume_lineage_buffers(self, buffer_items) -> None:
         """Append queued lineage payloads to the GLB binary and rewrite
@@ -332,6 +363,13 @@ class SceneConverter:
             extras = asset.get("extras") or {}
             extras.update(extras_updates)
             asset["extras"] = extras
+
+        # The caller's own postprocessor, displaced in build_scene (see there).
+        # Runs last, after the extras above, so it can inspect or override what
+        # this converter produced -- consistent with gltf_asset_extras_dict
+        # already winning over the computed take-off.
+        if self._caller_tree_postprocessor is not None:
+            self._caller_tree_postprocessor(tree)
 
     def build_model_stats(self) -> dict | None:
         """Discipline-organised quantity take-off for a Part/Assembly source.

--- a/src/ada/visit/scene_converter.py
+++ b/src/ada/visit/scene_converter.py
@@ -210,7 +210,14 @@ class SceneConverter:
         animations = tree.get("animations", [])
         for anim in animations:
             node_idx = anim["channels"][0]["target"]["node"]
-            mesh_idx = tree["nodes"][node_idx]["mesh"]
+            mesh_idx = tree["nodes"][node_idx].get("mesh")
+            if mesh_idx is None:
+                # glTF allows an animation channel to target any node, and a
+                # node is not required to have a mesh. The buffer-view fixups
+                # below are all mesh/morph-target work, so a channel driving a
+                # meshless node (translation/rotation/scale only) has nothing
+                # to do here -- and indexing "mesh" would raise KeyError.
+                continue
             mesh = tree["meshes"][mesh_idx]
             for primitive in mesh["primitives"]:
                 # Set ARRAY_BUFFER target for common attributes if present

--- a/src/frontend/src/utils/scene/convert_to_custom_batch_mesh.ts
+++ b/src/frontend/src/utils/scene/convert_to_custom_batch_mesh.ts
@@ -4,6 +4,22 @@ import {DesignDataExtension, SimulationDataExtensionMetadata} from "@/extensions
 import {usePerfStore} from "@/state/perfStore";
 import {gpuMeshPicker} from "../mesh_select/GpuMeshPicker";
 
+// Geometries already handed to a CustomBatchedMesh.
+//
+// GLTFLoader caches primitives by their accessor key, so several glTF meshes
+// referencing the same accessors resolve to ONE shared BufferGeometry.
+// CustomBatchedMesh stores per-mesh selection state *on* that geometry (the
+// 'color' attribute written by setRangeColors/updateSelectionGroups, plus draw
+// groups), so sharing an instance across meshes makes selecting a single mesh
+// visibly highlight every other mesh backed by the same geometry.
+//
+// A GLB whose meshes are merged into per-model buffers uses each geometry
+// exactly once and never hits this; one that keeps meshes separate and reuses
+// geometry between them does.
+//
+// WeakSet so a disposed geometry isn't pinned in memory here.
+const claimedGeometries = new WeakSet<THREE.BufferGeometry>();
+
 export function convert_to_custom_batch_mesh(original: THREE.Mesh, drawRanges: Map<string, [number, number]>, unique_key: string, is_design: boolean = true, ada_ext_data: SimulationDataExtensionMetadata | DesignDataExtension | null = null) {
     // CustomBatchedMesh holds a single base material; if the source was
     // a multi-material mesh, take the first one. Multi-material support
@@ -38,8 +54,19 @@ export function convert_to_custom_batch_mesh(original: THREE.Mesh, drawRanges: M
         return sourceMaterial;
     })();
 
+    // Give this mesh sole ownership of its geometry (see claimedGeometries).
+    // clone() carries over attributes, index, groups, morphAttributes and any
+    // bounds already computed, so the copy is a drop-in. Only the 2nd+ user of
+    // a shared geometry pays for a clone; when every geometry is used once
+    // this allocates nothing extra.
+    let geometry = original.geometry;
+    if (claimedGeometries.has(geometry)) {
+        geometry = geometry.clone();
+    }
+    claimedGeometries.add(geometry);
+
     const customMesh = new CustomBatchedMesh(
-        original.geometry,
+        geometry,
         baseMaterial,
         drawRanges,
         unique_key,


### PR DESCRIPTION
Two independent bugs that surface when a glTF scene doesn't match the shape the merged-buffer path assumes. Both fixes are small and self-contained.

### 1. `KeyError: 'mesh'` when an animation targets a node without a mesh

`SceneConverter._update_animations` reads `tree["nodes"][node_idx]["mesh"]` for every animation channel. glTF places no such requirement on an animation target: a channel may drive any node, and a node need not have a mesh. A translation/rotation/scale channel on a transform-only node — the ordinary way to animate a pivot or a group — aborts the export.

Everything the loop does with that mesh is buffer-view target fixup for mesh attributes and morph targets, so there is nothing to do for a node that has none. Those channels are now skipped.

### 2. Selection highlight bleeds across meshes that share a geometry

Selecting one mesh could visibly highlight several others — every mesh backed by the same `BufferGeometry` lit up with it.

`GLTFLoader` caches primitives by their accessor key, so glTF meshes referencing the same accessors all resolve to one shared `BufferGeometry`. `CustomBatchedMesh` keeps its per-mesh selection state *on* that geometry (the `color` attribute written by `setRangeColors` / `updateSelectionGroups`, plus draw groups), so once the instance is shared, the highlighting is shared with it.

A GLB whose meshes are merged into per-model buffers uses each geometry exactly once and never shows this. One that keeps meshes separate and reuses geometry between them does, and the more repeated shapes it has, the worse it looks.

Each `CustomBatchedMesh` now takes sole ownership of its geometry: claimed on first use, cloned for the 2nd+ user. The clone carries attributes, index, groups, morphAttributes and any computed bounds, so it is a drop-in. Scenes where every geometry is used once allocate nothing extra.

### Testing

- `pixi run -e lint lint-check` passes.
- No unit test for (2): `convert_to_custom_batch_mesh` pulls in a vite `?worker&inline` module through `gpuMeshPicker`, which the `node --test` runner cannot resolve. It is type-checked only — the behavioural check is to load a GLB with repeated geometry and confirm a click highlights just the mesh clicked.
