### PR TITLE
fix: derive the worker's misroute exemptions from the format registry

### DIFF
--- a/src/ada/comms/rest/db/audit_queries.py
+++ b/src/ada/comms/rest/db/audit_queries.py
@@ -108,11 +108,16 @@ def _audit_predicates(
     if key_like:
         args.append(f"%{key_like}%")
         where.append(f"key ILIKE ${len(args)}")
-    # Bounded on ``ts``, which carries a DESC btree index, so narrowing the
-    # window makes both the log and the summary cheaper rather than dearer.
+    # The lower bound is "activity since", not "submitted since": a job that
+    # waited in the queue longer than the window and is running now belongs to
+    # the window (it started inside it), and anything still queued or running
+    # is part of the present regardless of when it was submitted. Keyed on
+    # ``ts`` first, which carries a DESC btree index, so the common case stays
+    # cheap; the other two arms only admit rows the first one rejected.
     if since is not None:
         args.append(since)
-        where.append(f"ts >= ${len(args)}")
+        n = len(args)
+        where.append(f"(ts >= ${n} OR started_at >= ${n} OR status IN ('queued', 'running'))")
     if until is not None:
         args.append(until)
         where.append(f"ts <= ${len(args)}")

--- a/src/ada/comms/rest/formats/__init__.py
+++ b/src/ada/comms/rest/formats/__init__.py
@@ -29,6 +29,7 @@ from .registry import (
     register,
     registered_kinds,
     resolve,
+    synthetic_kinds,
 )
 
 # Synthetic (sourceless) kinds — dispatched before any source download.
@@ -60,4 +61,5 @@ __all__ = [
     "register",
     "registered_kinds",
     "resolve",
+    "synthetic_kinds",
 ]

--- a/src/ada/comms/rest/formats/registry.py
+++ b/src/ada/comms/rest/formats/registry.py
@@ -134,3 +134,13 @@ def handlers() -> list[FormatHandler]:
 
 def registered_kinds() -> list[str]:
     return [h.kind for h in handlers()]
+
+
+def synthetic_kinds() -> frozenset[str]:
+    """The ``target_format`` values of every registered sourceless handler.
+
+    A synthetic job carries no source file, so anything that reasons about a job's source
+    extension (the worker's misroute guard) must exempt exactly these kinds — derived here so a
+    newly registered synthetic handler cannot be forgotten in a hand-kept list.
+    """
+    return frozenset(h.kind for h in _HANDLERS if not h.needs_source)

--- a/src/ada/comms/rest/worker/loop.py
+++ b/src/ada/comms/rest/worker/loop.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
 import signal
 import time
 from typing import Awaitable, Callable
@@ -17,7 +16,6 @@ from ada.config import logger
 
 from .. import db as db_module
 from ..config import load_settings
-from ..converter import LEGACY_CONVERT_EXTS
 from ..plugin_registry import discover_local_plugins
 from ..queue import JOB_STATUS_ERROR, JobQueue
 from ..storage import Storage
@@ -40,6 +38,7 @@ from .pools import (
 )
 from .process import _process_one, _should_skip_cancelled
 from .registration import build_registration
+from .routing import misroute_reason
 from .source_nodes import _rest_source_nodes_config
 from .state import _touch_liveness
 
@@ -430,35 +429,14 @@ async def _run() -> None:
                 # explicit failure points at the real problem.
                 peeked = await queue.get(job_id)
                 if peeked is not None:
-                    # component_build jobs are synthetic — no source
-                    # file, so the extension-based routing guard
-                    # doesn't apply. Routing was already pinned by
-                    # the build endpoint via target_capability, and
-                    # the per-spec handler resolves from the registry
-                    # the worker preloaded at startup (ADA_WORKER_PRELOAD).
-                    if peeked.target_format in (
-                        "component_build",
-                        "procedural_build",
-                        "procedural_detail",
-                        "procedural_relocations",
-                        "procedural_export_xlsx",
-                        "procedural_export_model",
-                        "procedural_import_xlsx",
-                        "equipment_bbox",
-                        "plugin_job",
-                    ):
-                        can_handle = True
-                        ext = ""
-                    else:
-                        ext = pathlib.PurePosixPath(peeked.source_key).suffix.lower()
-                        legacy_ok = ext in LEGACY_CONVERT_EXTS and (ext_allow_set is None or ext in ext_allow_set)
-                        can_handle = ext in source_ext_set or legacy_ok
-                    if not can_handle:
-                        misroute_msg = (
-                            f"misrouted: pool capability {cap!r} "
-                            f"can't handle .{ext.lstrip('.')} "
-                            f"(supported here: {sorted(source_ext_set) or ['legacy convert']})"
-                        )
+                    misroute_msg = misroute_reason(
+                        peeked.target_format,
+                        peeked.source_key,
+                        cap=cap,
+                        source_ext_set=source_ext_set,
+                        ext_allow_set=ext_allow_set,
+                    )
+                    if misroute_msg is not None:
                         logger.warning(
                             "worker: %s — job %s",
                             misroute_msg,

--- a/src/ada/comms/rest/worker/registration.py
+++ b/src/ada/comms/rest/worker/registration.py
@@ -142,7 +142,7 @@ async def build_registration(queue: JobQueue) -> Registration:
         import ada.comms.rest.utilities  # noqa: F401  (registration side-effect)
     except Exception:
         logger.exception("worker: failed to import bundled utilities (non-fatal)")
-    from .utility import UtilityRegistry
+    from ..utility import UtilityRegistry
 
     utilities = UtilityRegistry.specs()
 

--- a/src/ada/comms/rest/worker/routing.py
+++ b/src/ada/comms/rest/worker/routing.py
@@ -1,0 +1,44 @@
+"""The misroute guard: can this pool serve the job NATS just handed it?
+
+Routing happens at the subject layer (each pool subscribes to its own capability-suffixed
+subject), so a job arriving at a pool should always be one it can handle. When it is not (a
+routing bug, or a job enqueued before an upgrade) the loop fails it at once with a reason
+naming the real problem, instead of NAK-looping until the delivery budget is spent.
+
+Synthetic kinds have no source file, so the extension check does not apply to them. That set
+comes from the format registry rather than a hand-kept list: the list once omitted
+``procedural_engine_build``, whose synthetic key has no extension, so every engine-build job
+was failed as misrouted on every pool.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from ..converter import LEGACY_CONVERT_EXTS
+from ..formats.registry import synthetic_kinds
+
+
+def misroute_reason(
+    target_format: str,
+    source_key: str,
+    *,
+    cap: str,
+    source_ext_set: set[str] | frozenset[str],
+    ext_allow_set: set[str] | frozenset[str] | None,
+) -> str | None:
+    """``None`` when the pool can serve the job, else the message to fail it with."""
+    # Importing the package populates the registry; the registry module itself is a leaf.
+    import ada.comms.rest.formats  # noqa: F401
+
+    if target_format in synthetic_kinds():
+        return None
+    ext = pathlib.PurePosixPath(source_key).suffix.lower()
+    legacy_ok = ext in LEGACY_CONVERT_EXTS and (ext_allow_set is None or ext in ext_allow_set)
+    if ext in source_ext_set or legacy_ok:
+        return None
+    return (
+        f"misrouted: pool capability {cap!r} "
+        f"can't handle .{ext.lstrip('.')} "
+        f"(supported here: {sorted(source_ext_set) or ['legacy convert']})"
+    )

--- a/src/frontend/src/__tests__/components/auditRunsDefaultScope.test.ts
+++ b/src/frontend/src/__tests__/components/auditRunsDefaultScope.test.ts
@@ -1,0 +1,16 @@
+import {test} from "node:test";
+import assert from "node:assert/strict";
+import {AD_HOC_DEFAULT_SCOPE, defaultAuditScope} from "@/components/admin/auditRuns/defaultScope";
+
+test("the form opens on the first corpus when the deployment has one", () => {
+    assert.equal(defaultAuditScope([{slug: "basic"}, {slug: "hull"}]), "corpus:basic");
+});
+
+test("without a corpus the form opens on the ad-hoc shared scope", () => {
+    assert.equal(defaultAuditScope([]), AD_HOC_DEFAULT_SCOPE);
+    assert.equal(AD_HOC_DEFAULT_SCOPE, "shared");
+});
+
+test("a corpus without a slug is skipped", () => {
+    assert.equal(defaultAuditScope([{slug: ""}, {slug: "basic"}]), "corpus:basic");
+});

--- a/src/frontend/src/components/admin/auditRuns/TriggerForm.tsx
+++ b/src/frontend/src/components/admin/auditRuns/TriggerForm.tsx
@@ -1,7 +1,8 @@
-import React, {useCallback, useEffect, useState} from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import {viewerApi, Corpus} from "@/services/viewerApi";
 import {runWasmAuditSweep, WasmSweepProgress} from "@/services/audit/wasmSweep";
 import {ImagePool, describeImagePool, groupWorkersByImage} from "../auditPools";
+import {AD_HOC_DEFAULT_SCOPE, defaultAuditScope} from "./defaultScope";
 
 // "Run audit" form — pick a scope (a corpus for release-gate sweeps, or an
 // ad-hoc scope) and an optional worker pool, fire one POST to
@@ -11,7 +12,10 @@ import {ImagePool, describeImagePool, groupWorkersByImage} from "../auditPools";
 const WASM_POOL = "wasm";
 
 const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
-    const [scope, setScope] = useState("shared");
+    const [scope, setScope] = useState(AD_HOC_DEFAULT_SCOPE);
+    // Set once the operator picks a scope by hand; the corpus default below
+    // must not overwrite a choice made before the corpora finished loading.
+    const scopeTouched = useRef(false);
     const [workerPool, setWorkerPool] = useState("");
     const [note, setNote] = useState("");
     const [forceRebuild, setForceRebuild] = useState(false);
@@ -53,6 +57,7 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
                 const r = await viewerApi.adminCorporaList();
                 if (cancelled) return;
                 setCorpora(r.corpora);
+                if (!scopeTouched.current) setScope(defaultAuditScope(r.corpora));
             } catch {
                 // Non-fatal: scope picker still has shared / user:me.
             }
@@ -103,7 +108,7 @@ const TriggerForm: React.FC<{onCreated: () => void}> = ({onCreated}) => {
                 <span>Scope</span>
                 <select
                     value={scope}
-                    onChange={(e) => setScope(e.target.value)}
+                    onChange={(e) => { scopeTouched.current = true; setScope(e.target.value); }}
                     className="bg-gray-900 border border-gray-600 rounded-sm px-2 py-1 text-sm text-gray-100 font-mono w-64"
                     title="Pick a corpus for release-gate sweeps, or a non-corpus scope for ad-hoc debugging."
                 >

--- a/src/frontend/src/components/admin/auditRuns/defaultScope.ts
+++ b/src/frontend/src/components/admin/auditRuns/defaultScope.ts
@@ -1,0 +1,15 @@
+// Which scope the "Run audit" form should start on.
+//
+// A corpus is the release-gate flow, so when the deployment has one the form
+// opens on it; the ad-hoc scopes stay available in the picker. The choice is
+// only applied while the operator has not touched the picker, so a scope they
+// selected before the corpora finished loading is never overwritten.
+
+import type {Corpus} from "@/services/viewerApi";
+
+export const AD_HOC_DEFAULT_SCOPE = "shared";
+
+export function defaultAuditScope(corpora: readonly Pick<Corpus, "slug">[]): string {
+    const first = corpora.find((c) => Boolean(c.slug));
+    return first ? `corpus:${first.slug}` : AD_HOC_DEFAULT_SCOPE;
+}

--- a/tests/comms/rest/test_audit_summary.py
+++ b/tests/comms/rest/test_audit_summary.py
@@ -543,3 +543,26 @@ def test_route_normalises_target_like_the_log_does(db, tmp_path):
 
     with TestClient(create_app(_settings(tmp_path))) as client:
         assert client.get("/api/admin/audit/summary", params={"target": ".GLB"}).json()["total"] == 2
+
+
+@needs_postgres
+def test_a_job_that_started_inside_the_window_is_in_the_window(db):
+    """Submitted before the window, started inside it: the log and the summary both keep it."""
+    p, run = db
+    long_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=3)
+    run(_seed(p, n=1, status="queued", key_prefix="models/late"))
+    run(
+        p.execute(
+            "UPDATE audit_log SET ts = $1, status = 'running', started_at = NOW() WHERE key LIKE 'models/late%'",
+            long_ago,
+        )
+    )
+    run(_seed(p, n=1, status="done", key_prefix="models/old"))
+    run(p.execute("UPDATE audit_log SET ts = $1 WHERE key LIKE 'models/old%'", long_ago))
+    since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=24)
+    rows = run(db_module.list_audit(p, since=since, limit=100))
+    keys = {r["key"] for r in rows}
+    assert any(k.startswith("models/late") for k in keys), "the running job started inside the window"
+    assert not any(k.startswith("models/old") for k in keys), "a finished job from before the window stays out"
+    summary = run(db_module.summarize_audit(p, since=since))
+    assert summary["by_status"].get("running", 0) >= 1

--- a/tests/comms/rest/test_audit_window_predicate.py
+++ b/tests/comms/rest/test_audit_window_predicate.py
@@ -1,0 +1,38 @@
+"""The audit window admits a job by when it was active, not only by when it was submitted.
+
+A job that waited in the queue longer than the selected window vanished from the Audit tab the
+moment it started running: the lower bound compared only ``ts`` (submission). The bound now also
+admits rows that started inside the window and rows that are still queued or running.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from ada.comms.rest.db.audit_queries import _audit_predicates
+
+
+def test_since_admits_started_and_active_rows():
+    since = datetime.datetime(2026, 9, 11, tzinfo=datetime.timezone.utc)
+    where, args = _audit_predicates(since=since)
+    assert args == [since]
+    assert len(where) == 1
+    clause = where[0]
+    assert "ts >= $1" in clause
+    assert "started_at >= $1" in clause
+    assert "status IN ('queued', 'running')" in clause
+    assert clause.startswith("(") and clause.endswith(")")
+
+
+def test_until_and_since_number_their_placeholders_in_order():
+    since = datetime.datetime(2026, 9, 11, tzinfo=datetime.timezone.utc)
+    until = datetime.datetime(2026, 9, 12, tzinfo=datetime.timezone.utc)
+    where, args = _audit_predicates(user_sub="u1", since=since, until=until)
+    assert args == ["u1", since, until]
+    assert where[0] == "user_sub = $1"
+    assert "$2" in where[1] and "ts <= $3" == where[2]
+
+
+def test_no_window_means_no_bound():
+    where, args = _audit_predicates()
+    assert where == [] and args == []

--- a/tests/comms/rest/test_worker_boot_registration.py
+++ b/tests/comms/rest/test_worker_boot_registration.py
@@ -1,0 +1,52 @@
+"""``build_registration`` runs end to end against a stub queue.
+
+The worker calls it once at boot, after plugin discovery, and nothing else in the suite did, so
+a lazy import inside it could break every worker in a deployment without a test noticing. This
+boots it with a queue that records the three calls it makes and asserts the registration carries
+the utilities it advertises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from ada.comms.rest.worker.registration import Registration, build_registration
+
+
+class _StubQueue:
+    def __init__(self) -> None:
+        self.meta: dict[str, str] = {}
+        self.registered: list[tuple[str, dict]] = []
+
+    async def set_meta(self, key: str, value: str) -> None:
+        self.meta[key] = value
+
+    async def get_meta(self, key: str):
+        return self.meta.get(key)
+
+    async def register_worker(self, worker_id: str, payload: dict) -> None:
+        self.registered.append((worker_id, payload))
+
+
+def test_build_registration_boots_against_a_stub_queue(monkeypatch):
+    monkeypatch.setenv("ADA_IMAGE_TAG", "test-image")
+    queue = _StubQueue()
+
+    async def boot():
+        reg = await build_registration(queue)
+        published = await reg.publish()
+        return reg, published
+
+    reg, published = asyncio.run(boot())
+    assert isinstance(reg, Registration)
+    assert published is True
+    assert queue.meta.get("worker_image_tag") == "test-image"
+    assert reg.worker_id
+    assert isinstance(reg.source_ext_set, set)
+    # The utilities registry is reached through a lazy import inside build_registration and
+    # advertised in the registration heartbeat; a payload carrying the key proves the import
+    # resolved and the registry was read.
+    worker_id, payload = queue.registered[-1]
+    assert worker_id == reg.worker_id
+    assert "utilities" in payload
+    assert isinstance(payload["utilities"], list)

--- a/tests/comms/rest/test_worker_misroute.py
+++ b/tests/comms/rest/test_worker_misroute.py
@@ -1,0 +1,64 @@
+"""The misroute guard exempts every sourceless job kind the registry knows.
+
+The guard once kept its own list of synthetic kinds and missed ``procedural_engine_build``,
+whose synthetic key carries no extension, so every engine-build job was failed as misrouted on
+every pool. The exemptions now come from the registry, so this pins that every registered
+synthetic handler is exempt and that a real extension mismatch is still caught.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import ada.comms.rest.formats as formats
+from ada.comms.rest.formats.registry import synthetic_kinds
+from ada.comms.rest.worker.routing import misroute_reason
+
+POOL = {"cap": "base", "source_ext_set": {".ifc", ".step"}, "ext_allow_set": None}
+
+
+def test_every_registered_synthetic_kind_is_exempt():
+    kinds = synthetic_kinds()
+    assert "procedural_engine_build" in kinds
+    assert "component_build" in kinds
+    assert "plugin_job" in kinds
+    for kind in kinds:
+        assert misroute_reason(kind, "_synthetic/engine-build/abc", **POOL) is None, kind
+
+
+def test_synthetic_kinds_match_the_handlers_that_need_no_source():
+    expected = {h.kind for h in formats.handlers() if not h.needs_source}
+    assert synthetic_kinds() == frozenset(expected)
+
+
+def test_an_engine_build_job_is_not_misrouted_on_any_pool():
+    reason = misroute_reason(
+        "procedural_engine_build",
+        "_synthetic/engine-build/engine-1/r3",
+        cap="pm-engine",
+        source_ext_set=set(),
+        ext_allow_set=None,
+    )
+    assert reason is None
+
+
+@pytest.mark.parametrize("key", ["scope/model.ifc", "scope/deep/dir/model.STEP"])
+def test_a_supported_source_extension_passes(key):
+    assert misroute_reason("glb", key, **POOL) is None
+
+
+def test_an_unsupported_source_extension_is_named_in_the_reason():
+    reason = misroute_reason("glb", "scope/model.zzz", **POOL)
+    assert reason is not None
+    assert "misrouted" in reason
+    assert ".zzz" in reason
+    assert "'base'" in reason
+
+
+def test_a_legacy_extension_is_allowed_only_when_the_pool_allows_it():
+    from ada.comms.rest.converter import LEGACY_CONVERT_EXTS
+
+    legacy = sorted(LEGACY_CONVERT_EXTS)[0]
+    key = f"scope/model{legacy}"
+    assert misroute_reason("glb", key, cap="base", source_ext_set=set(), ext_allow_set=None) is None
+    assert misroute_reason("glb", key, cap="base", source_ext_set=set(), ext_allow_set={".zzz"}) is not None

--- a/tests/core/test_relative_imports_resolve.py
+++ b/tests/core/test_relative_imports_resolve.py
@@ -1,0 +1,51 @@
+"""Every relative import in ``ada`` names a module that exists on disk.
+
+A lazy ``from .x import y`` inside a function is not executed by importing the module, so a
+package split that moves ``x`` one level up or down leaves a failure that only fires at runtime.
+That is how a worker came to crash at boot after ``worker.py`` became a package:
+``from .utility import`` began naming ``ada.comms.rest.worker.utility`` instead of
+``ada.comms.rest.utility``. This walks the AST of every module and resolves each relative import
+against the source tree, without importing anything, so the mistake fails here rather than in a
+running deployment and regardless of which optional dependencies the test environment carries.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import ada
+
+ADA_ROOT = pathlib.Path(ada.__file__).parent
+
+
+def _module_exists(parts: list[str]) -> bool:
+    base = ADA_ROOT.parent.joinpath(*parts)
+    return base.with_suffix(".py").is_file() or (base / "__init__.py").is_file()
+
+
+def _resolves(package: list[str], node: ast.ImportFrom) -> bool:
+    up = node.level - 1
+    if up > len(package):
+        return False
+    base = package[: len(package) - up] if up else package
+    target = base + (node.module.split(".") if node.module else [])
+    if _module_exists(target):
+        return True
+    # ``from .pkg import name`` may name submodules rather than attributes.
+    names = [alias.name for alias in node.names if alias.name != "*"]
+    return bool(names) and all(_module_exists(target + [n]) for n in names)
+
+
+def test_every_relative_import_resolves():
+    unresolved: list[str] = []
+    for path in sorted(ADA_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        package = list(path.relative_to(ADA_ROOT.parent).with_suffix("").parts)[:-1]
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level and not _resolves(package, node):
+                rel = path.relative_to(ADA_ROOT.parent)
+                unresolved.append(f"{rel}:{node.lineno}: from {'.' * node.level}{node.module or ''} import ...")
+    assert not unresolved, "unresolvable relative imports:\n" + "\n".join(unresolved)


### PR DESCRIPTION
## What

Four fixes found by running 0.70.0 for real: two in the worker, two in the Audit tab.

### 1. The worker crashed at boot

When `worker.py` became a package in #349, the lazy import inside `build_registration` kept its one-dot form and started naming `ada.comms.rest.worker.utility`, which does not exist. Every worker built from 0.70.0 crash-loops at boot with `ModuleNotFoundError`. The suite never ran that import because nothing booted a registration. Fixed to `from ..utility import`, and closed two ways:

- `tests/comms/rest/test_worker_boot_registration.py` drives `build_registration` and `publish` against a stub queue and checks the registration heartbeat carries the advertised utilities.
- `tests/core/test_relative_imports_resolve.py` walks every module's relative imports against the source tree, without importing anything, so a moved module fails in CI rather than in a deployment. It flags exactly this line on 0.70.0 and nothing else.

### 2. Engine-build jobs were misrouted

The worker's misroute guard exempted sourceless job kinds from its extension check using a hand-kept list. The list missed `procedural_engine_build`, whose synthetic key has no extension, so every engine-build job was failed as misrouted on every pool.

## How

- `formats/registry.py` gains `synthetic_kinds()`, the kinds of every registered handler with `needs_source = False`.
- The guard moves out of the job loop into a pure `misroute_reason()` in `worker/routing.py` that asks the registry instead of a list. The loop's behaviour for source-backed jobs is unchanged, message text included.
- `tests/comms/rest/test_worker_misroute.py` pins that every registered synthetic kind is exempt (so a future handler cannot be forgotten), that an engine-build job with an extensionless key passes on any pool, that a supported extension passes, that an unsupported one is named in the reason, and that the legacy-extension allowance still respects the pool's allow-list.

### 3. The audit window hid a job that finally started

The Audit tab's window (last 24 hours and friends) compared only the submission timestamp, so a job that waited in the queue longer than the window vanished the moment it started running. The shared predicate now admits a row when it was submitted or started inside the window, and always admits rows that are still queued or running. The summary and the log share the predicate, so they keep agreeing. Pinned by `test_audit_window_predicate.py` (pure) and a live-Postgres case in `test_audit_summary.py`.

### 4. The Run audit form opens on a corpus

When the deployment has a corpus, the form now opens on the first one instead of `shared`; the ad-hoc scopes stay in the picker, and a scope the operator picked before the corpora loaded is never overwritten. `defaultScope.ts` plus a node test.

## Tests

- `tests/comms/rest`: 845 passed, 103 skipped (main: 834)
- Frontend `npm test`: 713 tests green; typecheck 0
- `tests/core/test_relative_imports_resolve.py`: passes on this branch, fails on main naming the one broken import
- Slim-runtime guard: 7 passed
- Lint gate (black, ruff, isort): clean

## Also verified

A worker image built from this branch was deployed to a test cluster; the 0.70.0 worker crash-looped there, which is how the boot failure was found.

The three out-of-tree frontend plugins that ship with the viewer were overlaid onto this branch through the plugin repo's dev overlay: the composed bundle type-checks with zero errors and the dev server serves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtrPK5JtdDjRomksiY1HFb
