### PR TITLE
feat(export): a procedural model exports as a Genie workspace (gnx)

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -5169,15 +5169,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         / analysis file. ``?format=ifc`` serializes the DETAIL model (beams, plates,
         joints — the clash cuts ride along as IfcRelVoidsElement voids, equipment as
         IfcPump/IfcTank/…); ``?format=gxml`` serializes the SIMULATION model as a
-        Genie concept XML. Mirrors :func:`api_procedural_export_xlsx` (revision-keyed
+        Genie concept XML, and ``?format=gnx`` as a Genie workspace (the same XML,
+        zipped the way Genie saves one). Mirrors :func:`api_procedural_export_xlsx` (revision-keyed
         cache, ``?force=true`` to rebuild). Built-in engine only — a non-default
         engine emits GLB, not an in-process ada assembly the writers need. The
         worker writes ``derived_key``; the frontend polls then downloads the blob."""
         from .procedural import procedural_model_export_key
 
         fmt = (request.query_params.get("format") or "").strip().lower()
-        if fmt not in ("ifc", "gxml"):
-            raise HTTPException(status_code=400, detail="format must be 'ifc' or 'gxml'")
+        if fmt not in ("ifc", "gxml", "gnx"):
+            raise HTTPException(status_code=400, detail="format must be 'ifc', 'gxml' or 'gnx'")
         force = (request.query_params.get("force") or "").strip().lower() in ("1", "true", "yes")
         # IFC only: splice real catalog CAD geometry for equipment (default on). A
         # falsy value renders equipment as placeholder boxes; gxml ignores it (it
@@ -5194,7 +5195,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 detail=f"IFC/Genie export is only available for the built-in engine, not {engine!r}",
             )
 
-        # IFC = the detail model (with its fabrication detailing); Genie = the sim model.
+        # IFC = the detail model (with its fabrication detailing); Genie (XML or
+        # workspace) = the sim model.
         lod = "detail" if fmt == "ifc" else "sim"
         detailing = (row.get("doc") or {}).get("detailing") if fmt == "ifc" else None
 

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -2250,7 +2250,8 @@ async def _run_procedural_export_model(
 ) -> None:
     """Export a procedural model to a downloadable CAD/analysis file: ``ifc`` (the
     DETAIL model — the clash cuts ride along as IfcRelVoidsElement voids, equipment
-    as IfcPump/IfcTank/…) or ``gxml`` (the SIMULATION model as a Genie concept XML).
+    as IfcPump/IfcTank/…), ``gxml`` (the SIMULATION model as a Genie concept XML) or
+    ``gnx`` (that XML as a Genie workspace).
 
     Compiles the postgres-stored doc to an in-process adapy assembly (built-in
     engine only) at the format's LOD, serializes it, and stores the bytes at
