### PR TITLE
feat: Genie workspace (gnx) export, and in-process plugin listing without a queue

### DIFF
--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -3671,6 +3671,25 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return None
         return {p.strip() for p in parsed if p and p.strip()}
 
+    def _locally_registered_specs() -> list[dict]:
+        """Every spec this process registered itself.
+
+        The listing's counterpart of ``_locally_registered_spec``: a viewer with
+        no queue preloads its plugins INTO THE API and runs their jobs here, so
+        no worker ever advertises them. Without this the listing is empty in
+        exactly the deployment whose jobs run in this process, and a plugin's
+        own advertised options (what its run form offers) never reach the page.
+        Defensive for the same reason: the slim API image may not carry ``ada``.
+        """
+        try:
+            from ada.plugins import plugin_backend_specs
+        except Exception:
+            return []
+        try:
+            return plugin_backend_specs()
+        except Exception:
+            return []
+
     def _locally_registered_spec(plugin_id: str) -> dict | None:
         """The spec this process registered itself, if any.
 
@@ -3951,6 +3970,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "origin": "code" if slug in builtin_slugs else "db",
                 "online": True,
             }
+        # With no queue, plugin jobs run in THIS process (see `local_jobs`), so
+        # what it registered is online by definition — and the only source there
+        # is. Only then: behind a queue a job goes to a worker, and a spec this
+        # API happens to have imported says nothing about whether one is up.
+        if not queue.enabled:
+            for spec in _locally_registered_specs():
+                slug = spec.get("slug") or spec.get("id")
+                if slug and slug not in by_slug:
+                    by_slug[slug] = {**spec, "slug": slug, "origin": "code", "online": True}
 
         # `requires_admin` is reported as the EFFECTIVE gate, not merely what a
         # worker declared: a deployment can gate a plugin that declared nothing

--- a/src/ada/comms/rest/app.py
+++ b/src/ada/comms/rest/app.py
@@ -5169,15 +5169,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         / analysis file. ``?format=ifc`` serializes the DETAIL model (beams, plates,
         joints — the clash cuts ride along as IfcRelVoidsElement voids, equipment as
         IfcPump/IfcTank/…); ``?format=gxml`` serializes the SIMULATION model as a
-        Genie concept XML. Mirrors :func:`api_procedural_export_xlsx` (revision-keyed
+        Genie concept XML, and ``?format=gnx`` as a Genie workspace (the same XML,
+        zipped the way Genie saves one). Mirrors :func:`api_procedural_export_xlsx` (revision-keyed
         cache, ``?force=true`` to rebuild). Built-in engine only — a non-default
         engine emits GLB, not an in-process ada assembly the writers need. The
         worker writes ``derived_key``; the frontend polls then downloads the blob."""
         from .procedural import procedural_model_export_key
 
         fmt = (request.query_params.get("format") or "").strip().lower()
-        if fmt not in ("ifc", "gxml"):
-            raise HTTPException(status_code=400, detail="format must be 'ifc' or 'gxml'")
+        if fmt not in ("ifc", "gxml", "gnx"):
+            raise HTTPException(status_code=400, detail="format must be 'ifc', 'gxml' or 'gnx'")
         force = (request.query_params.get("force") or "").strip().lower() in ("1", "true", "yes")
         # IFC only: splice real catalog CAD geometry for equipment (default on). A
         # falsy value renders equipment as placeholder boxes; gxml ignores it (it
@@ -5194,7 +5195,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 detail=f"IFC/Genie export is only available for the built-in engine, not {engine!r}",
             )
 
-        # IFC = the detail model (with its fabrication detailing); Genie = the sim model.
+        # IFC = the detail model (with its fabrication detailing); Genie (XML or
+        # workspace) = the sim model.
         lod = "detail" if fmt == "ifc" else "sim"
         detailing = (row.get("doc") or {}).get("detailing") if fmt == "ifc" else None
 

--- a/src/ada/comms/rest/worker.py
+++ b/src/ada/comms/rest/worker.py
@@ -2250,7 +2250,8 @@ async def _run_procedural_export_model(
 ) -> None:
     """Export a procedural model to a downloadable CAD/analysis file: ``ifc`` (the
     DETAIL model — the clash cuts ride along as IfcRelVoidsElement voids, equipment
-    as IfcPump/IfcTank/…) or ``gxml`` (the SIMULATION model as a Genie concept XML).
+    as IfcPump/IfcTank/…), ``gxml`` (the SIMULATION model as a Genie concept XML) or
+    ``gnx`` (that XML as a Genie workspace).
 
     Compiles the postgres-stored doc to an in-process adapy assembly (built-in
     engine only) at the format's LOD, serializes it, and stores the bytes at
@@ -2274,8 +2275,8 @@ async def _run_procedural_export_model(
     if not model_id or not isinstance(revision, int):
         await _fail("export", "conversion_options.model_id and revision are required for procedural_export_model")
         return
-    if export_format not in ("ifc", "gxml"):
-        await _fail("export", f"unsupported export_format {export_format!r} (expected ifc or gxml)")
+    if export_format not in ("ifc", "gxml", "gnx"):
+        await _fail("export", f"unsupported export_format {export_format!r} (expected ifc, gxml or gnx)")
         return
     if db_pool is None:
         await _fail("export", "procedural export requires DATABASE_URL on the worker")
@@ -2366,6 +2367,14 @@ async def _run_procedural_export_model(
                 # embed_sat=False keeps the export CAD-backend-independent (plates as
                 # polygons; Genie rebuilds the ACIS on import).
                 asm.to_genie_xml(p, embed_sat=False)
+                if export_format == "gnx":
+                    # Repack that XML as a workspace rather than calling to_gnx(), which
+                    # builds the ACIS body through the CAD backend: a polygon XML gets
+                    # the empty-body SAT and Genie builds the body from the polygons on
+                    # load, exactly as when the XML is imported by hand.
+                    from ada.cadit.gxml.write.write_gnx import gnx_from_genie_xml
+
+                    p = str(gnx_from_genie_xml(p, os.path.join(d, "model.gnx")))
             with open(p, "rb") as fh:
                 return fh.read()
 

--- a/src/frontend/src/services/viewerApi.ts
+++ b/src/frontend/src/services/viewerApi.ts
@@ -2593,13 +2593,14 @@ export const viewerApi = {
 
   /** Enqueue an export of the committed revision to a downloadable CAD/analysis
    * file: `format: "ifc"` (the DETAIL model — clash cuts as IfcRelVoidsElement
-   * voids, equipment as IfcPump/IfcTank/…) or `"gxml"` (the SIMULATION model as a
-   * Genie concept XML). Built-in engine only. Poll `convertStatus` then
-   * `downloadBlob`, exactly like `exportProceduralModelXlsx`. */
+   * voids, equipment as IfcPump/IfcTank/…), `"gxml"` (the SIMULATION model as a
+   * Genie concept XML) or `"gnx"` (that XML as a Genie workspace). Built-in engine
+   * only. Poll `convertStatus` then `downloadBlob`, exactly like
+   * `exportProceduralModelXlsx`. */
   async exportProceduralModel(
     scope: ScopeUrl,
     modelId: string,
-    format: "ifc" | "gxml",
+    format: "ifc" | "gxml" | "gnx",
     opts?: { force?: boolean; cad?: boolean },
   ): Promise<ProceduralCompileResponse> {
     const params = new URLSearchParams({ format });

--- a/src/frontend/src/state/cellBuilderStore.ts
+++ b/src/frontend/src/state/cellBuilderStore.ts
@@ -865,10 +865,11 @@ interface CellBuilderState {
    * workbook matches what's on screen. */
   exportToExcel: () => Promise<void>;
   /** Export + download the committed model as a CAD/analysis file: "ifc" (the
-   * DETAIL model, clash cuts as IfcRelVoidsElement voids) or "gxml" (the
-   * SIMULATION model as a Genie concept XML). Commits first when dirty. IFC
-   * honours `exportIfcCad` (splice real catalog CAD equipment). */
-  exportModel: (format: "ifc" | "gxml") => Promise<void>;
+   * DETAIL model, clash cuts as IfcRelVoidsElement voids), "gxml" (the
+   * SIMULATION model as a Genie concept XML) or "gnx" (that XML as a Genie
+   * workspace). Commits first when dirty. IFC honours `exportIfcCad` (splice
+   * real catalog CAD equipment). */
+  exportModel: (format: "ifc" | "gxml" | "gnx") => Promise<void>;
   /** IFC export: splice real catalog CAD geometry for equipment (default on).
    * Off = placeholder boxes. gxml ignores this (Genie equipment concept type). */
   exportIfcCad: boolean;
@@ -3721,7 +3722,11 @@ export const useCellBuilderStore = create<CellBuilderState>((set, get) => {
       if (!active || get().xlsxBusy) return;
       const scope = currentScopePart();
       const label =
-        format === "ifc" ? "Download IFC (detail)" : "Download Genie XML (sim)";
+        format === "ifc"
+          ? "Download IFC (detail)"
+          : format === "gnx"
+            ? "Download Genie workspace (sim)"
+            : "Download Genie XML (sim)";
       set({ xlsxBusy: true });
       setProceduralToast(label, {
         status: "running",

--- a/tests/comms/rest/test_plugin_job_admin_gate.py
+++ b/tests/comms/rest/test_plugin_job_admin_gate.py
@@ -273,3 +273,22 @@ def test_the_listing_reports_the_effective_gate_not_just_the_declaration(tmp_pat
 
     spec = next(p for p in body["plugins"] if p["slug"] == "adapy-test-open")
     assert spec["requires_admin"] is True
+
+
+def test_the_listing_carries_what_this_process_registered_when_there_is_no_queue(tmp_path):
+    """A queue-less viewer runs plugin jobs in-process, so no worker advertises
+    them. The listing must still say the plugin is there, with the extra keys it
+    registered — that is how its run form learns what it may offer."""
+    register_plugin_backend(
+        "adapy-test-local",
+        job_entrypoint=f"{__name__}:_entrypoint",
+        run_options={"standards": [{"id": "std-a"}]},
+    )
+
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        body = client.get("/api/plugins").json()
+
+    spec = next(p for p in body["plugins"] if p["slug"] == "adapy-test-local")
+    assert spec["online"] is True
+    assert spec["run_options"] == {"standards": [{"id": "std-a"}]}

--- a/tests/core/topo_model/test_procedural_export.py
+++ b/tests/core/topo_model/test_procedural_export.py
@@ -74,6 +74,29 @@ def test_sim_model_exports_to_genie_xml_with_equipment_concepts():
     assert txt.count("<prism_shape") == len(eqs)
 
 
+def test_sim_model_exports_to_genie_workspace():
+    # The gnx export: the same polygon concept XML as gxml, repacked as a workspace
+    # (modelData.xml + acisGeometry.sat) — what the worker does for format=gnx.
+    import zipfile
+
+    from ada.cadit.gxml.write.write_gnx import gnx_from_genie_xml
+
+    asm = build_procedural_assembly(
+        _steel_structure_demo_doc(), name="SteelDemo", lod="sim", detailing=None, equipment_resolver=(lambda _k: None)
+    )
+    with tempfile.TemporaryDirectory() as d:
+        xml = os.path.join(d, "m.gxml")
+        asm.to_genie_xml(xml, embed_sat=False)
+        gnx = gnx_from_genie_xml(xml, os.path.join(d, "m.gnx"))
+        with zipfile.ZipFile(gnx) as z:
+            names = set(z.namelist())
+            model = z.read("modelData.xml").decode("utf-8", errors="ignore")
+
+    assert {"modelData.xml", "acisGeometry.sat"} <= names
+    assert "<straight_beam" in model
+    assert "<flat_plate" in model
+
+
 def _catalog_cad_doc():
     """A doc placing one catalog equipment (slug 'mypump') in a cell."""
     spaces = [{"NAME": "C1", "INCLUDE": True, "X": 0, "Y": 0, "Z": 0, "DX": 5, "DY": 5, "DZ": 3}]
@@ -149,6 +172,7 @@ def test_export_key_format_and_cad_variant():
 
     assert procedural_model_export_key("abc", 3, "ifc") == "_procedural/abc/r3.ifc"
     assert procedural_model_export_key("abc", 3, "gxml") == "_procedural/abc/r3.gxml"
+    assert procedural_model_export_key("abc", 3, "gnx") == "_procedural/abc/r3.gnx"
     # CAD-on IFC (default) and CAD-off (placeholder boxes) never collide in cache.
     assert procedural_model_export_key("abc", 3, "ifc", cad_equipment=True) == "_procedural/abc/r3.ifc"
     assert procedural_model_export_key("abc", 3, "ifc", cad_equipment=False) == "_procedural/abc/r3_box.ifc"


### PR DESCRIPTION
## What

Folds two independent, CI-green PRs into one so they land under a single CI run and a single release:

- #336 — fix(rest): list the plugins this process registered when there is no queue (by @oleandor)
- #343 — feat(export): a procedural model exports as a Genie workspace (`gnx`) (by @oleandor)

Both branches are merged in unchanged with merge commits, so their commits and authorship are preserved in this branch's history. The two touch `src/ada/comms/rest/app.py` at non-overlapping ranges and merged without conflict.

## #336 — plugins listing without a queue

A queue-less viewer preloads its plugins into the API process and runs their jobs there through `local_jobs`. No worker ever advertises them, so `GET /api/plugins` returned an empty list. When there is no queue, `api_plugins` now also lists the specs this process registered (`plugin_backend_specs()`), marked `origin: code`, `online: true`. A live worker's spec for the same slug still wins.

## #343 — Genie workspace export

`export-model` accepts `format=gnx`. The worker writes the same polygon concept XML as for `gxml` and repacks it with `gnx_from_genie_xml` (`modelData.xml` plus an empty-body `acisGeometry.sat`). No CAD backend is needed. Same rules as `gxml`: built-in engine only, revision-keyed cache under `_procedural/<id>/r<n>.gnx`, `?force=true` rebuilds. Frontend: `viewerApi.exportProceduralModel` and `cellBuilderStore.exportModel` accept `"gnx"`.

## Tests

- `tests/comms/rest/test_plugin_job_admin_gate.py` — the no-queue listing case.
- `tests/core/topo_model/test_procedural_export.py` — workspace export of the demo document and the gnx cache key.

Both PRs passed all 12 checks individually at their heads (`cbd9bf6`, `86010d6`); this branch is those two heads merged onto current `main`.

## Follow-ups noted in review, not changed here

- `gnx_from_genie_xml` names the model after the output stem, so the exported workspace opens in Genie as "model" rather than the assembly name.
- `_locally_registered_specs` and `_locally_registered_spec` in `app.py` share the same two try/except blocks and could share one helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StVzo66kiCk6MGeAJGaMDL