@@ -2274,8 +2275,8 @@ async def _run_procedural_export_model(
     if not model_id or not isinstance(revision, int):
         await _fail("export", "conversion_options.model_id and revision are required for procedural_export_model")
         return
-    if export_format not in ("ifc", "gxml"):
-        await _fail("export", f"unsupported export_format {export_format!r} (expected ifc or gxml)")
+    if export_format not in ("ifc", "gxml", "gnx"):
+        await _fail("export", f"unsupported export_format {export_format!r} (expected ifc, gxml or gnx)")
         return
     if db_pool is None:
         await _fail("export", "procedural export requires DATABASE_URL on the worker")
@@ -2366,6 +2367,14 @@ async def _run_procedural_export_model(
                 # embed_sat=False keeps the export CAD-backend-independent (plates as
                 # polygons; Genie rebuilds the ACIS on import).
                 asm.to_genie_xml(p, embed_sat=False)
+                if export_format == "gnx":
+                    # Repack that XML as a workspace rather than calling to_gnx(), which
+                    # builds the ACIS body through the CAD backend: a polygon XML gets
+                    # the empty-body SAT and Genie builds the body from the polygons on
+                    # load, exactly as when the XML is imported by hand.
+                    from ada.cadit.gxml.write.write_gnx import gnx_from_genie_xml
+
+                    p = str(gnx_from_genie_xml(p, os.path.join(d, "model.gnx")))
             with open(p, "rb") as fh:
                 return fh.read()
 

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -2593,13 +2593,14 @@ export const viewerApi = {
 
   /** Enqueue an export of the committed revision to a downloadable CAD/analysis
    * file: `format: "ifc"` (the DETAIL model — clash cuts as IfcRelVoidsElement
-   * voids, equipment as IfcPump/IfcTank/…) or `"gxml"` (the SIMULATION model as a
-   * Genie concept XML). Built-in engine only. Poll `convertStatus` then
-   * `downloadBlob`, exactly like `exportProceduralModelXlsx`. */
+   * voids, equipment as IfcPump/IfcTank/…), `"gxml"` (the SIMULATION model as a
+   * Genie concept XML) or `"gnx"` (that XML as a Genie workspace). Built-in engine
+   * only. Poll `convertStatus` then `downloadBlob`, exactly like
+   * `exportProceduralModelXlsx`. */
   async exportProceduralModel(
     scope: ScopeUrl,
     modelId: string,
-    format: "ifc" | "gxml",
+    format: "ifc" | "gxml" | "gnx",
     opts?: { force?: boolean; cad?: boolean },
   ): Promise<ProceduralCompileResponse> {
     const params = new URLSearchParams({ format });

--- a/src/frontend/src/state/cellBuilderStore.ts
+++ b/src/frontend/src/state/cellBuilderStore.ts
@@ -865,10 +865,11 @@ interface CellBuilderState {
    * workbook matches what's on screen. */
   exportToExcel: () => Promise<void>;
   /** Export + download the committed model as a CAD/analysis file: "ifc" (the
-   * DETAIL model, clash cuts as IfcRelVoidsElement voids) or "gxml" (the
-   * SIMULATION model as a Genie concept XML). Commits first when dirty. IFC
-   * honours `exportIfcCad` (splice real catalog CAD equipment). */
-  exportModel: (format: "ifc" | "gxml") => Promise<void>;
+   * DETAIL model, clash cuts as IfcRelVoidsElement voids), "gxml" (the
+   * SIMULATION model as a Genie concept XML) or "gnx" (that XML as a Genie
+   * workspace). Commits first when dirty. IFC honours `exportIfcCad` (splice
+   * real catalog CAD equipment). */
+  exportModel: (format: "ifc" | "gxml" | "gnx") => Promise<void>;
   /** IFC export: splice real catalog CAD geometry for equipment (default on).
    * Off = placeholder boxes. gxml ignores this (Genie equipment concept type). */
   exportIfcCad: boolean;
@@ -3721,7 +3722,11 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
       if (!active || get().xlsxBusy) return;
       const scope = currentScopePart();
       const label =
-        format === "ifc" ? "Download IFC (detail)" : "Download Genie XML (sim)";
+        format === "ifc"
+          ? "Download IFC (detail)"
+          : format === "gnx"
+            ? "Download Genie workspace (sim)"
+            : "Download Genie XML (sim)";
       set({ xlsxBusy: true });
       setProceduralToast(label, {
         status: "running",

--- a/tests/core/topo_model/test_procedural_export.py
+++ b/tests/core/topo_model/test_procedural_export.py
@@ -74,6 +74,29 @@ def test_sim_model_exports_to_genie_xml_with_equipment_concepts():
     assert txt.count("<prism_shape") == len(eqs)
 
 
+def test_sim_model_exports_to_genie_workspace():
+    # The gnx export: the same polygon concept XML as gxml, repacked as a workspace
+    # (modelData.xml + acisGeometry.sat) — what the worker does for format=gnx.
+    import zipfile
+
+    from ada.cadit.gxml.write.write_gnx import gnx_from_genie_xml
+
+    asm = build_procedural_assembly(
+        _steel_structure_demo_doc(), name="SteelDemo", lod="sim", detailing=None, equipment_resolver=(lambda _k: None)
+    )
+    with tempfile.TemporaryDirectory() as d:
+        xml = os.path.join(d, "m.gxml")
+        asm.to_genie_xml(xml, embed_sat=False)
+        gnx = gnx_from_genie_xml(xml, os.path.join(d, "m.gnx"))
+        with zipfile.ZipFile(gnx) as z:
+            names = set(z.namelist())
+            model = z.read("modelData.xml").decode("utf-8", errors="ignore")
+
+    assert {"modelData.xml", "acisGeometry.sat"} <= names
+    assert "<straight_beam" in model
+    assert "<flat_plate" in model
+
+
 def _catalog_cad_doc():
     """A doc placing one catalog equipment (slug 'mypump') in a cell."""
     spaces = [{"NAME": "C1", "INCLUDE": True, "X": 0, "Y": 0, "Z": 0, "DX": 5, "DY": 5, "DZ": 3}]
@@ -149,6 +172,7 @@ def test_export_key_format_and_cad_variant():
 
     assert procedural_model_export_key("abc", 3, "ifc") == "_procedural/abc/r3.ifc"
     assert procedural_model_export_key("abc", 3, "gxml") == "_procedural/abc/r3.gxml"
+    assert procedural_model_export_key("abc", 3, "gnx") == "_procedural/abc/r3.gnx"
     # CAD-on IFC (default) and CAD-off (placeholder boxes) never collide in cache.
     assert procedural_model_export_key("abc", 3, "ifc", cad_equipment=True) == "_procedural/abc/r3.ifc"
     assert procedural_model_export_key("abc", 3, "ifc", cad_equipment=False) == "_procedural/abc/r3_box.ifc"


### PR DESCRIPTION
## What

A procedural model can now be exported as a Genie workspace: `export-model` accepts `format=gnx` and returns the simulation model as a `.gnx`.

## Why

`export-model` wrote `ifc` (the detail model) and `gxml` (the simulation model as a Genie concept XML). To open the simulation model in Genie you had to import that XML by hand. A workspace opens directly.

## How

- The worker writes the same polygon concept XML as for `gxml` (`to_genie_xml(embed_sat=False)`). It then repacks it with `gnx_from_genie_xml`: `modelData.xml` and an empty-body `acisGeometry.sat`, zipped the way Genie saves a workspace.
- It does not call `to_gnx()`, because that builds the ACIS body through the CAD backend. The polygon route needs no CAD backend, and plates travel as polygons, as they do in the gxml export.
- The same rules apply as for gxml:
  - built-in engine only;
  - a revision-keyed cache (`_procedural/<id>/r<n>.gnx`);
  - `?force=true` rebuilds.
- Frontend: `viewerApi.exportProceduralModel` and `cellBuilderStore.exportModel` accept `"gnx"`, and the toast reads "Download Genie workspace (sim)". Core's own export buttons are unchanged; a UI shell can offer the new format.

## Tests

- `tests/core/topo_model/test_procedural_export.py` has two additions: a workspace export of the demo document (checking the archive's members and the beams and plates in its model data), and the gnx cache key. All 6 tests in the file pass.
- black, isort and ruff are clean on the changed Python files.
- No frontend strings were removed, so the committed bundle still passes provenance. I did not rebuild it.

## Not verified

- Opening the exported workspace in Genie.
- The worker job end to end against a database. The handler has no test; this PR only changes its format check and adds the repack step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
